### PR TITLE
Do not run `prettier` in `mdx` files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 # Ignore artifacts:
 build
 coverage
+
+# Ignore mdx files
+**/*.mdx


### PR DESCRIPTION
This pull request includes a small update to the `.prettierignore` file. The change adds a rule to ignore all `.mdx` files during Prettier formatting.

See [this slack thread](https://commercetools.slack.com/archives/C045CH797B2/p1745326581078499) for context/details