### PR TITLE
feat(reset): override styling of svgs and other media elements in chakra theme's @reset layer

### DIFF
--- a/packages/nimbus/src/theme/global-css.ts
+++ b/packages/nimbus/src/theme/global-css.ts
@@ -54,4 +54,14 @@ export const globalCss = defineGlobalStyles({
     bg: "colorPalette.9",
     color: "colorPalette.contrast",
   },
+  /** overrides for styling in the chakra theme's preflight @reset layer
+   * overview of preflight config:
+   * https://chakra-ui.com/docs/theming/overview#preflight
+   * values set in @reset layer by preflight option:
+   * https://github.com/chakra-ui/chakra-ui/blob/main/packages/react/src/styled-system/preflight.ts
+   */
+  "img, svg, video, canvas, audio, iframe, embed, object": {
+    display: "initial",
+    verticalAlign: "initial",
+  },
 });


### PR DESCRIPTION
The customers team [pointed out](https://commercetools.slack.com/archives/C08GSD5FAV6/p1749643760916179) that nimbus seemed to be causing an issue with `svg` elements not aligning correctly in non-nimbus components in the MC.  

Upon further investigation, [chakra's ](https://chakra-ui.com/docs/theming/overview#preflight)`preflight` css reset [does indeed](https://github.com/chakra-ui/chakra-ui/blob/39b814f597ba11fda6b5b0e727b303c145c52a79/packages/react/src/styled-system/preflight.ts#L45) override `svg` `display` and `verticalAlign` properties.

This fix overrides the `@reset` layer by setting `display: "initial"` and `verticalAlign: "initial"` for `img, svg, video, canvas, audio, iframe, embed, object` elements in the `globalCss` theme.