### PR TITLE
Craft 1567 | implement jsdom polyfill helper

### DIFF
--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.8",
+  "version": "0.0.9-rc1",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.9-rc1",
+  "version": "0.0.9-rc2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",
@@ -16,7 +16,13 @@
         "default": "./dist/index.cjs"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./setupJsdomPolyfills": {
+      "require": {
+        "types": "./dist/setup-jsdom-polyfills.d.ts",
+        "default": "./dist/setup-jsdom-polyfills.cjs.js"
+      }
+    }
   },
   "files": [
     "dist",

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.9-rc4",
+  "version": "0.0.9-rc5",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.9-rc2",
+  "version": "0.0.9-rc3",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",
@@ -9,7 +9,7 @@
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "default": "./dist/index.es.js"
       },
       "require": {
         "types": "./dist/index.d.ts",
@@ -20,7 +20,7 @@
     "./setupJsdomPolyfills": {
       "require": {
         "types": "./dist/setup-jsdom-polyfills.d.ts",
-        "default": "./dist/setup-jsdom-polyfills.cjs.js"
+        "default": "./dist/setup-jsdom-polyfills.cjs"
       }
     }
   },

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.9-rc3",
+  "version": "0.0.9-rc4",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",
@@ -19,7 +19,6 @@
     "./package.json": "./package.json",
     "./setupJsdomPolyfills": {
       "require": {
-        "types": "./dist/setup-jsdom-polyfills.d.ts",
         "default": "./dist/setup-jsdom-polyfills.cjs"
       }
     }

--- a/packages/nimbus/src/index.ts
+++ b/packages/nimbus/src/index.ts
@@ -1,4 +1,3 @@
 export * from "./components";
 export * from "./hooks";
 export * from "./theme";
-export * from "./test/setup-jsdom-polyfills";

--- a/packages/nimbus/src/index.ts
+++ b/packages/nimbus/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./components";
 export * from "./hooks";
 export * from "./theme";
+export * from "./test/setup-jsdom-polyfills";

--- a/packages/nimbus/src/test/setup-jsdom-polyfills.ts
+++ b/packages/nimbus/src/test/setup-jsdom-polyfills.ts
@@ -1,0 +1,39 @@
+export function setupJsdomPolyfills() {
+  // implementation of structuredClone polyfill to satisfy the Nimbus (Chakra UI) provider
+  if (typeof global.structuredClone !== "function") {
+    global.structuredClone = function structuredClone(value) {
+      if (value === null || value === undefined) {
+        return value;
+      }
+
+      try {
+        // For objects and arrays, use JSON methods
+        if (typeof value === "object") {
+          return JSON.parse(JSON.stringify(value));
+        }
+        // For primitive values, return directly
+        return value;
+      } catch (error) {
+        console.warn("structuredClone polyfill failed:", error);
+
+        // Returns a shallow copy as fallback
+        return Array.isArray(value) ? [...value] : { ...value };
+      }
+    };
+  }
+
+  // Polyfill window.matchMedia for JSDOM (used by Nimbus/Chakra for theming)
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: unknown) => ({
+      matches: false, // Default value, tests can override if needed
+      media: query,
+      onchange: null,
+      addListener: () => {}, // Deprecated but needed for some libs
+      removeListener: () => {}, // Deprecated but needed for some libs
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/packages/nimbus/src/test/setup-jsdom-polyfills.ts
+++ b/packages/nimbus/src/test/setup-jsdom-polyfills.ts
@@ -1,4 +1,4 @@
-export function setupJsdomPolyfills() {
+function setupJsdomPolyfills() {
   // implementation of structuredClone polyfill to satisfy the Nimbus (Chakra UI) provider
   if (typeof global.structuredClone !== "function") {
     global.structuredClone = function structuredClone(value) {
@@ -37,3 +37,7 @@ export function setupJsdomPolyfills() {
     }),
   });
 }
+
+module.exports = {
+  setupJsdomPolyfills,
+};

--- a/packages/nimbus/src/test/setup-jsdom-polyfills.ts
+++ b/packages/nimbus/src/test/setup-jsdom-polyfills.ts
@@ -1,43 +1,52 @@
-function setupJsdomPolyfills() {
-  // implementation of structuredClone polyfill to satisfy the Nimbus (Chakra UI) provider
-  if (typeof global.structuredClone !== "function") {
-    global.structuredClone = function structuredClone(value) {
-      if (value === null || value === undefined) {
-        return value;
+/**
+ * Polyfills necessary for the `NimbusProvider` not to crash in JSDOM environments (e.g. jest)
+ *
+ * To use with jest, update jest config like so:
+ * config = {
+ *   ...
+ *   setupFiles: [
+ *     '@commercetools/nimbus/setupJsdomPolyfills`,
+ *     ...
+ *  ]
+ * }
+ */
+
+// TODO: document this somewhere besides this file
+
+// implementation of structuredClone polyfill to satisfy the Nimbus (Chakra UI) provider
+if (typeof global.structuredClone !== "function") {
+  global.structuredClone = function structuredClone(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    try {
+      // For objects and arrays, use JSON methods
+      if (typeof value === "object") {
+        return JSON.parse(JSON.stringify(value));
       }
+      // For primitive values, return directly
+      return value;
+    } catch (error) {
+      console.warn("structuredClone polyfill failed:", error);
 
-      try {
-        // For objects and arrays, use JSON methods
-        if (typeof value === "object") {
-          return JSON.parse(JSON.stringify(value));
-        }
-        // For primitive values, return directly
-        return value;
-      } catch (error) {
-        console.warn("structuredClone polyfill failed:", error);
-
-        // Returns a shallow copy as fallback
-        return Array.isArray(value) ? [...value] : { ...value };
-      }
-    };
-  }
-
-  // Polyfill window.matchMedia for JSDOM (used by Nimbus/Chakra for theming)
-  Object.defineProperty(window, "matchMedia", {
-    writable: true,
-    value: (query: unknown) => ({
-      matches: false, // Default value, tests can override if needed
-      media: query,
-      onchange: null,
-      addListener: () => {}, // Deprecated but needed for some libs
-      removeListener: () => {}, // Deprecated but needed for some libs
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-    }),
-  });
+      // Returns a shallow copy as fallback
+      return Array.isArray(value) ? [...value] : { ...value };
+    }
+  };
 }
 
-module.exports = {
-  setupJsdomPolyfills,
-};
+// Polyfill window.matchMedia for JSDOM (used by Nimbus/Chakra for theming)
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: unknown) => ({
+    matches: false, // Default value, tests can override if needed
+    media: query,
+    onchange: null,
+    addListener: () => {}, // Deprecated but needed for some libs
+    removeListener: () => {}, // Deprecated but needed for some libs
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -46,9 +46,13 @@ export const baseConfig = {
   build: {
     sourcemap: true,
     lib: {
-      entry: resolve(__dirname, "./src/index.ts"),
+      entry: [
+        resolve(__dirname, "./src/index.ts"),
+        resolve(__dirname, "./src/test/setup-jsdom-polyfills.ts"),
+      ],
       name: "nimbus",
-      fileName: "index",
+      fileName: (format: string, entryName: string) =>
+        `${entryName}.${format}.js`,
       formats: ["es", "cjs"] satisfies LibraryFormats[],
     },
     rollupOptions: {

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -52,7 +52,12 @@ export const baseConfig = {
       ],
       name: "nimbus",
       fileName: (format: string, entryName: string) =>
-        `${entryName}.${format}.js`,
+        // `cjs` files need to end in `.cjs` when `type: module` is set in package.json,
+        // otherwise you get an error when you `require` them
+        format === "cjs"
+          ? `${entryName}.${format}`
+          : `${entryName}.${format}.js`,
+
       formats: ["es", "cjs"] satisfies LibraryFormats[],
     },
     rollupOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     '@emotion/is-prop-valid':
       specifier: ^1.3.1
       version: 1.3.1
-    '@emotion/react':
-      specifier: ^11.14.0
-      version: 11.14.0
     '@internationalized/date':
       specifier: ^3.8.0
       version: 3.8.2
@@ -43,18 +40,6 @@ catalogs:
       specifier: ^19.0.0
       version: 19.1.0
   tooling:
-    '@babel/core':
-      specifier: ^7.27.1
-      version: 7.27.1
-    '@babel/preset-typescript':
-      specifier: ^7.27.1
-      version: 7.27.1
-    '@eslint/js':
-      specifier: ^9.28.0
-      version: 9.28.0
-    '@preconstruct/cli':
-      specifier: ^2.8.12
-      version: 2.8.12
     '@storybook/addon-a11y':
       specifier: ^9.0.13
       version: 9.0.13
@@ -76,9 +61,6 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: ^4.4.1
       version: 4.4.1
-    '@vitejs/plugin-react-swc':
-      specifier: ^3.9.0
-      version: 3.9.0
     '@vitest/browser':
       specifier: ^3.2.4
       version: 3.2.4
@@ -88,42 +70,12 @@ catalogs:
     '@vueless/storybook-dark-mode':
       specifier: ^9.0.5
       version: 9.0.5
-    eslint:
-      specifier: ^9.26.0
-      version: 9.26.0
-    eslint-config-prettier:
-      specifier: ^10.1.2
-      version: 10.1.2
-    eslint-plugin-prettier:
-      specifier: ^5.4.0
-      version: 5.4.0
-    eslint-plugin-react-hooks:
-      specifier: ^5.2.0
-      version: 5.2.0
-    eslint-plugin-react-refresh:
-      specifier: ^0.4.20
-      version: 0.4.20
-    globals:
-      specifier: ^16.0.0
-      version: 16.0.0
-    hygen:
-      specifier: ^6.2.11
-      version: 6.2.11
     playwright:
       specifier: ^1.52.0
       version: 1.52.0
-    prettier:
-      specifier: ^3.5.3
-      version: 3.5.3
     storybook:
       specifier: ^9.0.13
       version: 9.0.13
-    tsx:
-      specifier: ^4.19.4
-      version: 4.19.4
-    typescript-eslint:
-      specifier: ^8.32.0
-      version: 8.32.0
     vite:
       specifier: ^6.3.5
       version: 6.3.5
@@ -136,16 +88,6 @@ catalogs:
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
-  utils:
-    '@types/lodash':
-      specifier: ^4.17.16
-      version: 4.17.16
-    '@types/node':
-      specifier: ^24.0.3
-      version: 24.0.3
-    lodash:
-      specifier: ^4.17.21
-      version: 4.17.21
 
 overrides:
   rollup: ^4.34.2
@@ -606,7 +548,7 @@ importers:
     devDependencies:
       '@babel/preset-typescript':
         specifier: catalog:tooling
-        version: 7.27.1(@babel/core@7.27.1)
+        version: 7.27.1(@babel/core@7.27.7)
       '@tokens-studio/sd-transforms':
         specifier: ^2.0.0
         version: 2.0.0(style-dictionary@4.3.3)
@@ -643,12 +585,24 @@ packages:
     resolution: {integrity: sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.27.7':
+    resolution: {integrity: sha512-xgu/ySj2mTiUFmdE9yCMfBxLp4DHd5DwmbbD05YAuICfodYT3VvRxbrh81LGQ/8UpSdtMdfKMn3KouYDX59DGQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.27.1':
     resolution: {integrity: sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@7.27.7':
+    resolution: {integrity: sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.27.1':
     resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.5':
+    resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.1':
@@ -657,6 +611,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.27.1':
     resolution: {integrity: sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.27.1':
@@ -675,6 +633,12 @@ packages:
 
   '@babel/helper-module-transforms@7.27.1':
     resolution: {integrity: sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.27.3':
+    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -713,8 +677,17 @@ packages:
     resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helpers@7.27.6':
+    resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.27.1':
     resolution: {integrity: sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.27.7':
+    resolution: {integrity: sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -768,12 +741,24 @@ packages:
     resolution: {integrity: sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.27.1':
     resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.27.7':
+    resolution: {integrity: sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.27.1':
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.7':
+    resolution: {integrity: sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -7200,6 +7185,8 @@ snapshots:
 
   '@babel/compat-data@7.27.1': {}
 
+  '@babel/compat-data@7.27.7': {}
+
   '@babel/core@7.27.1':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -7220,10 +7207,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.27.7':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.27.7)
+      '@babel/helpers': 7.27.6
+      '@babel/parser': 7.27.7
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.27.7
+      '@babel/types': 7.27.7
+      convert-source-map: 2.0.0
+      debug: 4.4.1
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.27.1':
     dependencies:
       '@babel/parser': 7.27.1
       '@babel/types': 7.27.1
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/generator@7.27.5':
+    dependencies:
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
@@ -7240,13 +7255,21 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.27.1)':
+  '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/compat-data': 7.27.7
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.27.1
       semver: 6.3.1
@@ -7256,7 +7279,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
       '@babel/traverse': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7276,15 +7299,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.27.1(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.27.3(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.7
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.27.1)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.27.7)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.7
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.27.1
@@ -7309,24 +7350,41 @@ snapshots:
       '@babel/template': 7.27.1
       '@babel/types': 7.27.1
 
+  '@babel/helpers@7.27.6':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.7
+
   '@babel/parser@7.27.1':
     dependencies:
       '@babel/types': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.27.1)':
+  '@babel/parser@7.27.7':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/types': 7.27.7
+
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.27.7)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.7)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -7341,25 +7399,25 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typescript@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-typescript@7.27.1(@babel/core@7.27.7)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.7
       '@babel/helper-annotate-as-pure': 7.27.1
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.27.7)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.1)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.27.1(@babel/core@7.27.1)':
+  '@babel/preset-typescript@7.27.1(@babel/core@7.27.7)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.27.1)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.7)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.27.7)
+      '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.27.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -7370,6 +7428,12 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.27.1
       '@babel/types': 7.27.1
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
 
   '@babel/traverse@7.27.1':
     dependencies:
@@ -7383,7 +7447,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.27.7':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.7
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.7
+      debug: 4.4.1
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.27.7':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1


### PR DESCRIPTION
In order for nimbus to be testable in test runners that rely on jsdom (`jest`, `vitest`), it is necessary to set up some browser polyfills. This pull request adds a polyfill helper function to satisfy the Nimbus (Chakra UI) provider.