### PR TITLE
chore(bug-report): create bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: <title>"
+labels: ["Type: Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before you submit, please search open/closed github issues and discussions since someone might have asked something similar before.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Nimbus Version Number
+      description: Please provide the version number you are using.
+    validations:
+      required: true
+  - type: input
+    id: browser-os
+    attributes:
+      label: Browser + OS
+      description: Please provide the operating system (e.g., Windows 11, macOS Sonoma, Ubuntu 24.04) and browser version (e.g., Chrome 116.0, Firefox 117.0) where the issue can be reproduced.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this bug?
+      multiple: true
+      options:
+        - Low
+        - Medium
+        - High
+        - Critical
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.


### PR DESCRIPTION
This pull request adds a new GitHub issue template for bug reports, based on the current UI-Kit bug report.

Issue template addition:

* Added `.github/ISSUE_TEMPLATE/BUG-REPORT.yml` to provide a structured form for submitting bug reports, ensuring all necessary details are collected for efficient triaging and resolution.