### PR TITLE
CRAFT 1586 | inline svg - use DOMPurify instead of maintaining custom dom sanitization code

### DIFF
--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -23,7 +23,10 @@
       }
     }
   },
-  "files": ["dist", "package.json"],
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -32,10 +35,14 @@
     "type": "git",
     "url": "https://github.com/commercetools/nimbus.git"
   },
-  "sideEffects": ["*.css"],
+  "sideEffects": [
+    "*.css"
+  ],
   "typesVersions": {
     "*": {
-      "*": ["./dist/index.d.ts"]
+      "*": [
+        "./dist/index.d.ts"
+      ]
     }
   },
   "dependencies": {
@@ -77,6 +84,7 @@
     "@vueless/storybook-dark-mode": "catalog:tooling",
     "apca-w3": "^0.1.9",
     "axe-core": "^4.10.2",
+    "dompurify": "catalog:",
     "glob": "catalog:tooling",
     "playwright": "catalog:tooling",
     "react": "catalog:react",

--- a/packages/nimbus/src/components/inline-svg/constants/sanitization.constants.ts
+++ b/packages/nimbus/src/components/inline-svg/constants/sanitization.constants.ts
@@ -11,9 +11,9 @@ export const DEFAULT_FORBIDDEN_TAGS = [
   "link",
   "base",
   "meta",
-] as const;
+];
 
 /**
  * Protocols allowed in URL attributes
  */
-export const ALLOWED_PROTOCOLS = ["http:", "https:", "#", "//"] as const;
+export const ALLOWED_PROTOCOLS = ["http:", "https:", "#", "//"];

--- a/packages/nimbus/src/components/inline-svg/hooks/use-inline-svg.ts
+++ b/packages/nimbus/src/components/inline-svg/hooks/use-inline-svg.ts
@@ -37,6 +37,7 @@ export function useInlineSvg(data: string) {
     const svgEl = doc.querySelector("svg");
 
     if (!svgEl) {
+      console.warn("InlineSvg: No SVG element found in markup");
       return {
         isValid: false,
         svgAttributes: {},

--- a/packages/nimbus/src/components/inline-svg/inline-svg.stories.tsx
+++ b/packages/nimbus/src/components/inline-svg/inline-svg.stories.tsx
@@ -58,13 +58,14 @@ const multiColorSvg = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/sv
 </svg>`;
 
 // Malicious SVG data for security testing
-const maliciousSvg = `<svg fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" onclick="alert('XSS')" onLoad="alert('XSS2')">
-  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" onmouseover="alert('XSS4')"/>
-  <polyline points="7.5 4.21 12 6.81 16.5 4.21"/>
+const maliciousSvg = `<svg fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" onclick="alert('XSS')" onLoad="alert('XSS2')">
+  <path xlink:href="data:x,<script>alert('XSS5')</script>" d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" onmouseover="alert('XSS4')"/>
+  <polyline xlink:malicious="<script>alert('XSS6')</script>"points="7.5 4.21 12 6.81 16.5 4.21"/>
   <polyline points="7.5 19.79 7.5 14.6 3 12"/>
   <polyline points="21 12 16.5 14.6 16.5 19.79"/>
   <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
   <line x1="12" x2="12" y1="22.08" y2="12"/>
+  <a xlink:href="https://www.google.com/"/>
   <style>body { display: none; }</style>
   <script>alert('XSS3')</script>
 </svg>`;
@@ -237,6 +238,16 @@ export const SecurityTest: Story = {
       allElements.forEach((element) => {
         Array.from(element.attributes).forEach((attr) => {
           expect(attr.name.toLowerCase().startsWith("on")).toBe(false);
+          // The xlink on the `a` tag is legit, so it should be kept
+          if (
+            element.tagName === "a" &&
+            attr.name.toLowerCase().startsWith("xlink")
+          ) {
+            expect(attr.value).toBe("https://www.google.com/");
+          } else {
+            // The xlink on the `path` and `polyline` tags are malicious, so they should be removed
+            expect(attr.name.toLowerCase().startsWith("xlink")).toBe(false);
+          }
         });
       });
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    dompurify:
+      specifier: ^3.2.6
+      version: 3.2.6
     express-rate-limit:
       specifier: ^8.0.1
       version: 8.0.1
@@ -574,6 +577,9 @@ importers:
       axe-core:
         specifier: ^4.10.2
         version: 4.10.3
+      dompurify:
+        specifier: 'catalog:'
+        version: 3.2.6
       glob:
         specifier: catalog:tooling
         version: 11.0.3
@@ -2556,6 +2562,9 @@ packages:
   '@types/slug@5.0.9':
     resolution: {integrity: sha512-6Yp8BSplP35Esa/wOG1wLNKiqXevpQTEF/RcL/NV6BBQaMmZh4YlDwCgrrFSoUE4xAGvnKd5c+lkQJmPrBAzfQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3522,6 +3531,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -8821,6 +8833,9 @@ snapshots:
 
   '@types/slug@5.0.9': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -10111,6 +10126,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@2.8.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 catalog:
   express-rate-limit: ^8.0.1
+  dompurify: ^3.2.6
 
 catalogMode: strict
 
@@ -14,56 +15,56 @@ catalogs:
     typescript: ~5.8.3
     typescript-eslint: ^8.38.0
     tsx: ^4.20.3
-    "@babel/core": ^7.28.0
-    "@babel/runtime": ^7.28.3
-    "@babel/preset-typescript": ^7.27.1
-    "@eslint/js": ^9.33.0
+    '@babel/core': ^7.28.0
+    '@babel/runtime': ^7.28.3
+    '@babel/preset-typescript': ^7.27.1
+    '@eslint/js': ^9.33.0
     eslint: ^9.34.0
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.4
     eslint-plugin-react-hooks: ^5.2.0
     eslint-plugin-react-refresh: ^0.4.20
     prettier: ^3.6.2
-    "@preconstruct/cli": ^2.8.12
-    "@vitejs/plugin-react": ^4.4.1
-    "@vitejs/plugin-react-swc": ^3.10.2
+    '@preconstruct/cli': ^2.8.12
+    '@vitejs/plugin-react': ^4.4.1
+    '@vitejs/plugin-react-swc': ^3.10.2
     vite: ^7.0.5
     vite-bundle-analyzer: ^1.0.0
     vite-plugin-dts: ^4.5.4
     vite-tsconfig-paths: ^5.1.4
     rollup: ^4.50.0
     rollup-plugin-tree-shakeable: ^1.0.3
-    "@vitest/browser": ^3.2.4
-    "@vitest/coverage-v8": ^3.2.4
-    "@testing-library/dom": 10.4.0
-    "@testing-library/user-event": ^14.6.1
-    "@testing-library/react": ^16.3.0
+    '@vitest/browser': ^3.2.4
+    '@vitest/coverage-v8': ^3.2.4
+    '@testing-library/dom': 10.4.0
+    '@testing-library/user-event': ^14.6.1
+    '@testing-library/react': ^16.3.0
     playwright: ^1.55.0
     vitest: ^3.2.4
     storybook: ^9.1.3
     eslint-plugin-storybook: ^9.1.3
-    "@storybook/addon-a11y": ^9.1.3
-    "@storybook/addon-docs": ^9.1.3
-    "@storybook/addon-vitest": ^9.1.3
-    "@storybook/react-vite": ^9.1.3
-    "@vueless/storybook-dark-mode": ^9.0.7
+    '@storybook/addon-a11y': ^9.1.3
+    '@storybook/addon-docs': ^9.1.3
+    '@storybook/addon-vitest': ^9.1.3
+    '@storybook/react-vite': ^9.1.3
+    '@vueless/storybook-dark-mode': ^9.0.7
   react:
-    "@types/react": ^19.1.8
-    "@types/react-dom": ^19.1.6
+    '@types/react': ^19.1.8
+    '@types/react-dom': ^19.1.6
     react: ^19.0.0
     react-dom: ^19.0.0
-    "@emotion/react": ^11.14.0
-    "@emotion/is-prop-valid": ^1.3.1
-    "@chakra-ui/cli": ^3.26.0
-    "@chakra-ui/react": ^3.26.0
+    '@emotion/react': ^11.14.0
+    '@emotion/is-prop-valid': ^1.3.1
+    '@chakra-ui/cli': ^3.26.0
+    '@chakra-ui/react': ^3.26.0
     next-themes: ^0.4.6
     react-aria: 3.43.1
     react-aria-components: 1.12.1
     react-stately: 3.41.0
-    "@react-aria/interactions": 3.25.5
-    "@react-aria/optimize-locales-plugin": 1.1.5
-    "@internationalized/date": ^3.9.0
+    '@react-aria/interactions': 3.25.5
+    '@react-aria/optimize-locales-plugin': 1.1.5
+    '@internationalized/date': ^3.9.0
   utils:
     lodash: ^4.17.21
-    "@types/lodash": ^4.17.20
-    "@types/node": ^24.0.3
+    '@types/lodash': ^4.17.20
+    '@types/node': ^24.0.3


### PR DESCRIPTION
Use dompurify instead of custom parsing solution so that:
- malicious/malformed attrs are removed from the svg but the svg is still displayed
- we do not have to maintain and test a custom sanitization workflow

DOMPurify is not causing the svg's in uikit to be styled incorrectly.  The issue is with uikit styling set on all icons by the [getIconStyle](https://github.com/commercetools/ui-kit/blob/e97e0c7e8f3e9393981bf1949573212d7c571c90/design-system/src/icon-utils.ts#L110) util, whichs adds a fill to all child tags of an svg unless the tag specifically has (`fill='none'`) set on the tag.

Therefore I think it makes sense to use DOMPurify over a custom sanitization method.