### PR TITLE
feat(tests): set up workflow to test in ci for pr's

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,9 @@
-name: Build and Deploy to GitHub Pages
+name: Build and Test Nimbus Components
 on:
   push:
     branches:
       - main
+  pull_request:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -31,20 +32,13 @@ jobs:
 
       - name: Lint
         run: pnpm lint
-        continue-on-error: true # continue even if linting fails (for now)
+        continue-on-error: true # continue even if linting fails (for now) TODO: typechecking once we feel ok failing on lint
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run tests
         run: pnpm test
-        continue-on-error: true
         timeout-minutes: 5 # Cancel this job after 5 minutes
         env:
           NODE_ENV: production
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./apps/docs/dist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,13 +26,13 @@ jobs:
         run: pnpm install
 
       - name: Build the project
-        run: pnpm build
+        run: pnpm build:tokens && pnpm run build:packages # no reason to build docs since they have no tests, if that changes we should build them
         env:
           NODE_ENV: production
 
-      - name: Lint
-        run: pnpm lint
-        continue-on-error: true # continue even if linting fails (for now) TODO: typechecking once we feel ok failing on lint
+      # - name: Lint # this takes surprisingly long and why bother if we're going to continue if it fails?
+      #   run: pnpm lint
+      #   continue-on-error: true # continue even if linting fails (for now) TODO: typechecking once we feel ok failing on lint
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to focus on building and testing Nimbus components instead of deploying to GitHub Pages. The changes streamline the workflow by removing unnecessary steps and enhancing the build process for components.

### Workflow Updates:
* Renamed `.github/workflows/gh-pages.yml` to `.github/workflows/build-and-test.yml` and updated the workflow name to "Build and Test Nimbus Components." Added a trigger for `pull_request` events.
* Modified the build step to use `pnpm build:tokens && pnpm run build:packages` instead of `pnpm build`, excluding documentation builds since they don't have tests.
* Commented out the linting step due to its long runtime and limited utility in the current workflow. Added a note to revisit this for typechecking in the future.
* Removed the deployment step to GitHub Pages, as it is no longer relevant to this workflow.