### PR TITLE
chore(dependabot): add configuration for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Configuration for pnpm dependencies in the monorepo root
+  - package-ecosystem: "npm" # "npm" = for pnpm, yarn, and npm projects
+    directory: "/" # Root directory where pnpm-lock.yaml and pnpm-workspace.yaml are located
+    schedule:
+      interval: "daily" # How often to check for updates (e.g., "daily", "weekly", "monthly")
+      time: "04:00" # Optional: Time of day to check (UTC)
+      timezone: "Europe/Berlin" # Optional: Specify timezone for the schedule time
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This PR is an attempt to provide a bit of context to dependabot, as it currently does not seem to grasp how dependencies are managed (monorepo, pnpm, workspaces, catalogs) and thus provides [unmergeable PR's](https://github.com/commercetools/nimbus/pull/92) (a change in the lock-file is not enough, the exact versions are specified in the `pnpm-workspace.yaml` file).

