### PR TITLE
chore(footer): experimental

### DIFF
--- a/packages/nimbus/src/components/date-range-picker/components/date-range-picker.custom-context.tsx
+++ b/packages/nimbus/src/components/date-range-picker/components/date-range-picker.custom-context.tsx
@@ -89,12 +89,7 @@ export const DateRangePickerCustomContext = ({
    * ================================
    */
   const textSlots = {
-    startTime: {
-      children: "Start time",
-    },
-    endTime: {
-      children: "End time",
-    },
+    // startTime and endTime slots are now provided directly in the popover
   };
 
   // DateRangePicker-specific: Separate time input slots for start and end times

--- a/packages/nimbus/src/components/date-range-picker/components/date-range-picker.time-input.tsx
+++ b/packages/nimbus/src/components/date-range-picker/components/date-range-picker.time-input.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text, TimeInput } from "@/components";
 import { useContext, useRef, useEffect } from "react";
-import { useLocale } from "react-aria";
+import { useLocale, TextContext } from "react-aria-components";
 import { DateRangePickerStateContext } from "react-aria-components";
 import type { DateRangePickerTimeInputProps } from "../date-range-picker.types";
 

--- a/packages/nimbus/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/nimbus/src/components/date-range-picker/date-range-picker.tsx
@@ -13,6 +13,8 @@ import {
   Group,
   Popover,
   Dialog,
+  Provider,
+  TextContext,
 } from "react-aria-components";
 import { useSlotRecipe } from "@chakra-ui/react";
 import { dateRangePickerSlotRecipe } from "./date-range-picker.recipe";
@@ -46,6 +48,16 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
   // For other granularities (time-based), force to false so users can set both date and time
   const shouldCloseOnSelect =
     granularity === "day" ? props.shouldCloseOnSelect : false;
+
+  // Text slots for the time input labels
+  const timeTextSlots = {
+    startTime: {
+      children: "Start time",
+    },
+    endTime: {
+      children: "End time",
+    },
+  };
 
   return (
     <DateRangePickerRootSlot {...recipeProps} {...styleProps} asChild>
@@ -106,10 +118,21 @@ export const DateRangePicker = (props: DateRangePickerProps) => {
           <DateRangePickerPopoverSlot asChild>
             <Popover placement="bottom end">
               <Dialog>
-                <DateRangePickerCalendarSlot>
-                  <RangeCalendar />
-                </DateRangePickerCalendarSlot>
-                <DateRangePickerTimeInput hideTimeZone={hideTimeZone} />
+                <Provider
+                  values={[
+                    [
+                      TextContext,
+                      {
+                        slots: timeTextSlots,
+                      },
+                    ],
+                  ]}
+                >
+                  <DateRangePickerCalendarSlot>
+                    <RangeCalendar />
+                  </DateRangePickerCalendarSlot>
+                  <DateRangePickerTimeInput hideTimeZone={hideTimeZone} />
+                </Provider>
               </Dialog>
             </Popover>
           </DateRangePickerPopoverSlot>


### PR DESCRIPTION
**Issue**
"Start time" and "End time" labels weren't showing in DateRangePicker footer due to React Portal breaking Context inheritance.

**Theory** 
DateRangePickerTimeInput renders inside a Popover (React Portal), which can't access the TextContext from the main DateRangePickerCustomContext.

**Possible Solution**
Move TextContext provider inside the Popover so portal-rendered components can access the slot content.

**PR Contains:**
- Added Provider with TextContext inside Popover
- Moved startTime/endTime slots from main context to popup context
- Wrapped RangeCalendar and DateRangePickerTimeInput in new provider

☹️ Not feeling this
<img width="500" height="628" alt="Screenshot 2025-07-22 at 18 49 40" src="https://github.com/user-attachments/assets/4ad67ec8-1e48-4602-b6dc-8fdbf8667aab" />


