### PR TITLE
refactor(toggle-button-group): update component title and adjust exports

### DIFF
--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
@@ -1,6 +1,6 @@
 ---
 id: Components-ToggleButtonGroup
-title: Toggle Button Group
+title: ToggleButtonGroup
 description: >-
   A set of closely related, mutually exclusive or complementary actions that are
   important enough to be displayed directly in the interface for quick access.

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.tsx
@@ -1,8 +1,6 @@
 import { ToggleButtonGroupRoot } from "./components/toggle-button-group.root";
 import { ToggleButtonGroupButton } from "./components/toggle-button-group.button";
 
-export { ToggleButtonGroupRoot, ToggleButtonGroupButton };
-
 /**
  * ToggleButtonGroup
  * ============================================================
@@ -11,4 +9,9 @@ export { ToggleButtonGroupRoot, ToggleButtonGroupButton };
 export const ToggleButtonGroup = {
   Root: ToggleButtonGroupRoot,
   Button: ToggleButtonGroupButton,
+};
+
+export {
+  ToggleButtonGroupRoot as _ToggleButtonGroupRoot,
+  ToggleButtonGroupButton as _ToggleButtonGroupButton,
 };


### PR DESCRIPTION
# Summary

- Changed the title in the documentation from "Toggle Button Group" to "ToggleButtonGroup" for consistency.
- Updated exports in the TypeScript file to include prefixed component names for better clarity.

[Ticket](https://commercetools.atlassian.net/browse/FCT-1551)