### PR TITLE
refactor(color-mode): remove ColorModeLabel component from color mode

### DIFF
--- a/packages/nimbus/src/components/nimbus-provider/color-mode.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/color-mode.tsx
@@ -25,8 +25,3 @@ export function useColorModeValue<T>(light: T, dark: T) {
   const { colorMode } = useColorMode();
   return colorMode === "light" ? light : dark;
 }
-
-export function ColorModeLabel() {
-  const { colorMode } = useColorMode();
-  return colorMode === "light" ? "Light Theme" : "DarkTheme";
-}

--- a/packages/nimbus/src/components/nimbus-provider/index.ts
+++ b/packages/nimbus/src/components/nimbus-provider/index.ts
@@ -1,2 +1,2 @@
 export * from "./nimbus-provider.tsx";
-export { useColorMode, useColorModeValue, ColorModeLabel } from "./color-mode";
+export { useColorMode, useColorModeValue } from "./color-mode";


### PR DESCRIPTION
# Summary

Removes an unused and rather useless component from the nimbus exports.