### PR TITLE
FCT-1520: Nimbus - Add PasswordInput Component

### DIFF
--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -33,5 +33,4 @@ export * from "./toggle-button-group";
 export * from "./form-field";
 export * from "./icon";
 export * from "./tag-group";
-
-
+export * from "./password-input";

--- a/packages/nimbus/src/components/password-input/index.ts
+++ b/packages/nimbus/src/components/password-input/index.ts
@@ -1,0 +1,2 @@
+export * from "./password-input";
+export * from "./password-input.types";

--- a/packages/nimbus/src/components/password-input/password-input.mdx
+++ b/packages/nimbus/src/components/password-input/password-input.mdx
@@ -19,4 +19,16 @@ tags:
 An input component that takes in password as input with toggleable visibility.
 It supports the same props as the [TextInput](/components/inputs/textinput) component.
 
+## Usage
+
+Use as you would use a regular TextInput component, but without the `type` prop.
+
+```jsx-live
+const App = () => <PasswordInput placeholder="Enter a password" />
+```
+
+## Props
+
+List of available props:
+
 <PropTable id="PasswordInput" />

--- a/packages/nimbus/src/components/password-input/password-input.mdx
+++ b/packages/nimbus/src/components/password-input/password-input.mdx
@@ -1,0 +1,22 @@
+---
+id: PasswordInput
+title: PasswordInput
+description: An input component that takes in password as input with toggleable visibility
+documentState: InitialDraft
+order: 999
+menu:
+  - Components
+  - Inputs
+  - PasswordInput
+tags:
+  - forms
+  - password
+  - input
+---
+
+# PasswordInput
+
+An input component that takes in password as input with toggleable visibility.
+It supports the same props as the [TextInput](/components/inputs/textinput) component.
+
+<PropTable id="PasswordInput" />

--- a/packages/nimbus/src/components/password-input/password-input.stories.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.stories.tsx
@@ -3,7 +3,7 @@ import { Box, Stack } from "@/components";
 import { PasswordInput } from "./password-input";
 
 export default {
-  title: "Components/Forms/PasswordInput",
+  title: "Components/PasswordInput",
   component: PasswordInput,
 } as Meta<typeof PasswordInput>;
 
@@ -43,26 +43,13 @@ export const WithSizes: Story = {
   ),
 };
 
-export const WithPlaceholder: Story = {
-  render: (args) => (
-    <Box maxWidth="500px">
-      <label htmlFor="password">Password</label>
-      <PasswordInput
-        id="password"
-        placeholder="Enter your password"
-        {...args}
-      />
-    </Box>
-  ),
-};
-
 export const Disabled: Story = {
   render: (args) => (
     <Box maxWidth="500px">
       <label htmlFor="password">Password (Disabled)</label>
       <PasswordInput
         id="password"
-        disabled
+        isDisabled
         value="DisabledPassword123"
         {...args}
       />

--- a/packages/nimbus/src/components/password-input/password-input.stories.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box, Stack } from "@/components";
 import { PasswordInput } from "./password-input";
+import { useState } from "react";
+import { within, expect, userEvent } from "@storybook/test";
+import { Text } from "@/components";
 
 export default {
   title: "Components/PasswordInput",
@@ -15,44 +18,134 @@ export const Base: Story = {
     placeholder: "Password",
   },
   render: (args) => <PasswordInput {...args} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Enter your password");
+    await step("Is focusable with <tab> key", async () => {
+      await userEvent.tab();
+      await expect(input).toHaveFocus();
+    });
+    await step("Can toggle visibility with button", async () => {
+      const toggleButton = canvas.getByRole("button");
+      await userEvent.click(toggleButton);
+      await expect(input).toHaveAttribute("type", "text");
+      await userEvent.click(toggleButton);
+      await expect(input).toHaveAttribute("type", "password");
+    });
+    await step("Can toggle with keyboard (Enter/Space)", async () => {
+      const toggleButton = canvas.getByRole("button");
+      toggleButton.focus();
+      await userEvent.keyboard("{enter}");
+      await expect(input).toHaveAttribute("type", "text");
+      await userEvent.keyboard(" ");
+      await expect(input).toHaveAttribute("type", "password");
+    });
+  },
 };
 
 export const WithVariants: Story = {
+  args: {
+    ["aria-label"]: "Enter your password",
+    placeholder: "Password",
+  },
   render: (args) => (
     <Stack gap="600">
       <Box>
-        <PasswordInput id="password1" variant="solid" {...args} />
+        <PasswordInput variant="solid" {...args} />
       </Box>
       <Box>
-        <PasswordInput id="password2" variant="ghost" {...args} />
+        <PasswordInput variant="ghost" {...args} />
       </Box>
     </Stack>
   ),
 };
 
 export const WithSizes: Story = {
+  args: {
+    ["aria-label"]: "Enter your password",
+    placeholder: "Password",
+  },
   render: (args) => (
     <Stack gap="600">
       <Box>
-        <PasswordInput id="password-sm" size="sm" {...args} />
+        <PasswordInput size="sm" {...args} />
       </Box>
       <Box>
-        <PasswordInput id="password-md" size="md" {...args} />
+        <PasswordInput size="md" {...args} />
       </Box>
     </Stack>
   ),
 };
 
 export const Disabled: Story = {
-  render: (args) => (
-    <Box maxWidth="500px">
-      <label htmlFor="password">Password (Disabled)</label>
-      <PasswordInput
-        id="password"
-        isDisabled
-        value="DisabledPassword123"
-        {...args}
-      />
-    </Box>
-  ),
+  args: {
+    ["aria-label"]: "Enter your password",
+    placeholder: "Password",
+    isDisabled: true,
+  },
+  render: (args) => <PasswordInput {...args} />,
+};
+
+export const Required: Story = {
+  args: {
+    isRequired: true,
+    placeholder: "Required password",
+    ["aria-label"]: "Required password",
+  },
+  render: (args) => <PasswordInput {...args} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Required password");
+    await step("Has aria-required attribute", async () => {
+      await expect(input).toHaveAttribute("aria-required", "true");
+    });
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    isInvalid: true,
+    placeholder: "Invalid password",
+    ["aria-label"]: "Invalid password",
+  },
+  render: (args) => <PasswordInput {...args} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Invalid password");
+    await step("Has invalid state", async () => {
+      await expect(input).toHaveAttribute("data-invalid", "true");
+    });
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    return (
+      <Stack gap="400">
+        <PasswordInput
+          value={value}
+          onChange={setValue}
+          placeholder="Controlled password"
+          aria-label="Controlled password"
+        />
+        <Text data-testid="value-display">Current value: {value}</Text>
+      </Stack>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("Controlled password");
+    const valueDisplay = canvas.getByTestId("value-display");
+    await step("Updates controlled value", async () => {
+      await userEvent.type(input, "Secret");
+      await expect(input).toHaveValue("Secret");
+      await expect(valueDisplay).toHaveTextContent("Current value: Secret");
+    });
+    await step("Clears controlled value", async () => {
+      await userEvent.clear(input);
+      await expect(input).toHaveValue("");
+      await expect(valueDisplay).toHaveTextContent("Current value:");
+    });
+  },
 };

--- a/packages/nimbus/src/components/password-input/password-input.stories.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Box, Stack } from "@/components";
+import { PasswordInput } from "./password-input";
+
+export default {
+  title: "Components/Forms/PasswordInput",
+  component: PasswordInput,
+} as Meta<typeof PasswordInput>;
+
+type Story = StoryObj<typeof PasswordInput>;
+
+export const Base: Story = {
+  args: {
+    ["aria-label"]: "Enter your password",
+    placeholder: "Password",
+  },
+  render: (args) => <PasswordInput {...args} />,
+};
+
+export const WithVariants: Story = {
+  render: (args) => (
+    <Stack gap="600">
+      <Box>
+        <PasswordInput id="password1" variant="solid" {...args} />
+      </Box>
+      <Box>
+        <PasswordInput id="password2" variant="ghost" {...args} />
+      </Box>
+    </Stack>
+  ),
+};
+
+export const WithSizes: Story = {
+  render: (args) => (
+    <Stack gap="600">
+      <Box>
+        <PasswordInput id="password-sm" size="sm" {...args} />
+      </Box>
+      <Box>
+        <PasswordInput id="password-md" size="md" {...args} />
+      </Box>
+    </Stack>
+  ),
+};
+
+export const WithPlaceholder: Story = {
+  render: (args) => (
+    <Box maxWidth="500px">
+      <label htmlFor="password">Password</label>
+      <PasswordInput
+        id="password"
+        placeholder="Enter your password"
+        {...args}
+      />
+    </Box>
+  ),
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <Box maxWidth="500px">
+      <label htmlFor="password">Password (Disabled)</label>
+      <PasswordInput
+        id="password"
+        disabled
+        value="DisabledPassword123"
+        {...args}
+      />
+    </Box>
+  ),
+};

--- a/packages/nimbus/src/components/password-input/password-input.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.tsx
@@ -1,0 +1,62 @@
+import { forwardRef, useState } from "react";
+import { Box, IconButton } from "@/components";
+import { TextInput } from "@/components/text-input";
+import { Visibility, VisibilityOff } from "@commercetools/nimbus-icons";
+import type { PasswordInputProps } from "./password-input.types";
+
+/**
+ * PasswordInput
+ * ============================================================
+ * An input component that takes in password as input with toggleable visibility
+ *
+ * Features:
+ *
+ * - Based on TextInput with added password visibility toggle
+ * - Allows toggling between type="password" and type="text"
+ * - Positions the toggle button at the right edge of the input
+ * - Inherits all TextInput features and props
+ */
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  (props, forwardedRef) => {
+    const { size = "md" } = props;
+    const [showPassword, setShowPassword] = useState(false);
+    const toggleVisibility = () => setShowPassword(!showPassword);
+
+    const iconSize = size === "md" ? "xs" : "2xs";
+    const iconPositionProps =
+      size === "md"
+        ? {
+            size: "xs",
+            right: "400",
+            top: "100",
+          }
+        : {
+            top: "50",
+            right: "400",
+          };
+
+    return (
+      <Box display="inline-block" position="relative">
+        <TextInput
+          {...props}
+          ref={forwardedRef}
+          type={showPassword ? "text" : "password"}
+          paddingRight="1200"
+        />
+        <Box position="absolute" {...iconPositionProps}>
+          <IconButton
+            size={iconSize}
+            variant="ghost"
+            tone="primary"
+            aria-label={showPassword ? "Hide password" : "Show password"}
+            onClick={toggleVisibility}
+          >
+            {showPassword ? <VisibilityOff /> : <Visibility />}
+          </IconButton>
+        </Box>
+      </Box>
+    );
+  }
+);
+
+PasswordInput.displayName = "PasswordInput";

--- a/packages/nimbus/src/components/password-input/password-input.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useState } from "react";
-import { Box, IconButton } from "@/components";
+import { Box, IconButton, Tooltip, TooltipTrigger } from "@/components";
 import { TextInput } from "@/components/text-input";
 import { Visibility, VisibilityOff } from "@commercetools/nimbus-icons";
 import type { PasswordInputProps } from "./password-input.types";
@@ -52,16 +52,21 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           pr={iconButtonSafeSpace}
         />
         <Box position="absolute" {...iconPositionProps}>
-          <IconButton
-            size={iconSize}
-            variant="ghost"
-            tone="primary"
-            aria-label={showPassword ? "Hide password" : "Show password"}
-            onClick={toggleVisibility}
-            isDisabled={isDisabled}
-          >
-            {showPassword ? <VisibilityOff /> : <Visibility />}
-          </IconButton>
+          <TooltipTrigger>
+            <IconButton
+              size={iconSize}
+              variant="ghost"
+              tone="primary"
+              aria-label={showPassword ? "Hide password" : "Show password"}
+              onClick={toggleVisibility}
+              isDisabled={isDisabled}
+            >
+              {showPassword ? <VisibilityOff /> : <Visibility />}
+            </IconButton>
+            <Tooltip>
+              {showPassword ? "Hide password" : "Show Password"}
+            </Tooltip>
+          </TooltipTrigger>
         </Box>
       </Box>
     );

--- a/packages/nimbus/src/components/password-input/password-input.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.tsx
@@ -58,7 +58,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
               variant="ghost"
               tone="primary"
               aria-label={showPassword ? "Hide password" : "Show password"}
-              onClick={toggleVisibility}
+              onPress={toggleVisibility}
               isDisabled={isDisabled}
             >
               {showPassword ? <VisibilityOff /> : <Visibility />}

--- a/packages/nimbus/src/components/password-input/password-input.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.tsx
@@ -18,7 +18,7 @@ import type { PasswordInputProps } from "./password-input.types";
  */
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   (props, forwardedRef) => {
-    const { size = "md" } = props;
+    const { size = "md", isDisabled } = props;
     const [showPassword, setShowPassword] = useState(false);
     const toggleVisibility = () => setShowPassword(!showPassword);
 
@@ -26,9 +26,8 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
     const iconPositionProps =
       size === "md"
         ? {
-            size: "xs",
-            right: "400",
             top: "100",
+            right: "400",
           }
         : {
             top: "50",
@@ -50,6 +49,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
             tone="primary"
             aria-label={showPassword ? "Hide password" : "Show password"}
             onClick={toggleVisibility}
+            isDisabled={isDisabled}
           >
             {showPassword ? <VisibilityOff /> : <Visibility />}
           </IconButton>

--- a/packages/nimbus/src/components/password-input/password-input.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.tsx
@@ -22,7 +22,12 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
     const [showPassword, setShowPassword] = useState(false);
     const toggleVisibility = () => setShowPassword(!showPassword);
 
+    /** size icon based on input size */
     const iconSize = size === "md" ? "xs" : "2xs";
+    /**
+     * position the icon button at the right edge of the input based on
+     * the size of the input
+     */
     const iconPositionProps =
       size === "md"
         ? {
@@ -34,13 +39,17 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
             right: "400",
           };
 
+    /** safe space between the text within the input and the icon button */
+    const iconButtonSafeSpace = size === "md" ? "1400" : "1100";
+
     return (
       <Box display="inline-block" position="relative">
         <TextInput
-          {...props}
+          width="full"
           ref={forwardedRef}
           type={showPassword ? "text" : "password"}
-          paddingRight="1200"
+          {...props}
+          pr={iconButtonSafeSpace}
         />
         <Box position="absolute" {...iconPositionProps}>
           <IconButton

--- a/packages/nimbus/src/components/password-input/password-input.types.ts
+++ b/packages/nimbus/src/components/password-input/password-input.types.ts
@@ -1,4 +1,4 @@
-import type { TextInputProps } from "@/components/text-input/text-input.types";
+import type { TextInputProps } from "../text-input/text-input.types";
 
 /**
  * Interface for PasswordInput component props

--- a/packages/nimbus/src/components/password-input/password-input.types.ts
+++ b/packages/nimbus/src/components/password-input/password-input.types.ts
@@ -1,0 +1,8 @@
+import type { TextInputProps } from "@/components/text-input/text-input.types";
+
+/**
+ * Interface for PasswordInput component props
+ * Extends TextInputProps but omits the type prop since it's controlled internally
+ * We want to keep this as an explicit interface to allow for future additions
+ */
+export interface PasswordInputProps extends Omit<TextInputProps, "type"> {}


### PR DESCRIPTION
# ✨ Add PasswordInput Component

## Overview
This PR introduces a new PasswordInput component to the Nimbus design system, providing a secure and user-friendly way for users to enter passwords with the option to toggle visibility.

- [Storybook Stories](https://nimbus-storybook-git-fct-1520-nimbus-compo-8df53a-commercetools.vercel.app/?path=/docs/components-passwordinput--docs)
- [Documentation](https://nimbus-documentation-git-fct-1520-nimbus-c-a7586e-commercetools.vercel.app/components/inputs/passwordinput) (no usage guidelines yet)

## Features
- **Password Visibility Toggle:**
Users can easily switch between masked and visible password input using an integrated toggle button.
- **Accessibility:**
  - Fully keyboard-accessible, including toggling visibility with Enter/Space.
  - Proper ARIA labels for improved screen reader support.
  - Toggle button is disabled when the input is disabled.
- **Variants & Sizes:**
  - Supports multiple visual variants (solid, ghost) and sizes (sm, md) for design flexibility.
- **State Support:**
  - Handles disabled, required, and invalid states.
  - Supports both controlled and uncontrolled usage patterns.
- **Storybook Coverage:**
  - Comprehensive stories demonstrating all features, variants, and states.
  - Includes interaction and accessibility tests.

## Motivation
The new PasswordInput component enhances the Nimbus component library by providing a best-practice, accessible password field with built-in visibility toggling, ensuring consistency and usability across applications.
