### PR TITLE
FCT-1450-Publishing Prep....pt 5

### DIFF
--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -24,9 +24,7 @@
     "access": "public"
   },
   "sideEffects": [
-    "*.css",
-    "./dist/index.js",
-    "./dist/index.umd.cjs"
+    "*.css"
   ],
   "source": "src/index.ts",
   "typesVersions": {

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -8,14 +8,15 @@ import dts from "vite-plugin-dts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Add all external dependencies that should not be bundled
+// External dependencies that should not be bundled.
 const external = [
   // React core
   "react",
   "react-dom",
   "react/jsx-runtime",
 
-  // React Aria ecosystem
+  // RA ecosystem.
+  // 04/24-Bundled for now, options will be explored later. Once decided, comment/uncomment corresponding deps in the rollupOptions.globals section below.
   // "react-aria",
   // "react-aria-components",
   // "react-stately/*",
@@ -53,7 +54,6 @@ export const baseConfig = {
       formats: ["es", "umd"],
     },
     rollupOptions: {
-      // Externalized deps that shouldn't be bundled into your library
       external,
       output: {
         // Provide global variables to use in the UMD build for externalized deps
@@ -62,15 +62,15 @@ export const baseConfig = {
           "react-dom": "ReactDOM",
           "react/jsx-runtime": "jsxRuntime",
 
-          // React Aria ecosystem
-          "react-aria-components": "ReactAriaComponents",
-          "react-aria": "ReactAria",
-          "@react-aria/utils": "ReactAriaUtils",
-          "@react-aria/autocomplete": "ReactAriaAutocomplete",
-          "@react-aria/overlays": "ReactAriaOverlays",
-          "@react-aria/focus": "ReactAriaFocus",
-          "@react-aria/interactions": "ReactAriaInteractions",
-          "react-stately": "ReactStately",
+          // RA ecosystem.
+          // "react-aria-components": "ReactAriaComponents",
+          // "react-aria": "ReactAria",
+          // "@react-aria/utils": "ReactAriaUtils",
+          // "@react-aria/autocomplete": "ReactAriaAutocomplete",
+          // "@react-aria/overlays": "ReactAriaOverlays",
+          // "@react-aria/focus": "ReactAriaFocus",
+          // "@react-aria/interactions": "ReactAriaInteractions",
+          // "react-stately": "ReactStately",
 
           // UI frameworks & styling
           "@chakra-ui/react": "ChakraUI",


### PR DESCRIPTION
This focus here is on the `Nimbus` package itself. It's currently [published](https://www.npmjs.com/package/@commercetools/nimbus), but immediately X app once you try to use it.

This is clearly in infant stages, but the main objective of this PR is to get the published package into a consumable state. 

The changes here tackle bundling & external dependency ~divas~ issues that cause 2 critical issues once the package is consumed:
1.) `Uncaught TypeError: z is undefined`
...and the next hurdle was...
2.) ```✘ [ERROR] No matching export in "../../node_modules/.pnpm/@[react-aria+utils@3.28.2_react-dom]@[17.0.2_react@17.0.2__react]@17.0.2/node_modules/@react-aria/utils/dist/import.mjs" for import "UPDATE_ACTIVEDESCENDANT"```


This has been tested via [Verdaccio](https://verdaccio.org/) a few times. 
<img width="921" alt="Screenshot 2025-04-23 at 15 49 11" src="https://github.com/user-attachments/assets/764a9505-52d8-4cd3-9d5f-7e606074488e" />

Disclaimer - I am not saying there wont be a pt6, but this will at least get us a step forward to getting there. 


 