### PR TITLE
chore(gitignore): add Storybook log and static files to .gitignore

### DIFF
--- a/packages/nimbus/.gitignore
+++ b/packages/nimbus/.gitignore
@@ -174,4 +174,6 @@ dist
 # Finder (MacOS) folder config
 .DS_Store
 
+# Storybook
 *storybook.log
+storybook-static/


### PR DESCRIPTION
The output folder for the static-build of storybook was not in the .gitignore file yet.