### PR TITLE
Add bundle analysis tool/script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tsx": "catalog:tooling",
     "typescript": "catalog:tooling",
     "typescript-eslint": "catalog:tooling",
+    "vite-bundle-analyzer": "catalog:tooling",
     "vitest": "catalog:tooling"
   }
 }

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -93,6 +93,7 @@
     "dev": "vite build --watch",
     "test": "vitest",
     "build-theme-typings": "pnpm chakra typegen ./src/theme/index.ts",
+    "bundles:analyze": "ANALYZE_BUNDLE=true vite build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   }

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -6,6 +6,7 @@ import type { LibraryFormats } from "vite";
 import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 import dts from "vite-plugin-dts";
+import { analyzer } from "vite-bundle-analyzer";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -71,12 +72,15 @@ export const baseConfig = {
 
 export default defineConfig((/* config */) => {
   const isWatchMode = process.argv.includes("--watch");
+  const isAnalyzeMode = !!process.env.ANALYZE_BUNDLE;
 
   const config = baseConfig;
 
   if (!isWatchMode) {
     config.plugins.push(dts({ rollupTypes: true }));
   }
-
+  if (isAnalyzeMode) {
+    config.plugins.push(analyzer());
+  }
   return config;
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ catalogs:
     vite:
       specifier: ^6.3.5
       version: 6.3.5
+    vite-bundle-analyzer:
+      specifier: ^1.0.0
+      version: 1.0.0
     vite-plugin-dts:
       specifier: ^4.5.4
       version: 4.5.4
@@ -200,6 +203,9 @@ importers:
       typescript-eslint:
         specifier: catalog:tooling
         version: 8.32.0(eslint@9.26.0)(typescript@5.8.3)
+      vite-bundle-analyzer:
+        specifier: catalog:tooling
+        version: 1.0.0
       vitest:
         specifier: catalog:tooling
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/browser@3.2.4)(msw@2.7.0(@types/node@24.0.3)(typescript@5.8.3))(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0)
@@ -6985,6 +6991,10 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-bundle-analyzer@1.0.0:
+    resolution: {integrity: sha512-Y9u467LqvDyvvd7+6BVm9drgIUGrRbZHcV//GUsziTvIKm+cQcREDrZFBiLzShvUokmUCA9BVeLGuIiNhkxGUQ==}
+    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -15833,6 +15843,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  vite-bundle-analyzer@1.0.0: {}
 
   vite-node@3.2.4(@types/node@24.0.3)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ catalogs:
     "@vitejs/plugin-react": ^4.4.1
     "@vitejs/plugin-react-swc": ^3.10.2
     vite: ^6.3.5
+    vite-bundle-analyzer: ^1.0.0
     vite-plugin-dts: ^4.5.4
     vite-tsconfig-paths: ^5.1.4
     rollup: ^4.44.1


### PR DESCRIPTION
Adds vite-bundle-analyzer vite plugin and bundles:analyze script to enable visual analysis of bundle size.

To use, run `pnpm bundles:analyze` from the `packages/nimbus` directory.
![Screenshot 2025-07-03 at 12 56 16 PM](https://github.com/user-attachments/assets/b66cb6e9-fd28-4ab5-80cd-7ae849bc9755)
