### PR TITLE
Bw/focus editor on toolbar menu close

### DIFF
--- a/packages/nimbus/src/components/rich-text-input/components/rich-text-editor.tsx
+++ b/packages/nimbus/src/components/rich-text-input/components/rich-text-editor.tsx
@@ -3,11 +3,18 @@ import {
   useCallback,
   useImperativeHandle,
   forwardRef,
+  useRef,
   type ForwardedRef,
   type FocusEventHandler,
   type ReactNode,
 } from "react";
-import { createEditor, type Descendant } from "slate";
+import {
+  createEditor,
+  type Descendant,
+  Transforms,
+  Editor,
+  type Range,
+} from "slate";
 import { Slate, Editable, withReact } from "slate-react";
 import { withHistory } from "slate-history";
 import isHotkey from "is-hotkey";
@@ -67,6 +74,9 @@ export const RichTextEditor = forwardRef<
     toolbar,
   } = props;
 
+  // Store the last cursor position when editor loses focus
+  const lastSelectionRef = useRef<Range | null>(null);
+
   // Create editor with plugins
   const editor = useMemo(() => {
     const baseEditor = createEditor();
@@ -113,18 +123,44 @@ export const RichTextEditor = forwardRef<
       if (onFocus) {
         onFocus(event);
       }
+
+      // Restore cursor position if we have a saved selection
+      if (lastSelectionRef.current) {
+        // Use requestAnimationFrame to ensure the editor is fully focused and ready
+        requestAnimationFrame(() => {
+          try {
+            // Check if the saved selection is still valid
+            if (
+              lastSelectionRef.current &&
+              Editor.hasPath(editor, lastSelectionRef.current.anchor.path) &&
+              Editor.hasPath(editor, lastSelectionRef.current.focus.path)
+            ) {
+              Transforms.select(editor, lastSelectionRef.current);
+            }
+          } catch (error) {
+            // If the selection is invalid, clear it and let the editor use default focus behavior
+            console.warn("Could not restore cursor position:", error);
+          }
+        });
+      }
     },
-    [onFocus]
+    [onFocus, editor]
   );
 
   // Handle blur
   const handleBlur = useCallback(
     (event: React.FocusEvent<HTMLDivElement>) => {
+      // Save current cursor position when losing focus
+      const { selection } = editor;
+      if (selection) {
+        lastSelectionRef.current = selection;
+      }
+
       if (onBlur) {
         onBlur(event);
       }
     },
-    [onBlur]
+    [onBlur, editor]
   );
 
   // Expose methods through ref

--- a/packages/nimbus/src/components/rich-text-input/components/rich-text-toolbar.tsx
+++ b/packages/nimbus/src/components/rich-text-input/components/rich-text-toolbar.tsx
@@ -198,7 +198,6 @@ export const RichTextToolbar = ({
           onAction={(styleId) => handleTextStyleChange(String(styleId))}
           onClose={() => {
             // This is a workaround to ensure the editor is focused when the menu is closed
-
             requestAnimationFrame(() =>
               setTimeout(() => {
                 focusEditor(editor);


### PR DESCRIPTION
This pull request improves the user experience of the `RichTextInput` component by ensuring that the cursor position is preserved and restored when the editor loses and regains focus, especially after interacting with the formatting toolbar. It also adds a Storybook test to verify this behavior.

**Cursor position restoration in the rich text editor:**
- Added logic in `rich-text-editor.tsx` to save the current cursor position (`selection`) when the editor loses focus and restore it when focus returns, using `lastSelectionRef` and Slate's `Transforms.select`. This ensures users can continue typing exactly where they left off after interacting with toolbar menus. [[1]](diffhunk://#diff-2cc46ea5aa3b35789d188420f4089812be99c1aa472f4836cec22758a2106011R6-R17) [[2]](diffhunk://#diff-2cc46ea5aa3b35789d188420f4089812be99c1aa472f4836cec22758a2106011R77-R79) [[3]](diffhunk://#diff-2cc46ea5aa3b35789d188420f4089812be99c1aa472f4836cec22758a2106011R126-R163)

**Toolbar focus management:**
- Updated `rich-text-toolbar.tsx` to programmatically refocus the editor after the formatting menu closes, using a new `focusEditor` utility and a slight delay to ensure the editor is ready. [[1]](diffhunk://#diff-c039a1eb33b5e7c83c7309f0d74dc2226b15344679972a74b93128b010027295R34) [[2]](diffhunk://#diff-c039a1eb33b5e7c83c7309f0d74dc2226b15344679972a74b93128b010027295R200-R206)

**Testing and documentation:**
- Added a new Storybook story, `OnFocusCursorPositionRestoration`, to `rich-text-input.stories.tsx` that tests and demonstrates the cursor restoration behavior after using the toolbar. [[1]](diffhunk://#diff-cad8d7967ff77ab87d8a837cdfc69bf1b8b2fb6d83a88016c3ef142bb4b17d24L5-R5) [[2]](diffhunk://#diff-cad8d7967ff77ab87d8a837cdfc69bf1b8b2fb6d83a88016c3ef142bb4b17d24R876-R943)