### PR TITLE
chore(nimbus): fix test in prod

### DIFF
--- a/packages/nimbus/src/components/alert/alert.stories.tsx
+++ b/packages/nimbus/src/components/alert/alert.stories.tsx
@@ -60,7 +60,7 @@ export const Base: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const alertRoot = canvas.getByTestId("base-alert");
-    const dismissButton = canvas.getByTestId("dismiss-button");
+    const dismissButton = await canvas.findByTestId("dismiss-button");
     // Find the icon inside the button
     const dismissIcon = within(dismissButton).getByRole("img", {
       hidden: true,


### PR DESCRIPTION
## Summary

This fixes our CI runner to _not_ run for 6 hours straight

For some reason, without this, `NODE_ENV=production pnpm test` failed. I can only assume it's due to some _very_ minute performance issues surrounding branching off of a component mounted with `useContext`