### PR TITLE
FCT-1469: Nimbus - TextInput - Resolve layouting issues with style-props

### DIFF
--- a/packages/nimbus/src/components/form-field/form-field.stories.tsx
+++ b/packages/nimbus/src/components/form-field/form-field.stories.tsx
@@ -246,7 +246,7 @@ export const Required: Story = {
     });
 
     await step("Input has required attribute", async () => {
-      await expect(input).toHaveAttribute("required");
+      await expect(input).toHaveAttribute("aria-required");
     });
   },
 };

--- a/packages/nimbus/src/components/text-input/text-input.slots.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.slots.tsx
@@ -19,6 +19,7 @@ const { withContext } = createRecipeContext({ recipe: textInputRecipe });
  * Root component that provides the styling context for the TextInput component.
  * Uses Chakra UI's recipe context system for consistent styling across instances.
  */
-export const TextInputRoot = withContext<HTMLInputElement, TextInputRootProps>(
-  "input"
-);
+export const TextInputRootSlot = withContext<
+  HTMLInputElement,
+  TextInputRootProps
+>("input");

--- a/packages/nimbus/src/components/text-input/text-input.slots.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.slots.tsx
@@ -11,7 +11,10 @@ export interface TextInputRecipeProps
   extends RecipeVariantProps<typeof textInputRecipe>,
     UnstyledProp {}
 
-export type TextInputRootProps = HTMLChakraProps<"input", TextInputRecipeProps>;
+export type TextInputRootSlotProps = HTMLChakraProps<
+  "input",
+  TextInputRecipeProps
+>;
 
 const { withContext } = createRecipeContext({ recipe: textInputRecipe });
 
@@ -21,5 +24,5 @@ const { withContext } = createRecipeContext({ recipe: textInputRecipe });
  */
 export const TextInputRootSlot = withContext<
   HTMLInputElement,
-  TextInputRootProps
+  TextInputRootSlotProps
 >("input");

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -88,6 +88,37 @@ export const Variants: Story = {
   },
 };
 
+export const Required: Story = {
+  args: {
+    isRequired: true,
+    placeholder: "required text input",
+    ["aria-label"]: "test-input-required",
+  },
+  render: (args) => {
+    return (
+      <Stack direction="row" gap="400" alignItems="center">
+        {inputVariants.map((variant) => (
+          <TextInput
+            key={variant as string}
+            {...args}
+            variant={variant}
+            placeholder={`${variant as string} required`}
+            aria-label={`${variant as string}-required`}
+          />
+        ))}
+      </Stack>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("solid-required");
+
+    await step("Has aria-required attribute", async () => {
+      await expect(input).toHaveAttribute("aria-required", "true");
+    });
+  },
+};
+
 export const Disabled: Story = {
   args: {
     isDisabled: true,
@@ -277,6 +308,29 @@ export const InputTypes: Story = {
           <TextInput key={type} {...args} placeholder={type} type={type} />
         ))}
       </Stack>
+    );
+  },
+};
+
+export const NativeOnChange: Story = {
+  args: {
+    ["aria-label"]: "test-input",
+    onNativeChange: fn(),
+  },
+  play: async ({ canvasElement, step, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("test-input");
+
+    await step(
+      "Calls onNativeChange handler with a synthetic event",
+      async () => {
+        await userEvent.type(input, "Hello");
+        await expect(args.onNativeChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({ value: "Hello" }),
+          })
+        );
+      }
     );
   },
 };

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -305,26 +305,3 @@ export const InputTypes: Story = {
     );
   },
 };
-
-export const NativeOnChange: Story = {
-  args: {
-    ["aria-label"]: "test-input",
-    onNativeChange: fn(),
-  },
-  play: async ({ canvasElement, step, args }) => {
-    const canvas = within(canvasElement);
-    const input = canvas.getByLabelText("test-input");
-
-    await step(
-      "Calls onNativeChange handler with a synthetic event",
-      async () => {
-        await userEvent.type(input, "Hello");
-        await expect(args.onNativeChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            target: expect.objectContaining({ value: "Hello" }),
-          })
-        );
-      }
-    );
-  },
-};

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -96,22 +96,16 @@ export const Required: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="row" gap="400" alignItems="center">
-        {inputVariants.map((variant) => (
-          <TextInput
-            key={variant as string}
-            {...args}
-            variant={variant}
-            placeholder={`${variant as string} required`}
-            aria-label={`${variant as string}-required`}
-          />
-        ))}
-      </Stack>
+      <TextInput
+        {...args}
+        placeholder="required text input"
+        aria-label="test-input-required"
+      />
     );
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByLabelText("solid-required");
+    const input = canvas.getByLabelText("test-input-required");
 
     await step("Has aria-required attribute", async () => {
       await expect(input).toHaveAttribute("aria-required", "true");

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -53,8 +53,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       onChange: chainedOnChange,
     };
 
-    console.log("finalInputProps", finalInputProps);
-
     return (
       <TextInputRootSlot {...recipeProps} {...styleProps} asChild>
         <Input ref={ref} {...finalInputProps} />

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -1,17 +1,17 @@
 import { forwardRef, useRef, type ChangeEvent } from "react";
+import { mergeRefs, useRecipe } from "@chakra-ui/react";
+import { useObjectRef, useTextField } from "react-aria";
+import { Input } from "react-aria-components";
+import { extractStyleProps } from "@/utils/extractStyleProps";
+
 import { TextInputRootSlot } from "./text-input.slots";
 import type { TextInputProps } from "./text-input.types";
-import { useObjectRef } from "react-aria";
-import { mergeRefs, useRecipe } from "@chakra-ui/react";
 import { textInputRecipe } from "./text-input.recipe";
-import { Input } from "react-aria-components";
-import { useTextField } from "react-aria";
-import { extractStyleProps } from "@/utils/extractStyleProps";
 
 /**
  * TextInput
  * ============================================================
- * An input component that takes in a text as input
+ * An input component that takes in text as input
  *
  * Features:
  *
@@ -23,41 +23,25 @@ import { extractStyleProps } from "@/utils/extractStyleProps";
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   (props, forwardedRef) => {
     const recipe = useRecipe({ recipe: textInputRecipe });
+
     const localRef = useRef<HTMLInputElement>(null);
     const ref = useObjectRef(mergeRefs(localRef, forwardedRef));
 
     const [recipeProps, remainingProps] = recipe.splitVariantProps(props);
     const [styleProps, otherProps] = extractStyleProps(remainingProps);
-
     const { inputProps } = useTextField(otherProps, ref);
 
-    const handleNativeOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-      if (props.onNativeChange) {
-        props.onNativeChange(event);
-      }
-    };
-
-    const originalAriaOnChange = inputProps.onChange;
-
-    const chainedOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-      handleNativeOnChange(event);
-
-      if (originalAriaOnChange) {
-        originalAriaOnChange(event);
-      }
-    };
-
-    const finalInputProps = {
-      ...otherProps,
-      ...inputProps,
-      onChange: chainedOnChange,
-    };
-
     return (
-      <TextInputRootSlot {...recipeProps} {...styleProps} asChild>
-        <Input ref={ref} {...finalInputProps} />
+      <TextInputRootSlot
+        {...recipeProps}
+        {...styleProps}
+        {...otherProps}
+        asChild
+      >
+        <Input ref={ref} {...inputProps} />
       </TextInputRootSlot>
     );
   }
 );
+
 TextInput.displayName = "TextInput";

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -1,10 +1,11 @@
 import { forwardRef, useRef } from "react";
-import { TextInputRoot } from "./text-input.slots";
+import { TextInputRootSlot } from "./text-input.slots";
 import type { TextInputProps } from "./text-input.types";
 import { useObjectRef } from "react-aria";
 import { mergeRefs, useRecipe } from "@chakra-ui/react";
 import { textInputRecipe } from "./text-input.recipe";
-import { TextField, Input } from "react-aria-components";
+import { Input } from "react-aria-components";
+import { useTextField } from "react-aria";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 
 /**
@@ -21,18 +22,19 @@ import { extractStyleProps } from "@/utils/extractStyleProps";
  */
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   (props, forwardedRef) => {
+    const recipe = useRecipe({ recipe: textInputRecipe });
     const localRef = useRef<HTMLInputElement>(null);
     const ref = useObjectRef(mergeRefs(localRef, forwardedRef));
-    const recipe = useRecipe({ recipe: textInputRecipe });
-    const [recipeProps, leftOverProps] = recipe.splitVariantProps(props);
-    const [styleProps, textfieldProps] = extractStyleProps(leftOverProps);
+
+    const [recipeProps, remainingProps] = recipe.splitVariantProps(props);
+    const [styleProps, otherProps] = extractStyleProps(remainingProps);
+
+    const { inputProps } = useTextField(otherProps, ref);
 
     return (
-      <TextField {...textfieldProps}>
-        <TextInputRoot ref={ref} {...recipeProps} {...styleProps} asChild>
-          <Input />
-        </TextInputRoot>
-      </TextField>
+      <TextInputRootSlot {...recipeProps} {...styleProps} asChild>
+        <Input ref={ref} {...otherProps} {...inputProps} />
+      </TextInputRootSlot>
     );
   }
 );

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -32,27 +32,23 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const { inputProps } = useTextField(otherProps, ref);
 
     const handleNativeOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-      // You can access event.target, event.key, event.preventDefault(), etc.
-      // props.onChange might still be called with just the value by inputProps.onChange
       if (props.onNativeChange) {
         props.onNativeChange(event);
       }
     };
 
-    // A practical way to use chain for the event:
     const originalAriaOnChange = inputProps.onChange;
 
     const chainedOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-      // Call your custom handler with the native event
       handleNativeOnChange(event);
 
-      // Ensure React Aria's original onChange logic (which calls your props.onChange with value) still runs
       if (originalAriaOnChange) {
-        originalAriaOnChange(event); // React Aria's handler expects the event and extracts the value
+        originalAriaOnChange(event);
       }
     };
 
     const finalInputProps = {
+      ...otherProps,
       ...inputProps,
       onChange: chainedOnChange,
     };
@@ -61,7 +57,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
     return (
       <TextInputRootSlot {...recipeProps} {...styleProps} asChild>
-        <Input ref={ref} {...otherProps} {...finalInputProps} />
+        <Input ref={ref} {...finalInputProps} />
       </TextInputRootSlot>
     );
   }

--- a/packages/nimbus/src/components/text-input/text-input.types.ts
+++ b/packages/nimbus/src/components/text-input/text-input.types.ts
@@ -1,12 +1,6 @@
-import type { ChangeEvent } from "react";
 import type { TextInputRootSlotProps } from "./text-input.slots";
 import type { TextFieldProps } from "react-aria-components";
 
 export interface TextInputProps
   extends TextFieldProps,
-    Omit<TextInputRootSlotProps, keyof TextFieldProps | "as" | "asChild"> {
-  /**
-   * Callback with the original, synthetic react input-onChange event
-   */
-  onNativeChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-}
+    Omit<TextInputRootSlotProps, keyof TextFieldProps | "as" | "asChild"> {}

--- a/packages/nimbus/src/components/text-input/text-input.types.ts
+++ b/packages/nimbus/src/components/text-input/text-input.types.ts
@@ -1,7 +1,12 @@
-import type { TextInputRootProps } from "./text-input.slots";
+import type { ChangeEvent } from "react";
+import type { TextInputRootSlotProps } from "./text-input.slots";
 import type { TextFieldProps } from "react-aria-components";
 
-// Helper type to merge props and resolve conflicts
 export interface TextInputProps
   extends TextFieldProps,
-    Omit<TextInputRootProps, keyof TextFieldProps | "as" | "asChild"> {}
+    Omit<TextInputRootSlotProps, keyof TextFieldProps | "as" | "asChild"> {
+  /**
+   * Callback with the original, synthetic react input-onChange event
+   */
+  onNativeChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+}


### PR DESCRIPTION
After ditching the idea of changing the`onChange` handler back to propagating a regular `ChangeEvent` instead of the value itself, the only functional change is ditching react-arias `TextField` component in favor of the `useTextField` hook.

I did this, cause the `TextField` component was adding an additional, unnecessary div around the input which caused some issues when attempting to apply additional style-props to the `TextInput`.

The component is now wiring only the needed props (`inputProps`) from the hook to `Input`.