### PR TITLE
chore(deps): update Storybook dependencies to version 9.0.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,14 +59,14 @@ catalogs:
       specifier: ^9.0.18
       version: 9.0.18
     '@storybook/addon-docs':
-      specifier: ^9.0.16
-      version: 9.0.16
+      specifier: ^9.0.18
+      version: 9.0.18
     '@storybook/addon-vitest':
-      specifier: ^9.0.16
-      version: 9.0.16
+      specifier: ^9.0.18
+      version: 9.0.18
     '@storybook/react-vite':
-      specifier: ^9.0.16
-      version: 9.0.16
+      specifier: ^9.0.18
+      version: 9.0.18
     '@testing-library/react':
       specifier: ^16.3.0
       version: 16.3.0
@@ -122,8 +122,8 @@ catalogs:
       specifier: ^1.0.3
       version: 1.0.3
     storybook:
-      specifier: ^9.0.16
-      version: 9.0.16
+      specifier: ^9.0.18
+      version: 9.0.18
     tsx:
       specifier: ^4.20.3
       version: 4.20.3
@@ -509,16 +509,16 @@ importers:
         version: 1.1.5
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 9.0.18(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        version: 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 9.0.16(@types/react@19.1.8)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        version: 9.0.18(@types/react@19.1.8)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
-        version: 9.0.16(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4)
+        version: 9.0.18(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))
+        version: 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))
       '@testing-library/react':
         specifier: catalog:tooling
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -566,7 +566,7 @@ importers:
         version: 1.0.3
       storybook:
         specifier: catalog:tooling
-        version: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+        version: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       vite:
         specifier: catalog:tooling
         version: 7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0)
@@ -2060,17 +2060,17 @@ packages:
     peerDependencies:
       storybook: ^9.0.18
 
-  '@storybook/addon-docs@9.0.16':
-    resolution: {integrity: sha512-/ZXaxMC/JqL0cnVuyPHXdJhNvgCrKvxcnM3ACdgBLsEIGcIqegPF+Ahkb2f9sjU36sR7ihT81cL/7cUvQwzd4Q==}
+  '@storybook/addon-docs@9.0.18':
+    resolution: {integrity: sha512-1mLhaRDx8s1JAF51o56OmwMnIsg4BOQJ8cn+4wbMjh14pDFALrovlFl/BpAXnV1VaZqHjCB4ZWuP+y5CwXEpeQ==}
     peerDependencies:
-      storybook: ^9.0.16
+      storybook: ^9.0.18
 
-  '@storybook/addon-vitest@9.0.16':
-    resolution: {integrity: sha512-amIJLeAcREF/imEmAhZmsPc3kvtEDVdk7O6uvh8/ql8UYNN5Tnc+ud6CsfIZO82ru+PupoYKrt6SC8EwpQ8YMQ==}
+  '@storybook/addon-vitest@9.0.18':
+    resolution: {integrity: sha512-uPLh9H7kRho+raxyIBCm8Ymd3j0VPuWIQ1HSAkdx8itmNafNqs4HE67Z8Cfl259YzdWU/j5BhZqoiT62BCbIDw==}
     peerDependencies:
       '@vitest/browser': ^3.0.0
       '@vitest/runner': ^3.0.0
-      storybook: ^9.0.16
+      storybook: ^9.0.18
       vitest: ^3.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -2080,16 +2080,16 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@9.0.16':
-    resolution: {integrity: sha512-zXockUexeRy3ABG7DFLEvJqJe4mGL0JkI7FMrpwiKaHCQNaD87vR0xkRVeh0a3B8GKUNxoYtpYKvdzc9DobQHQ==}
+  '@storybook/builder-vite@9.0.18':
+    resolution: {integrity: sha512-lfbrozA6UPVizDrgbPEe04WMtxIraESwUkmwW3+Lxh8rKEUj5cXngcrJUW+meQNNaggdZZWEqeEtweuaLIR+Hg==}
     peerDependencies:
-      storybook: ^9.0.16
+      storybook: ^9.0.18
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/csf-plugin@9.0.16':
-    resolution: {integrity: sha512-MSmfPwI0j1mMAc+R3DVkVBQf2KLzaVn2SLdEwweesx63Nh9j3zu9CqKEa0zOuDX1lR2M0DZU0lV6K4sc2EYI4A==}
+  '@storybook/csf-plugin@9.0.18':
+    resolution: {integrity: sha512-MQ3WwXnMua5sX0uYyuO7dC5WOWuJCLqf8CsOn3zQ2ptNoH6hD7DFx5ZOa1uD6VxIuJ3LkA+YqfSRBncomJoRnA==}
     peerDependencies:
-      storybook: ^9.0.16
+      storybook: ^9.0.18
 
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
@@ -2101,29 +2101,29 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/react-dom-shim@9.0.16':
-    resolution: {integrity: sha512-5aIK+31R41mRUvDB4vmBv8hwh3IVHIk/Zbs6kkWF2a+swOsB2+a06aLX21lma4/0T/AuFVXHWat0+inQ4nrXRg==}
+  '@storybook/react-dom-shim@9.0.18':
+    resolution: {integrity: sha512-qGR/d9x9qWRRxITaBVQkMnb73kwOm+N8fkbZRxc7U4lxupXRvkMIDh247nn71SYVBnvbh6//AL7P6ghiPWZYjA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.0.16
+      storybook: ^9.0.18
 
-  '@storybook/react-vite@9.0.16':
-    resolution: {integrity: sha512-a+UsoymyvPH4bJJVI+asj02N8U2wlkGyzhUqF6LUM9gXzixRMxoRHkchCKLdqLhE+//STrwC0YFF3GG6Y5oMEg==}
+  '@storybook/react-vite@9.0.18':
+    resolution: {integrity: sha512-dHzUoeY0/S35TvSYxCkPuBlNQZx4Zj9QDhAZ0qdv+nSll++uPgqSe2y2vF+2p+XVYhjDn+YX5LORv00YtuQezg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.0.16
+      storybook: ^9.0.18
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/react@9.0.16':
-    resolution: {integrity: sha512-1jk9fBe8vEoZrba9cK19ZDdZgYMXUNl3Egjj5RsTMYMc1L2mtIu9o56VyK/1V4Q52N9IyawHvmIIuxc5pCZHkQ==}
+  '@storybook/react@9.0.18':
+    resolution: {integrity: sha512-CCH6Vj/O6I07PrhCHxc1pvCWYMfZhRzK7CVHAtrBP9xxnYA7OoXhM2wymuDogml5HW1BKtyVMeQ3oWZXFNgDXQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.0.16
+      storybook: ^9.0.18
       typescript: ~5.8.3
     peerDependenciesMeta:
       typescript:
@@ -5568,8 +5568,8 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
-  storybook@9.0.16:
-    resolution: {integrity: sha512-DzjzeggdzlXKKBK1L9iqNKqqNpyfeaL1hxxeAOmqgeMezwy5d5mCJmjNcZEmx+prsRmvj1OWm4ZZAg6iP/wABg==}
+  storybook@9.0.18:
+    resolution: {integrity: sha512-ruxpEpizwoYQTt1hBOrWyp9trPYWD9Apt1TJ37rs1rzmNQWpSNGJDMg91JV4mUhBChzRvnid/oRBFFCWJz/dfw==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -8270,31 +8270,31 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storybook/addon-a11y@9.0.18(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/addon-a11y@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.2
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
 
-  '@storybook/addon-docs@9.0.16(@types/react@19.1.8)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/addon-docs@9.0.18(@types/react@19.1.8)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.1.8)(react@19.1.0)
-      '@storybook/csf-plugin': 9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      '@storybook/csf-plugin': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@storybook/react-dom-shim': 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      '@storybook/react-dom-shim': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-vitest@9.0.16(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4)':
+  '@storybook/addon-vitest@9.0.18(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prompts: 2.4.2
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@24.0.3)(typescript@5.8.3))(playwright@1.52.0)(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))(vitest@3.2.4)
@@ -8304,16 +8304,16 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))':
+  '@storybook/builder-vite@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
-      '@storybook/csf-plugin': 9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      '@storybook/csf-plugin': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
       vite: 7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0)
 
-  '@storybook/csf-plugin@9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/csf-plugin@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
     dependencies:
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -8323,25 +8323,25 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/react-dom-shim@9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/react-dom-shim@9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
 
-  '@storybook/react-vite@9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))':
+  '@storybook/react-vite@9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.45.1)
-      '@storybook/builder-vite': 9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))
-      '@storybook/react': 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
+      '@storybook/builder-vite': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0))
+      '@storybook/react': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 19.1.0
       react-docgen: 8.0.0
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       tsconfig-paths: 4.2.0
       vite: 7.0.5(@types/node@24.0.3)(terser@5.39.0)(tsx@4.20.3)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -8349,13 +8349,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)':
+  '@storybook/react@9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      '@storybook/react-dom-shim': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -12776,7 +12776,7 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2):
+  storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,30 +6,32 @@ catalogMode: strict
 
 catalogs:
   tooling:
+    # Core utilities
     globals: ^16.3.0
     glob: ^11.0.3
     typescript: ~5.8.3
     typescript-eslint: ^8.38.0
     tsx: ^4.20.3
+
+    # Babel dependencies
     "@babel/core": ^7.28.0
     "@babel/runtime": ^7.27.6
     "@babel/preset-typescript": ^7.27.1
+
+    # ESLint dependencies
     "@eslint/js": ^9.30.1
     eslint: ^9.30.1
     eslint-config-prettier: ^10.1.2
     eslint-plugin-prettier: ^5.5.1
     eslint-plugin-react-hooks: ^5.2.0
     eslint-plugin-react-refresh: ^0.4.20
-    eslint-plugin-storybook: ^9.0.16
+
+    # Development tools
     prettier: ^3.6.2
     "@preconstruct/cli": ^2.8.12
     hygen: ^6.2.11
-    "@storybook/addon-a11y": ^9.0.18
-    "@storybook/addon-docs": ^9.0.16
-    "@storybook/addon-vitest": ^9.0.16
-    "@storybook/react-vite": ^9.0.16
-    storybook: ^9.0.16
-    "@vueless/storybook-dark-mode": ^9.0.6
+
+    # Build tools (Vite & Rollup)
     "@vitejs/plugin-react": ^4.4.1
     "@vitejs/plugin-react-swc": ^3.10.2
     vite: ^7.0.5
@@ -38,6 +40,8 @@ catalogs:
     vite-tsconfig-paths: ^5.1.4
     rollup: ^4.45.1
     rollup-plugin-tree-shakeable: ^1.0.3
+
+    # Testing dependencies
     "@vitest/browser": ^3.2.4
     "@vitest/coverage-v8": ^3.2.4
     "@testing-library/dom": 10.4.0
@@ -45,17 +49,34 @@ catalogs:
     "@testing-library/react": ^16.3.0
     playwright: ^1.52.0
     vitest: ^3.2.4
+
+    # Storybook dependencies
+    storybook: ^9.0.18
+    eslint-plugin-storybook: ^9.0.18
+    "@storybook/addon-a11y": ^9.0.18
+    "@storybook/addon-docs": ^9.0.18
+    "@storybook/addon-vitest": ^9.0.18
+    "@storybook/react-vite": ^9.0.18
+    "@vueless/storybook-dark-mode": ^9.0.6
+
   react:
+    # Core React packages
     "@types/react": ^19.1.8
     "@types/react-dom": ^19.1.6
     react: ^19.0.0
     react-dom: ^19.0.0
+
+    # Emotion (CSS-in-JS) dependencies
     "@emotion/react": ^11.14.0
     "@emotion/is-prop-valid": ^1.3.1
+
+    # UI framework dependencies
     "@chakra-ui/cli": ^3.17.0
     "@chakra-ui/react": ^3.22.0
     "@pandacss/types": ^0.53.6
     next-themes: ^0.4.6
+
+    # React Aria dependencies
     react-aria: 3.41.1
     react-aria-components: 1.10.1
     react-stately: 3.39.0


### PR DESCRIPTION
Bumps various Storybook packages from version 9.0.16 to 9.0.18 in both pnpm-lock.yaml and pnpm-workspace.yaml, ensuring compatibility and access to the latest features and fixes.

- Updated '@storybook/addon-docs', '@storybook/addon-vitest', '@storybook/react-vite', and 'storybook' to version 9.0.18.
- Adjusted peer dependencies and version specifications accordingly.

This update enhances the development environment by incorporating the latest improvements from Storybook.