### PR TITLE
chore(nimbus): get rid of remaining default exports

### DIFF
--- a/packages/nimbus/src/components/alert/alert.tsx
+++ b/packages/nimbus/src/components/alert/alert.tsx
@@ -1,8 +1,8 @@
-import AlertTitle from "./components/alert.title";
-import AlertDescription from "./components/alert.description";
-import AlertActions from "./components/alert.actions";
-import AlertDismissButton from "./components/alert.dismiss-button";
-import AlertRoot from "./components/alert.root";
+import { AlertTitle } from "./components/alert.title";
+import { AlertDescription } from "./components/alert.description";
+import { AlertActions } from "./components/alert.actions";
+import { AlertDismissButton } from "./components/alert.dismiss-button";
+import { AlertRoot } from "./components/alert.root";
 
 /**
  * Alert

--- a/packages/nimbus/src/components/alert/components/alert.actions.tsx
+++ b/packages/nimbus/src/components/alert/components/alert.actions.tsx
@@ -3,7 +3,7 @@ import { AlertActions as AlertActionsSlot } from "../alert.slots";
 import type { AlertActionsProps } from "../alert.types";
 import { AlertContext } from "./alert.root";
 
-const AlertActions = ({ children, ...props }: AlertActionsProps) => {
+export const AlertActions = ({ children, ...props }: AlertActionsProps) => {
   const context = useContext(AlertContext);
 
   useEffect(() => {
@@ -23,5 +23,3 @@ const AlertActions = ({ children, ...props }: AlertActionsProps) => {
 };
 
 AlertActions.displayName = "Alert.Actions";
-
-export default AlertActions;

--- a/packages/nimbus/src/components/alert/components/alert.description.tsx
+++ b/packages/nimbus/src/components/alert/components/alert.description.tsx
@@ -3,7 +3,10 @@ import { AlertDescription as AlertDescriptionSlot } from "../alert.slots";
 import type { AlertDescriptionProps } from "../alert.types";
 import { AlertContext } from "./alert.root";
 
-const AlertDescription = ({ children, ...props }: AlertDescriptionProps) => {
+export const AlertDescription = ({
+  children,
+  ...props
+}: AlertDescriptionProps) => {
   const context = useContext(AlertContext);
 
   useEffect(() => {
@@ -23,5 +26,3 @@ const AlertDescription = ({ children, ...props }: AlertDescriptionProps) => {
 };
 
 AlertDescription.displayName = "Alert.Description";
-
-export default AlertDescription;

--- a/packages/nimbus/src/components/alert/components/alert.dismiss-button.tsx
+++ b/packages/nimbus/src/components/alert/components/alert.dismiss-button.tsx
@@ -5,7 +5,7 @@ import { Clear } from "@commercetools/nimbus-icons";
 import { IconButton } from "../../icon-button";
 import { AlertContext } from "./alert.root";
 
-const AlertDismissButton = ({
+export const AlertDismissButton = ({
   children,
   ...props
 }: AlertDismissButtonProps) => {
@@ -37,5 +37,3 @@ const AlertDismissButton = ({
 };
 
 AlertDismissButton.displayName = "Alert.DismissButton";
-
-export default AlertDismissButton;

--- a/packages/nimbus/src/components/alert/components/alert.root.tsx
+++ b/packages/nimbus/src/components/alert/components/alert.root.tsx
@@ -47,46 +47,45 @@ export const AlertContext = createContext<AlertContextValue | undefined>(
  * ============================================================
  * Provides feedback to the user about the status of an action or system event
  */
-const AlertRoot: AlertRootComponent = forwardRef<HTMLDivElement, AlertProps>(
-  ({ children, ...props }, ref) => {
-    const [titleNode, setTitle] = useState<ReactNode>(null);
-    const [descriptionNode, setDescription] = useState<ReactNode>(null);
-    const [actionsNode, setActions] = useState<ReactNode>(null);
-    const [dismissNode, setDismiss] = useState<ReactNode>(null);
+export const AlertRoot: AlertRootComponent = forwardRef<
+  HTMLDivElement,
+  AlertProps
+>(({ children, ...props }, ref) => {
+  const [titleNode, setTitle] = useState<ReactNode>(null);
+  const [descriptionNode, setDescription] = useState<ReactNode>(null);
+  const [actionsNode, setActions] = useState<ReactNode>(null);
+  const [dismissNode, setDismiss] = useState<ReactNode>(null);
 
-    // Memoize the context value so we don't cause unnecessary re-renders
-    const contextValue = useMemo(
-      () => ({
-        setTitle,
-        setDescription,
-        setActions,
-        setDismiss,
-      }),
-      [setTitle, setDescription, setActions, setDismiss]
-    );
+  // Memoize the context value so we don't cause unnecessary re-renders
+  const contextValue = useMemo(
+    () => ({
+      setTitle,
+      setDescription,
+      setActions,
+      setDismiss,
+    }),
+    [setTitle, setDescription, setActions, setDismiss]
+  );
 
-    return (
-      <AlertContext.Provider value={contextValue}>
-        <AlertRootSlot ref={ref} {...props} role="alert">
-          <AlertIcon alignItems="flex-start">
-            {getIconFromTone(props.tone)}
-          </AlertIcon>
-          <Stack flex="1" gap="200">
-            <Box>
-              {titleNode}
-              {descriptionNode}
-            </Box>
-            {actionsNode}
-          </Stack>
-          {dismissNode}
+  return (
+    <AlertContext.Provider value={contextValue}>
+      <AlertRootSlot ref={ref} {...props} role="alert">
+        <AlertIcon alignItems="flex-start">
+          {getIconFromTone(props.tone)}
+        </AlertIcon>
+        <Stack flex="1" gap="200">
+          <Box>
+            {titleNode}
+            {descriptionNode}
+          </Box>
+          {actionsNode}
+        </Stack>
+        {dismissNode}
 
-          {children}
-        </AlertRootSlot>
-      </AlertContext.Provider>
-    );
-  }
-);
+        {children}
+      </AlertRootSlot>
+    </AlertContext.Provider>
+  );
+});
 
 AlertRoot.displayName = "Alert.Root";
-
-export default AlertRoot;

--- a/packages/nimbus/src/components/alert/components/alert.title.tsx
+++ b/packages/nimbus/src/components/alert/components/alert.title.tsx
@@ -3,7 +3,7 @@ import { AlertTitle as AlertTitleSlot } from "../alert.slots";
 import type { AlertTitleProps } from "../alert.types";
 import { AlertContext } from "./alert.root";
 
-const AlertTitle = ({ children, ...props }: AlertTitleProps) => {
+export const AlertTitle = ({ children, ...props }: AlertTitleProps) => {
   const context = useContext(AlertContext);
 
   useEffect(() => {
@@ -25,5 +25,3 @@ const AlertTitle = ({ children, ...props }: AlertTitleProps) => {
 };
 
 AlertTitle.displayName = "Alert.Title";
-
-export default AlertTitle;

--- a/packages/nimbus/src/components/card/card.tsx
+++ b/packages/nimbus/src/components/card/card.tsx
@@ -1,6 +1,6 @@
-import CardRoot from "./components/card.root";
-import CardHeader from "./components/card.header";
-import CardContent from "./components/card.content";
+import { CardRoot } from "./components/card.root";
+import { CardHeader } from "./components/card.header";
+import { CardContent } from "./components/card.content";
 
 export const Card = {
   Root: CardRoot,

--- a/packages/nimbus/src/components/card/components/card.content.tsx
+++ b/packages/nimbus/src/components/card/components/card.content.tsx
@@ -25,5 +25,3 @@ export const CardContent = ({ children, ...props }: CardContentProps) => {
 };
 
 CardContent.displayName = "Card.Content";
-
-export default CardContent;

--- a/packages/nimbus/src/components/card/components/card.header.tsx
+++ b/packages/nimbus/src/components/card/components/card.header.tsx
@@ -5,7 +5,7 @@ import {
 } from "../card.slots";
 import { CardContext } from "./card.root";
 
-const CardHeader = ({ children, ...props }: CardHeaderProps) => {
+export const CardHeader = ({ children, ...props }: CardHeaderProps) => {
   const context = useContext(CardContext);
 
   useEffect(() => {
@@ -24,5 +24,3 @@ const CardHeader = ({ children, ...props }: CardHeaderProps) => {
   return null;
 };
 CardHeader.displayName = "Card.Header";
-
-export default CardHeader;

--- a/packages/nimbus/src/components/card/components/card.root.tsx
+++ b/packages/nimbus/src/components/card/components/card.root.tsx
@@ -19,7 +19,7 @@ export const CardContext = createContext<CardContextValue | undefined>(
   undefined
 );
 
-const CardRoot = forwardRef<HTMLDivElement, CardProps>(
+export const CardRoot = forwardRef<HTMLDivElement, CardProps>(
   ({ children, ...props }, ref) => {
     const { isFocused, isFocusVisible, focusProps } = useFocusRing();
     const [headerNode, setHeader] = useState<ReactNode>(null);
@@ -58,5 +58,3 @@ const CardRoot = forwardRef<HTMLDivElement, CardProps>(
 );
 
 CardRoot.displayName = "Card.Root";
-
-export default CardRoot;


### PR DESCRIPTION
> [!NOTE]
> There is no API change, this is purely cosmetic

This pull request refactors the `Alert` and `Card` components in the `nimbus` package to adopt named exports instead of default exports. This change improves consistency and simplifies imports across the codebase. The refactor also includes updates to the corresponding component files to align with this new export style.

### Refactoring to Named Exports

#### `Alert` Component:
* Updated `Alert` subcomponents (`AlertTitle`, `AlertDescription`, `AlertActions`, `AlertDismissButton`, and `AlertRoot`) to use named exports instead of default exports. This involved modifying the export statements and updating import statements in `alert.tsx`. [[1]](diffhunk://#diff-fdc9cddea72402630596664133ed4f1edd85554437530797f0e1a27fc93e5c8cL1-R5) [[2]](diffhunk://#diff-bd6cf87f65eba4d440215e2dc9f8fa238f3be28a6988f039e8cfe8737dc8f4f9L6-R6) [[3]](diffhunk://#diff-bd6cf87f65eba4d440215e2dc9f8fa238f3be28a6988f039e8cfe8737dc8f4f9L26-L27) [[4]](diffhunk://#diff-2a891374b0f8e2f2997ac92e56b9596e36ff15f4c7175ebc2ae9338799e6adf8L6-R9) [[5]](diffhunk://#diff-2a891374b0f8e2f2997ac92e56b9596e36ff15f4c7175ebc2ae9338799e6adf8L26-L27) [[6]](diffhunk://#diff-7bc20c3cd4aff3fd45d6902358b83938966b2443876a4cd844335a6b6012a98dL8-R8) [[7]](diffhunk://#diff-7bc20c3cd4aff3fd45d6902358b83938966b2443876a4cd844335a6b6012a98dL40-L41) [[8]](diffhunk://#diff-e690a8229493e33b1c7333e2dea764343fabc3259eccfb1508969691ea0fb18fL50-R53) [[9]](diffhunk://#diff-e690a8229493e33b1c7333e2dea764343fabc3259eccfb1508969691ea0fb18fL87-L92) [[10]](diffhunk://#diff-9fc747103fc9d157dcadad727ebd24c25018ae9661e350f26bad31d1d0739dcaL6-R6) [[11]](diffhunk://#diff-9fc747103fc9d157dcadad727ebd24c25018ae9661e350f26bad31d1d0739dcaL28-L29)

#### `Card` Component:
* Updated `Card` subcomponents (`CardRoot`, `CardHeader`, and `CardContent`) to use named exports instead of default exports. Adjusted the export statements in their respective files and updated import statements in `card.tsx`. [[1]](diffhunk://#diff-db2642f9b1e4cd6f936f13713012d71706bc40d0f66be2da49a691e426a9f7ebL1-R3) [[2]](diffhunk://#diff-c5cae8594e42f14512a7a142488f2911328345c0393db8458ffa92e5249fead1L28-L29) [[3]](diffhunk://#diff-3cf2f89e993100276c5b8d502fdf8c9ab1d64617c4ae738487ee31a868fe4398L8-R8) [[4]](diffhunk://#diff-3cf2f89e993100276c5b8d502fdf8c9ab1d64617c4ae738487ee31a868fe4398L27-L28) [[5]](diffhunk://#diff-689b3df57f6c26167bc7d381ce1f4375783af59188aad67f70178d3f98971b82L22-R22) [[6]](diffhunk://#diff-689b3df57f6c26167bc7d381ce1f4375783af59188aad67f70178d3f98971b82L61-L62)