### PR TITLE
refactor(card): update exports to include prefixed component names

### DIFF
--- a/packages/nimbus/src/components/card/card.tsx
+++ b/packages/nimbus/src/components/card/card.tsx
@@ -2,10 +2,14 @@ import { CardRoot } from "./components/card.root";
 import { CardHeader } from "./components/card.header";
 import { CardContent } from "./components/card.content";
 
-export { CardRoot, CardHeader, CardContent };
-
 export const Card = {
   Root: CardRoot,
   Header: CardHeader,
   Content: CardContent,
+};
+
+export {
+  CardRoot as _CardRoot,
+  CardHeader as _CardHeader,
+  CardContent as _CardContent,
 };


### PR DESCRIPTION
# Summary

Prepend exports with an underscore to indicate that this exports are only used for the typescript type parser.