### PR TITLE
fix(IconButton): fix issue where iconButton was causing unexpected behavior in Select component

### DIFF
--- a/packages/nimbus/src/components/icon-button/icon-button.tsx
+++ b/packages/nimbus/src/components/icon-button/icon-button.tsx
@@ -12,14 +12,10 @@ import { Button } from "@/components";
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   ({ children, ...props }, ref) => {
     // button context must be passed down as props to button component, or it is lost
-    const [buttonContextProps, buttonRef] = useContextProps(
-      props,
-      ref,
-      ButtonContext
-    );
+    const [buttonContextProps] = useContextProps(props, ref, ButtonContext);
 
     return (
-      <Button px={0} py={0} ref={buttonRef} {...buttonContextProps}>
+      <Button px={0} py={0} {...buttonContextProps} ref={ref}>
         {children}
       </Button>
     );


### PR DESCRIPTION
fix(icon button): use merged props from `useContextProps`, but do not use resulting ref

Fixes an issue where the `IconButton` component was causing the popover to display in an unexpected position when the `clear` button is present in the `Select` component
![image](https://github.com/user-attachments/assets/4745341e-6c50-43fa-b06f-b4e830375317)
![image (1)](https://github.com/user-attachments/assets/acc9c938-8e54-4651-8e23-a83223e85b5b)

Issue is fixed by not passing the `ref` generated by `useContextProps` to the `Button` component, and instead allowing the `useButton` hook to generate the appropriate `ref` in the underlying `Button` component.  This can be verified by looking at the [formfield storybook for this branch](https://nimbus-storybook-git-bw-fix-icon-button-issue-commercetools.vercel.app/?path=/story/components-formfield--using-a-select-input).
![Screenshot 2025-05-15 at 8 15 11 AM](https://github.com/user-attachments/assets/cca0d87f-640f-49d7-bd98-1dfb72a0c8b5)
