### PR TITLE
fix(select, tag): update disabled recipe syntax

### DIFF
--- a/packages/nimbus/src/components/combobox/combobox.recipe.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.recipe.tsx
@@ -35,7 +35,7 @@ export const comboBoxSlotRecipe = defineSlotRecipe({
       _hover: {
         bg: "primary.2",
       },
-      '&[data-disabled="true"]': {
+      "&[data-disabled='true']": {
         layerStyle: "disabled",
         focusRing: "none",
         "& input, & button": {

--- a/packages/nimbus/src/components/select/select.recipe.tsx
+++ b/packages/nimbus/src/components/select/select.recipe.tsx
@@ -30,7 +30,7 @@ export const selectSlotRecipe = defineSlotRecipe({
       // [data-open]
       // [data-invalid]
       // [data-required]
-      "&[data-disabled]": {
+      '&[data-disabled="true"]': {
         layerStyle: "disabled",
         pointerEvents: "none",
       },

--- a/packages/nimbus/src/components/select/select.recipe.tsx
+++ b/packages/nimbus/src/components/select/select.recipe.tsx
@@ -30,7 +30,7 @@ export const selectSlotRecipe = defineSlotRecipe({
       // [data-open]
       // [data-invalid]
       // [data-required]
-      '&[data-disabled="true"]': {
+      "&[data-disabled='true']": {
         layerStyle: "disabled",
         pointerEvents: "none",
       },
@@ -149,7 +149,7 @@ export const selectSlotRecipe = defineSlotRecipe({
         textStyle: "xs",
       },
 
-      '&[data-disabled="true"]': {
+      "&[data-disabled='true']": {
         layerStyle: "disabled",
       },
     },

--- a/packages/nimbus/src/components/tag-group/tag-group.recipe.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.recipe.tsx
@@ -29,16 +29,16 @@ export const tagGroupSlotRecipe = defineSlotRecipe({
       fontSize: "400",
       lineHeight: "500",
       focusVisibleRing: "outside",
-      '&[data-disabled="true"] &': {
+      "&[data-disabled='true'] &": {
         layerStyle: "disabled",
         pointerEvents: "none",
       },
-      '&[data-selected="true"]': {
+      "&[data-selected='true']": {
         background: "colorPalette.9",
         color: "colorPalette.contrast",
         cursor: "button",
       },
-      '&[aria-selected="true"]': {
+      "&[aria-selected='true']": {
         cursor: "button",
       },
       "& [role='gridcell']": {

--- a/packages/nimbus/src/components/tag-group/tag-group.recipe.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.recipe.tsx
@@ -29,16 +29,16 @@ export const tagGroupSlotRecipe = defineSlotRecipe({
       fontSize: "400",
       lineHeight: "500",
       focusVisibleRing: "outside",
-      "&[data-disabled] &": {
+      '&[data-disabled="true"] &': {
         layerStyle: "disabled",
         pointerEvents: "none",
       },
-      "&[data-selected]": {
+      '&[data-selected="true"]': {
         background: "colorPalette.9",
         color: "colorPalette.contrast",
         cursor: "button",
       },
-      "&[aria-selected]": {
+      '&[aria-selected="true"]': {
         cursor: "button",
       },
       "& [role='gridcell']": {


### PR DESCRIPTION
This pull request updates the handling of `data-disabled`, `data-selected`, and `aria-selected` attributes in component recipes for `Tag` and `Select`.

Attribute handling updates:

* [`packages/nimbus/src/components/select/select.recipe.tsx`](diffhunk://#diff-31e6b790167ce54b8a21f8e6acbc6bea4c203887c19940743934640b618e224eL33-R33): Changed `&[data-disabled]` to `&[data-disabled="true"]` for more explicit attribute matching.
* [`packages/nimbus/src/components/tag-group/tag-group.recipe.tsx`](diffhunk://#diff-130e007c197b6a006ec1595c418ad56bcc54cefaef52fedfb070ab593acb4ff1L32-R41): Updated `&[data-disabled] &`, `&[data-selected]`, and `&[aria-selected]` to use explicit attribute-value pairs (`&[data-disabled="true"] &`, `&[data-selected="true"]`, and `&[aria-selected="true"]`). This ensures attribute values are clearly specified.