### PR TITLE
refactor(accordion): rename and restructure accordion components

### DIFF
--- a/packages/nimbus/src/components/accordion/accordion.slots.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.slots.tsx
@@ -33,7 +33,7 @@ export const AccordionTitle = withContext<
   HTMLChakraProps<"div">
 >("div", "accordionTitle");
 
-export const HeaderRightContent = withContext<
+export const AccordionHeaderRightContent = withContext<
   HTMLDivElement,
   HTMLChakraProps<"div">
 >("div", "headerContentRight");

--- a/packages/nimbus/src/components/accordion/accordion.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.tsx
@@ -1,14 +1,22 @@
-import { HeaderRightContent } from "./accordion.slots";
-import { AccordionGroup } from "./components/accordion-group";
+import { AccordionHeaderRightContent } from "./accordion.slots";
+import { AccordionRoot } from "./components/accordion-root";
 import { AccordionHeader } from "./components/accordion-header";
 import { AccordionContent } from "./components/accordion-content";
 import { AccordionItem } from "./components/accordion-item";
 
 // Create the Accordion namespace object as an object literal
 export const Accordion = {
-  Root: AccordionGroup,
+  Root: AccordionRoot,
   Item: AccordionItem,
   Header: AccordionHeader,
   Content: AccordionContent,
-  HeaderRightContent,
+  HeaderRightContent: AccordionHeaderRightContent,
+};
+
+export {
+  AccordionRoot as _AccordionRoot,
+  AccordionItem as _AccordionItem,
+  AccordionHeader as _AccordionHeader,
+  AccordionContent as _AccordionContent,
+  AccordionHeaderRightContent as _AccordionHeaderRightContent,
 };

--- a/packages/nimbus/src/components/accordion/components/accordion-content.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-content.tsx
@@ -1,14 +1,25 @@
-import React, { forwardRef, useContext } from "react";
+import React, {
+  forwardRef,
+  useContext,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 import { AccordionPanel } from "../accordion.slots";
 import { useObjectRef } from "react-aria";
 import { mergeProps, mergeRefs } from "@chakra-ui/react";
-import type { DisclosureGroupProps } from "../accordion.types";
 import { ItemContext } from "../accordion-context";
+
+type AccordionContentProps = {
+  /**
+   * The content to display
+   */
+  children: ReactNode;
+} & ComponentProps<typeof AccordionPanel>;
 
 // Create Content component
 export const AccordionContent = forwardRef<
   HTMLDivElement,
-  DisclosureGroupProps
+  AccordionContentProps
 >((props, forwardedRef) => {
   const context = useContext(ItemContext);
   const ref = useObjectRef<HTMLDivElement>(

--- a/packages/nimbus/src/components/accordion/components/accordion-header.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-header.tsx
@@ -1,18 +1,24 @@
-import React, { forwardRef, useContext } from "react";
+import React, { forwardRef, useContext, type ReactNode } from "react";
 import {
   AccordionTrigger,
   AccordionTitle,
-  HeaderRightContent,
+  AccordionHeaderRightContent,
 } from "../accordion.slots";
 import { mergeRefs } from "@chakra-ui/react";
 import { Flex } from "@/components";
 import { KeyboardArrowRight } from "@commercetools/nimbus-icons";
-import type { DisclosureGroupProps } from "../accordion.types";
 import { ItemContext } from "../accordion-context";
+
+type AccordionHeaderProps = {
+  /**
+   * The text / content to display in the Header
+   */
+  children: ReactNode;
+};
 
 export const AccordionHeader = forwardRef<
   HTMLButtonElement,
-  DisclosureGroupProps
+  AccordionHeaderProps
 >(({ children }, ref) => {
   const context = useContext(ItemContext);
   if (!context) {
@@ -25,7 +31,10 @@ export const AccordionHeader = forwardRef<
     rightContent: React.ReactNode[];
   }>(
     (acc, child) => {
-      if (React.isValidElement(child) && child.type === HeaderRightContent) {
+      if (
+        React.isValidElement(child) &&
+        child.type === AccordionHeaderRightContent
+      ) {
         acc.rightContent.push(child);
       } else {
         acc.main.push(child);
@@ -54,9 +63,9 @@ export const AccordionHeader = forwardRef<
         </AccordionTitle>
       </AccordionTrigger>
       {headerContent.rightContent.length > 0 && (
-        <HeaderRightContent data-slot="headerContentRight">
+        <AccordionHeaderRightContent data-slot="headerContentRight">
           {headerContent.rightContent}
-        </HeaderRightContent>
+        </AccordionHeaderRightContent>
       )}
     </Flex>
   );

--- a/packages/nimbus/src/components/accordion/components/accordion-root.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-root.tsx
@@ -5,7 +5,7 @@ import { useSlotRecipe } from "@chakra-ui/react";
 import type { DisclosureGroupProps } from "../accordion.types";
 import { DisclosureGroupStateContext } from "../accordion-context";
 
-export const AccordionGroup = forwardRef<HTMLDivElement, DisclosureGroupProps>(
+export const AccordionRoot = forwardRef<HTMLDivElement, DisclosureGroupProps>(
   ({ children, onExpandedChange, ...props }, forwardedRef) => {
     const state = useDisclosureGroupState({
       ...props,


### PR DESCRIPTION
# Summary

The Accordion PropsTable now show the available props for each subcomponent.

![image](https://github.com/user-attachments/assets/9249605c-1991-4773-9aa7-3b80b6b9f64b)


[Ticket](https://commercetools.atlassian.net/browse/FCT-1551)

## Changes

- Renamed `HeaderRightContent` to `AccordionHeaderRightContent` for clarity.
- Updated imports and exports in the accordion module to reflect the new naming.
- Introduced `AccordionRoot` component to manage accordion state and structure.
- Enhanced `AccordionContent` and `AccordionHeader` components with improved prop types and context usage.
- Refactored header content handling to utilize the new right content component.