### PR TITLE
CRAFT 1679 | Optimize chakra for build performance

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/ci
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm playwright:install && pnpm test
         timeout-minutes: 5
         env:
           NODE_ENV: production

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/ci
 
       - name: Run tests
-        run: pnpm playwright:install && pnpm test
+        run: pnpm test
         timeout-minutes: 5
         env:
           NODE_ENV: production

--- a/_templates/component/new/component.recipe.tsx.ejs.t
+++ b/_templates/component/new/component.recipe.tsx.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: packages/nimbus/src/components/<%= h.changeCase.paramCase(name) %>/<%= h.changeCase.paramCase(name) %>.recipe.tsx
 ---
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the <%= h.changeCase.pascalCase(name) %> component.

--- a/_templates/component/new/component.slots.tsx.ejs.t
+++ b/_templates/component/new/component.slots.tsx.ejs.t
@@ -6,7 +6,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { <%= h.changeCase.camel(name) %>Recipe } from "./<%= h.changeCase.paramCase(name) %>.recipe";
 

--- a/_templates/component/new/component.types.ts.ejs.t
+++ b/_templates/component/new/component.types.ts.ejs.t
@@ -2,7 +2,7 @@
 to: packages/nimbus/src/components/<%= h.changeCase.paramCase(name) %>/<%= h.changeCase.paramCase(name) %>.types.ts
 ---
 import type { <%= h.changeCase.pascalCase(name) %>RootProps } from "./<%= h.changeCase.paramCase(name) %>.slots"
-import type { RecipeVariantProps } from "@chakra-ui/react"
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system"
 import { <%= h.changeCase.camelCase(name) %>Recipe } from "./<%= h.changeCase.paramCase(name) %>.recipe"
 
 /**

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools/nimbus",
-  "version": "0.0.11",
+  "version": "0.0.12-rc1",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "type": "module",

--- a/packages/nimbus/src/components/accordion/accordion.recipe.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Accordion component.

--- a/packages/nimbus/src/components/accordion/accordion.slots.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.slots.tsx
@@ -1,7 +1,7 @@
 import {
   createSlotRecipeContext,
   type HTMLChakraProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import type { AccordionRootProps } from "./accordion.types";
 
 const { withProvider, withContext } = createSlotRecipeContext({

--- a/packages/nimbus/src/components/accordion/accordion.types.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.types.tsx
@@ -1,4 +1,7 @@
-import type { RecipeVariantProps, HTMLChakraProps } from "@chakra-ui/react";
+import type {
+  RecipeVariantProps,
+  HTMLChakraProps,
+} from "@chakra-ui/react/styled-system";
 import { accordionSlotRecipe } from "./accordion.recipe";
 import { type DisclosureProps } from "react-aria-components";
 import type { ReactNode, RefObject, RefAttributes } from "react";

--- a/packages/nimbus/src/components/accordion/components/accordion-root.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-root.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, type Key } from "react";
 import { AccordionRoot as AccordionRootSlot } from "../accordion.slots";
 import { useDisclosureGroupState } from "react-stately";
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import type { DisclosureGroupProps } from "../accordion.types";
 import { DisclosureGroupStateContext } from "../accordion-context";
 

--- a/packages/nimbus/src/components/alert/alert.recipe.tsx
+++ b/packages/nimbus/src/components/alert/alert.recipe.tsx
@@ -1,5 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
-
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 /**
  * Recipe configuration for the Alert component.
  * Defines the styling variants and base styles using Chakra UI's recipe system.

--- a/packages/nimbus/src/components/alert/alert.slots.tsx
+++ b/packages/nimbus/src/components/alert/alert.slots.tsx
@@ -1,4 +1,4 @@
-import { createSlotRecipeContext } from "@chakra-ui/react";
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
 import { alertRecipe } from "./alert.recipe";
 import type {
   AlertActionsProps,

--- a/packages/nimbus/src/components/alert/alert.types.tsx
+++ b/packages/nimbus/src/components/alert/alert.types.tsx
@@ -2,7 +2,7 @@ import type {
   HTMLChakraProps,
   RecipeProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { alertRecipe } from "./alert.recipe";
 import type { TextProps } from "../text";
 import type { ButtonProps } from "../button";

--- a/packages/nimbus/src/components/avatar/avatar.recipe.tsx
+++ b/packages/nimbus/src/components/avatar/avatar.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 export const avatarRecipe = defineRecipe({
   className: "avatar",

--- a/packages/nimbus/src/components/avatar/avatar.slots.tsx
+++ b/packages/nimbus/src/components/avatar/avatar.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { avatarRecipe } from "./avatar.recipe";
 
 interface AvatarRecipeProps extends RecipeProps<"div">, UnstyledProp {}

--- a/packages/nimbus/src/components/avatar/avatar.tsx
+++ b/packages/nimbus/src/components/avatar/avatar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Image } from "@chakra-ui/react";
+import { Image } from "@chakra-ui/react/image";
 import { type AvatarProps } from "./avatar.types";
 import { AvatarRoot } from "./avatar.slots.tsx";
 

--- a/packages/nimbus/src/components/avatar/avatar.types.ts
+++ b/packages/nimbus/src/components/avatar/avatar.types.ts
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from "react";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { avatarRecipe } from "./avatar.recipe.tsx";
 import type { AvatarRootProps } from "./avatar.slots";
 export interface AvatarComponentProps

--- a/packages/nimbus/src/components/badge/badge.recipe.tsx
+++ b/packages/nimbus/src/components/badge/badge.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Badge component.

--- a/packages/nimbus/src/components/badge/badge.slots.tsx
+++ b/packages/nimbus/src/components/badge/badge.slots.tsx
@@ -1,4 +1,4 @@
-import { createRecipeContext } from "@chakra-ui/react";
+import { createRecipeContext } from "@chakra-ui/react/styled-system";
 
 import { badgeRecipe } from "./badge.recipe";
 import type { BadgeRootProps } from "./badge.types";

--- a/packages/nimbus/src/components/badge/badge.types.tsx
+++ b/packages/nimbus/src/components/badge/badge.types.tsx
@@ -3,7 +3,7 @@ import type {
   UnstyledProp,
   HTMLChakraProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { badgeRecipe } from "./badge.recipe";
 
 /**

--- a/packages/nimbus/src/components/box/box.tsx
+++ b/packages/nimbus/src/components/box/box.tsx
@@ -1,4 +1,5 @@
-import { Box as ChakraBox, type HTMLChakraProps } from "@chakra-ui/react";
+import { type HTMLChakraProps } from "@chakra-ui/react/styled-system";
+import { Box as ChakraBox } from "@chakra-ui/react/box";
 
 export interface BoxProps extends HTMLChakraProps<"div"> {
   children?: React.ReactNode;

--- a/packages/nimbus/src/components/button/button.recipe.ts
+++ b/packages/nimbus/src/components/button/button.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 export const buttonRecipe = defineRecipe({
   className: "nimbus-button",

--- a/packages/nimbus/src/components/button/button.slots.tsx
+++ b/packages/nimbus/src/components/button/button.slots.tsx
@@ -3,10 +3,10 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-  defaultSystem,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { buttonRecipe } from "./button.recipe";
 import shouldForwardProp from "@emotion/is-prop-valid";
+import { system } from "@/theme";
 
 /**
  * Base recipe props interface that combines Chakra UI's recipe props
@@ -42,7 +42,7 @@ export const ButtonRoot = withContext<HTMLButtonElement, ButtonRootProps>(
     /** make sure the `onPress` properties won't end up as attribute on the rendered DOM element */
     shouldForwardProp(prop, variantKeys) {
       const chakraSfp =
-        !variantKeys?.includes(prop) && !defaultSystem.isValidProperty(prop);
+        !variantKeys?.includes(prop) && !system.isValidProperty(prop);
       return shouldForwardProp(prop) && chakraSfp && !prop.includes("onPress");
     },
   }

--- a/packages/nimbus/src/components/calendar/calendar.recipe.ts
+++ b/packages/nimbus/src/components/calendar/calendar.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 export const calendarSlotRecipe = defineSlotRecipe({
   slots: [

--- a/packages/nimbus/src/components/calendar/calendar.slots.tsx
+++ b/packages/nimbus/src/components/calendar/calendar.slots.tsx
@@ -3,7 +3,7 @@ import {
   createSlotRecipeContext,
   type HTMLChakraProps,
   type RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { calendarSlotRecipe } from "./calendar.recipe";
 import type { CalendarProps } from "react-aria-components";
 import type { DateValue } from "@internationalized/date";

--- a/packages/nimbus/src/components/calendar/calendar.tsx
+++ b/packages/nimbus/src/components/calendar/calendar.tsx
@@ -7,7 +7,7 @@ import { CalendarRootSlot } from "./calendar.slots";
 import { CalendarGrids } from "./components/calendar.grids";
 import { CalendarHeader } from "./components/calendar.header";
 import { calendarSlotRecipe } from "./calendar.recipe";
-import { useRecipe } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 import { CalendarCustomContext } from "./components/calendar.custom-context";
 

--- a/packages/nimbus/src/components/calendar/calendar.types.ts
+++ b/packages/nimbus/src/components/calendar/calendar.types.ts
@@ -1,6 +1,6 @@
 import type { DateValue } from "@internationalized/date";
 import type { CalendarProps as AriaCalendarProps } from "react-aria-components";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import type { calendarSlotRecipe } from "./calendar.recipe";
 import type { CalendarRootSlotProps } from "./calendar.slots";
 

--- a/packages/nimbus/src/components/card/card.recipe.tsx
+++ b/packages/nimbus/src/components/card/card.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Card component.

--- a/packages/nimbus/src/components/card/card.slots.tsx
+++ b/packages/nimbus/src/components/card/card.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { cardRecipe } from "./card.recipe";
 

--- a/packages/nimbus/src/components/card/card.types.ts
+++ b/packages/nimbus/src/components/card/card.types.ts
@@ -1,5 +1,5 @@
 import type { CardRootProps } from "./card.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { cardRecipe } from "./card.recipe";
 
 /**

--- a/packages/nimbus/src/components/checkbox/checkbox.recipe.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Checkbox component.

--- a/packages/nimbus/src/components/checkbox/checkbox.slots.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.slots.tsx
@@ -3,7 +3,7 @@ import {
   createSlotRecipeContext,
   type HTMLChakraProps,
   type RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { checkboxSlotRecipe } from "./checkbox.recipe";
 
 const { withProvider, withContext } = createSlotRecipeContext({

--- a/packages/nimbus/src/components/checkbox/checkbox.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { useToggleState } from "react-stately";
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { VisuallyHidden } from "@/components";
 import { Check, Remove as Minus } from "@commercetools/nimbus-icons";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/checkbox/checkbox.types.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.types.tsx
@@ -1,5 +1,5 @@
 import type { CheckboxRootProps } from "./checkbox.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { checkboxSlotRecipe } from "./checkbox.recipe";
 import type { AriaCheckboxProps } from "react-aria";
 

--- a/packages/nimbus/src/components/code/code.recipe.ts
+++ b/packages/nimbus/src/components/code/code.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 export const codeRecipe = defineRecipe({
   className: "nimbus-code",

--- a/packages/nimbus/src/components/code/code.tsx
+++ b/packages/nimbus/src/components/code/code.tsx
@@ -1,4 +1,4 @@
-import { Code as ChakraCode } from "@chakra-ui/react";
+import { Code as ChakraCode } from "@chakra-ui/react/code";
 
 /**
  * # Code

--- a/packages/nimbus/src/components/combobox/combobox.recipe.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 import { selectSlotRecipe } from "../select/select.recipe";
 import { checkboxSlotRecipe } from "../checkbox/checkbox.recipe";
 

--- a/packages/nimbus/src/components/combobox/combobox.slots.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.slots.tsx
@@ -1,4 +1,4 @@
-import { createSlotRecipeContext } from "@chakra-ui/react";
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
 import type {
   ComboBoxRootProps,
   ComboBoxValueSlotProps,

--- a/packages/nimbus/src/components/combobox/combobox.types.ts
+++ b/packages/nimbus/src/components/combobox/combobox.types.ts
@@ -4,7 +4,7 @@ import type {
   HTMLChakraProps,
   RecipeProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import type {
   ComboBoxProps as RaComboBoxProps,
   AutocompleteProps as RaAutoCompleteProps,

--- a/packages/nimbus/src/components/combobox/components/combobox.root.tsx
+++ b/packages/nimbus/src/components/combobox/components/combobox.root.tsx
@@ -1,4 +1,4 @@
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { comboBoxSlotRecipe } from "../combobox.recipe";
 import { ComboBoxRootSlot } from "../combobox.slots";
 import { SingleSelectRoot } from "./combobox.single-select-root";

--- a/packages/nimbus/src/components/date-input/date-input.recipe.ts
+++ b/packages/nimbus/src/components/date-input/date-input.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the DateInput component.

--- a/packages/nimbus/src/components/date-input/date-input.slots.tsx
+++ b/packages/nimbus/src/components/date-input/date-input.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { dateInputSlotRecipe } from "./date-input.recipe";
 

--- a/packages/nimbus/src/components/date-input/date-input.tsx
+++ b/packages/nimbus/src/components/date-input/date-input.tsx
@@ -9,7 +9,7 @@ import {
   DateInput as DateInputField,
   DateSegment,
 } from "react-aria-components";
-import { useRecipe } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { dateInputSlotRecipe } from "./date-input.recipe";
 import type { DateInputProps } from "./date-input.types";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/date-input/date-input.types.ts
+++ b/packages/nimbus/src/components/date-input/date-input.types.ts
@@ -1,5 +1,5 @@
 import type { DateInputRootProps } from "./date-input.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { dateInputSlotRecipe } from "./date-input.recipe";
 import type { DateValue } from "react-aria";
 import type { DateFieldProps } from "react-aria-components";

--- a/packages/nimbus/src/components/date-picker/date-picker.recipe.ts
+++ b/packages/nimbus/src/components/date-picker/date-picker.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the DatePicker component.

--- a/packages/nimbus/src/components/date-picker/date-picker.slots.tsx
+++ b/packages/nimbus/src/components/date-picker/date-picker.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { datePickerSlotRecipe } from "./date-picker.recipe";
 

--- a/packages/nimbus/src/components/date-picker/date-picker.tsx
+++ b/packages/nimbus/src/components/date-picker/date-picker.tsx
@@ -14,7 +14,7 @@ import {
   Popover,
   Dialog,
 } from "react-aria-components";
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { datePickerSlotRecipe } from "./date-picker.recipe";
 import type { DatePickerProps } from "./date-picker.types";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/date-picker/date-picker.types.ts
+++ b/packages/nimbus/src/components/date-picker/date-picker.types.ts
@@ -1,7 +1,7 @@
 import type { DateInputProps } from "@/components/date-input";
 import type { DatePickerStateOptions } from "react-stately";
 import type { DateValue } from "react-aria";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { datePickerSlotRecipe } from "./date-picker.recipe";
 
 /**

--- a/packages/nimbus/src/components/date-range-picker/date-range-picker.recipe.tsx
+++ b/packages/nimbus/src/components/date-range-picker/date-range-picker.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 export const dateRangePickerSlotRecipe = defineSlotRecipe({
   className: "nimbus-date-range-picker",

--- a/packages/nimbus/src/components/date-range-picker/date-range-picker.slots.tsx
+++ b/packages/nimbus/src/components/date-range-picker/date-range-picker.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { dateRangePickerSlotRecipe } from "./date-range-picker.recipe";
 

--- a/packages/nimbus/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/nimbus/src/components/date-range-picker/date-range-picker.tsx
@@ -14,7 +14,7 @@ import {
   Popover,
   Dialog,
 } from "react-aria-components";
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { dateRangePickerSlotRecipe } from "./date-range-picker.recipe";
 import type { DateRangePickerProps } from "./date-range-picker.types";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/date-range-picker/date-range-picker.types.ts
+++ b/packages/nimbus/src/components/date-range-picker/date-range-picker.types.ts
@@ -1,5 +1,5 @@
 import type { DateRangePickerRootProps } from "./date-range-picker.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { dateRangePickerSlotRecipe } from "./date-range-picker.recipe";
 import type { DateRangePickerProps as ReactAriaDateRangePickerProps } from "react-aria-components";
 import type { DateValue } from "react-aria";

--- a/packages/nimbus/src/components/dialog/dialog.recipe.ts
+++ b/packages/nimbus/src/components/dialog/dialog.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 export const dialogSlotRecipe = defineSlotRecipe({
   slots: [

--- a/packages/nimbus/src/components/dialog/dialog.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.tsx
@@ -1,4 +1,5 @@
-import { Dialog as ChakraDialog, Portal } from "@chakra-ui/react";
+import { Dialog as ChakraDialog } from "@chakra-ui/react/dialog";
+import { Portal } from "@chakra-ui/react/portal";
 
 interface DialogContentProps extends ChakraDialog.ContentProps {
   portalled?: boolean;

--- a/packages/nimbus/src/components/divider/divider.recipe.ts
+++ b/packages/nimbus/src/components/divider/divider.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Divider component.

--- a/packages/nimbus/src/components/divider/divider.slots.tsx
+++ b/packages/nimbus/src/components/divider/divider.slots.tsx
@@ -1,4 +1,4 @@
-import { createRecipeContext } from "@chakra-ui/react";
+import { createRecipeContext } from "@chakra-ui/react/styled-system";
 
 import { dividerRecipe } from "./divider.recipe";
 import type { DividerRootProps } from "./divider.types";

--- a/packages/nimbus/src/components/divider/divider.types.ts
+++ b/packages/nimbus/src/components/divider/divider.types.ts
@@ -3,7 +3,7 @@ import type {
   UnstyledProp,
   HTMLChakraProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { dividerRecipe } from "./divider.recipe";
 import type { SeparatorProps } from "react-aria";
 

--- a/packages/nimbus/src/components/flex/flex.tsx
+++ b/packages/nimbus/src/components/flex/flex.tsx
@@ -5,4 +5,4 @@
  *
  * @see {@link https://nimbus-documentation.vercel.app/components/layout/flex}
  */
-export { Flex } from "@chakra-ui/react";
+export { Flex } from "@chakra-ui/react/flex";

--- a/packages/nimbus/src/components/form-field/form-field.recipe.tsx
+++ b/packages/nimbus/src/components/form-field/form-field.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 const columnLayout = `
 "label"

--- a/packages/nimbus/src/components/form-field/form-field.slots.tsx
+++ b/packages/nimbus/src/components/form-field/form-field.slots.tsx
@@ -4,7 +4,7 @@ import {
   type RecipeVariantProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { formFieldRecipe } from "./form-field.recipe";
 

--- a/packages/nimbus/src/components/grid/grid.tsx
+++ b/packages/nimbus/src/components/grid/grid.tsx
@@ -2,7 +2,7 @@ import {
   Grid as ChakraGrid,
   GridItem,
   type GridProps as ChakraGridProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/grid";
 
 /**
  * # Grid

--- a/packages/nimbus/src/components/heading/heading.recipe.ts
+++ b/packages/nimbus/src/components/heading/heading.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 export const headingRecipe = defineRecipe({
   className: "nimbus-heading",

--- a/packages/nimbus/src/components/heading/heading.tsx
+++ b/packages/nimbus/src/components/heading/heading.tsx
@@ -5,4 +5,4 @@
  *
  * @see {@link https://nimbus-documentation.vercel.app/components/typography/heading}
  */
-export { Heading } from "@chakra-ui/react";
+export { Heading } from "@chakra-ui/react/typography";

--- a/packages/nimbus/src/components/icon/icon.recipe.tsx
+++ b/packages/nimbus/src/components/icon/icon.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Icon component.

--- a/packages/nimbus/src/components/icon/icon.slots.tsx
+++ b/packages/nimbus/src/components/icon/icon.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { iconRecipe } from "./icon.recipe";
 

--- a/packages/nimbus/src/components/icon/icon.types.ts
+++ b/packages/nimbus/src/components/icon/icon.types.ts
@@ -1,5 +1,5 @@
 import type { IconRootSlotProps } from "./icon.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { iconRecipe } from "./icon.recipe";
 import type { BoxProps } from "../box";
 

--- a/packages/nimbus/src/components/image/image.tsx
+++ b/packages/nimbus/src/components/image/image.tsx
@@ -1,7 +1,7 @@
 import {
   Image as ChakraImage,
   type ImageProps as ChakraImageProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/image";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ImageProps extends ChakraImageProps {}

--- a/packages/nimbus/src/components/kbd/kbd.recipe.ts
+++ b/packages/nimbus/src/components/kbd/kbd.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 export const kbdRecipe = defineRecipe({
   className: "nimbus-kbd",

--- a/packages/nimbus/src/components/kbd/kbd.slots.ts
+++ b/packages/nimbus/src/components/kbd/kbd.slots.ts
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { kbdRecipe } from "./kbd.recipe";
 

--- a/packages/nimbus/src/components/kbd/kbd.tsx
+++ b/packages/nimbus/src/components/kbd/kbd.tsx
@@ -1,5 +1,6 @@
 import { KeyboardContext, useContextProps } from "react-aria-components";
-import { mergeRefs, type KbdProps as ChakraKbdProps } from "@chakra-ui/react";
+import { mergeRefs } from "@chakra-ui/react";
+import { type KbdProps as ChakraKbdProps } from "@chakra-ui/react/kbd";
 import { useRef } from "react";
 import type React from "react";
 import { useObjectRef } from "react-aria";

--- a/packages/nimbus/src/components/link/link.recipe.ts
+++ b/packages/nimbus/src/components/link/link.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Link component.

--- a/packages/nimbus/src/components/link/link.slots.tsx
+++ b/packages/nimbus/src/components/link/link.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { linkRecipe } from "./link.recipe";
 

--- a/packages/nimbus/src/components/link/link.types.tsx
+++ b/packages/nimbus/src/components/link/link.types.tsx
@@ -1,5 +1,5 @@
 import type { LinkRootProps } from "./link.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import type { AriaLinkOptions } from "react-aria";
 import { linkRecipe } from "./link.recipe";
 

--- a/packages/nimbus/src/components/list/list.recipe.ts
+++ b/packages/nimbus/src/components/list/list.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 export const listSlotRecipe = defineSlotRecipe({
   className: "nimbus-list",

--- a/packages/nimbus/src/components/list/list.tsx
+++ b/packages/nimbus/src/components/list/list.tsx
@@ -1,4 +1,4 @@
-import { List as ChakraList } from "@chakra-ui/react";
+import { List as ChakraList } from "@chakra-ui/react/list";
 
 const ListRoot = ChakraList.Root;
 const ListItem = ChakraList.Item;

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.recipe.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the LoadingSpinner component.

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.slots.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { loadingSpinnerRecipe } from "./loading-spinner.recipe";
 

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.stories.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.stories.tsx
@@ -3,7 +3,7 @@ import { LoadingSpinner } from "./loading-spinner";
 import { Stack } from "./../stack";
 import type { LoadingSpinnerProps } from "./loading-spinner.types";
 import { within, expect } from "storybook/test";
-import { Box } from "@chakra-ui/react";
+import { Box } from "@/components";
 
 const sizes: LoadingSpinnerProps["size"][] = ["lg", "md", "sm", "xs", "2xs"];
 

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.types.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.types.tsx
@@ -1,5 +1,5 @@
 import type { LoadingSpinnerRootProps } from "./loading-spinner.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { loadingSpinnerRecipe } from "./loading-spinner.recipe";
 
 /**

--- a/packages/nimbus/src/components/menu/components/menu.root.tsx
+++ b/packages/nimbus/src/components/menu/components/menu.root.tsx
@@ -1,4 +1,4 @@
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { MenuTrigger as RaMenuTrigger } from "react-aria-components";
 import type { MenuRootProps } from "../menu.types";
 import { MenuRootSlot } from "../menu.slots";

--- a/packages/nimbus/src/components/menu/menu.recipe.tsx
+++ b/packages/nimbus/src/components/menu/menu.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Menu component.

--- a/packages/nimbus/src/components/menu/menu.slots.tsx
+++ b/packages/nimbus/src/components/menu/menu.slots.tsx
@@ -1,7 +1,7 @@
 import {
   createSlotRecipeContext,
   type HTMLChakraProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { menuSlotRecipe } from "./menu.recipe";
 
 const { withProvider, withContext } = createSlotRecipeContext({

--- a/packages/nimbus/src/components/menu/menu.types.ts
+++ b/packages/nimbus/src/components/menu/menu.types.ts
@@ -9,7 +9,7 @@ import type {
   MenuSectionProps as RaMenuSectionProps,
   SubmenuTriggerProps as RaSubmenuTriggerProps,
 } from "react-aria-components";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import type { MenuTriggerSlotProps } from "./menu.slots";
 import { menuSlotRecipe } from "./menu.recipe";
 

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 import { designTokens } from "@commercetools/nimbus-tokens";
 
 /**

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.slots.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeVariantProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { multilineTextInputRecipe } from "./multiline-text-input.recipe";
 

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback } from "react";
-import { mergeRefs, useRecipe } from "@chakra-ui/react";
+import { mergeRefs } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { useObjectRef, useTextField } from "react-aria";
 import { TextArea } from "react-aria-components";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
@@ -1,4 +1,4 @@
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider } from "@chakra-ui/react/styled-system";
 import { I18nProvider, RouterProvider } from "react-aria";
 import { system } from "@/theme";
 import type { NimbusProviderProps } from "./nimbus-provider.types";

--- a/packages/nimbus/src/components/number-input/number-input.recipe.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the NumberInput component.

--- a/packages/nimbus/src/components/number-input/number-input.slots.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeVariantProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { Button as RaButton } from "react-aria-components";
 import type { AriaButtonProps } from "react-aria";
 

--- a/packages/nimbus/src/components/number-input/number-input.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
-import { mergeRefs, useSlotRecipe } from "@chakra-ui/react";
+import { mergeRefs } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { useObjectRef, useNumberField, useLocale } from "react-aria";
 import { useNumberFieldState } from "react-stately";
 import { Box } from "@/components";

--- a/packages/nimbus/src/components/progress-bar/progress-bar.recipe.tsx
+++ b/packages/nimbus/src/components/progress-bar/progress-bar.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the ProgressBar component.

--- a/packages/nimbus/src/components/progress-bar/progress-bar.slots.tsx
+++ b/packages/nimbus/src/components/progress-bar/progress-bar.slots.tsx
@@ -1,10 +1,10 @@
-import { createSlotRecipeContext } from "@chakra-ui/react";
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
 import type {
   RecipeProps,
   UnstyledProp,
   HTMLChakraProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import type { AriaProgressBarProps } from "react-aria";
 import { progressBarSlotRecipe } from "./progress-bar.recipe.tsx";
 

--- a/packages/nimbus/src/components/progress-bar/progress-bar.tsx
+++ b/packages/nimbus/src/components/progress-bar/progress-bar.tsx
@@ -4,7 +4,8 @@ import {
   Label as RaLabel,
 } from "react-aria-components";
 import { useObjectRef } from "react-aria";
-import { mergeRefs, useSlotRecipe } from "@chakra-ui/react";
+import { mergeRefs } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { Flex, Box } from "@/components";
 import {
   ProgressBarRootSlot,

--- a/packages/nimbus/src/components/radio-input/components/radio-input.root.tsx
+++ b/packages/nimbus/src/components/radio-input/components/radio-input.root.tsx
@@ -1,4 +1,4 @@
-import { useSlotRecipe } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { radioInputSlotRecipe } from "../radio-input.recipe";
 import { RadioGroup as RaRadioGroup } from "react-aria-components";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/radio-input/radio-input.recipe.tsx
+++ b/packages/nimbus/src/components/radio-input/radio-input.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the RadioInput component.

--- a/packages/nimbus/src/components/radio-input/radio-input.slots.tsx
+++ b/packages/nimbus/src/components/radio-input/radio-input.slots.tsx
@@ -1,4 +1,5 @@
-import { createSlotRecipeContext } from "@chakra-ui/react";
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
 import type {
   RadioInputOptionSlotProps,
   RadioInputRootSlotProps,

--- a/packages/nimbus/src/components/radio-input/radio-input.types.ts
+++ b/packages/nimbus/src/components/radio-input/radio-input.types.ts
@@ -2,7 +2,7 @@ import type {
   HTMLChakraProps,
   RecipeVariantProps,
   RecipeProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { radioInputSlotRecipe } from "./radio-input.recipe";
 import type {
   RadioGroupProps as RaRadioGroupProps,

--- a/packages/nimbus/src/components/range-calendar/range-calendar.recipe.ts
+++ b/packages/nimbus/src/components/range-calendar/range-calendar.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 export const rangeCalendarSlotRecipe = defineSlotRecipe({
   slots: [

--- a/packages/nimbus/src/components/range-calendar/range-calendar.slots.tsx
+++ b/packages/nimbus/src/components/range-calendar/range-calendar.slots.tsx
@@ -3,7 +3,7 @@ import {
   createSlotRecipeContext,
   type HTMLChakraProps,
   type RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { rangeCalendarSlotRecipe } from "./range-calendar.recipe";
 import type { RangeCalendarProps } from "react-aria-components";
 import type { DateValue } from "@internationalized/date";

--- a/packages/nimbus/src/components/range-calendar/range-calendar.tsx
+++ b/packages/nimbus/src/components/range-calendar/range-calendar.tsx
@@ -7,7 +7,7 @@ import { RangeCalendarRootSlot } from "./range-calendar.slots";
 import { RangeCalendarGrids } from "./components/range-calendar.grids";
 import { RangeCalendarHeader } from "./components/range-calendar.header";
 import { rangeCalendarSlotRecipe } from "./range-calendar.recipe";
-import { useRecipe } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 import { RangeCalendarCustomContext } from "./components/range-calendar.custom-context";
 

--- a/packages/nimbus/src/components/range-calendar/range-calendar.types.ts
+++ b/packages/nimbus/src/components/range-calendar/range-calendar.types.ts
@@ -1,6 +1,6 @@
 import type { DateValue } from "@internationalized/date";
 import type { RangeCalendarProps as AriaRangeCalendarProps } from "react-aria-components";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import type { rangeCalendarSlotRecipe } from "./range-calendar.recipe";
 import type { RangeCalendarRootSlotProps } from "./range-calendar.slots";
 

--- a/packages/nimbus/src/components/select/components/select.root.tsx
+++ b/packages/nimbus/src/components/select/components/select.root.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { chakra, useSlotRecipe } from "@chakra-ui/react";
+import { chakra, useSlotRecipe } from "@chakra-ui/react/styled-system";
 
 import {
   KeyboardArrowDown as DropdownIndicatorIcon,

--- a/packages/nimbus/src/components/select/select.recipe.tsx
+++ b/packages/nimbus/src/components/select/select.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Select component.

--- a/packages/nimbus/src/components/select/select.slots.tsx
+++ b/packages/nimbus/src/components/select/select.slots.tsx
@@ -3,7 +3,7 @@ import {
   createSlotRecipeContext,
   type HTMLChakraProps,
   type RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { selectSlotRecipe } from "./select.recipe";
 import { type SelectProps as RaSelectProps } from "react-aria-components";
 

--- a/packages/nimbus/src/components/simple-grid/simple-grid.tsx
+++ b/packages/nimbus/src/components/simple-grid/simple-grid.tsx
@@ -2,7 +2,7 @@ import {
   SimpleGrid as ChakraSimpleGrid,
   GridItem,
   type SimpleGridProps as ChakraSimpleGridProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/grid";
 
 /**
  * # SimpleGrid

--- a/packages/nimbus/src/components/stack/stack.tsx
+++ b/packages/nimbus/src/components/stack/stack.tsx
@@ -1,7 +1,7 @@
 import {
   Stack as ChakraStack,
   type StackProps as ChakraStackProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/stack";
 
 export interface StackProps extends ChakraStackProps {
   children?: React.ReactNode;

--- a/packages/nimbus/src/components/switch/switch.recipe.tsx
+++ b/packages/nimbus/src/components/switch/switch.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Switch component.

--- a/packages/nimbus/src/components/switch/switch.slots.tsx
+++ b/packages/nimbus/src/components/switch/switch.slots.tsx
@@ -3,7 +3,7 @@ import {
   createSlotRecipeContext,
   type HTMLChakraProps,
   type RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { switchSlotRecipe } from "./switch.recipe";
 
 const { withProvider, withContext } = createSlotRecipeContext({

--- a/packages/nimbus/src/components/switch/switch.tsx
+++ b/packages/nimbus/src/components/switch/switch.tsx
@@ -1,7 +1,8 @@
 import { useRef } from "react";
 import { useToggleState } from "react-stately";
 import { useFocusRing, useSwitch, useObjectRef, mergeProps } from "react-aria";
-import { useSlotRecipe, mergeRefs } from "@chakra-ui/react";
+import { mergeRefs } from "@chakra-ui/react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { VisuallyHidden } from "@/components";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 import type { SwitchProps } from "./switch.types";

--- a/packages/nimbus/src/components/switch/switch.types.tsx
+++ b/packages/nimbus/src/components/switch/switch.types.tsx
@@ -1,4 +1,7 @@
-import type { HTMLChakraProps, RecipeVariantProps } from "@chakra-ui/react";
+import type {
+  HTMLChakraProps,
+  RecipeVariantProps,
+} from "@chakra-ui/react/styled-system";
 import { switchSlotRecipe } from "./switch.recipe";
 import type { AriaCheckboxProps } from "react-aria";
 

--- a/packages/nimbus/src/components/table/table.recipe.ts
+++ b/packages/nimbus/src/components/table/table.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 export const tableSlotRecipe = defineSlotRecipe({
   className: "chakra-table",

--- a/packages/nimbus/src/components/table/table.tsx
+++ b/packages/nimbus/src/components/table/table.tsx
@@ -5,4 +5,4 @@
  *
  * @see {@link https://nimbus-documentation.vercel.app/components/data-display/table}
  */
-export { Table } from "@chakra-ui/react";
+export { Table } from "@chakra-ui/react/table";

--- a/packages/nimbus/src/components/tag-group/tag-group.recipe.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the TagGroup component.

--- a/packages/nimbus/src/components/tag-group/tag-group.slots.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.slots.tsx
@@ -3,7 +3,7 @@ import {
   createSlotRecipeContext,
   type WithProviderOptions,
   type WithContextOptions,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import {
   TagGroup as RaTagGroup,

--- a/packages/nimbus/src/components/tag-group/tag-group.types.ts
+++ b/packages/nimbus/src/components/tag-group/tag-group.types.ts
@@ -3,7 +3,7 @@ import type {
   HTMLChakraProps,
   RecipeProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import {
   TagGroup as RaTagGroup,
   type TagGroupProps as RaTagGroupProps,

--- a/packages/nimbus/src/components/text-input/text-input.recipe.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the TextInput component.

--- a/packages/nimbus/src/components/text-input/text-input.slots.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeVariantProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { textInputRecipe } from "./text-input.recipe";
 

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
-import { mergeRefs, useRecipe } from "@chakra-ui/react";
+import { mergeRefs } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { useObjectRef, useTextField } from "react-aria";
 import { Input } from "react-aria-components";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/text/text.tsx
+++ b/packages/nimbus/src/components/text/text.tsx
@@ -1,7 +1,7 @@
 import {
   Text as ChakraText,
   type TextProps as ChakraTextProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/typography";
 import { TextContext, useContextProps } from "react-aria-components";
 
 export interface TextProps extends Omit<ChakraTextProps, "slot"> {

--- a/packages/nimbus/src/components/time-input/time-input.recipe.ts
+++ b/packages/nimbus/src/components/time-input/time-input.recipe.ts
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the TimeInput component.

--- a/packages/nimbus/src/components/time-input/time-input.slots.tsx
+++ b/packages/nimbus/src/components/time-input/time-input.slots.tsx
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createSlotRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { timeInputRecipe } from "./time-input.recipe";
 

--- a/packages/nimbus/src/components/time-input/time-input.tsx
+++ b/packages/nimbus/src/components/time-input/time-input.tsx
@@ -5,7 +5,7 @@ import {
 } from "./time-input.slots";
 
 import { TimeField, DateInput, DateSegment } from "react-aria-components";
-import { useRecipe } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { timeInputRecipe } from "./time-input.recipe";
 import type { TimeInputProps } from "./time-input.types";
 import { extractStyleProps } from "@/utils/extractStyleProps";

--- a/packages/nimbus/src/components/time-input/time-input.types.ts
+++ b/packages/nimbus/src/components/time-input/time-input.types.ts
@@ -1,5 +1,5 @@
 import type { TimeInputRootProps } from "./time-input.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { timeInputRecipe } from "./time-input.recipe";
 import type { TimeFieldStateOptions } from "react-stately";
 import type { TimeValue } from "react-aria";

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.recipe.tsx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.recipe.tsx
@@ -1,4 +1,4 @@
-import { defineSlotRecipe } from "@chakra-ui/react";
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 import { buttonRecipe } from "../button/button.recipe";
 
 /**

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.slots.tsx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.slots.tsx
@@ -1,4 +1,4 @@
-import { createSlotRecipeContext } from "@chakra-ui/react";
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
 import { buttonGroupRecipe } from "./toggle-button-group.recipe";
 import type {
   ToggleButtonGroupButtonProps,

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.types.tsx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.types.tsx
@@ -2,7 +2,7 @@ import type {
   HTMLChakraProps,
   RecipeProps,
   RecipeVariantProps,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { buttonGroupRecipe } from "./toggle-button-group.recipe";
 import type {
   AriaToggleButtonGroupProps,

--- a/packages/nimbus/src/components/toggle-button/toggle-button.recipe.ts
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.recipe.ts
@@ -1,5 +1,5 @@
 import { buttonRecipe } from "@/components/button/button.recipe";
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 export const toggleButtonRecipe = defineRecipe({
   className: "nimbus-toggle-button",

--- a/packages/nimbus/src/components/toggle-button/toggle-button.slots.tsx
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.slots.tsx
@@ -3,10 +3,10 @@ import {
   type RecipeVariantProps,
   type UnstyledProp,
   createRecipeContext,
-  defaultSystem,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 import { toggleButtonRecipe } from "./toggle-button.recipe";
 import shouldForwardProp from "@emotion/is-prop-valid";
+import { system } from "@/theme";
 
 /**
  * Base recipe props interface that combines Chakra UI's recipe props
@@ -44,7 +44,7 @@ export const ToggleButtonRoot = withContext<
   /** make sure the `onPress` properties won't end up as attribute on the rendered DOM element */
   shouldForwardProp(prop, variantKeys) {
     const chakraSfp =
-      !variantKeys?.includes(prop) && !defaultSystem.isValidProperty(prop);
+      !variantKeys?.includes(prop) && !system.isValidProperty(prop);
     return shouldForwardProp(prop) && chakraSfp && !prop.includes("onPress");
   },
 });

--- a/packages/nimbus/src/components/toggle-button/toggle-button.tsx
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.tsx
@@ -1,4 +1,4 @@
-import { useRecipe } from "@chakra-ui/react";
+import { useRecipe } from "@chakra-ui/react/styled-system";
 import { ToggleButton as RaToggleButton } from "react-aria-components";
 import { extractStyleProps } from "@/utils/extractStyleProps";
 

--- a/packages/nimbus/src/components/tooltip/tooltip.recipe.ts
+++ b/packages/nimbus/src/components/tooltip/tooltip.recipe.ts
@@ -1,4 +1,4 @@
-import { defineRecipe } from "@chakra-ui/react";
+import { defineRecipe } from "@chakra-ui/react/styled-system";
 
 /**
  * Recipe configuration for the Tooltip component.

--- a/packages/nimbus/src/components/tooltip/tooltip.slots.ts
+++ b/packages/nimbus/src/components/tooltip/tooltip.slots.ts
@@ -3,7 +3,7 @@ import {
   type RecipeProps,
   type UnstyledProp,
   createRecipeContext,
-} from "@chakra-ui/react";
+} from "@chakra-ui/react/styled-system";
 
 import { type TooltipProps as RATooltipProps } from "react-aria-components";
 

--- a/packages/nimbus/src/components/tooltip/tooltip.types.ts
+++ b/packages/nimbus/src/components/tooltip/tooltip.types.ts
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import type { TooltipProps as RATooltipProps } from "react-aria-components";
 import type { TooltipRootProps } from "./tooltip.slots";
-import type { RecipeVariantProps } from "@chakra-ui/react";
+import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
 import { tooltipRecipe } from "./tooltip.recipe";
 
 /**

--- a/packages/nimbus/src/utils/extractStyleProps.ts
+++ b/packages/nimbus/src/utils/extractStyleProps.ts
@@ -1,4 +1,4 @@
-import { defaultSystem } from "@chakra-ui/react";
+import { system } from "@/theme";
 
 /**
  * Extracts chakra-ui style-props from an object, separating them from other props
@@ -15,7 +15,7 @@ export function extractStyleProps<T extends object>(
   Object.keys(props).forEach((key) => {
     if (
       Object.prototype.hasOwnProperty.call(props, key) &&
-      defaultSystem.isValidProperty(key)
+      system.isValidProperty(key)
     ) {
       styleProps[key] = props[key as keyof T];
       delete otherProps[key];

--- a/packages/nimbus/vitest.config.ts
+++ b/packages/nimbus/vitest.config.ts
@@ -19,6 +19,15 @@ export default defineConfig(async () => {
     defineConfig({
       // cache directory for better performance
       cacheDir: ".vitest-cache",
+      // Fix for CI dependency optimization issues
+      optimizeDeps: {
+        include: [
+          "@chakra-ui/react",
+          "@chakra-ui/react/kbd",
+          "@storybook/react-vite",
+          "storybook/test",
+        ],
+      },
       plugins: [
         storybookTest({
           // The location of your Storybook config, main.js|ts


### PR DESCRIPTION
When making a comparison of how chunking nimbus affects consuming app bundle size in `application-account`, I noticed that chakra is importing all of its' ui components, most of which nimbus does not use.

This PR implements chakra's [recommended bundle size optimizations](https://chakra-ui.com/guides/component-bundle-optimization), resulting in a ~70% reduction in its' bundle size.

Before optimization 175kb:
<img width="1179" height="758" alt="Screenshot 2025-08-07 at 3 01 15 PM" src="https://github.com/user-attachments/assets/605a5917-5a0b-40b8-8cd5-e45d3e6bb68e" />

After optimization 52kb:
<img width="1563" height="1148" alt="Screenshot 2025-08-07 at 3 27 57 PM" src="https://github.com/user-attachments/assets/56d246d4-bd97-4581-9c92-db472c07030a" />


This pull request updates all component imports in the Nimbus codebase to use the new `@chakra-ui/react/styled-system` and related package structure, replacing previous imports from `@chakra-ui/react`. This change ensures compatibility with Chakra UI's latest modular package organization and prepares the codebase for future updates.

**Migration to Chakra UI's new package structure:**

* Updated all imports of `defineRecipe`, `defineSlotRecipe`, `createRecipeContext`, `createSlotRecipeContext`, `RecipeVariantProps`, `HTMLChakraProps`, and related types/functions to use `@chakra-ui/react/styled-system` instead of `@chakra-ui/react` across recipe, slot, and types files for components such as Accordion, Alert, Avatar, Badge, Box, and Button. [[1]](diffhunk://#diff-8994e293e7f42a404447550f16d6eddf7141205b05d750a62caf3db2fdd320cbL4-R4) [[2]](diffhunk://#diff-df82e1574a4463807fa1e8684fd692cec80310794dbc397c7a04c853b62b8937L9-R9) [[3]](diffhunk://#diff-42a19fcaab6d58f7ed6b3590568502023626c6cfcffed9b750d611c6eb705383L5-R5) [[4]](diffhunk://#diff-aca61edb672c506f7c4a88ba286b72321ef5e1bb89368a7faf01c102b956052eL1-R1) [[5]](diffhunk://#diff-af843e7ac50f492eb718e22c24c3705db99337320b0a320c64abf297457e88ecL4-R4) [[6]](diffhunk://#diff-cb5b0373b6b37aefbcd22df438e8018c3bb7d319c8f765670bce22013821c4eeL1-R4) [[7]](diffhunk://#diff-77255083fbb8905c082e1f622ae1a9b8bbb101ee82a4f96ced7cbc6c73d40933L4-R4) [[8]](diffhunk://#diff-b81de2e76c7b2819628c38b89c760a16c61b66f6ce06d2930a5b5722af971ddaL1-R1) [[9]](diffhunk://#diff-024d8e808f5811d5e3b72dca8af9efb0cc10432ec90b165c4b97215627bbaf30L1-R1) [[10]](diffhunk://#diff-2d0e4423771d32006857564b2d2bca224f74f12328602b47d35fb7f9f667fcb2L5-R5) [[11]](diffhunk://#diff-4a164959dcefe241f695d0918f633bcf5446c7ed9a528440190f4266ce5a0243L1-R1) [[12]](diffhunk://#diff-b2198476741cf89201aa3d37147dddf17f888f4a984df30cfb913315fcc44463L6-R6) [[13]](diffhunk://#diff-3d0361fcd4ec8ba7467d195973296f68507c9ee9690ef1c08d1d88aa7d747c2aL2-R2) [[14]](diffhunk://#diff-82965ef28f2d8207e25e3fb644c20d34556a4bb30f3f9524a34d83ac6d781367L1-R1) [[15]](diffhunk://#diff-0e84b8e579b2f0ef28ac024c97d5abe0850d59102208b11d0029fd6a85cd7cd4L1-R1) [[16]](diffhunk://#diff-e3014635142b3923039511cb0d2ae0868a88f69b3fb2d1d4fdd572c761694f85L6-R6) [[17]](diffhunk://#diff-64faa5111a033b6b138e4a447ee7261e2535d443e551f72e04ea51ff143ad376L1-R1)

**Component-specific import adjustments:**

* Changed imports for `Image` and `Box` components to use `@chakra-ui/react/image` and `@chakra-ui/react/box` respectively, reflecting Chakra UI's new modular exports. [[1]](diffhunk://#diff-2649126f39238d463836a76ea0e543e68b811a84fab55bf4aa205de9c76bb369L2-R2) [[2]](diffhunk://#diff-fb90fd762c474d25359514462e3dc7f90252b6039f388208bf635d2b98e7fd5fL1-R2)

These changes collectively modernize the codebase and ensure all components are using the recommended Chakra UI packages for styling and type definitions.