### PR TITLE
feat(inputs): change background color in `TextInput` and `Select`

### DIFF
--- a/packages/nimbus/src/components/select/select.recipe.tsx
+++ b/packages/nimbus/src/components/select/select.recipe.tsx
@@ -183,7 +183,7 @@ export const selectSlotRecipe = defineSlotRecipe({
     variant: {
       outline: {
         root: {
-          bg: "bg",
+          bg: "primary.1",
           "&:hover": {
             bg: "primary.2",
           },

--- a/packages/nimbus/src/components/text-input/text-input.recipe.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.recipe.tsx
@@ -48,7 +48,7 @@ export const textInputRecipe = defineRecipe({
       solid: {
         "--border-width": "sizes.25",
         "--border-color": "colors.neutral.7",
-        backgroundColor: "neutral.1",
+        backgroundColor: "primary.1",
         _hover: {
           backgroundColor: "primary.2",
         },


### PR DESCRIPTION
This pull request updates the visual design of the `select` and `text-input` components by changing their background colors to align with the `primary` color palette. These changes enhance consistency across the UI and improve hover states.

### Visual Design Updates:

* [`packages/nimbus/src/components/select/select.recipe.tsx`](diffhunk://#diff-31e6b790167ce54b8a21f8e6acbc6bea4c203887c19940743934640b618e224eL186-R186): Updated the `bg` property for the `outline` variant's `root` to use `primary.1` instead of `bg`.
* [`packages/nimbus/src/components/text-input/text-input.recipe.tsx`](diffhunk://#diff-6dbd82208cb09e0e72e08dca9cdcff085f555f1cd6ae7aa80f1f8eb9a9635068L51-R51): Changed the `backgroundColor` for the `solid` variant from `neutral.1` to `primary.1`.