### PR TITLE
chore(nimbus): remove Bleed component and update exports

### DIFF
--- a/packages/nimbus/src/components/bleed/bleed.tsx
+++ b/packages/nimbus/src/components/bleed/bleed.tsx
@@ -1,1 +1,0 @@
-export { Bleed } from "@chakra-ui/react";

--- a/packages/nimbus/src/components/bleed/index.ts
+++ b/packages/nimbus/src/components/bleed/index.ts
@@ -1,1 +1,0 @@
-export * from "./bleed";

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -1,6 +1,5 @@
 export * from "./avatar";
 export * from "./box";
-export * from "./bleed";
 export * from "./button";
 export * from "./code";
 export * from "./dialog";
@@ -35,4 +34,3 @@ export * from "./icon";
 export * from "./tag-group";
 export * from "./switch";
 export * from "./password-input";
-


### PR DESCRIPTION
# Summary

As discussed, we currently don't plan or work with this component, if we ever need it again, we can bring it back and invest the resources to document it properly.