### PR TITLE
feat(Nimbus inputs cleanup): update boderwith for invalid inputs

### DIFF
--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.tsx
@@ -29,6 +29,7 @@ export const multilineTextInputRecipe = defineRecipe({
       layerStyle: "disabled",
     },
     "&[data-invalid='true']": {
+      "--border-width": "sizes.50",
       "--border-color": "colors.critical.7",
       color: "critical.11",
     },

--- a/packages/nimbus/src/components/number-input/number-input.recipe.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.recipe.tsx
@@ -131,6 +131,10 @@ export const numberInputRecipe = defineSlotRecipe({
           },
         },
         input: {
+          "&[data-invalid='true']": {
+            boxShadow: "inset 0 0 0 var(--border-width) var(--border-color)",
+            "--border-width": "sizes.50",
+          },
           boxShadow: "inset 0 0 0 var(--border-width) var(--border-color)",
           backgroundColor: "neutral.1",
           _hover: {
@@ -138,6 +142,10 @@ export const numberInputRecipe = defineSlotRecipe({
           },
         },
         incrementButton: {
+          "&[data-invalid='true']": {
+            borderTop: "2px solid var(--border-color)",
+            borderRight: "2px solid var(--border-color)",
+          },
           borderTop: "var(--border-width) solid var(--border-color)",
           borderRight: "var(--border-width) solid var(--border-color)",
           borderLeft: "var(--border-width) solid var(--border-color)",
@@ -148,6 +156,10 @@ export const numberInputRecipe = defineSlotRecipe({
           },
         },
         decrementButton: {
+          "&[data-invalid='true']": {
+            borderBottom: "2px solid var(--border-color)",
+            borderRight: "2px solid var(--border-color)",
+          },
           borderBottom: "var(--border-width) solid var(--border-color)",
           borderRight: "var(--border-width) solid var(--border-color)",
           borderLeft: "var(--border-width) solid var(--border-color)",
@@ -166,16 +178,28 @@ export const numberInputRecipe = defineSlotRecipe({
           },
         },
         input: {
+          "&[data-invalid='true']": {
+            boxShadow: "inset 0 0 0 var(--border-width) var(--border-color)",
+            "--border-width": "sizes.50",
+          },
           _hover: {
             backgroundColor: "primary.2",
           },
         },
         incrementButton: {
+          "&[data-invalid='true']": {
+            borderTop: "2px solid var(--border-color)",
+            borderRight: "2px solid var(--border-color)",
+          },
           _hover: {
             backgroundColor: "primaryAlpha.3",
           },
         },
         decrementButton: {
+          "&[data-invalid='true']": {
+            borderBottom: "2px solid var(--border-color)",
+            borderRight: "2px solid var(--border-color)",
+          },
           _hover: {
             backgroundColor: "primaryAlpha.3",
           },

--- a/packages/nimbus/src/components/text-input/text-input.recipe.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.recipe.tsx
@@ -26,6 +26,7 @@ export const textInputRecipe = defineRecipe({
     },
     "&[data-invalid='true']": {
       "--border-color": "colors.critical.7",
+      "--border-width": "sizes.50",
       color: "critical.11",
     },
   },


### PR DESCRIPTION
This pull request introduces enhancements to the styling of form input components in the Nimbus design system. The changes focus on improving the visual feedback for invalid states by adding or modifying border width and color properties.

### Enhancements to invalid state styling:

* **Multiline Text Input**: Added a `--border-width` property to the invalid state styling, ensuring consistent border width for invalid inputs. (`packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.tsx`, [packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.tsxR32](diffhunk://#diff-b455672625340303e8965873d15fb96d00cc774dfd89a42393dc474ef72eb099R32))
* **Text Input**: Introduced a `--border-width` property to the invalid state styling, aligning it with other input components for uniformity. (`packages/nimbus/src/components/text-input/text-input.recipe.tsx`, [packages/nimbus/src/components/text-input/text-input.recipe.tsxR29](diffhunk://#diff-6dbd82208cb09e0e72e08dca9cdcff085f555f1cd6ae7aa80f1f8eb9a9635068R29))

### Updates to Number Input:

* **Input Field**: Added invalid state styles, including a box shadow and `--border-width` property, to highlight invalid inputs. (`packages/nimbus/src/components/number-input/number-input.recipe.tsx`, [[1]](diffhunk://#diff-f896d14bb20b8fb495b015a353d7939d09fa2c42ae1d9282df744be3a792ec1aR134-R148) [[2]](diffhunk://#diff-f896d14bb20b8fb495b015a353d7939d09fa2c42ae1d9282df744be3a792ec1aR181-R202)
* **Increment and Decrement Buttons**: Enhanced invalid state styling by adding specific border properties (`border-top`, `border-right`, `border-bottom`) to visually indicate errors. (`packages/nimbus/src/components/number-input/number-input.recipe.tsx`, [[1]](diffhunk://#diff-f896d14bb20b8fb495b015a353d7939d09fa2c42ae1d9282df744be3a792ec1aR159-R162) [[2]](diffhunk://#diff-f896d14bb20b8fb495b015a353d7939d09fa2c42ae1d9282df744be3a792ec1aR181-R202)