### PR TITLE
CRAFT-1600 | Single Select Combobox UX

### DIFF
--- a/packages/nimbus/src/components/combobox/components/combobox.multi-select-root.tsx
+++ b/packages/nimbus/src/components/combobox/components/combobox.multi-select-root.tsx
@@ -103,15 +103,15 @@ export const MultiSelectRoot = <T extends object>({
       // Set state value
       setOpen(open);
       // When popover goes from open to closed, prevent immediate focus from opening it again (eg when esc key hit, or click outside popover)
-      // TODO: this is definitely a hack, at some point focus management
-      // should be better handled so that there is a set of conditions that
-      // we can use to reliably toggle on focus
+      // Use requestAnimationFrame + setTimeout to ensure focus events have completed
       if (!open) {
         preventNextFocusOpen.current = true;
-        // Reset the flag after a short delay
-        setTimeout(() => {
-          preventNextFocusOpen.current = false;
-        }, 100);
+        // Use RAF to wait for the current frame to complete, then add a small buffer
+        requestAnimationFrame(() => {
+          setTimeout(() => {
+            preventNextFocusOpen.current = false;
+          }, 50);
+        });
       }
     },
     [isDisabled, isReadOnly, onOpenChangeProp, isOpen]

--- a/packages/nimbus/src/components/combobox/components/combobox.single-select-input.tsx
+++ b/packages/nimbus/src/components/combobox/components/combobox.single-select-input.tsx
@@ -22,9 +22,30 @@ export const SingleSelectInput = (props: SingleSelectInputProps) => {
   const [inputProps, inputRef] = useContextProps({}, ref || null, InputContext);
   // This component exists because it has to be a child of the root to get the combobox state
   const state = useContext(ComboBoxStateContext);
-  // this method checks the inputValue against the textValue of every item in the collection, and if it doesnt match any items, sets a custom value
+
   const handleInputKeyDown = useCallback(
+    // This method clears the input if the user has focused on a pre-populated combobox and starts typing
     (e: KeyboardEvent) => {
+      if (
+        state?.selectedKey &&
+        inputRef.current &&
+        // cursor is at the beginning of input...
+        inputRef.current.selectionStart === 0 &&
+        inputRef.current.selectionEnd === 0 &&
+        // ...and it has a value, which can only happen on focus
+        inputRef.current.value.length > 0 &&
+        e.key.length === 1 && // Single character key
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        // Set the input value to the typed key (which clears the previous value)
+        state.setInputValue(e.key);
+        return;
+      }
+      // This method checks the inputValue against the textValue of every item in the collection, and if it doesnt match any items, sets a custom value
       if (
         e.key === "Enter" &&
         inputValue &&

--- a/packages/nimbus/src/components/combobox/components/combobox.single-select-root.tsx
+++ b/packages/nimbus/src/components/combobox/components/combobox.single-select-root.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useRef } from "react";
 import {
   ComboBox as RaComboBox,
   Popover as RaPopover,
@@ -15,6 +16,7 @@ export const SingleSelectRoot = <T extends object>({
   allowsCustomValue,
   onSubmitCustomValue,
   renderEmptyState,
+  shouldFocusWrap = true,
   isLoading,
   ref,
   ...rest
@@ -25,17 +27,27 @@ export const SingleSelectRoot = <T extends object>({
       'ComboBox: When "onSubmitCustomValue" is provided, "inputValue" must be controlled with "onInputChange"'
     );
   }
-
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleFocus = useCallback(() => {
+    // If the input has a value on focus, put the cursor to the beginning of the input so that it can be cleared if the user enters text
+    if (inputRef.current && inputRef.current.value) {
+      // Chrome will force the cursor to the end if we don't wait for the rendering frame to complete
+      requestAnimationFrame(() => inputRef.current?.setSelectionRange(0, 0));
+    }
+  }, [inputRef]);
   return (
     <RaComboBox
       inputValue={inputValue}
       onInputChange={onInputChange}
+      onFocus={handleFocus}
       allowsCustomValue={allowsCustomValue}
       menuTrigger="focus"
+      shouldFocusWrap={shouldFocusWrap}
       {...rest}
       ref={ref}
     >
       <SingleSelectInput
+        ref={inputRef}
         placeholder={placeholder}
         inputValue={inputValue}
         allowsCustomValue={allowsCustomValue}


### PR DESCRIPTION
Updates the single-select combobox to better handle user input in cases where the combobox has a previous value set.

When there is a `selectedKey` set on the single select, the user can more easily update it by typing in the input:

- when the input gains focus, the cursor moves to the beginning of the input
- if the user enters text, the previous value is cleared and that text is displayed
- if the user selects an option, the new option is the displayed value
- if the user does not select an option, the selected value replaces the user's input when the combobox is blurred.

Current `main`:
![Screen Recording 2025-06-25 at 2 40 24 PM](https://github.com/user-attachments/assets/cdd92beb-d167-48f9-910a-e67a5f48afe8)

This branch:
![Screen Recording 2025-06-25 at 2 40 53 PM](https://github.com/user-attachments/assets/112928ff-da7a-455c-b90f-9514324c41fc)

Also makes focus management when toggling the dropdown more robust, and uses `closePopover` method consistently in tests.
