### PR TITLE
BUGFIX: make sure recipe theme typings are generated

### DIFF
--- a/packages/nimbus/src/components/number-input/number-input.slots.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.slots.tsx
@@ -36,7 +36,7 @@ export type NumberInputDecrementButtonSlotProps = HTMLChakraProps<
   AriaButtonProps;
 
 const { withContext, withProvider } = createSlotRecipeContext({
-  key: "number-input",
+  key: "numberInput",
 });
 
 /**

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -10,6 +10,18 @@ import { numberInputRecipe } from "@/components/number-input/number-input.recipe
 import { radioInputSlotRecipe } from "@/components/radio-input/radio-input.recipe";
 import { comboBoxSlotRecipe } from "@/components/combobox/combobox.recipe";
 
+/**
+ * Keys for the slotRecipes object MUST be a valid JS identifier!!!!!!!!!!
+ *
+ * you MUST be able to access the key with dot notation: ✅ slotRecipes.exampleComponent ✅
+ * NOT with bracket notation: ❌ slotRecipes["example-component"] ❌
+ *
+ * Failure to do so will make it so that `pnpm build-theme-typings` will fail silently
+ * due to some truly awful interplay between `@chakra-ui/cli` and `prettier`
+ *
+ * Silent failure results in there being no generated types for slot recipes, and causes all kinds of
+ * false typescript errors that are really hard to debug.
+ */
 export const slotRecipes = {
   dialog: dialogSlotRecipe,
   list: listSlotRecipe,
@@ -19,7 +31,7 @@ export const slotRecipes = {
   accordion: accordionSlotRecipe,
   taggroup: tagGroupSlotRecipe,
   switch: switchSlotRecipe,
-  "number-input": numberInputRecipe,
+  numberInput: numberInputRecipe,
   radioInput: radioInputSlotRecipe,
   combobox: comboBoxSlotRecipe,
 };


### PR DESCRIPTION
fix(slot recipe types): update slotRecipe theme declaration object to not have key that requires bracket notation, fix number input slot recipe declaration

This pull request includes changes to improve consistency and prevent build errors in the `slotRecipes` object and related components. The most important changes involve renaming keys to ensure compatibility with tooling and adding documentation to clarify naming requirements.

### Consistency improvements:

* [`packages/nimbus/src/components/number-input/number-input.slots.tsx`](diffhunk://#diff-64c8bdec1bc51adce1e3d0378a33f3955f62f8d5935b921c851699e5df992afaL39-R39): Updated the `key` property in `createSlotRecipeContext` from `"number-input"` to `"numberInput"` for consistency with other keys.
* [`packages/nimbus/src/theme/slot-recipes/index.ts`](diffhunk://#diff-a0c0b51c3a05b3e71eb9faa9d95dd314e0fbd04d50aff7e44ab46771ffc14365L22-R34): Renamed the `"number-input"` key in the `slotRecipes` object to `numberInput` to ensure compatibility with `pnpm build-theme-typings` and avoid silent build failures.

### Documentation enhancements:

* [`packages/nimbus/src/theme/slot-recipes/index.ts`](diffhunk://#diff-a0c0b51c3a05b3e71eb9faa9d95dd314e0fbd04d50aff7e44ab46771ffc14365R13-R24): Added a detailed comment explaining that keys in the `slotRecipes` object must be valid JavaScript identifiers accessible via dot notation, and described the consequences of failing to follow this rule.