### PR TITLE
fix(nimbus): include package.json as export in exports-object

### DIFF
--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -15,10 +15,12 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.umd.cjs"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "package.json"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
I just merged the [PR](https://github.com/commercetools/nimbus/pull/77) with the change that displays the current nimbus version in the docs-app. Unfortunately though, the latest PR regarding the package-publishing changed the way exports work, making it necessary to explicitly declare the `package.json` file as export.