### PR TITLE
chore(pnpm): update Storybook dependencies to version 8.6.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,26 +47,26 @@ catalogs:
       specifier: ^2.8.10
       version: 2.8.10
     '@storybook/addon-a11y':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@storybook/addon-essentials':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@storybook/experimental-addon-test':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@storybook/preview-api':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@storybook/react':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@storybook/react-vite':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@storybook/test':
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     '@testing-library/react':
       specifier: ^16.2.0
       version: 16.2.0
@@ -113,8 +113,8 @@ catalogs:
       specifier: 3.4.2
       version: 3.4.2
     storybook:
-      specifier: ^8.5.3
-      version: 8.5.5
+      specifier: ^8.6.4
+      version: 8.6.4
     storybook-dark-mode:
       specifier: ^4.0.2
       version: 4.0.2
@@ -446,25 +446,25 @@ importers:
         version: 0.47.1
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 8.5.5(storybook@8.5.5(prettier@3.4.2))
+        version: 8.6.4(storybook@8.6.4(prettier@3.4.2))
       '@storybook/addon-essentials':
         specifier: catalog:tooling
-        version: 8.5.5(@types/react@18.3.18)(storybook@8.5.5(prettier@3.4.2))
+        version: 8.6.4(@types/react@18.3.18)(storybook@8.6.4(prettier@3.4.2))
       '@storybook/experimental-addon-test':
         specifier: catalog:tooling
-        version: 8.5.5(@vitest/browser@3.0.5)(@vitest/runner@3.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))(vitest@3.0.5)
+        version: 8.6.4(@vitest/browser@3.0.5)(@vitest/runner@3.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))(vitest@3.0.5)
       '@storybook/preview-api':
         specifier: catalog:tooling
-        version: 8.5.5(storybook@8.5.5(prettier@3.4.2))
+        version: 8.6.4(storybook@8.6.4(prettier@3.4.2))
       '@storybook/react':
         specifier: catalog:tooling
-        version: 8.5.5(@storybook/test@8.5.5(storybook@8.5.5(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))(typescript@5.6.3)
+        version: 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))(typescript@5.6.3)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 8.5.5(@storybook/test@8.5.5(storybook@8.5.5(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.5.5(prettier@3.4.2))(typescript@5.6.3)(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))
+        version: 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.6.4(prettier@3.4.2))(typescript@5.6.3)(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))
       '@storybook/test':
         specifier: catalog:tooling
-        version: 8.5.5(storybook@8.5.5(prettier@3.4.2))
+        version: 8.6.4(storybook@8.6.4(prettier@3.4.2))
       '@testing-library/react':
         specifier: catalog:tooling
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -500,10 +500,10 @@ importers:
         version: 1.50.1
       storybook:
         specifier: catalog:tooling
-        version: 8.5.5(prettier@3.4.2)
+        version: 8.6.4(prettier@3.4.2)
       storybook-dark-mode:
         specifier: catalog:tooling
-        version: 4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))
+        version: 4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))
       vite:
         specifier: catalog:tooling
         version: 5.4.14(@types/node@22.13.4)(terser@5.39.0)
@@ -3045,81 +3045,86 @@ packages:
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
-  '@storybook/addon-a11y@8.5.5':
-    resolution: {integrity: sha512-+svmnXdUhuwawNQqvYWkPsxniVYtjorr56myrqcMcexbX4SjtD/SX8cFlqTU0AGTWzrmGjSTEePCfWrG7C6R7g==}
+  '@storybook/addon-a11y@8.6.4':
+    resolution: {integrity: sha512-B3/d2cRlnpAlE3kh+OBaly6qrWN9DEqwDyZsNeobaiXnNp11xoHZP2OWjEwXldc0pKls41jeOksXyXrILfvTng==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-actions@8.5.5':
-    resolution: {integrity: sha512-XJtE69QBXROM0xvAAFohkwuBLLnuEFBvAnmsY4+pfk001BCEZf7UXDY/XKD3Ew/Uou6o7oco7RmStycSlXU2Ng==}
+  '@storybook/addon-actions@8.6.4':
+    resolution: {integrity: sha512-mCcyfkeb19fJX0dpQqqZCnWBwjVn0/27xcpR0mbm/KW2wTByU6bKFFujgrHsX3ONl97IcIaUnmwwUwBr1ebZXw==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-backgrounds@8.5.5':
-    resolution: {integrity: sha512-NWXOu9PIPd+/cUbicUv3Qmfj1L13sGUAeI5nkbTxgALtqW0ZdqmQDSsqlABz18jgd6JO1Wc4C5FW7L5wfaJG3A==}
+  '@storybook/addon-backgrounds@8.6.4':
+    resolution: {integrity: sha512-lRYGumlYdd1RptQJvOTRMx/q2pDmg2MO5GX4la7VfI8KrUyeuC1ZOSRDEcXeTuAZWJztqmtymg6bB7cAAoxCFA==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-controls@8.5.5':
-    resolution: {integrity: sha512-prPXe2pdE+eRykUKYX5ipPfq6ySpWY0YiEL3jzNDvnxgzNwsk0JUnqfwsOndF3mabKmfA1S+bxkaJlD+VI11ow==}
+  '@storybook/addon-controls@8.6.4':
+    resolution: {integrity: sha512-oMMP9Bj0RMfYmaitjFt6oBSjKH4titUqP+wE6PrZ3v+Om56f4buqfNKXRf80As2OrsZn0pjj95muWzVVHqIhyQ==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-docs@8.5.5':
-    resolution: {integrity: sha512-pQVu6IAwcD7sV7i6alnugT1kHv2EMAhqeS5/Vq2JJoA/QaiHxF83f2L3eCVxP2nKbHYUttdBpIQ+acIsw3jx7Q==}
+  '@storybook/addon-docs@8.6.4':
+    resolution: {integrity: sha512-+kbcjvEAH0Xs+k+raAwfC0WmJilWhxBYnLLeazP3m5AkVI3sIjbzuuZ78NR0DCdRkw9BpuuXMHv5o4tIvLIUlw==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-essentials@8.5.5':
-    resolution: {integrity: sha512-T7+Vcj/RST6N+prH1fnCh7arqUu09NdeVVRdwOOti9GrbxcZ2wiueuNyuEpR5fZ0Z/fLviXzV56VOm9OjVbwmg==}
+  '@storybook/addon-essentials@8.6.4':
+    resolution: {integrity: sha512-3pF0ZDl5EICqe0eOupPQq6PxeupwkLsfTWANuuJUYTJur82kvJd3Chb7P9vqw0A0QBx6106mL6PIyjrFJJMhLg==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-highlight@8.5.5':
-    resolution: {integrity: sha512-z7tSZLwNpDcOOb7XJItRGzYH3giUccmkk5LZSZ3ZD8oaiVDEDKFllJnLAFXP5K8RB1jF/8VmGQEqqQAMopzLYw==}
+  '@storybook/addon-highlight@8.6.4':
+    resolution: {integrity: sha512-jFREXnSE/7VuBR8kbluN+DBVkMXEV7MGuCe8Ytb1/D2Q0ohgJe395dfVgEgSMXErOwsn//NV/NgJp6JNXH2DrA==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-measure@8.5.5':
-    resolution: {integrity: sha512-iw819jNkQE/e8C5f/AnSFT39BGYvtxUIFQb8E1eS8Hjc3IZvMLcSDNHrxCuCgdPq4XZXvjekIimH6saxtKmaJg==}
+  '@storybook/addon-measure@8.6.4':
+    resolution: {integrity: sha512-IpVL1rTy1tO8sy140eU3GdVB1QJ6J62+V6GSstcmqTLxDJQk5jFfg7hVbPEAZZ2sPFmeyceP9AMoBBo0EB355A==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-outline@8.5.5':
-    resolution: {integrity: sha512-9+TLCUu/2YPL/r9LzOkQc4TBZ6PrxyB0+8uwTZ08pMrQH0zhtuwHWu/VNoR1MILjLx6Qt5bVHntvH0oKMfEa6g==}
+  '@storybook/addon-outline@8.6.4':
+    resolution: {integrity: sha512-28nAslKTy0zWMdxAZcipMDYrEp1TkXVooAsqMGY5AMXMiORi1ObjhmjTLhVt1dXp+aDg0X+M3B6PqoingmHhqQ==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-toolbars@8.5.5':
-    resolution: {integrity: sha512-siD3h3Zuc5xITwB1e3jN5dJFDsWZIjXJHhDdItbcCjsvYnv59+7Onma9n+WpZkIX8/HDhIIB1rCpBhr/7IVXTQ==}
+  '@storybook/addon-toolbars@8.6.4':
+    resolution: {integrity: sha512-PU2lvgwCKDn93zpp5MEog103UUmSSugcxDf18xaoa9D15Qtr+YuQHd2hXbxA7+dnYL9lA7MLYsstfxE91ieM4Q==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/addon-viewport@8.5.5':
-    resolution: {integrity: sha512-D9QpDDym/5Y5T99nBLM5IRwpb3tqkRoIZlJJzZZbSMSBOnJxMqKevWqSPNWnpXnP2MS67Tm8HPbRMz1iXey6tQ==}
+  '@storybook/addon-viewport@8.6.4':
+    resolution: {integrity: sha512-O5Ij+SRVg6grY6JOL5lOpsFyopZxuZEl2GHfh2SUf9hfowNS0QAgFpJupqXkwZzRSrlf9uKrLkjB6ulLgN2gOQ==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/blocks@8.5.5':
-    resolution: {integrity: sha512-O/59Dj2E4t3QtJkUyRgO0X4anAC5dx0M0gfsYACEUWFubhog9x5gw3xgPhFtc1UhezKBedM1nguqdPXHus1mTg==}
+  '@storybook/blocks@8.6.4':
+    resolution: {integrity: sha512-+oPXwT3KzJzsdkQuGEzBqOKTIFlb6qmlCWWbDwAnP0SEqYHoTVRTAIa44icFP0EZeIe+ypFVAm1E7kWTLmw1hQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^8.5.5
+      storybook: ^8.6.4
     peerDependenciesMeta:
       react:
         optional: true
       react-dom:
         optional: true
 
-  '@storybook/builder-vite@8.5.5':
-    resolution: {integrity: sha512-7KI84jdpHyPivtZmnPAbe3bLZLOv+6iEEvr64+oYt9ZF/CPBtPtlCRMWj2EOWoGzGYFPX48iPhGhhyC5WjLJ1w==}
+  '@storybook/builder-vite@8.6.4':
+    resolution: {integrity: sha512-FuSP2GhWVVTt6NdX0UJHhPOqhu09X4apSk+KWUf3aITRIJg9gbPYtJDBmxv1vXQEgvfCDdYBYbeG1khiO/Ghfw==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
   '@storybook/components@8.5.5':
     resolution: {integrity: sha512-w86hFVLUqLRH9l1EEZGOVNLt8eRAXqaSHtLvTX9y/bPzN10Z98BABD2Qx/hbuqneH/vp98VPYPU/hoGOh3J1NA==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/components@8.6.4':
+    resolution: {integrity: sha512-91VEVFWOgHkEFoNFMk6gs1AuOE9Yp7N283BXQOW+AgP+atpzED6t/fIBPGqJ2ewAuzLJ+cFOrasSzoNwVfg3Jg==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
@@ -3128,28 +3133,25 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/core@8.5.5':
-    resolution: {integrity: sha512-uQoMv6Zd941/vsjE8kP87pp1f5YHLyct+2J/FGUI5ukBOJLgS+K9khF82wfDL0JRULibV3b59g73tsttc3ZdcA==}
+  '@storybook/core@8.6.4':
+    resolution: {integrity: sha512-glDbjEBi3wokw1T+KQtl93irHO9N0LCwgylWfWVXYDdQjUJ7pGRQGnw73gPX7Ds9tg3myXFC83GjmY94UYSMbA==}
     peerDependencies:
       prettier: ^2 || ^3
     peerDependenciesMeta:
       prettier:
         optional: true
 
-  '@storybook/csf-plugin@8.5.5':
-    resolution: {integrity: sha512-R2i+s5eO7i88tuT6um7jidZ/wt0Ar5lEdb2M5bbnZjTZqRAF9YpoRgDDXwTYWyDz55CDTmpMU3O0BFXLeF+ZpQ==}
+  '@storybook/csf-plugin@8.6.4':
+    resolution: {integrity: sha512-7UpEp4PFTy1iKjZiRaYMG7zvnpLIRPyD0+lUJUlLYG4UIemV3onvnIi1Je1tSZ4hfTup+ulom7JLztVSHZGRMg==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/csf@0.1.12':
-    resolution: {integrity: sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==}
-
-  '@storybook/experimental-addon-test@8.5.5':
-    resolution: {integrity: sha512-YPIUCM1kpGAeUT/+tyFNgfpMjmiQVhESN9cEc89mTk6ldvUaoDhtfLiRm8JbWn4tBrCZMtmpmpm0dquZ2lR9Ww==}
+  '@storybook/experimental-addon-test@8.6.4':
+    resolution: {integrity: sha512-apFNRotG8+I0RNEFZt0oz5y5bvirQ4j/mu1IQNUSuX1tPyA6tV8VcFNBH/hgliX3xKLWrt3FMJEFo1xLGsa3BA==}
     peerDependencies:
       '@vitest/browser': ^2.1.1 || ^3.0.0
       '@vitest/runner': ^2.1.1 || ^3.0.0
-      storybook: ^8.5.5
+      storybook: ^8.6.4
       vitest: ^2.1.1 || ^3.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -3169,49 +3171,54 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/instrumenter@8.5.5':
-    resolution: {integrity: sha512-t4PlhgMTAFt/vSoqaydtATlcKJTEypxGnwlzx4lg5snrzmhYrtDUXTD/t25rrC0EjbEf412mlSS9BYRaogBAbg==}
+  '@storybook/instrumenter@8.6.4':
+    resolution: {integrity: sha512-8OtIWLhayTUdqJEeXiPm6l3LTdSkWgQzzV2l2HIe4Adedeot+Rkwu6XHmyRDpnb0+Ish6zmMDqtJBxC2PQsy6Q==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
   '@storybook/manager-api@8.5.5':
     resolution: {integrity: sha512-JQgnFskT1lhgT05m9zTeeW1FZIQbXjzRWEWbqYLcaiAnhbTb7B0IN8y1SOFQRLxXFrNa38T1AVHJj//Zv7KR3g==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/preview-api@8.5.5':
-    resolution: {integrity: sha512-TUJFeswIp2sYstrxLr97pWN+0qqkfN2iihe+cVfjsUEbW1pn0/SpqJVty3WKq44vCoUylulybzbSKkkN8+RYhA==}
+  '@storybook/manager-api@8.6.4':
+    resolution: {integrity: sha512-w/Nn/VznfbIg2oezDfzZNwSTDY5kBZbzxVBHLCnIcyu2AKt2Yto3pfGi60SikFcTrsClaAKT7D92kMQ9qdQNQQ==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/react-dom-shim@8.5.5':
-    resolution: {integrity: sha512-K4fR61jS9WJqXmrfczS1S7ukJjQw5vjTnxCJbqVpkpW9b5J0KpZr1aM6rvFLH6bNZPWefSRlRHeosaj5ro95IQ==}
+  '@storybook/preview-api@8.6.4':
+    resolution: {integrity: sha512-5HBfxggzxGz0dg2c61NpPiQJav7UAmzsQlzmI5SzWOS6lkaylcDG8giwKzASVCXVWBxNji9qIDFM++UH090aDg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/react-dom-shim@8.6.4':
+    resolution: {integrity: sha512-kTGJ3aFdmfCFzYaDFGmZWfTXr9xhbUaf0tJ6+nEjc4tME6mFwMI+tTUT6U/J6mJhZuc2DjvIRA7bM0x77dIDqw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
-  '@storybook/react-vite@8.5.5':
-    resolution: {integrity: sha512-blmX+SD2Xf0A2Eq21t/QkUFSPw6Ax2dWSpssoHhMvu42iywZEcOgrYDoMGe0qu1pd8Qdnqy/SrQC0OTTWPRlkg==}
+  '@storybook/react-vite@8.6.4':
+    resolution: {integrity: sha512-MEmD6sP2tUI/SYCXCeWGTs8umZj+N0e3DHXCQUz0nCsJH7kuCTTipOTBQvr/GuEstNd7BNG5k8aLIRrXLjAvdA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@storybook/test': 8.5.5
+      '@storybook/test': 8.6.4
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.5.5
+      storybook: ^8.6.4
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       '@storybook/test':
         optional: true
 
-  '@storybook/react@8.5.5':
-    resolution: {integrity: sha512-XWzKdQ6csiYbjs4oD6PBKpZi21fPDJ7h550CmyDobWiGqFDYhPOndUnfQvg7D6nr0fROlC+MrtvsrtECPeJSFQ==}
+  '@storybook/react@8.6.4':
+    resolution: {integrity: sha512-pfv4hMhu3AScOh0l86uIzmXLSQ0XA/e0reIVwQcxKht6miaKArhx9GkS4mMp6SO23ZoV5G/nfLgUaMVPVE0ZPg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@storybook/test': 8.5.5
+      '@storybook/test': 8.6.4
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.5.5
+      storybook: ^8.6.4
       typescript: '>= 4.2.x'
     peerDependenciesMeta:
       '@storybook/test':
@@ -3219,13 +3226,18 @@ packages:
       typescript:
         optional: true
 
-  '@storybook/test@8.5.5':
-    resolution: {integrity: sha512-8hVvT+TopKmh9iKZdTHmMz4kelz+gKwjCquw59ynoZBZ4saJdEdqmIaoPaFPAJukuGAP7qQKO6AnYFsufNw4gw==}
+  '@storybook/test@8.6.4':
+    resolution: {integrity: sha512-JPjfbaMMuCBT47pg3/MDD9vYFF5OGPAOWEB9nJWJ9IjYAb2Nd8OYJQIDoYJQNT+aLkTVLtvzGnVNwdxpouAJcQ==}
     peerDependencies:
-      storybook: ^8.5.5
+      storybook: ^8.6.4
 
   '@storybook/theming@8.5.5':
     resolution: {integrity: sha512-h/dsoA9RmWbIYjRNAVlJzjmrtLo5ZdNKEIZ0BDdpnuDhU3NEADtI4RrF4fwgoiA4ZNNUod0agvjUtzwgV1VF2Q==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/theming@8.6.4':
+    resolution: {integrity: sha512-g9Ns4uenC9oAWETaJ/tEKEIPMdS+CqjNWZz5Wbw1bLNhXwADZgKrVqawzZi64+bYYtQ+i8VCTjPoFa6s2eHiDQ==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
@@ -7018,8 +7030,8 @@ packages:
   storybook-dark-mode@4.0.2:
     resolution: {integrity: sha512-zjcwwQ01R5t1VsakA6alc2JDIRVtavryW8J3E3eKLDIlAMcvsgtpxlelWkZs2cuNspk6Z10XzhQVrUWtYc3F0w==}
 
-  storybook@8.5.5:
-    resolution: {integrity: sha512-F9+D5/sgo3WkxpB96ZmyW+mEmB5mM5+I6pbLrenFbeNvzgsgCAq0bqtJKqd9qWnGwa43iPxcl8c7/fE4qbeKvQ==}
+  storybook@8.6.4:
+    resolution: {integrity: sha512-XXh1Acvf1r3BQX0BDLQw6yhZ7yUGvYxIcKOBuMdetnX7iXtczipJTfw0uyFwk0ltkKEE9PpJvivYmARF3u64VQ==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -7301,10 +7313,6 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
-
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
 
   type-fest@4.34.1:
     resolution: {integrity: sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==}
@@ -10902,120 +10910,123 @@ snapshots:
 
   '@stitches/core@1.2.8': {}
 
-  '@storybook/addon-a11y@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-a11y@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      '@storybook/addon-highlight': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/test': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/addon-highlight': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/test': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       axe-core: 4.10.2
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/addon-actions@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-actions@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-backgrounds@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-controls@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.5.5(@types/react@18.3.18)(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-docs@8.6.4(@types/react@18.3.18)(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.18)(react@18.3.1)
-      '@storybook/blocks': 8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/csf-plugin': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/react-dom-shim': 8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/blocks': 8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/csf-plugin': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/react-dom-shim': 8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.5.5(@types/react@18.3.18)(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-essentials@8.6.4(@types/react@18.3.18)(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      '@storybook/addon-actions': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-backgrounds': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-controls': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-docs': 8.5.5(@types/react@18.3.18)(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-highlight': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-measure': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-outline': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-toolbars': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/addon-viewport': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      storybook: 8.5.5(prettier@3.4.2)
+      '@storybook/addon-actions': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-backgrounds': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-controls': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-docs': 8.6.4(@types/react@18.3.18)(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-highlight': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-measure': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-outline': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-toolbars': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/addon-viewport': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-highlight@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/addon-measure@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-measure@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-outline@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-toolbars@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/addon-viewport@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/addon-viewport@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/blocks@8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/blocks@8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      '@storybook/csf': 0.1.12
       '@storybook/icons': 1.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.5.5(storybook@8.5.5(prettier@3.4.2))(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))':
+  '@storybook/builder-vite@8.6.4(storybook@8.6.4(prettier@3.4.2))(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))':
     dependencies:
-      '@storybook/csf-plugin': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/csf-plugin': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       browser-assert: 1.2.1
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
       vite: 5.4.14(@types/node@22.13.4)(terser@5.39.0)
 
-  '@storybook/components@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/components@8.5.5(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/core-events@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/components@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/core@8.5.5(prettier@3.4.2)':
+  '@storybook/core-events@8.5.5(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      '@storybook/csf': 0.1.12
+      storybook: 8.6.4(prettier@3.4.2)
+
+  '@storybook/core@8.6.4(prettier@3.4.2)(storybook@8.6.4(prettier@3.4.2))':
+    dependencies:
+      '@storybook/theming': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.24.2
@@ -11030,28 +11041,24 @@ snapshots:
       prettier: 3.4.2
     transitivePeerDependencies:
       - bufferutil
+      - storybook
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/csf-plugin@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       unplugin: 1.16.1
 
-  '@storybook/csf@0.1.12':
+  '@storybook/experimental-addon-test@8.6.4(@vitest/browser@3.0.5)(@vitest/runner@3.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))(vitest@3.0.5)':
     dependencies:
-      type-fest: 2.19.0
-
-  '@storybook/experimental-addon-test@8.5.5(@vitest/browser@3.0.5)(@vitest/runner@3.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))(vitest@3.0.5)':
-    dependencies:
-      '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/instrumenter': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/test': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/instrumenter': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/test': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       polished: 4.3.1
       prompts: 2.4.2
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@vitest/browser': 3.0.5(@types/node@22.13.4)(playwright@1.50.1)(typescript@5.6.3)(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))(vitest@3.0.5)
@@ -11068,78 +11075,85 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/instrumenter@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/instrumenter@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/manager-api@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/manager-api@8.5.5(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/preview-api@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/manager-api@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/react-dom-shim@8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/preview-api@8.6.4(storybook@8.6.4(prettier@3.4.2))':
+    dependencies:
+      storybook: 8.6.4(prettier@3.4.2)
+
+  '@storybook/react-dom-shim@8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/react-vite@8.5.5(@storybook/test@8.5.5(storybook@8.5.5(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.5.5(prettier@3.4.2))(typescript@5.6.3)(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))':
+  '@storybook/react-vite@8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.6)(storybook@8.6.4(prettier@3.4.2))(typescript@5.6.3)(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.6.3)(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
-      '@storybook/builder-vite': 8.5.5(storybook@8.5.5(prettier@3.4.2))(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))
-      '@storybook/react': 8.5.5(@storybook/test@8.5.5(storybook@8.5.5(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))(typescript@5.6.3)
+      '@storybook/builder-vite': 8.6.4(storybook@8.6.4(prettier@3.4.2))(vite@5.4.14(@types/node@22.13.4)(terser@5.39.0))
+      '@storybook/react': 8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))(typescript@5.6.3)
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 18.3.1
       react-docgen: 7.1.1
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
       tsconfig-paths: 4.2.0
       vite: 5.4.14(@types/node@22.13.4)(terser@5.39.0)
     optionalDependencies:
-      '@storybook/test': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/test': 8.6.4(storybook@8.6.4(prettier@3.4.2))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@8.5.5(@storybook/test@8.5.5(storybook@8.5.5(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))(typescript@5.6.3)':
+  '@storybook/react@8.6.4(@storybook/test@8.6.4(storybook@8.6.4(prettier@3.4.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))(typescript@5.6.3)':
     dependencies:
-      '@storybook/components': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/components': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/preview-api': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/react-dom-shim': 8.5.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/theming': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/manager-api': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/preview-api': 8.6.4(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/react-dom-shim': 8.6.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/theming': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
     optionalDependencies:
-      '@storybook/test': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/test': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       typescript: 5.6.3
 
-  '@storybook/test@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/test@8.6.4(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/instrumenter': 8.6.4(storybook@8.6.4(prettier@3.4.2))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
 
-  '@storybook/theming@8.5.5(storybook@8.5.5(prettier@3.4.2))':
+  '@storybook/theming@8.5.5(storybook@8.6.4(prettier@3.4.2))':
     dependencies:
-      storybook: 8.5.5(prettier@3.4.2)
+      storybook: 8.6.4(prettier@3.4.2)
+
+  '@storybook/theming@8.6.4(storybook@8.6.4(prettier@3.4.2))':
+    dependencies:
+      storybook: 8.6.4(prettier@3.4.2)
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.26.8)':
     dependencies:
@@ -15951,14 +15965,14 @@ snapshots:
 
   std-env@3.8.0: {}
 
-  storybook-dark-mode@4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.5.5(prettier@3.4.2)):
+  storybook-dark-mode@4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.4(prettier@3.4.2)):
     dependencies:
-      '@storybook/components': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/core-events': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/components': 8.5.5(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/core-events': 8.5.5(storybook@8.6.4(prettier@3.4.2))
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/manager-api': 8.5.5(storybook@8.5.5(prettier@3.4.2))
-      '@storybook/theming': 8.5.5(storybook@8.5.5(prettier@3.4.2))
+      '@storybook/manager-api': 8.5.5(storybook@8.6.4(prettier@3.4.2))
+      '@storybook/theming': 8.5.5(storybook@8.6.4(prettier@3.4.2))
       fast-deep-equal: 3.1.3
       memoizerific: 1.11.3
     transitivePeerDependencies:
@@ -15966,9 +15980,9 @@ snapshots:
       - react-dom
       - storybook
 
-  storybook@8.5.5(prettier@3.4.2):
+  storybook@8.6.4(prettier@3.4.2):
     dependencies:
-      '@storybook/core': 8.5.5(prettier@3.4.2)
+      '@storybook/core': 8.6.4(prettier@3.4.2)(storybook@8.6.4(prettier@3.4.2))
     optionalDependencies:
       prettier: 3.4.2
     transitivePeerDependencies:
@@ -16234,8 +16248,6 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.21.3: {}
-
-  type-fest@2.19.0: {}
 
   type-fest@4.34.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,14 +27,14 @@ catalogs:
     # Hygen
     "hygen": ^6.2.11
     # Storybook
-    "@storybook/addon-a11y": ^8.5.3
-    "@storybook/addon-essentials": ^8.5.3
-    "@storybook/experimental-addon-test": ^8.5.3
-    "@storybook/preview-api": ^8.5.3
-    "@storybook/react": ^8.5.3
-    "@storybook/react-vite": ^8.5.3
-    "@storybook/test": ^8.5.3
-    "storybook": ^8.5.3
+    "@storybook/addon-a11y": ^8.6.4
+    "@storybook/addon-essentials": ^8.6.4
+    "@storybook/experimental-addon-test": ^8.6.4
+    "@storybook/preview-api": ^8.6.4
+    "@storybook/react": ^8.6.4
+    "@storybook/react-vite": ^8.6.4
+    "@storybook/test": ^8.6.4
+    "storybook": ^8.6.4
     "storybook-dark-mode": ^4.0.2
     # Vite
     "@vitejs/plugin-react": ^4.3.4


### PR DESCRIPTION
This pull request includes an update to the `pnpm-workspace.yaml` file to upgrade several Storybook dependencies to their latest versions.

Dependency updates:

* Upgraded `@storybook/addon-a11y` from version `^8.5.3` to `^8.6.4`.
* Upgraded `@storybook/addon-essentials` from version `^8.5.3` to `^8.6.4`.
* Upgraded `@storybook/experimental-addon-test` from version `^8.5.3` to `^8.6.4`.
* Upgraded `@storybook/preview-api` from version `^8.5.3` to `^8.6.4`.
* Upgraded `@storybook/react` from version `^8.5.3` to `^8.6.4`.
* Upgraded `@storybook/react-vite` from version `^8.5.3` to `^8.6.4`.
* Upgraded `@storybook/test` from version `^8.5.3` to `^8.6.4`. (F2733513L