### PR TITLE
Nimbus - Data table - fix interactive columns against horizontal scroll

### DIFF
--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -336,7 +336,11 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
            * need to be in the same order in the header and row components*/}
           {/* Selection checkbox cell if selection is enabled */}
           {selectionBehavior === "toggle" && (
-            <DataTableCell data-slot="selection" isDisabled={isDisabled}>
+            <DataTableCell
+              className="data-table-sticky-cell"
+              data-slot="selection"
+              isDisabled={isDisabled}
+            >
               <Box
                 display="flex"
                 alignItems="center"
@@ -355,7 +359,11 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
 
           {/* Expand/collapse cell if expand column is shown */}
           {showExpandColumn && (
-            <DataTableCell data-slot="expand" isDisabled={isDisabled}>
+            <DataTableCell
+              className="data-table-sticky-cell"
+              data-slot="expand"
+              isDisabled={isDisabled}
+            >
               {hasNestedContent ? (
                 <DataTableExpandButton
                   w="100%"
@@ -401,7 +409,11 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
               );
             }}
           </RaCollection>
-          <DataTableCell data-slot="pin-row-cell" isDisabled={isDisabled}>
+          <DataTableCell
+            className={"data-table-sticky-cell"}
+            data-slot="pin-row-cell"
+            isDisabled={isDisabled}
+          >
             <Box
               data-slot={
                 isPinned

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -403,11 +403,11 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
           </RaCollection>
           <DataTableCell data-slot="pin-row-cell" isDisabled={isDisabled}>
             <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              w="100%"
-              h="100%"
+              data-slot={
+                isPinned
+                  ? "nimbus-table-cell-pin-button-pinned"
+                  : "nimbus-table-cell-pin-button"
+              }
             >
               <Tooltip.Root>
                 <IconButton
@@ -416,7 +416,6 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
                   variant="ghost"
                   aria-label={isPinned ? "Unpin row" : "Pin row"}
                   colorPalette="primary"
-                  className={`nimbus-table-cell-pin-button ${isPinned ? "nimbus-table-cell-pin-button-pinned" : ""}`}
                   onClick={(e) => {
                     e.stopPropagation();
                     togglePin(row.id);

--- a/packages/nimbus/src/components/data-table/data-table.recipe.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.tsx
@@ -115,17 +115,13 @@ export const dataTableRecipe = defineSlotRecipe({
               opacity: 1,
             },
           },
+          "& .data-table-row[data-disabled='true']": {
+            opacity: 0.8,
+          },
         },
       },
       "& .data-table-row[data-selected='true']": {
-        background: "{colors.primary.4}",
-        "& [data-slot='selection']": {
-          backgroundColor: "inherit",
-        },
-        "& [data-slot='expand']": {
-          backgroundColor: "inherit",
-        },
-        "& [data-slot='pin-row-cell']": {
+        "& .data-table-sticky-cell": {
           backgroundColor: "inherit",
         },
       },

--- a/packages/nimbus/src/components/data-table/data-table.recipe.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.tsx
@@ -45,9 +45,6 @@ export const dataTableRecipe = defineSlotRecipe({
         color: "neutral.11",
         focusRing: "outside",
         hyphens: "auto",
-        "& [data-slot='expand']": {
-          padding: 0,
-        },
         "& [data-slot='pin-row-cell']": {
           alignItems: "center",
           justifyContent: "center",
@@ -75,10 +72,42 @@ export const dataTableRecipe = defineSlotRecipe({
             opacity: 1,
           },
         },
+        "& [data-slot='selection']": {
+          backgroundColor: "white",
+          position: "sticky",
+          left: 0,
+          zIndex: 11,
+        },
+        "& [data-slot='expand']": {
+          backgroundColor: "white",
+          position: "sticky",
+          left: 0, // Default position when no selection column
+          zIndex: 12,
+        },
+        // When selection column is present, move expand column to the right
+        "& [data-slot='selection'] ~ [data-slot='expand']": {
+          left: "72px", // Width of selection column
+        },
         _hover: {
           backgroundColor: "{colors.primary.3}",
           transition: "background-color 100ms ease",
           transform: "translate3d(0, 0, 0)",
+          "& [data-slot='selection']": {
+            backgroundColor: "{colors.primary.3}",
+            position: "sticky",
+            left: 0,
+            zIndex: 11,
+          },
+          "& [data-slot='expand']": {
+            backgroundColor: "{colors.primary.3}",
+            position: "sticky",
+            left: 0, // Default position when no selection column
+            zIndex: 12,
+          },
+          // When selection column is present, move expand column to the right on hover
+          "& [data-slot='selection'] ~ [data-slot='expand']": {
+            left: "72px", // Width of selection column
+          },
           "& [data-slot='pin-row-cell']": {
             backgroundColor: "{colors.primary.3}",
             position: "sticky",
@@ -92,6 +121,12 @@ export const dataTableRecipe = defineSlotRecipe({
       },
       "& .data-table-row[data-selected='true']": {
         background: "{colors.primary.4}",
+        "& [data-slot='selection']": {
+          backgroundColor: "{colors.primary.4}",
+        },
+        "& [data-slot='expand']": {
+          backgroundColor: "{colors.primary.4}",
+        },
         "& [data-slot='pin-row-cell']": {
           backgroundColor: "{colors.primary.4}",
         },
@@ -100,6 +135,14 @@ export const dataTableRecipe = defineSlotRecipe({
         // layerStyle: "disabled",
         opacity: 0.8,
         cursor: "not-allowed",
+        "& [data-slot='selection']": {
+          backgroundColor: "white",
+          opacity: 0.8,
+        },
+        "& [data-slot='expand']": {
+          backgroundColor: "white",
+          opacity: 0.8,
+        },
         "& [data-slot='pin-row-cell']": {
           backgroundColor: "white",
           opacity: 0.8,
@@ -107,12 +150,31 @@ export const dataTableRecipe = defineSlotRecipe({
       },
       "& .data-table-row-pinned": {
         boxShadow: "var(--pinned-shadow-left), var(--pinned-shadow-right)",
+
+        "& [data-slot='selection']": {
+          backgroundColor: "white",
+          position: "sticky",
+          left: 0,
+          zIndex: 3,
+          clipPath: "inset(2px 0)",
+        },
+        "& [data-slot='expand']": {
+          backgroundColor: "white",
+          position: "sticky",
+          left: 0, // Default position when no selection column
+          zIndex: 3,
+          clipPath: "inset(2px 0)",
+        },
+        // When selection column is present in pinned rows, move expand column
+        "& [data-slot='selection'] ~ [data-slot='expand']": {
+          left: "72px", // Width of selection column
+        },
         "& [data-slot='pin-row-cell']": {
           backgroundColor: "white",
           position: "sticky",
           right: 0,
           zIndex: 3,
-          clipPath: "inset(2px)",
+          clipPath: "inset(2px 0)",
         },
         "&.data-table-row-pinned-first": {
           boxShadow:
@@ -237,18 +299,34 @@ export const dataTableRecipe = defineSlotRecipe({
           flexShrink: 0,
         },
       },
-      "&.selection-column-header, &.expand-column-header": {
+      "&.selection-column-header": {
         cursor: "default",
         paddingTop: "100",
         paddingBottom: "100",
         paddingLeft: "600",
         paddingRight: "600",
+        position: "sticky",
+        left: 0,
+        zIndex: 13,
+        backgroundColor: "colorPalette.2",
         "&:hover": {
-          backgroundColor: "transparent",
+          backgroundColor: "colorPalette.2",
         },
       },
       "&.expand-column-header": {
+        cursor: "default",
         padding: "0",
+        position: "sticky",
+        left: 0, // Default position when no selection column
+        zIndex: 12,
+        backgroundColor: "colorPalette.2",
+        "&:hover": {
+          backgroundColor: "colorPalette.2",
+        },
+      },
+      // When selection column is present, adjust expand column header position
+      "&.selection-column-header + &.expand-column-header": {
+        left: "72px", // Width of selection column
       },
       "&.pin-rows-column-header": {
         cursor: "default",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.tsx
@@ -64,6 +64,8 @@ export const dataTableRecipe = defineSlotRecipe({
           borderBottom: "none",
         },
         "& [data-slot='pin-row-cell']": {
+          position: "sticky",
+          right: 0,
           zIndex: 3,
           "& [data-slot='nimbus-table-cell-pin-button']": {
             opacity: 0,
@@ -72,16 +74,15 @@ export const dataTableRecipe = defineSlotRecipe({
             opacity: 1,
           },
         },
-        "& [data-slot='selection']": {
+        "& .data-table-sticky-cell": {
           backgroundColor: "white",
           position: "sticky",
           left: 0,
+        },
+        "& [data-slot='selection']": {
           zIndex: 11,
         },
         "& [data-slot='expand']": {
-          backgroundColor: "white",
-          position: "sticky",
-          left: 0, // Default position when no selection column
           zIndex: 12,
         },
         // When selection column is present, move expand column to the right
@@ -92,16 +93,15 @@ export const dataTableRecipe = defineSlotRecipe({
           backgroundColor: "{colors.primary.3}",
           transition: "background-color 100ms ease",
           transform: "translate3d(0, 0, 0)",
-          "& [data-slot='selection']": {
-            backgroundColor: "{colors.primary.3}",
+          "& .data-table-sticky-cell": {
+            transition: "background-color 100ms ease",
+            backgroundColor: "inherit",
             position: "sticky",
-            left: 0,
+          },
+          "& [data-slot='selection']": {
             zIndex: 11,
           },
           "& [data-slot='expand']": {
-            backgroundColor: "{colors.primary.3}",
-            position: "sticky",
-            left: 0, // Default position when no selection column
             zIndex: 12,
           },
           // When selection column is present, move expand column to the right on hover
@@ -109,8 +109,6 @@ export const dataTableRecipe = defineSlotRecipe({
             left: "72px", // Width of selection column
           },
           "& [data-slot='pin-row-cell']": {
-            backgroundColor: "{colors.primary.3}",
-            position: "sticky",
             right: 0,
             zIndex: 10,
             "& [data-slot='nimbus-table-cell-pin-button']": {
@@ -122,47 +120,33 @@ export const dataTableRecipe = defineSlotRecipe({
       "& .data-table-row[data-selected='true']": {
         background: "{colors.primary.4}",
         "& [data-slot='selection']": {
-          backgroundColor: "{colors.primary.4}",
+          backgroundColor: "inherit",
         },
         "& [data-slot='expand']": {
-          backgroundColor: "{colors.primary.4}",
+          backgroundColor: "inherit",
         },
         "& [data-slot='pin-row-cell']": {
-          backgroundColor: "{colors.primary.4}",
+          backgroundColor: "inherit",
         },
       },
       "& .data-table-row[data-disabled='true']": {
         // layerStyle: "disabled",
         opacity: 0.8,
         cursor: "not-allowed",
-        "& [data-slot='selection']": {
-          backgroundColor: "white",
-          opacity: 0.8,
-        },
-        "& [data-slot='expand']": {
-          backgroundColor: "white",
-          opacity: 0.8,
-        },
-        "& [data-slot='pin-row-cell']": {
-          backgroundColor: "white",
-          opacity: 0.8,
-        },
+        backgroundColor: "inherit",
       },
       "& .data-table-row-pinned": {
         boxShadow: "var(--pinned-shadow-left), var(--pinned-shadow-right)",
-
-        "& [data-slot='selection']": {
+        "& .data-table-sticky-cell": {
           backgroundColor: "white",
           position: "sticky",
           left: 0,
           zIndex: 3,
-          clipPath: "inset(2px 0)",
+        },
+        "& [data-slot='selection']": {
+          clipPath: "inset(2px 0 2px 2px)",
         },
         "& [data-slot='expand']": {
-          backgroundColor: "white",
-          position: "sticky",
-          left: 0, // Default position when no selection column
-          zIndex: 3,
           clipPath: "inset(2px 0)",
         },
         // When selection column is present in pinned rows, move expand column
@@ -172,9 +156,7 @@ export const dataTableRecipe = defineSlotRecipe({
         "& [data-slot='pin-row-cell']": {
           backgroundColor: "white",
           position: "sticky",
-          right: 0,
-          zIndex: 3,
-          clipPath: "inset(2px 0)",
+          clipPath: "inset(2px 2px 2px 0)",
         },
         "&.data-table-row-pinned-first": {
           boxShadow:

--- a/packages/nimbus/src/components/data-table/data-table.recipe.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.tsx
@@ -16,7 +16,6 @@ export const dataTableRecipe = defineSlotRecipe({
     "cell",
     "footer",
     "selectionCell",
-    "detailsButton",
     "expandButton",
     "nestedIcon",
     "headerSortIcon",
@@ -46,21 +45,16 @@ export const dataTableRecipe = defineSlotRecipe({
         color: "neutral.11",
         focusRing: "outside",
         hyphens: "auto",
-        "&[data-slot='expand']": {
+        "& [data-slot='expand']": {
           padding: 0,
         },
-        "&[data-slot='pin-row-cell']": {
+        "& [data-slot='pin-row-cell']": {
           alignItems: "center",
           justifyContent: "center",
-        },
-        "& .nimbus-table-cell-copy-button": {
-          display: "none",
-        },
-        "& .nimbus-table-cell-pin-button": {
-          display: "none",
-        },
-        "& .nimbus-table-cell-pin-button-pinned": {
-          display: "inherit",
+          position: "sticky",
+          right: 0,
+          zIndex: 10,
+          backgroundColor: "white",
         },
       },
       "& .data-table-row": {
@@ -72,37 +66,54 @@ export const dataTableRecipe = defineSlotRecipe({
         "&:last-child": {
           borderBottom: "none",
         },
+        "& [data-slot='pin-row-cell']": {
+          zIndex: 3,
+          "& [data-slot='nimbus-table-cell-pin-button']": {
+            opacity: 0,
+          },
+          "& [data-slot='nimbus-table-cell-pin-button-pinned']": {
+            opacity: 1,
+          },
+        },
         _hover: {
           backgroundColor: "{colors.primary.3}",
           transition: "background-color 100ms ease",
           transform: "translate3d(0, 0, 0)",
-          "& .data-table-row-details-button": {
-            opacity: 1,
+          "& [data-slot='pin-row-cell']": {
+            backgroundColor: "{colors.primary.3}",
+            position: "sticky",
+            right: 0,
+            zIndex: 10,
+            "& [data-slot='nimbus-table-cell-pin-button']": {
+              opacity: 1,
+            },
           },
-          "& .nimbus-table-cell-copy-button": {
-            display: "inherit",
-          },
-          "& .nimbus-table-cell-pin-button": {
-            display: "inherit",
-          },
-        },
-        "& .data-table-row-details-button": {
-          opacity: 0,
-        },
-        "& .data-table-row-details-button:focus": {
-          opacity: 1,
         },
       },
       "& .data-table-row[data-selected='true']": {
         background: "{colors.primary.4}",
+        "& [data-slot='pin-row-cell']": {
+          backgroundColor: "{colors.primary.4}",
+        },
       },
       "& .data-table-row[data-disabled='true']": {
         // layerStyle: "disabled",
         opacity: 0.8,
         cursor: "not-allowed",
+        "& [data-slot='pin-row-cell']": {
+          backgroundColor: "white",
+          opacity: 0.8,
+        },
       },
       "& .data-table-row-pinned": {
         boxShadow: "var(--pinned-shadow-left), var(--pinned-shadow-right)",
+        "& [data-slot='pin-row-cell']": {
+          backgroundColor: "white",
+          position: "sticky",
+          right: 0,
+          zIndex: 3,
+          clipPath: "inset(2px)",
+        },
         "&.data-table-row-pinned-first": {
           boxShadow:
             "var(--pinned-shadow-left), var(--pinned-shadow-right), var(--pinned-shadow-top)",
@@ -239,6 +250,20 @@ export const dataTableRecipe = defineSlotRecipe({
       "&.expand-column-header": {
         padding: "0",
       },
+      "&.pin-rows-column-header": {
+        cursor: "default",
+        paddingTop: "100",
+        paddingBottom: "100",
+        paddingLeft: "600",
+        paddingRight: "600",
+        position: "sticky",
+        right: 0,
+        zIndex: 11,
+        backgroundColor: "colorPalette.2",
+        "&:hover": {
+          backgroundColor: "colorPalette.2",
+        },
+      },
       "&[aria-sort]": {
         fontWeight: 600,
         cursor: "pointer",
@@ -258,9 +283,6 @@ export const dataTableRecipe = defineSlotRecipe({
         backgroundColor: "{colors.primary.3}",
         transition: "background-color 200ms ease",
         transform: "translate3d(0, 0, 0)",
-        "& .nimbus-data-table__detailsButton": {
-          opacity: 1,
-        },
       },
       "& td, div": {
         userSelect: "none",
@@ -292,17 +314,8 @@ export const dataTableRecipe = defineSlotRecipe({
       focusRing: "outside",
       hyphens: "auto",
       height: "100%",
-      _hover: {
-        "& .nimbus-table-cell-copy-button:not([data-disabled='true'])": {
-          display: "inherit",
-        },
-      },
       "&[data-slot='expand']": {
         padding: 0,
-      },
-      "& .nimbus-table-cell-copy-button": {
-        display: "none",
-        ml: "100",
       },
       "&[data-nested-cell]": {
         boxShadow: "inset 2px 0 0 {colors.primary.10}",
@@ -312,18 +325,6 @@ export const dataTableRecipe = defineSlotRecipe({
       width: "100%",
     },
     selectionCell: {},
-    detailsButton: {
-      margin: "auto",
-      colorPalette: "primary",
-      opacity: 0,
-      focusRing: "outside",
-      _focus: {
-        opacity: 1,
-      },
-      "&[data-disabled='true']": {
-        opacity: 0,
-      },
-    },
     nestedIcon: {},
     headerSortIcon: {
       transition: "transform 300ms cubic-bezier(0.4, 0.0, 0.2, 1)",

--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -1819,8 +1819,15 @@ export const RowPinning: Story = {
         // Pin button should exist in DOM but be hidden via CSS
         const pinButton = within(firstDataRow).getByLabelText(/pin row/i);
         expect(pinButton).toBeInTheDocument();
-        expect(pinButton).toHaveClass("nimbus-table-cell-pin-button");
-        expect(pinButton).not.toHaveClass(
+
+        // Check the wrapper element has the correct data-slot attribute
+        const pinButtonWrapper = pinButton.parentElement;
+        expect(pinButtonWrapper).toHaveAttribute(
+          "data-slot",
+          "nimbus-table-cell-pin-button"
+        );
+        expect(pinButtonWrapper).not.toHaveAttribute(
+          "data-slot",
           "nimbus-table-cell-pin-button-pinned"
         );
       }
@@ -1850,10 +1857,16 @@ export const RowPinning: Story = {
       await waitFor(async () => {
         // Row should now have pinned styling
         expect(firstDataRow).toHaveClass("data-table-row-pinned");
-        // Pin button should show "unpin" state and have pinned class
+        // Pin button should show "unpin" state and have pinned data-slot
         const unpinButton = within(firstDataRow).getByLabelText(/unpin row/i);
         expect(unpinButton).toBeInTheDocument();
-        expect(unpinButton).toHaveClass("nimbus-table-cell-pin-button-pinned");
+
+        // Check the wrapper element has the pinned data-slot attribute
+        const unpinButtonWrapper = unpinButton.parentElement;
+        expect(unpinButtonWrapper).toHaveAttribute(
+          "data-slot",
+          "nimbus-table-cell-pin-button-pinned"
+        );
       });
     });
 
@@ -1865,9 +1878,13 @@ export const RowPinning: Story = {
       expect(firstDataRow).toHaveClass("data-table-row-pinned");
       expect(firstDataRow).toHaveClass("data-table-row-pinned-single");
 
-      // Pin button should be visible with pinned class
+      // Pin button should be visible with pinned data-slot attribute
       const pinButton = within(firstDataRow).getByLabelText(/unpin row/i);
-      expect(pinButton).toHaveClass("nimbus-table-cell-pin-button-pinned");
+      const pinButtonWrapper = pinButton.parentElement;
+      expect(pinButtonWrapper).toHaveAttribute(
+        "data-slot",
+        "nimbus-table-cell-pin-button-pinned"
+      );
     });
 
     await step("Can pin multiple rows", async () => {


### PR DESCRIPTION
- The selection checkbox buttons of the data table, along with the collapsible button and the pin row buttons currently scroll along with the data table. These three columns should be fixed while scrolling horizontally. they should always remain in their position while the rest of the table columns scroll horizontally. 
- Make the pin rows feature of the Data table sticky and always visible without it scrolling out of view.
- Fix pin hover effect that somehow stopped worked.
- Use the opportunity to clean up unused leftover code. 

How to test:
- Go to the all features story 
- Enable `Show all columns"
- Enable Text truncation for a simplified ui. 
- Interact with the select, expand and pin buttons, and also scroll the table horizontally. 

**Result**: these 3 buttons should always stay fixed when the table is scrolled horizontally.