### PR TITLE
FCT-1450-publishing-prep-pt3

### DIFF
--- a/packages/nimbus/src/components/alert/alert.stories.tsx
+++ b/packages/nimbus/src/components/alert/alert.stories.tsx
@@ -277,7 +277,7 @@ export const NoActions: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const alert = canvas.getByTestId("alert-no-actions");
-    const dismissButton = within(alert).getByTestId(
+    const dismissButton = await within(alert).findByTestId(
       "dismiss-no-actions-button"
     );
 


### PR DESCRIPTION
Related to https://github.com/commercetools/nimbus/pull/58

Though tests run w/o issue locally, they are still getting hung up in the workflow (eg [here](https://github.com/commercetools/nimbus/actions/runs/14472520080/job/40596932711)) and can be tested locally by running `NODE_ENV=production pnpm test`









