### PR TITLE
chore(n): fix `SplitButton` icon API

### DIFF
--- a/packages/nimbus/src/components/split-button/split-button.mdx
+++ b/packages/nimbus/src/components/split-button/split-button.mdx
@@ -1,7 +1,9 @@
 ---
 id: Components-SplitButton
 title: SplitButton
-description: A button that combines a primary action with a dropdown menu of related actions.
+description:
+  A button that combines a primary action with a dropdown menu of related
+  actions.
 lifecycleState: Alpha
 order: 999
 menu:
@@ -16,11 +18,15 @@ figmaLink: >-
 
 # SplitButton
 
-A button that combines a primary action with a dropdown menu of related actions, providing a flexible and accessible way to group related functionality.
+A button that combines a primary action with a dropdown menu of related actions,
+providing a flexible and accessible way to group related functionality.
 
 ## Overview
 
-The SplitButton component addresses the need for interfaces that require a dominant action with several less frequently used, but still important, related options. It provides a separate primary action button and a dropdown trigger for additional options.
+The SplitButton component addresses the need for interfaces that require a
+dominant action with several less frequently used, but still important, related
+options. It provides a separate primary action button and a dropdown trigger for
+additional options.
 
 ### Resources
 
@@ -37,16 +43,21 @@ Get familiar with the features.
 The basic SplitButton with a primary action and dropdown menu items.
 
 ```jsx-live
-const App = () => (
-  <SplitButton
-    onAction={(actionId) => alert(`Action: ${actionId}`)}
-    aria-label="More save options"
-  >
-    <Menu.Item id="save">Save</Menu.Item>
-    <Menu.Item id="save-publish">Save and Publish</Menu.Item>
-    <Menu.Item id="save-next">Save and Open Next</Menu.Item>
-  </SplitButton>
-)
+const App = () => {
+  const { Save } = icons;
+
+  return (
+    <SplitButton
+      onAction={(actionId) => alert(`Action: ${actionId}`)}
+      aria-label="More save options"
+      icon={<Save />}
+    >
+      <Menu.Item id="save">Save</Menu.Item>
+      <Menu.Item id="save-publish">Save and Publish</Menu.Item>
+      <Menu.Item id="save-next">Save and Open Next</Menu.Item>
+    </SplitButton>
+  );
+}
 ```
 
 ### Document Management Actions
@@ -54,40 +65,50 @@ const App = () => (
 A typical document management scenario with various file operations.
 
 ```jsx-live
-const App = () => (
-  <SplitButton
-    onAction={(actionId) => alert(`Action: ${actionId}`)}
-    aria-label="More document actions"
-  >
-    <Menu.Item id="share">Share Document</Menu.Item>
-    <Menu.Item id="copy-link">Copy Link</Menu.Item>
-    <Menu.Item id="email">Send via Email</Menu.Item>
-    <Menu.Item id="download">Download PDF</Menu.Item>
-    <Menu.Item id="print">Print Document</Menu.Item>
-  </SplitButton>
-)
+const App = () => {
+  const { Share } = icons;
+
+  return (
+    <SplitButton
+      onAction={(actionId) => alert(`Action: ${actionId}`)}
+      aria-label="More document actions"
+      icon={<Share />}
+    >
+      <Menu.Item id="share">Share Document</Menu.Item>
+      <Menu.Item id="copy-link">Copy Link</Menu.Item>
+      <Menu.Item id="email">Send via Email</Menu.Item>
+      <Menu.Item id="download">Download PDF</Menu.Item>
+      <Menu.Item id="print">Print Document</Menu.Item>
+    </SplitButton>
+  );
+}
 ```
 
 ### Task Actions with Critical Action
 
-Common task management actions showing how critical (destructive) actions are highlighted.
+Common task management actions showing how critical (destructive) actions are
+highlighted.
 
 ```jsx-live
-const App = () => (
-  <SplitButton
-    onAction={(actionId) => alert(`Action: ${actionId}`)}
-    aria-label="More task actions"
-  >
-    <Menu.Item id="complete">Complete Task</Menu.Item>
-    <Menu.Item id="edit">Edit Task</Menu.Item>
-    <Menu.Item id="duplicate">Duplicate Task</Menu.Item>
-    <Menu.Item id="archive">Archive Task</Menu.Item>
-    <Divider />
-    <Menu.Item id="delete" isCritical>Delete Task</Menu.Item>
-  </SplitButton>
-)
-```
+const App = () => {
+  const { Edit } = icons;
 
+  return (
+    <SplitButton
+      onAction={(actionId) => alert(`Action: ${actionId}`)}
+      aria-label="More task actions"
+      icon={<Edit />}
+    >
+      <Menu.Item id="complete">Complete Task</Menu.Item>
+      <Menu.Item id="edit">Edit Task</Menu.Item>
+      <Menu.Item id="duplicate">Duplicate Task</Menu.Item>
+      <Menu.Item id="archive">Archive Task</Menu.Item>
+      <Menu.Separator />
+      <Menu.Item id="delete" isCritical>Delete Task</Menu.Item>
+    </SplitButton>
+  );
+}
+```
 
 ### Organized Menu Sections
 
@@ -188,20 +209,27 @@ const App = () => (
 The SplitButton component provides a split-action interface:
 
 1. **Primary Button**: Automatically executes the first enabled Menu.Item action
-2. **Dropdown Trigger**: Separate arrow button opens the dropdown menu with all actions
-3. **Smart Selection**: If the first Menu.Item is disabled, automatically selects the next enabled one
-4. **Menu Actions**: Selecting items from the dropdown triggers the `onAction` callback
+2. **Dropdown Trigger**: Separate arrow button opens the dropdown menu with all
+   actions
+3. **Smart Selection**: If the first Menu.Item is disabled, automatically
+   selects the next enabled one
+4. **Menu Actions**: Selecting items from the dropdown triggers the `onAction`
+   callback
 
 ## Guidelines
 
-The SplitButton provides a space-efficient way to present a primary action alongside related secondary actions, maintaining visual hierarchy while offering comprehensive functionality.
+The SplitButton provides a space-efficient way to present a primary action
+alongside related secondary actions, maintaining visual hierarchy while offering
+comprehensive functionality.
 
 ### Best Practices
 
-- **Order Actions by Priority**: Place the most common or important action first in your Menu.Items
+- **Order Actions by Priority**: Place the most common or important action first
+  in your Menu.Items
 - **Related Actions**: Group logically related actions in the dropdown menu
 - **Appropriate Grouping**: Use Menu.Section to organize complex action sets
-- **Consistent Labeling**: Use clear, action-oriented labels that match your application's terminology
+- **Consistent Labeling**: Use clear, action-oriented labels that match your
+  application's terminology
 - **Critical Actions**: Use the `isCritical` prop for destructive actions
 - **Accessible Labels**: Provide meaningful aria-labels for screen readers
 
@@ -210,7 +238,8 @@ The SplitButton provides a space-efficient way to present a primary action along
 > [!TIP]\
 > When to use
 
-- When you have one dominant action with several related but less frequent options
+- When you have one dominant action with several related but less frequent
+  options
 - For document or data management interfaces with multiple export/save options
 - In task management systems where actions are contextually related
 - When you need to consolidate multiple related buttons to save space
@@ -221,7 +250,8 @@ The SplitButton provides a space-efficient way to present a primary action along
 
 - When actions are unrelated or serve different purposes
 - For navigation between different sections or pages
-- When all actions are equally important (use separate buttons or a Menu instead)
+- When all actions are equally important (use separate buttons or a Menu
+  instead)
 - For simple binary choices (use a toggle or two separate buttons)
 - When the primary action isn't clearly more important than alternatives
 
@@ -236,7 +266,8 @@ The SplitButton provides a space-efficient way to present a primary action along
 
 ### Critical Actions
 
-Use the `isCritical` prop on Menu.Item to highlight destructive or irreversible actions.
+Use the `isCritical` prop on Menu.Item to highlight destructive or irreversible
+actions.
 
 ```jsx-live
 const App = () => (
@@ -259,10 +290,14 @@ const App = () => (
 ### Features
 
 - **Split Button Interface**: Primary action button with dropdown trigger
-- **Automatic Selection**: Smart primary action selection from the first enabled Menu.Item
-- **Menu Integration**: Built on top of the Menu component for dropdown functionality  
-- **Keyboard Navigation**: Full keyboard support with Tab, Enter, Space, Arrow keys, and Escape
-- **Flexible Content**: Supports icons and rich menu content through slots
+- **Automatic Selection**: Smart primary action selection from the first enabled
+  Menu.Item
+- **Menu Integration**: Built on top of the Menu component for dropdown
+  functionality
+- **Keyboard Navigation**: Full keyboard support with Tab, Enter, Space, Arrow
+  keys, and Escape
+- **Flexible Content**: Supports icons through the icon prop and rich menu
+  content
 - **Accessible**: Built-in ARIA attributes and screen reader support
 - **Visual Variants**: Multiple size, variant, and tone options
 - **Critical Action Support**: Visual highlighting for destructive menu items
@@ -275,7 +310,9 @@ const App = () => (
 
 ## Accessibility
 
-The SplitButton component is built with accessibility in mind, providing full keyboard navigation and screen reader support for both the primary action and dropdown functionality.
+The SplitButton component is built with accessibility in mind, providing full
+keyboard navigation and screen reader support for both the primary action and
+dropdown functionality.
 
 ### Keyboard Interactions
 

--- a/packages/nimbus/src/components/split-button/split-button.stories.tsx
+++ b/packages/nimbus/src/components/split-button/split-button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within, expect, fn, waitFor } from "storybook/test";
 import { SplitButton } from "./index";
-import { Stack, Icon, Divider } from "@/components";
+import { Stack, Divider } from "@/components";
 import { Menu } from "@/components/menu";
 import { Save, Edit, Share } from "@commercetools/nimbus-icons";
 
@@ -24,10 +24,8 @@ export const Basic: Story = {
       defaultOpen={true}
       onAction={(id) => console.log(`Action: ${id}`)}
       aria-label="More actions"
+      icon={<Save />}
     >
-      <Icon slot="icon">
-        <Save />
-      </Icon>
       <Menu.Item id="save">Save</Menu.Item>
       <Menu.Item id="save-publish">Save and publish</Menu.Item>
       <Menu.Item id="save-next">Save and open next</Menu.Item>
@@ -147,10 +145,8 @@ export const DocumentManagement: Story = {
     <SplitButton
       onAction={(id) => alert(`${id} clicked!`)}
       aria-label="Document actions"
+      icon={<Share />}
     >
-      <Icon slot="icon">
-        <Share />
-      </Icon>
       <Menu.Item id="share">Share Document</Menu.Item>
       <Menu.Item id="copy-link">Copy Link</Menu.Item>
       <Menu.Item id="email">Send via Email</Menu.Item>
@@ -178,10 +174,8 @@ export const WithComplexContent: Story = {
     <SplitButton
       onAction={(id) => alert(`${id} clicked!`)}
       aria-label="Task actions"
+      icon={<Edit />}
     >
-      <Icon slot="icon">
-        <Edit />
-      </Icon>
       <Menu.Item id="complete">Complete Task</Menu.Item>
       <Menu.Item id="edit">Edit Task</Menu.Item>
       <Menu.Item id="duplicate">Duplicate Task</Menu.Item>
@@ -196,26 +190,32 @@ export const WithComplexContent: Story = {
 export const SizeVariants: Story = {
   render: () => (
     <Stack direction="row" gap="400" alignItems="center">
-      <SplitButton size="2xs" onAction={fn()} aria-label="Size variant actions">
-        <Icon slot="icon">
-          <Save />
-        </Icon>
+      <SplitButton
+        size="2xs"
+        onAction={fn()}
+        aria-label="Size variant actions"
+        icon={<Save />}
+      >
         <Menu.Item id="action1">Action 1</Menu.Item>
         <Menu.Item id="action2">Action 2</Menu.Item>
       </SplitButton>
 
-      <SplitButton size="xs" onAction={fn()} aria-label="Size variant actions">
-        <Icon slot="icon">
-          <Save />
-        </Icon>
+      <SplitButton
+        size="xs"
+        onAction={fn()}
+        aria-label="Size variant actions"
+        icon={<Save />}
+      >
         <Menu.Item id="action1">Action 1</Menu.Item>
         <Menu.Item id="action2">Action 2</Menu.Item>
       </SplitButton>
 
-      <SplitButton size="md" onAction={fn()} aria-label="Size variant actions">
-        <Icon slot="icon">
-          <Save />
-        </Icon>
+      <SplitButton
+        size="md"
+        onAction={fn()}
+        aria-label="Size variant actions"
+        icon={<Save />}
+      >
         <Menu.Item id="action1">Action 1</Menu.Item>
         <Menu.Item id="action2">Action 2</Menu.Item>
       </SplitButton>
@@ -236,10 +236,8 @@ export const SplitButtonVariants: Story = {
             tone="primary"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button save actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="save-publish">Save & Publish</Menu.Item>
           </SplitButton>
@@ -250,10 +248,8 @@ export const SplitButtonVariants: Story = {
             tone="primary"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button save actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="save-publish">Save & Publish</Menu.Item>
           </SplitButton>
@@ -264,10 +260,8 @@ export const SplitButtonVariants: Story = {
             tone="primary"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button save actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="save-publish">Save & Publish</Menu.Item>
           </SplitButton>
@@ -283,10 +277,8 @@ export const SplitButtonVariants: Story = {
             tone="primary"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button solid actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="export">Export</Menu.Item>
           </SplitButton>
@@ -296,10 +288,8 @@ export const SplitButtonVariants: Story = {
             tone="neutral"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button subtle actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="export">Export</Menu.Item>
           </SplitButton>
@@ -309,10 +299,8 @@ export const SplitButtonVariants: Story = {
             tone="primary"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button outline actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="export">Export</Menu.Item>
           </SplitButton>
@@ -322,10 +310,8 @@ export const SplitButtonVariants: Story = {
             tone="critical"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button outline critical actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="export">Export</Menu.Item>
           </SplitButton>
@@ -335,10 +321,8 @@ export const SplitButtonVariants: Story = {
             tone="primary"
             onAction={(id) => alert(`${id} clicked!`)}
             aria-label="Split button ghost actions"
+            icon={<Save />}
           >
-            <Icon slot="icon">
-              <Save />
-            </Icon>
             <Menu.Item id="save">Save</Menu.Item>
             <Menu.Item id="export">Export</Menu.Item>
           </SplitButton>
@@ -351,18 +335,21 @@ export const SplitButtonVariants: Story = {
 export const DisabledStates: Story = {
   render: () => (
     <Stack direction="row" gap="400">
-      <SplitButton isDisabled onAction={fn()} aria-label="Disabled actions">
-        <Icon slot="icon">
-          <Save />
-        </Icon>
+      <SplitButton
+        isDisabled
+        onAction={fn()}
+        aria-label="Disabled actions"
+        icon={<Save />}
+      >
         <Menu.Item id="action1">Disabled Action</Menu.Item>
         <Menu.Item id="action2">Another Action</Menu.Item>
       </SplitButton>
 
-      <SplitButton onAction={fn()} aria-label="Mixed state actions">
-        <Icon slot="icon">
-          <Save />
-        </Icon>
+      <SplitButton
+        onAction={fn()}
+        aria-label="Mixed state actions"
+        icon={<Save />}
+      >
         <Menu.Item id="available">Available Action</Menu.Item>
         <Menu.Item id="disabled" isDisabled>
           Disabled Item
@@ -383,10 +370,8 @@ export const AutomaticSelectionDemo: Story = {
       <SplitButton
         onAction={(id) => alert(`${id} clicked!`)}
         aria-label="Automatic selection demo"
+        icon={<Save />}
       >
-        <Icon slot="icon">
-          <Save />
-        </Icon>
         <Menu.Item id="save">Save</Menu.Item>
         <Menu.Item id="save-publish">Save and publish</Menu.Item>
         <Menu.Item id="save-next">Save and open next</Menu.Item>
@@ -407,11 +392,8 @@ export const WithSections: Story = {
       <SplitButton
         onAction={(id) => alert(`${id} clicked!`)}
         aria-label="Sectioned document actions"
+        icon={<Save />}
       >
-        <Icon slot="icon">
-          <Save />
-        </Icon>
-
         <Menu.Section label="File Actions">
           <Menu.Item id="save">Save Document</Menu.Item>
           <Menu.Item id="save-as">Save As Copy</Menu.Item>
@@ -440,10 +422,11 @@ export const WithSections: Story = {
 
 export const AccessibilityTest: Story = {
   render: () => (
-    <SplitButton aria-label="More sending options" onAction={fn()}>
-      <Icon slot="icon">
-        <Save />
-      </Icon>
+    <SplitButton
+      aria-label="More sending options"
+      onAction={fn()}
+      icon={<Save />}
+    >
       <Menu.Item id="send">Send Message</Menu.Item>
       <Menu.Item id="schedule">Schedule Send</Menu.Item>
       <Menu.Item id="draft">Save as Draft</Menu.Item>
@@ -555,10 +538,8 @@ export const EdgeCasesAndFallbacks: Story = {
         <SplitButton
           aria-label="Disabled first option test"
           onAction={(id) => alert(`Action: ${id}`)}
+          icon={<Save />}
         >
-          <Icon slot="icon">
-            <Save />
-          </Icon>
           <Menu.Item id="save" isDisabled>
             Save Document
           </Menu.Item>
@@ -577,11 +558,10 @@ export const EdgeCasesAndFallbacks: Story = {
         <SplitButton
           aria-label="No menu items test"
           onAction={(id) => alert(`Action: ${id}`)}
+          icon={<Save />}
         >
-          <Icon slot="icon">
-            <Save />
-          </Icon>
           {/* No Menu.Item components */}
+          <></>
         </SplitButton>
         <p style={{ fontSize: "12px", color: "#666" }}>
           Expected: Button shows "No actions available" and is disabled
@@ -598,10 +578,8 @@ export const EdgeCasesAndFallbacks: Story = {
         <SplitButton
           aria-label="All disabled items test"
           onAction={(id) => alert(`Action: ${id}`)}
+          icon={<Save />}
         >
-          <Icon slot="icon">
-            <Save />
-          </Icon>
           <Menu.Item id="save" isDisabled>
             Save Document
           </Menu.Item>
@@ -621,10 +599,8 @@ export const EdgeCasesAndFallbacks: Story = {
         <SplitButton
           aria-label="Empty section test"
           onAction={(id) => alert(`Action: ${id}`)}
+          icon={<Save />}
         >
-          <Icon slot="icon">
-            <Save />
-          </Icon>
           <Menu.Section label="Empty Section">
             {/* No Menu.Item components */}
           </Menu.Section>
@@ -641,10 +617,8 @@ export const EdgeCasesAndFallbacks: Story = {
         <SplitButton
           aria-label="Missing ID test"
           onAction={(id) => alert(`Action: ${id}`)}
+          icon={<Save />}
         >
-          <Icon slot="icon">
-            <Save />
-          </Icon>
           <Menu.Item>No ID Item</Menu.Item>
           <Menu.Item id="valid">Valid Item</Menu.Item>
           <Menu.Item>Another No ID</Menu.Item>

--- a/packages/nimbus/src/components/split-button/split-button.tsx
+++ b/packages/nimbus/src/components/split-button/split-button.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "@/components/button";
 import { IconButton } from "@/components/icon-button";
 import { Menu } from "@/components/menu";
+import { Icon } from "@/components/icon";
 import type { SplitButtonProps } from "./split-button.types";
 import {
   SplitButtonRootSlot,
@@ -36,6 +37,7 @@ export const SplitButton = (props: SplitButtonProps) => {
     isOpen,
     defaultOpen,
     onOpenChange,
+    icon,
   } = props;
 
   const buttonProps = { size, variant, tone };
@@ -81,18 +83,8 @@ export const SplitButton = (props: SplitButtonProps) => {
     return "children" in props;
   };
 
-  // Separate Icon slots from Menu items
-  const childArray = React.Children.toArray(props.children);
-  const iconElement = childArray.find(
-    (child): child is React.ReactElement =>
-      React.isValidElement(child) &&
-      (child.props as { slot?: string })?.slot === "icon"
-  );
-  const menuItems = childArray.filter(
-    (child) =>
-      !React.isValidElement(child) ||
-      (child.props as { slot?: string })?.slot !== "icon"
-  );
+  // All children are menu items
+  const menuItems = props.children;
 
   /**
    * Check if there are any actionable (enabled) Menu.Items in the children.
@@ -189,7 +181,7 @@ export const SplitButton = (props: SplitButtonProps) => {
             isDisabled={isPrimaryDisabled}
             onPress={executePrimaryAction}
           >
-            {iconElement}
+            {icon && <Icon>{icon}</Icon>}
             {buttonContent.content}
           </Button>
         </SplitButtonPrimaryButtonSlot>

--- a/packages/nimbus/src/components/split-button/split-button.types.ts
+++ b/packages/nimbus/src/components/split-button/split-button.types.ts
@@ -15,9 +15,11 @@ export interface SplitButtonProps
    */
   "aria-label": string;
   /**
-   * Children should contain:
-   * - Icon slot: Icon component with slot="icon" containing an icon element
-   * - Menu components: Menu.Item, Menu.Section, Divider
+   * Icon element to display in the primary button (automatically wrapped in Icon component)
+   */
+  icon?: ReactNode;
+  /**
+   * Children should contain Menu components: Menu.Item, Menu.Section, Menu.Separator
    *
    * The component automatically selects the first enabled Menu.Item as the primary action.
    */


### PR DESCRIPTION
## Summary

This PR alters the SplitButton consumer API to prefer a prop for `Icon` rather than a slot.