### PR TITLE
Rich Text Editor - PoC for moving focus from toolbar to editor

### DIFF
--- a/packages/nimbus/src/components/rich-text-input/components/rich-text-toolbar.tsx
+++ b/packages/nimbus/src/components/rich-text-input/components/rich-text-toolbar.tsx
@@ -31,6 +31,7 @@ import {
   toggleMark,
   toggleBlock,
   usePreservedSelection,
+  focusEditor,
 } from "./rich-text-utils";
 import type { CustomElement } from "./rich-text-utils/types";
 import { FormattingMenu } from "./formatting-menu";
@@ -196,6 +197,15 @@ export const RichTextToolbar = ({
       <Group>
         <Menu.Root
           onAction={(styleId) => handleTextStyleChange(String(styleId))}
+          onClose={() => {
+            console.log("onClose called");
+            requestAnimationFrame(() =>
+              setTimeout(() => {
+                console.log("focus editor called");
+                focusEditor(editor);
+              }, 50)
+            );
+          }}
         >
           <Tooltip.Root delay={0} closeDelay={0}>
             <Menu.Trigger


### PR DESCRIPTION
This pull request introduces an improvement to the `RichTextToolbar` component by ensuring the editor is refocused when the formatting menu is closed. This should enhance the user experience by allowing users to continue typing immediately after interacting with the formatting options.

**Rich Text Toolbar usability improvements:**

* Added an `onClose` handler to the formatting menu in `RichTextToolbar` that refocuses the editor after the menu is closed, using `focusEditor` with a short delay to ensure proper timing.
* Imported the `focusEditor` utility function from `rich-text-utils` to support the new focus behavior.