### PR TITLE
chore: set timeout for test job in GitHub Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Run tests
         run: pnpm test
         continue-on-error: true
+        timeout-minutes: 5 # Cancel this job after 5 minutes
         env:
           NODE_ENV: production
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/gh-pages.yml` file. The change sets a timeout for the test job to cancel it after 5 minutes if it is still running. This is more than enough (currently) and avoids occupying a runner for 5 hours if there is an issue with a test.

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45R42): Added a `timeout-minutes` parameter to the test job to cancel it after 5 minutes.