### PR TITLE
refactor(form-field): get the props-table to work

### DIFF
--- a/packages/nimbus/src/components/form-field/components/form-field.context.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.context.tsx
@@ -1,0 +1,39 @@
+import { createContext, type ReactNode } from "react";
+import type {
+  FormFieldDescriptionSlotProps,
+  FormFieldErrorSlotProps,
+  FormFieldInputSlotProps,
+  FormFieldLabelSlotProps,
+} from "../form-field.slots";
+
+export type FormFieldContextPayloadType = {
+  label: ReactNode;
+  labelSlotProps?: FormFieldLabelSlotProps;
+  input: ReactNode;
+  inputSlotProps?: FormFieldInputSlotProps;
+  description: ReactNode;
+  descriptionSlotProps?: FormFieldDescriptionSlotProps;
+  error: ReactNode;
+  errorSlotProps?: FormFieldErrorSlotProps;
+  info: ReactNode;
+  isInvalid?: boolean;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+};
+
+export type FormFieldContextType = {
+  context: FormFieldContextPayloadType;
+  setContext: React.Dispatch<React.SetStateAction<FormFieldContextPayloadType>>;
+};
+
+export const FormFieldContext = createContext<FormFieldContextType>({
+  context: {
+    label: null,
+    description: null,
+    error: null,
+    info: null,
+    input: null,
+  },
+  setContext: () => {},
+});

--- a/packages/nimbus/src/components/form-field/components/form-field.description.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.description.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from "react";
-import { FormFieldContext } from "../form-field";
+import { FormFieldContext } from "./form-field.context";
 import type { FormFieldDescriptionSlotProps } from "../form-field.slots";
 
 export const FormFieldDescription = ({

--- a/packages/nimbus/src/components/form-field/components/form-field.error.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.error.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from "react";
-import { FormFieldContext } from "../form-field";
+import { FormFieldContext } from "./form-field.context";
 import type { FormFieldErrorSlotProps } from "../form-field.slots";
 
 export const FormFieldError = ({

--- a/packages/nimbus/src/components/form-field/components/form-field.info-box.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.info-box.tsx
@@ -1,7 +1,14 @@
 import { useContext, useEffect, type ReactNode } from "react";
-import { FormFieldContext } from "../form-field";
+import { FormFieldContext } from "./form-field.context";
 
-export const FormFieldInfoBox = ({ children }: { children: ReactNode }) => {
+type FormFieldInfoBoxProps = {
+  /**
+   * The content to display in the InfoBox
+   */
+  children: ReactNode;
+};
+
+export const FormFieldInfoBox = ({ children }: FormFieldInfoBoxProps) => {
   const { setContext } = useContext(FormFieldContext);
 
   useEffect(() => {

--- a/packages/nimbus/src/components/form-field/components/form-field.input.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.input.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from "react";
-import { FormFieldContext } from "../form-field";
+import { FormFieldContext } from "./form-field.context";
 import type { FormFieldInputSlotProps } from "../form-field.slots";
 
 export const FormFieldInput = ({

--- a/packages/nimbus/src/components/form-field/components/form-field.label.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.label.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from "react";
-import { FormFieldContext } from "../form-field";
+import { FormFieldContext } from "./form-field.context";
 import type { FormFieldLabelSlotProps } from "../form-field.slots";
 
 export const FormFieldLabel = ({

--- a/packages/nimbus/src/components/form-field/components/form-field.root.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.root.tsx
@@ -11,7 +11,7 @@ import { useField } from "react-aria";
 import {
   FormFieldContext,
   type FormFieldContextPayloadType,
-} from "../form-field";
+} from "./form-field.context";
 import {
   FormFieldDescriptionSlot,
   FormFieldErrorSlot,

--- a/packages/nimbus/src/components/form-field/form-field.tsx
+++ b/packages/nimbus/src/components/form-field/form-field.tsx
@@ -1,48 +1,9 @@
-import { createContext, type ReactNode } from "react";
 import { FormFieldRoot } from "./components/form-field.root";
 import { FormFieldLabel } from "./components/form-field.label";
 import { FormFieldInput } from "./components/form-field.input";
 import { FormFieldDescription } from "./components/form-field.description";
 import { FormFieldError } from "./components/form-field.error";
 import { FormFieldInfoBox } from "./components/form-field.info-box";
-import type {
-  FormFieldDescriptionSlotProps,
-  FormFieldErrorSlotProps,
-  FormFieldInputSlotProps,
-  FormFieldLabelSlotProps,
-} from "./form-field.slots";
-
-export type FormFieldContextPayloadType = {
-  label: ReactNode;
-  labelSlotProps?: FormFieldLabelSlotProps;
-  input: ReactNode;
-  inputSlotProps?: FormFieldInputSlotProps;
-  description: ReactNode;
-  descriptionSlotProps?: FormFieldDescriptionSlotProps;
-  error: ReactNode;
-  errorSlotProps?: FormFieldErrorSlotProps;
-  info: ReactNode;
-  isInvalid?: boolean;
-  isRequired?: boolean;
-  isDisabled?: boolean;
-  isReadOnly?: boolean;
-};
-
-export type FormFieldContextType = {
-  context: FormFieldContextPayloadType;
-  setContext: React.Dispatch<React.SetStateAction<FormFieldContextPayloadType>>;
-};
-
-export const FormFieldContext = createContext<FormFieldContextType>({
-  context: {
-    label: null,
-    description: null,
-    error: null,
-    info: null,
-    input: null,
-  },
-  setContext: () => {},
-});
 
 export const FormField = {
   Root: FormFieldRoot,
@@ -51,4 +12,13 @@ export const FormField = {
   Description: FormFieldDescription,
   Error: FormFieldError,
   InfoBox: FormFieldInfoBox,
+};
+
+export {
+  FormFieldRoot as _FormFieldRoot,
+  FormFieldLabel as _FormFieldLabel,
+  FormFieldInput as _FormFieldInput,
+  FormFieldDescription as _FormFieldDescription,
+  FormFieldError as _FormFieldError,
+  FormFieldInfoBox as _FormFieldInfoBox,
 };


### PR DESCRIPTION
# Summary

The `FormFieldContext` component is not exported anymore, the PropsTable for `FormField` now shows all sub-components props.

## Changes

- Moved `FormFieldContext` and its types to a new file so that it's not exported by default anymore
- Updated component imports to reference the new context file.
- Added the necessary "types-exports" to the main component file

![image](https://github.com/user-attachments/assets/ee8df7c8-dc47-4c6e-bb25-fda76e75b7cb)




