### PR TITLE
chore(nimbus): add changeset reminder check to PR workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,3 +32,22 @@ jobs:
         timeout-minutes: 5
         env:
           NODE_ENV: production
+
+      - name: Check for changeset
+        run: |
+          # Check if this PR needs a changeset by looking for changes that would release packages
+          CHANGESET_OUTPUT=$(pnpm changeset:status --since=origin/main 2>&1)
+
+          if echo "$CHANGESET_OUTPUT" | grep -q "NO packages"; then
+            echo "⚠️  No changeset detected for this PR"
+            echo ""
+            echo "📝 If your changes affect users, please create a changeset:"
+            echo "   pnpm changeset"
+            echo ""
+            echo "ℹ️  This is a reminder, not a requirement"
+            echo "   PRs can still be merged without changesets for non-user-facing changes"
+            exit 1
+          else
+            echo "✅ Changeset detected - thank you!"
+          fi
+        continue-on-error: true


### PR DESCRIPTION
## Summary

Add non-blocking changeset reminder to PR workflow to help developers remember to create changesets for user-facing changes.

## Changes

  - **CI Enhancement**: Added changeset validation step to `build-and-test.yml` workflow
  - **Non-Blocking**: Uses `continue-on-error: true` - PRs can still merge without changesets
  - **Clear Messaging**: Provides helpful guidance when changesets are missing
  - **Leverages Existing Tools**: Uses established `pnpm changeset:status` command

## Developer Experience

  - **Missing changeset**: Shows ⚠️ warning with `pnpm changeset` guidance
  - **Has changeset**: Shows ✅ confirmation
  - **Always mergeable**: Maintains workflow flexibility for urgent fixes