### PR TITLE
chore(nimbus): squelch aria warning in useField

### DIFF
--- a/packages/nimbus/src/components/form-field/components/form-field.root.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.root.tsx
@@ -46,12 +46,23 @@ export const FormFieldRoot = forwardRef<HTMLDivElement, FormFieldProps>(
       isReadOnly,
     });
 
+    const useFieldArgs: Parameters<typeof useField>[0] = {
+      description: context.description,
+      errorMessage: context.error,
+    };
+
+    if (context.label) {
+      useFieldArgs.label = context.label;
+    } else {
+      // Context will always start out null, so we need to stub out some aria attributes
+      useFieldArgs["aria-label"] = "empty-label";
+      useFieldArgs["aria-labelledby"] = "empty-label";
+    }
+
+    console.log(useFieldArgs);
+
     const { labelProps, fieldProps, descriptionProps, errorMessageProps } =
-      useField({
-        label: context.label,
-        description: context.description,
-        errorMessage: context.error,
-      });
+      useField(useFieldArgs);
 
     useEffect(() => {
       setContext((prevContext) => ({


### PR DESCRIPTION
## Summary

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/e0eccadb-1d2e-4a23-b146-9864d711243d" />

I kept getting these warnings in a Merchant Center migration branch, and wound up tracing it back to the `useField` hook