### PR TITLE
tech-time(docs): Improve dev-experience of nimbus consumers

### DIFF
--- a/packages/nimbus/src/components/accordion/accordion.mdx
+++ b/packages/nimbus/src/components/accordion/accordion.mdx
@@ -17,8 +17,6 @@ figmaLink: >-
 
 # Accordion
 
----
-
 A collapsable component lets users show and hide sections of related content on
 a page.
 

--- a/packages/nimbus/src/components/accordion/components/accordion-root.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-root.tsx
@@ -5,6 +5,13 @@ import { useSlotRecipe } from "@chakra-ui/react";
 import type { DisclosureGroupProps } from "../accordion.types";
 import { DisclosureGroupStateContext } from "../accordion-context";
 
+/**
+ * # Accordion
+ * 
+ * Displays an Accordion.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/navigation/accordion}
+ */
 export const AccordionRoot = forwardRef<HTMLDivElement, DisclosureGroupProps>(
   ({ children, onExpandedChange, ...props }, forwardedRef) => {
     const state = useDisclosureGroupState({

--- a/packages/nimbus/src/components/alert/alert.mdx
+++ b/packages/nimbus/src/components/alert/alert.mdx
@@ -17,8 +17,6 @@ figmaLink: >-
 
 # Alert
 
----
-
 For urgent, high-impact messages, such as system alerts, alert banners are used
 to ensure visibility and encourage immediate user response.
 

--- a/packages/nimbus/src/components/alert/components/alert.root.tsx
+++ b/packages/nimbus/src/components/alert/components/alert.root.tsx
@@ -37,9 +37,11 @@ export const AlertContext = createContext<AlertContextValue | undefined>(
 );
 
 /**
- * Alert
- * ============================================================
+ * # Alert
+ * 
  * Provides feedback to the user about the status of an action or system event
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/feedback/alert}
  */
 export const AlertRoot: AlertRootComponent = (props) => {
   const { ref, children, ...restProps } = props;

--- a/packages/nimbus/src/components/avatar/avatar.mdx
+++ b/packages/nimbus/src/components/avatar/avatar.mdx
@@ -16,8 +16,6 @@ figmaLink: >-
 
 # Avatar
 
----
-
 A small image or icon that identifies and personalizes the user within the
 interface.
 

--- a/packages/nimbus/src/components/badge/badge.tsx
+++ b/packages/nimbus/src/components/badge/badge.tsx
@@ -4,17 +4,11 @@ import type { BadgeProps } from "./badge.types";
 import { mergeRefs } from "@chakra-ui/react";
 import { useObjectRef, mergeProps } from "react-aria";
 /**
- * Badge
- * ============================================================
- * badge
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
- * - accepts all native html 'HTMLSpanElement' attributes (including aria- & data-attributes)
- * - supports 'variants', 'sizes', etc. configured in the recipe
- * - allows overriding styles by using style-props
- * - supports 'asChild' and 'as' to modify the underlying html-element (polymorphic)
+ * # Badge
+ * 
+ * Briefly highlights or categorizes associated UI elements with concise visual cues for status or metadata.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/data-display/badge}
  */
 
 export const Badge = (props: BadgeProps) => {

--- a/packages/nimbus/src/components/box/box.tsx
+++ b/packages/nimbus/src/components/box/box.tsx
@@ -5,6 +5,13 @@ export interface BoxProps extends HTMLChakraProps<"div"> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
+/**
+ * # Box
+ * 
+ * A basic layout component that serves as a wrapper or container.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/layout/box}
+ */
 export const Box = (props: BoxProps) => {
   const { ref, ...restProps } = props;
   return <ChakraBox ref={ref} {...restProps} />;

--- a/packages/nimbus/src/components/button/button.mdx
+++ b/packages/nimbus/src/components/button/button.mdx
@@ -17,8 +17,6 @@ figmaLink: >-
 
 # Button
 
----
-
 A button serves as a standardized, reusable component for triggering actions and
 navigating.
 

--- a/packages/nimbus/src/components/button/button.tsx
+++ b/packages/nimbus/src/components/button/button.tsx
@@ -5,6 +5,13 @@ import { mergeRefs } from "@chakra-ui/react";
 import { ButtonRoot } from "./button.slots.tsx";
 import type { ButtonProps } from "./button.types.ts";
 
+/**
+ * # Button
+ * 
+ * Displays a Button.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/button}
+ */
 export const Button = (props: ButtonProps) => {
   const { ref: forwardedRef, as, asChild, children, ...rest } = props;
 

--- a/packages/nimbus/src/components/calendar/calendar.tsx
+++ b/packages/nimbus/src/components/calendar/calendar.tsx
@@ -11,6 +11,13 @@ import { useRecipe } from "@chakra-ui/react";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 import { CalendarCustomContext } from "./components/calendar.custom-context";
 
+/**
+ * # Calendar
+ * 
+ * Calendars display a grid of days in one or more months and allow users to select a single date.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/calendar}
+ */
 export const Calendar = (props: CalendarProps<DateValue>) => {
   const recipe = useRecipe({ recipe: calendarSlotRecipe });
   const [recipeProps, remainingProps] = recipe.splitVariantProps(props);

--- a/packages/nimbus/src/components/card/card.mdx
+++ b/packages/nimbus/src/components/card/card.mdx
@@ -14,10 +14,6 @@ figmaLink: >-
   https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=1793-8790&m=dev
 ---
 
-# Card
-
----
-
 A versatile container component presents self-contained information, often combining text, images, and actions, making it ideal for displaying summaries or content previews.
 
 ## Overview

--- a/packages/nimbus/src/components/card/components/card.root.tsx
+++ b/packages/nimbus/src/components/card/components/card.root.tsx
@@ -13,6 +13,13 @@ export const CardContext = createContext<CardContextValue | undefined>(
   undefined
 );
 
+/**
+ * # Card
+ * 
+ * A versatile container component presents self-contained information
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/data-display/card}
+ */
 export const CardRoot = ({ children, ref, ...props }: CardProps) => {
   const { isFocused, isFocusVisible, focusProps } = useFocusRing();
   const [headerNode, setHeader] = useState<ReactNode>(null);

--- a/packages/nimbus/src/components/checkbox/checkbox.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.tsx
@@ -21,17 +21,11 @@ import {
 } from "./checkbox.slots";
 
 /**
- * Checkbox
- * ============================================================
- * displays a checkbox and an associated label
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
- * - accepts all native html 'HTMLDivElement' attributes (including aria- & data-attributes)
- * - supports 'variants', 'sizes', etc. configured in the recipe
- * - allows overriding styles by using style-props
- * - supports 'asChild' and 'as' to modify the underlying html-element (polymorphic)
+ * # Checkbox
+ * 
+ * Displays a checkbox.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/checkbox}
  */
 export const Checkbox = (props: CheckboxProps) => {
   const { ref: forwardedRef } = props;

--- a/packages/nimbus/src/components/code/code.tsx
+++ b/packages/nimbus/src/components/code/code.tsx
@@ -1,6 +1,12 @@
 import { Code as ChakraCode } from "@chakra-ui/react";
 
 /**
+ * # Code
+ * 
+ * renders code blocks
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/typography/code}
+ * 
  * @experimental This component is experimental and may change or be removed in future versions.
  */
 export const Code = ChakraCode;

--- a/packages/nimbus/src/components/combobox/components/combobox.root.tsx
+++ b/packages/nimbus/src/components/combobox/components/combobox.root.tsx
@@ -6,6 +6,13 @@ import { MultiSelectRoot } from "./combobox.multi-select-root";
 import type { ComboBoxRootProps } from "../combobox.types";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 
+/**
+ * # ComboBox
+ * 
+ * A combo box combines a text input with a dropdown list, allowing users to filter a list of options to items matching a query.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/combobox}
+ */
 export const ComboBoxRoot = <T extends object>({
   children,
   ref,

--- a/packages/nimbus/src/components/date-input/date-input.tsx
+++ b/packages/nimbus/src/components/date-input/date-input.tsx
@@ -15,9 +15,11 @@ import type { DateInputProps } from "./date-input.types";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 
 /**
- * DateInput
- * ============================================================
- * allows entering a date in the currently selected locale
+ * # DateInput
+ * 
+ * allows entering a date
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/dateinput}
  */
 export const DateInput = (props: DateInputProps) => {
   const recipe = useRecipe({ recipe: dateInputSlotRecipe });

--- a/packages/nimbus/src/components/date-picker/date-picker.tsx
+++ b/packages/nimbus/src/components/date-picker/date-picker.tsx
@@ -23,10 +23,11 @@ import { DatePickerTimeInput } from "./components/date-picker.time-input";
 import { DatePickerCustomContext } from "./components/date-picker.custom-context";
 
 /**
- * DatePicker
- * ============================================================
- * Combines a DateInput with a Calendar popover for date selection.
- * Users can either type a date directly or select from the calendar.
+ * # DatePicker
+ * 
+ * a UI component for users to enter or select a specific calendar date.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/datepicker}
  */
 export const DatePicker = (props: DatePickerProps) => {
   const { size = "md", variant, granularity = "day" } = props;

--- a/packages/nimbus/src/components/dialog/dialog.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.tsx
@@ -46,6 +46,12 @@ interface DialogComponents {
 }
 
 /**
+ * # Dialog
+ * 
+ * displays a dialog
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/feedback/dialog}
+ * 
  * @experimental This component is experimental and may change or be removed in future versions.
  */
 // Export the Dialog composite with proper typing

--- a/packages/nimbus/src/components/divider/divider.mdx
+++ b/packages/nimbus/src/components/divider/divider.mdx
@@ -12,10 +12,7 @@ menu:
 tags:
   - document
 ---
-
 # Divider
-
----
 
 A divider provides a visual separator between sections of content, improving readability and creating clear boundaries in layouts.
 
@@ -162,7 +159,5 @@ const App = () => (
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | The orientation of the divider |
 
 The component also accepts all standard Chakra UI styling props for customization (e.g., `borderColor`, `borderWidth`, `borderStyle`, etc.).
-
----
 
 *This component is built with React Aria for accessibility and uses Chakra UI's styling system.* 

--- a/packages/nimbus/src/components/flex/flex.tsx
+++ b/packages/nimbus/src/components/flex/flex.tsx
@@ -1,1 +1,8 @@
+/**
+ * # Flex
+ * 
+ * the Flex component is used to create layouts based on css display flex
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/layout/flex}
+ */
 export { Flex } from "@chakra-ui/react";

--- a/packages/nimbus/src/components/form-field/components/form-field.root.tsx
+++ b/packages/nimbus/src/components/form-field/components/form-field.root.tsx
@@ -25,9 +25,11 @@ import { Box, IconButton } from "@/components";
 import { ErrorOutline, HelpOutline } from "@commercetools/nimbus-icons";
 
 /**
- * FormField
- * ============================================================
- * displays inputs in a FormField context
+ * # FormField
+ * 
+ * displays miscellaneous inputs in a FormField context
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/formfield}
  */
 export const FormFieldRoot = forwardRef<HTMLDivElement, FormFieldProps>(
   (

--- a/packages/nimbus/src/components/grid/grid.tsx
+++ b/packages/nimbus/src/components/grid/grid.tsx
@@ -5,13 +5,11 @@ import {
 } from "@chakra-ui/react";
 
 /**
- * Grid
- * ============================================================
- * The Grid Layout Component provides a flexible and responsive way to structure content using a two-dimensional grid system. It allows elements to be arranged in rows and columns, enabling dynamic and efficient layouts for different screen sizes.
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
+ * # Grid
+ * 
+ * An easily customizable Grid component, re-exported from Chakra UI, that provides a consistent layout structure across different products.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/layout/grid}
  */
 export interface GridProps extends ChakraGridProps {
   children?: React.ReactNode;

--- a/packages/nimbus/src/components/heading/heading.tsx
+++ b/packages/nimbus/src/components/heading/heading.tsx
@@ -1,1 +1,8 @@
+/**
+ * # Heading
+ * 
+ * renders a heading
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/typography/heading}
+ */
 export { Heading } from "@chakra-ui/react";

--- a/packages/nimbus/src/components/icon-button/icon-button.mdx
+++ b/packages/nimbus/src/components/icon-button/icon-button.mdx
@@ -16,8 +16,6 @@ figmaLink: >-
 
 # Icon Button
 
----
-
 Provides a compact and visually efficient way to represent actions, especially
 when space is limited or the action is universally understood.
 

--- a/packages/nimbus/src/components/icon-button/icon-button.tsx
+++ b/packages/nimbus/src/components/icon-button/icon-button.tsx
@@ -5,10 +5,11 @@ import type { IconButtonProps } from "./icon-button.types";
 import { Button } from "@/components";
 
 /**
- * IconButton
- * ============================================================
- * displays a button with only an icon as child. It is based
- * on the regular `Button` component, but with a few adjustments.
+ * # IconButton
+ * 
+ * displays a button with an icon only as child
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/iconbutton}
  */
 export const IconButton = (props: IconButtonProps) => {
   const { children, ref: forwardedRef, ...restProps } = props;

--- a/packages/nimbus/src/components/icon/icon.tsx
+++ b/packages/nimbus/src/components/icon/icon.tsx
@@ -2,8 +2,11 @@ import { IconRootSlot } from "./icon.slots";
 import type { IconProps } from "./icon.types";
 
 /**
- * Icon
+ * # Icon
+ * 
  * displays icon components
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/media/icon}
  */
 export const Icon = (props: IconProps) => {
   const { ref, ...restProps } = props;

--- a/packages/nimbus/src/components/image/image.tsx
+++ b/packages/nimbus/src/components/image/image.tsx
@@ -7,9 +7,11 @@ import {
 export interface ImageProps extends ChakraImageProps {}
 
 /**
- * Image
- *
- * Use this component to display an image.
+ * # Image
+ * 
+ * A component to display images with support for fallback.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/media/image}
  */
 export const Image = (props: ImageProps) => {
   return <ChakraImage {...props} />;

--- a/packages/nimbus/src/components/kbd/kbd.tsx
+++ b/packages/nimbus/src/components/kbd/kbd.tsx
@@ -1,6 +1,11 @@
 import { Kbd as ChakraKbd } from "@chakra-ui/react";
 
 /**
+ * # Kbd
+ * 
+ * marks a string as keyboard input
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/typography/kbd}
  * @experimental This component is experimental and may change or be removed in future versions.
  */
 export const Kbd = ChakraKbd;

--- a/packages/nimbus/src/components/link/link.tsx
+++ b/packages/nimbus/src/components/link/link.tsx
@@ -5,17 +5,11 @@ import { useLink, useObjectRef, mergeProps } from "react-aria";
 import { mergeRefs } from "@chakra-ui/react";
 
 /**
- * Link
- * ============================================================
+ * # Link
+ * 
  * To allow a user to navigate to a different page or resource
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
- * - accepts all native html 'HTMLAnchorElement' attributes (including aria- & data-attributes)
- * - supports 'variants', 'sizes', etc. configured in the recipe
- * - allows overriding styles by using style-props
- * - supports 'asChild' and 'as' to modify the underlying html-element (polymorphic)
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/navigation/link}
  */
 export const Link = (props: LinkProps) => {
   const { as, asChild, children, ref: forwardedRef, ...rest } = props;

--- a/packages/nimbus/src/components/list/list.tsx
+++ b/packages/nimbus/src/components/list/list.tsx
@@ -5,6 +5,11 @@ const ListItem = ChakraList.Item;
 const ListIndicator = ChakraList.Indicator;
 
 /**
+ * # List
+ * 
+ * displays a list
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/typography/list}
  * @experimental This component is experimental and may change or be removed in future versions.
  */
 export const List = {

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.mdx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.mdx
@@ -14,10 +14,7 @@ figmaLink: >-
   https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=1699-52373&m=dev
 
 ---
-
-# Loading spinner
-
----
+# LoadingSpinner
 
 A visual indicator that displays the loading status of an ongoing process. It can represent either determinate or indeterminate progress.
 

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.tsx
@@ -8,9 +8,11 @@ const pointerPath =
   "M12 1.5C13.3789 1.5 14.7443 1.77159 16.0182 2.29927C17.2921 2.82694 18.4496 3.60036 19.4246 4.57538C20.3996 5.55039 21.1731 6.70791 21.7007 7.98183C22.2284 9.25574 22.5 10.6211 22.5 12";
 
 /**
- * LoadingSpinner
- * ============================================================
+ * # LoadingSpinner
+ * 
  * Indicates ongoing processes or loading states
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/feedback/loadingspinner}
  */
 export const LoadingSpinner = (props: LoadingSpinnerProps) => {
   const { ref, "aria-label": ariaLabel = "Loading data", ...restProps } = props;

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.tsx
@@ -9,17 +9,11 @@ import type { MultilineTextInputProps } from "./multiline-text-input.types";
 import { multilineTextInputRecipe } from "./multiline-text-input.recipe";
 
 /**
- * MultilineTextInput
- * ============================================================
- * A textarea component that takes in multiline text as input
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
- * - accepts all native html 'HTMLTextAreaElement' attributes (including aria- & data-attributes)
- * - supports 'variants', 'sizes', etc. configured in the recipe
- * - allows overriding styles by using style-props
- * - supports auto-growing height based on content when `autoGrow` is enabled
+ * # Multiline Text Input
+ * 
+ * A multiline text input component for capturing longer text content.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/forms/multiline-text-input}
  */
 export const MultilineTextInput = (props: MultilineTextInputProps) => {
   const { ref: forwardedRef, rows = 1, autoGrow = false, ...restProps } = props; // The default `rows` attribute for a textarea is 2, so we need to override it

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
@@ -4,6 +4,13 @@ import { system } from "@/theme";
 import type { NimbusProviderProps } from "./nimbus-provider.types";
 import { NimbusColorModeProvider } from "./components/nimbus-provider.color-mode-provider";
 
+/**
+ * # NimbusProvider
+ * 
+ * provides an environment for the rest of the components to work in
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/utilities/nimbusprovider}
+ */
 export function NimbusProvider({
   children,
   locale,

--- a/packages/nimbus/src/components/number-input/number-input.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.tsx
@@ -17,18 +17,11 @@ import {
 import type { NumberInputProps } from "./number-input.types";
 import { numberInputRecipe } from "./number-input.recipe";
 /**
- * NumberInput
- * ============================================================
- * An input component that accepts only numbers with increment/decrement buttons
- *
- * Features:
- *
- * - supports ref forwarding to the underlying DOM element
- * - supports number-specific props like min, max, step
- * - includes increment/decrement buttons for easy number adjustment
- * - supports 'variants', 'sizes', etc. configured in the recipe
- * - allows overriding styles by using style-props
- * - provides full accessibility support
+ * # NumberInput
+ * 
+ * A number input allows users to enter numerical values and adjust them incrementally.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/number-input}
  */
 export const NumberInput = (props: NumberInputProps) => {
   const { size, ref: forwardedRef, ...restProps } = props;

--- a/packages/nimbus/src/components/password-input/password-input.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.tsx
@@ -5,16 +5,11 @@ import { Visibility, VisibilityOff } from "@commercetools/nimbus-icons";
 import type { PasswordInputProps } from "./password-input.types";
 
 /**
- * PasswordInput
- * ============================================================
- * An input component that takes in password as input with toggleable visibility
- *
- * Features:
- *
- * - Based on TextInput with added password visibility toggle
- * - Allows toggling between type="password" and type="text"
- * - Positions the toggle button at the right edge of the input
- * - Inherits all TextInput features and props
+ * # PasswordInput
+ * 
+ * A password input is a text field that hides entered characters for secure password entry.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/passwordinput}
  */
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   (props, forwardedRef) => {

--- a/packages/nimbus/src/components/radio-input/components/radio-input.root.tsx
+++ b/packages/nimbus/src/components/radio-input/components/radio-input.root.tsx
@@ -5,6 +5,13 @@ import { extractStyleProps } from "@/utils/extractStyleProps";
 import type { RadioInputRootProps } from "../radio-input.types";
 import { RadioInputRootSlot } from "../radio-input.slots";
 
+/**
+ * # RadioInput
+ * 
+ * A set of closely related, mutually exclusive or complementary actions that are important enough to be displayed directly in the interface for quick access.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/radio-input}
+ */
 export const RadioInputRoot = (props: RadioInputRootProps) => {
   const recipe = useSlotRecipe({ recipe: radioInputSlotRecipe });
   const [recipeProps, restRecipeProps] = recipe.splitVariantProps(props);

--- a/packages/nimbus/src/components/select/components/select.root.tsx
+++ b/packages/nimbus/src/components/select/components/select.root.tsx
@@ -23,6 +23,13 @@ import { type SelectRootProps } from "./../select.types";
 import { selectSlotRecipe } from "../select.recipe";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 
+/**
+ * # Select
+ * 
+ * displays a collapsible list of options and allows a user to select one of them.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/select}
+ */
 export const SelectRoot = forwardRef<HTMLDivElement, SelectRootProps>(
   ({ children, isLoading, isDisabled, ...props }, ref) => {
     const recipe = useSlotRecipe({ recipe: selectSlotRecipe });

--- a/packages/nimbus/src/components/simple-grid/simple-grid.tsx
+++ b/packages/nimbus/src/components/simple-grid/simple-grid.tsx
@@ -5,13 +5,11 @@ import {
 } from "@chakra-ui/react";
 
 /**
- * SimpleGrid
- * ============================================================
- * The SimpleGrid Layout Component provides a flexible and responsive way to structure content.
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
+ * # SimpleGrid
+ * 
+ * displays a simple grid / matrix
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/layout/simplegrid}
  */
 export interface SimpleGridProps extends ChakraSimpleGridProps {
   children?: React.ReactNode;

--- a/packages/nimbus/src/components/stack/stack.tsx
+++ b/packages/nimbus/src/components/stack/stack.tsx
@@ -8,6 +8,13 @@ export interface StackProps extends ChakraStackProps {
   ref?: React.Ref<HTMLDivElement>;
 }
 
+/**
+ * # Stack
+ * 
+ * An easily customizable Stack component, re-exported from Chakra UI, that provides a consistent layout structure across different products.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/layout/stack}
+ */
 export const Stack = (props: StackProps) => {
   const { ref, ...restProps } = props;
   return <ChakraStack ref={ref} {...restProps} />;

--- a/packages/nimbus/src/components/switch/switch.tsx
+++ b/packages/nimbus/src/components/switch/switch.tsx
@@ -14,9 +14,11 @@ import {
 import { switchSlotRecipe } from "./switch.recipe";
 
 /**
- * Switch
- * ============================================================
- * displays a switch toggle and optionally an associated label
+ * # Switch
+ * 
+ * A clear, visual toggle, allowing users to activate or deactivate a setting quickly.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/switch}
  */
 export const Switch = ({ ref: externalRef, ...props }: SwitchProps) => {
   const localRef = useRef<HTMLInputElement>(null);

--- a/packages/nimbus/src/components/table/table.tsx
+++ b/packages/nimbus/src/components/table/table.tsx
@@ -1,1 +1,8 @@
+/**
+ * # Table
+ * 
+ * displays a table
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/data-display/table}
+ */
 export { Table } from "@chakra-ui/react";

--- a/packages/nimbus/src/components/tag-group/components/tag-group.root.tsx
+++ b/packages/nimbus/src/components/tag-group/components/tag-group.root.tsx
@@ -1,6 +1,13 @@
 import { TagGroupRootSlot } from "../tag-group.slots";
 import type { TagGroupRootComponent } from "../tag-group.types";
 
+/**
+ * # TagGroup
+ * 
+ * A tag group is a focusable list of labels, categories, keywords, filters, or other items, with support for keyboard navigation, selection, and removal.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/data-display/tag-group}
+ */
 export const TagGroupRoot: TagGroupRootComponent = ({
   children,
   onRemove,

--- a/packages/nimbus/src/components/tag-group/tag-group.mdx
+++ b/packages/nimbus/src/components/tag-group/tag-group.mdx
@@ -16,8 +16,6 @@ figmaLink: >-
 
 # TagGroup
 
----
-
 A tag group is a focusable list of labels, categories, keywords, filters, or other items, with support for keyboard navigation, selection, and removal.
 
 ## Overview

--- a/packages/nimbus/src/components/text-input/text-input.mdx
+++ b/packages/nimbus/src/components/text-input/text-input.mdx
@@ -13,7 +13,6 @@ tags:
 ---
 
 # TextInput
----
 
 Allows users to enter information like names, addresses, emails, passwords, search queries, or any other text-based data.
 

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -9,16 +9,11 @@ import type { TextInputProps } from "./text-input.types";
 import { textInputRecipe } from "./text-input.recipe";
 
 /**
- * TextInput
- * ============================================================
- * An input component that takes in text as input
- *
- * Features:
- *
- * - allows forwarding refs to the underlying DOM element
- * - accepts all native html 'HTMLInputElement' attributes (including aria- & data-attributes)
- * - supports 'variants', 'sizes', etc. configured in the recipe
- * - allows overriding styles by using style-props
+ * # TextInput
+ * 
+ * An input component that takes in a text as input
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/textinput}
  */
 export const TextInput = (props: TextInputProps) => {
   const { ref: forwardedRef, ...restProps } = props;

--- a/packages/nimbus/src/components/text/text.tsx
+++ b/packages/nimbus/src/components/text/text.tsx
@@ -10,9 +10,11 @@ export interface TextProps extends Omit<ChakraTextProps, "slot"> {
 }
 
 /**
- * Text
- *
- * Use this component to display text.
+ * # Text
+ * 
+ * the Text component is used to display text
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/typography/text}
  */
 export const Text = ({ ref: forwardedRef, ...props }: TextProps) => {
   const [contextProps, ref] = useContextProps(

--- a/packages/nimbus/src/components/toggle-button-group/components/toggle-button-group.root.tsx
+++ b/packages/nimbus/src/components/toggle-button-group/components/toggle-button-group.root.tsx
@@ -1,6 +1,13 @@
 import { ToggleButtonGroupRoot as ToggleButtonGroupRootSlot } from "../toggle-button-group.slots";
 import type { ToggleButtonGroupRootComponent } from "../toggle-button-group.types";
 
+/**
+ * # ToggleButtonGroup
+ * 
+ * A set of closely related, mutually exclusive or complementary actions that are important enough to be displayed directly in the interface for quick access.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/inputs/togglebuttongroup}
+ */
 export const ToggleButtonGroupRoot: ToggleButtonGroupRootComponent = (
   props
 ) => {

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
@@ -18,8 +18,6 @@ figmaLink: >-
 
 # Button Group
 
----
-
 A set of closely related, mutually exclusive or complementary actions that are important enough to be displayed directly in the interface for quick access.
 
 ## Overview

--- a/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
+++ b/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
@@ -3,13 +3,11 @@ import { TooltipTrigger } from "react-aria-components";
 import type { TooltipTriggerComponentProps } from "react-aria-components";
 
 /**
- * TooltipRoot
- * ============================================================
- * Root component that wraps around a trigger element and Tooltip content.
- * It handles opening and closing the Tooltip when the user hovers over or focuses the trigger,
- * and positioning the Tooltip relative to the trigger.
- *
- * This acts as the context provider for the compound Tooltip component.
+ * # Tooltip
+ * 
+ * A contextual popup that displays a description for an element.
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/feedback/tooltip}
  */
 export function TooltipRoot({
   // Match delays to current ui-kit tooltip

--- a/packages/nimbus/src/components/tooltip/tooltip.mdx
+++ b/packages/nimbus/src/components/tooltip/tooltip.mdx
@@ -17,8 +17,6 @@ figmaLink: >-
 
 # Tooltips
 
----
-
 Tooltips display informative text when users hover over or focus on an element.
 
 ## Overview

--- a/packages/nimbus/src/components/visually-hidden/visually-hidden.tsx
+++ b/packages/nimbus/src/components/visually-hidden/visually-hidden.tsx
@@ -10,6 +10,13 @@ export interface VisuallyHiddenProps
   as?: "span" | "div";
 }
 
+/**
+ * # VisuallyHidden
+ * 
+ * makes content accessible to screen readers but hides it visually
+ * 
+ * @see {@link https://nimbus-documentation.vercel.app/components/accessibility/visually-hidden}
+ */
 export const VisuallyHidden = (props: VisuallyHiddenProps) => {
   const { as = "div", ...leftoverProps } = props;
   return <ReactAriaViusallyHidden elementType={as} {...leftoverProps} />;


### PR DESCRIPTION
Nothing too exciting, essentially just adjustments of comments and docs, but hey, I think for consumers it'll be great if they can quickly access the docs.

I first though I'd need to create placeholders within the JSDoc comments and have some fancy process that replaces the placeholder with the corresponding live-domain (produciton or preview-branch), but honestly, all that matters is the live-domain and this kind of repetitive search and replace operations are perfect use-case for cursor.

<img width="958" height="308" alt="image" src="https://github.com/user-attachments/assets/8651dc33-aff1-4413-97b1-e5dfd456ef34" />


> [!NOTE]
> Oh, and I also fixed all markdown files that had an additional ruler below the h1 heading (the h1 heading already has a bottom-border). 
