### PR TITLE
FCT 1611 | icons documentation: icons display their name in a tooltip

### DIFF
--- a/apps/docs/src/components/document-renderer/components/token-demos/icon-search/icon-search.tsx
+++ b/apps/docs/src/components/document-renderer/components/token-demos/icon-search/icon-search.tsx
@@ -5,6 +5,8 @@ import {
   Stack,
   SimpleGrid,
   useCopyToClipboard,
+  Tooltip,
+  MakeElementFocusable,
 } from "@commercetools/nimbus";
 import { useEffect, useState } from "react";
 import take from "lodash/take";
@@ -57,22 +59,27 @@ export const IconSearch = () => {
         {take(filteredIcons ?? [], q.length ? 128 : 256).map((iconId) => {
           const Component = icons[iconId as keyof typeof icons];
           return (
-            <Flex
-              p="400"
-              border="solid-25"
-              borderColor="neutral.5"
-              ml="-1px"
-              mb="-1px"
-              aspectRatio={1}
-              cursor={"pointer"}
-              _hover={{ bg: "neutral.2" }}
-              onClick={() => onCopyRequest(iconId)}
-              key={iconId}
-            >
-              <Text m="auto" textStyle="3xl" color="neutral.12">
-                <Component />
-              </Text>
-            </Flex>
+            <Tooltip.Root>
+              <MakeElementFocusable>
+                <Flex
+                  p="400"
+                  border="solid-25"
+                  borderColor="neutral.5"
+                  ml="-1px"
+                  mb="-1px"
+                  aspectRatio={1}
+                  cursor={"pointer"}
+                  _hover={{ bg: "neutral.2" }}
+                  onClick={() => onCopyRequest(iconId)}
+                  key={iconId}
+                >
+                  <Text m="auto" textStyle="3xl" color="neutral.12">
+                    <Component />
+                  </Text>
+                </Flex>
+              </MakeElementFocusable>
+              <Tooltip.Content>{iconId}</Tooltip.Content>
+            </Tooltip.Root>
           );
         })}
       </SimpleGrid>


### PR DESCRIPTION
This pull request introduces enhancements to the `IconSearch` component in `apps/docs/src/components/document-renderer/components/token-demos/icon-search/icon-search.tsx`. The changes improve accessibility and usability by adding tooltips and focusable elements.

### Accessibility improvements:
* Added `Tooltip` and `MakeElementFocusable` imports to enable tooltips and focusable elements for better accessibility. (`apps/docs/src/components/document-renderer/components/token-demos/icon-search/icon-search.tsx`)
* Wrapped each icon in `Tooltip.Root` and `MakeElementFocusable` to allow keyboard focus and display a tooltip with the icon ID. (`apps/docs/src/components/document-renderer/components/token-demos/icon-search/icon-search.tsx`) [[1]](diffhunk://#diff-2dc2340eea7d16a1c3b88b8fbc8b3e1b258c73f5b129b8294ce167ddcc68b3edR62-R63) [[2]](diffhunk://#diff-2dc2340eea7d16a1c3b88b8fbc8b3e1b258c73f5b129b8294ce167ddcc68b3edR80-R82)