### PR TITLE
feat(storybook): add accessibility test configuration to preview sett…

### DIFF
--- a/packages/nimbus/.storybook/preview.tsx
+++ b/packages/nimbus/.storybook/preview.tsx
@@ -75,6 +75,8 @@ const preview: Preview = {
        * to learn more about the available options.
        */
       options: {},
+      // fail the test runner if a11y violations are found
+      test: "error",
     },
   },
   tags: ["autodocs", "a11y-test"],


### PR DESCRIPTION
# Summary
This PR enables running the a11y check via the runner/vitest (in CI).

[Storybook Docs](https://storybook.js.org/docs/writing-tests/accessibility-testing#test-behavior) 

![image](https://github.com/user-attachments/assets/4dda0f13-f1b2-406d-b57a-437bad96616f)
