### PR TITLE
chore(nimbus): fix duplicate onChange event handling in text input

### DIFF
--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.7",
+  "version": "0.0.7-rc9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -243,6 +243,7 @@ export const Controlled: Story = {
   render: () => {
     const [value, setValue] = useState("");
     const onChangeRequest = (e: string) => {
+      console.log("onChangeRequest", e);
       setValue(e);
     };
 

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -239,12 +239,14 @@ export const SmokeTest: Story = {
   },
 };
 
+const mockOnChangeRequest = fn();
+
 export const Controlled: Story = {
   render: () => {
     const [value, setValue] = useState("");
     const onChangeRequest = (e: string) => {
-      console.log("onChangeRequest", e);
       setValue(e);
+      mockOnChangeRequest(e);
     };
 
     return (
@@ -274,6 +276,14 @@ export const Controlled: Story = {
       await userEvent.clear(input);
       await expect(input).toHaveValue("");
       await expect(valueDisplay).toHaveTextContent("Current value:");
+    });
+
+    await step("Does not call onChange with an event", async () => {
+      await userEvent.type(input, "Hello");
+      // Expect the input to never have been called with an object type
+      for (const call of mockOnChangeRequest.mock.calls) {
+        await expect(typeof call[0]).toBe("string");
+      }
     });
   },
 };

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -32,12 +32,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const { inputProps } = useTextField(otherProps, ref);
 
     return (
-      <TextInputRootSlot
-        {...recipeProps}
-        {...styleProps}
-        {...otherProps}
-        asChild
-      >
+      <TextInputRootSlot {...recipeProps} {...styleProps} asChild>
         <Input ref={ref} {...inputProps} />
       </TextInputRootSlot>
     );


### PR DESCRIPTION
## Summary

Our `TextInput` component's `onChange` `value` would seemingly switch between an event and a string value. In reality, it was called twice.

It causes validation errors on the consumer end because `.trim()` is not a valid function for the event's type of `object`

![image](https://github.com/user-attachments/assets/090ac6f7-e4d5-472c-bb14-b1a5464c6bf5)
