### PR TITLE
CRAFT 1506 | Tooltip positioning and documentation fixes

### DIFF
--- a/packages/nimbus/src/components/icon-button/icon-button.mdx
+++ b/packages/nimbus/src/components/icon-button/icon-button.mdx
@@ -163,20 +163,20 @@ const App = () => {
 
 #### Tooltip
 
-For accessibility compliance (and good user experience for all) all icon buttons
-must have a tooltip. Go to tooltips for more formation about the component.
+For accessibility compliance (and good user experience for all) icon buttons
+that do not have a label must have a tooltip. Go to tooltips for more information about the component.
 
 ```jsx-live
 const App = () => {
   return (
-    <TooltipTrigger delay={0} closeDelay={0}>
+    <Tooltip.Root delay={0} closeDelay={0}>
       <IconButton variant="ghost" tone="primary">
         <Icons.Edit/>
       </IconButton>
-      <Tooltip>
+      <Tooltip.Content>
         Edit
-      </Tooltip>
-    </TooltipTrigger>
+      </Tooltip.Content>
+    </Tooltip.Root>
   );
 };
 ```

--- a/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
+++ b/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
@@ -11,10 +11,15 @@ import type { TooltipTriggerComponentProps } from "react-aria-components";
  *
  * This acts as the context provider for the compound Tooltip component.
  */
-export function TooltipRoot(props: TooltipTriggerComponentProps) {
+export function TooltipRoot({
+  // Match delays to current ui-kit tooltip
+  delay = "300",
+  closeDelay = "200",
+  ...props
+}: TooltipTriggerComponentProps) {
   // Note: In React 19, ref forwarding is automatic for function components
   // The ref should be placed on the trigger element directly when needed
-  return <TooltipTrigger {...props} />;
+  return <TooltipTrigger delay={delay} closeDelay={closeDelay} {...props} />;
 }
 
 TooltipRoot.displayName = "Tooltip.Root";

--- a/packages/nimbus/src/components/tooltip/tooltip.mdx
+++ b/packages/nimbus/src/components/tooltip/tooltip.mdx
@@ -29,9 +29,10 @@ Tooltips offer concise, non-obtrusive guidance and supplemental information, enh
 
 Deep dive on details and access design library.
 
-[TECH RELATED LINK](https://react-spectrum.adobe.com/react-aria/Tooltip.html#tooltip)
-[TECH RELATED LINK](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)
+[React-Aria Tooltip Docs](https://react-spectrum.adobe.com/react-aria/Tooltip.html#tooltip)
+[ARIA Tooltip Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)
 [Figma library](https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=1695-45519&m)
+
 
 ## API
 
@@ -42,7 +43,7 @@ The Tooltip component is structured as a compound component with two main parts:
 The root component that wraps around a trigger element and manages the tooltip state. It handles opening and closing the tooltip when the user hovers over or focuses the trigger.
 
 **Props:**
-- `delay?: number` - Delay in milliseconds before showing the tooltip (default: 1500)
+- `delay?: number` - Delay in milliseconds before showing the tooltip (default: **1500**)
 - `closeDelay?: number` - Delay in milliseconds before hiding the tooltip (default: 500)
 - `isOpen?: boolean` - Controls the open state of the tooltip
 - `defaultOpen?: boolean` - Sets the initial open state of the tooltip
@@ -156,19 +157,19 @@ Control where the tooltip appears relative to its trigger:
 ```jsx-live
 const App = () => (
   <Stack direction="horizontal" alignItems="center" marginLeft="800" padding="800" gap="400">
-    <Tooltip.Root>
+    <Tooltip.Root delay={0}>
       <Button>Top placement</Button>
       <Tooltip.Content placement="top">Tooltip on top</Tooltip.Content>
     </Tooltip.Root>
-    <Tooltip.Root>
+    <Tooltip.Root delay={0}>
       <Button>Bottom placement</Button>
       <Tooltip.Content placement="bottom">Tooltip on bottom</Tooltip.Content>
     </Tooltip.Root>
-    <Tooltip.Root>
+    <Tooltip.Root delay={0}>
       <Button>Left placement</Button>
       <Tooltip.Content placement="left">Tooltip on left</Tooltip.Content>
     </Tooltip.Root>
-    <Tooltip.Root>
+    <Tooltip.Root delay={0}>
       <Button>Right placement</Button>
       <Tooltip.Content placement="right">Tooltip on right</Tooltip.Content>
     </Tooltip.Root>

--- a/packages/nimbus/src/theme/global-css.ts
+++ b/packages/nimbus/src/theme/global-css.ts
@@ -70,6 +70,13 @@ export const globalCss = defineGlobalStyles({
    * values set in @reset layer by preflight option:
    * https://github.com/chakra-ui/chakra-ui/blob/main/packages/react/src/styled-system/preflight.ts
    */
+  body: {
+    /** stops reset layer from triggering react-aria bug in overlay/tooltip positioning:
+     * https://github.com/adobe/react-spectrum/issues/7654
+     * https://github.com/adobe/react-spectrum/issues/7960
+     */
+    position: "initial",
+  },
   "img, svg, video, canvas, audio, iframe, embed, object": {
     display: "initial",
     verticalAlign: "initial",


### PR DESCRIPTION
feat(tooltips): update IconButton docs to use compound tooltip component, update tooltip delay to match ui-kit, update tooltip docs links to have labels, override position: relative style on document.body from chakra reset layer that was triggering a react-aria overlay positioning bug that was causing tooltips to not position themselves correctly to the left or right

This pull request introduces updates to the tooltip functionality and accessibility in the `nimbus` package. The changes include improvements to tooltip components, updates to documentation for clarity, and a fix for a positioning bug in `react-aria`. Below is a breakdown of the most important changes:

### Tooltip Component Enhancements:
* Updated `Tooltip.Root` to support `delay` and `closeDelay` props, allowing customization of tooltip timing. This change aligns with the current UI kit behavior. (`packages/nimbus/src/components/tooltip/components/tooltip.root.tsx`, [packages/nimbus/src/components/tooltip/components/tooltip.root.tsxL14-R22](diffhunk://#diff-d33f287ca0d02ae816ab921d54943ee2e04d68adf6699d4a550672f1c8c242faL14-R22))
* Replaced `TooltipTrigger` with `Tooltip.Root` and `Tooltip.Content` in examples to simplify the tooltip structure and improve accessibility compliance. (`packages/nimbus/src/components/icon-button/icon-button.mdx`, [packages/nimbus/src/components/icon-button/icon-button.mdxL166-R179](diffhunk://#diff-0131510eb66a9f6fe98b121074bc68d5dd7f26f617f1afa3d03f42ae47d68fa3L166-R179))

### Documentation Improvements:
* Replaced technical links with clearer labels, such as "React-Aria Tooltip Docs" and "ARIA Tooltip Pattern," for better readability. (`packages/nimbus/src/components/tooltip/tooltip.mdx`, [packages/nimbus/src/components/tooltip/tooltip.mdxL32-R36](diffhunk://#diff-acb587ae0ef3b527abab9399c9e6a2fdc05354a8d87618410e8a4b6343ce0cfaL32-R36))
* Enhanced tooltip API documentation by emphasizing default values and improving formatting for clarity. (`packages/nimbus/src/components/tooltip/tooltip.mdx`, [packages/nimbus/src/components/tooltip/tooltip.mdxL45-R46](diffhunk://#diff-acb587ae0ef3b527abab9399c9e6a2fdc05354a8d87618410e8a4b6343ce0cfaL45-R46))

### Bug Fixes:
* Added a global CSS rule to prevent a `react-aria` bug affecting overlay/tooltip positioning by setting the `body` element's `position` to `initial`. (`packages/nimbus/src/theme/global-css.ts`, [packages/nimbus/src/theme/global-css.tsR73-R79](diffhunk://#diff-5b190fc13c1696654d03f2915a818843e87bf1857856e9dd386564b01ce1b408R73-R79))