### PR TITLE
feat(nimbus): centralize locale to nimbus provider

### DIFF
--- a/packages/nimbus/src/components/nimbus-provider/locale-context.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/locale-context.tsx
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react";
+
+export const LocaleContext = createContext<string>("en-US");
+
+export const useLocale = () => useContext(LocaleContext);

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
@@ -5,6 +5,7 @@ import {
   // defaultSystem as defaultSystemChakra,
 } from "@chakra-ui/react";
 import { ColorModeProvider, type ColorModeProviderProps } from "./color-mode";
+import { LocaleContext } from "./locale-context";
 import { system } from "../../theme";
 import { useEffect, useState } from "react";
 
@@ -40,11 +41,21 @@ export function useColorScheme() {
   return colorScheme;
 }
 
-export function NimbusProvider({ children, ...props }: ColorModeProviderProps) {
+export function NimbusProvider({
+  children,
+  locale,
+  ...props
+}: ColorModeProviderProps & { locale?: string }) {
+  // The provider can accept an optional locale prop, ex from App-Kit
+  // then we fallback first to the navigator.language, then to "en-US"
+  const resolvedLocale = locale || navigator.language || "en-US";
+
   return (
     <ChakraProvider value={system}>
       <ColorModeProvider enableSystem={false} {...props}>
-        <>{children}</>
+        <LocaleContext.Provider value={resolvedLocale}>
+          {children}
+        </LocaleContext.Provider>
       </ColorModeProvider>
     </ChakraProvider>
   );


### PR DESCRIPTION
This pull request introduces a new `LocaleContext` to manage locale settings within the `NimbusProvider` component, allowing for better localization support. The most important changes include creating the `LocaleContext`, updating the `NimbusProvider` to accept an optional `locale` prop, and integrating the context into the provider hierarchy.

### Localization support:

* [`packages/nimbus/src/components/nimbus-provider/locale-context.tsx`](diffhunk://#diff-23b3b35674322600d961cf9155d42b203d78e1a063d3e3679772e0392373a6a6R1-R5): Introduced a new `LocaleContext` using React's `createContext` and added a `useLocale` hook for accessing the context.
* [`packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx`](diffhunk://#diff-f195313a1c4f0d31ce04c41efba07bc4a97e7e394e7e5cb836bb0e9ee67905efL43-R58): Updated the `NimbusProvider` to accept an optional `locale` prop, falling back to `navigator.language` or `en-US` if not provided. The `LocaleContext.Provider` was added to the component tree to supply the resolved locale to child components.

### Integration updates:

* [`packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx`](diffhunk://#diff-f195313a1c4f0d31ce04c41efba07bc4a97e7e394e7e5cb836bb0e9ee67905efR8): Imported the `LocaleContext` from `locale-context.tsx` to integrate it into the `NimbusProvider`.