### PR TITLE
CRAFT-1759 - Package Nimbus i18n for App-Kit Integration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
   "commit": false,
   "fixed": [
     [
+      "@commercetools-nimbus/i18n",
       "@commercetools/nimbus",
       "@commercetools/nimbus-tokens",
       "@commercetools/nimbus-icons"

--- a/package.json
+++ b/package.json
@@ -11,16 +11,15 @@
     ]
   },
   "scripts": {
-    "build": "pnpm build:tokens && pnpm run build:packages && pnpm run build:docs && pnpm run compile-i18n",
+    "build": "pnpm build:tokens && pnpm run build:packages && pnpm run build:docs",
     "build:packages": "pnpm -r --filter './packages/*' build",
     "build:docs": "pnpm --filter './apps/docs' build",
     "build:tokens": "pnpm --filter @commercetools/nimbus-tokens run build && preconstruct build",
     "changeset": "changeset",
     "changeset:version-and-format": "changeset version && prettier --write --parser json '**/package.json' && pnpm install --lockfile-only",
     "changeset:status": "changeset status --verbose",
-    "compile-i18n": "pnpm --filter @commercetools-nimbus/i18n compile-data",
     "component:new": "pnpm hygen component new",
-    "extract-intl": "pnpm dlx @formatjs/cli extract --format=transifex --out-file=./packages/i18n/data/core.json '{packages,src/components}/**/*.i18n.ts'",
+    "extract-intl": "pnpm dlx @formatjs/cli extract --format=transifex --out-file=./packages/i18n/data/core.json '{packages,src/components}/**/*.i18n.ts' && pnpm --filter @commercetools-nimbus/i18n build",
     "generate:tokens": "pnpm --filter @commercetools/nimbus-tokens run build",
     "lint": "eslint .",
     "typecheck": "pnpm -r --filter './packages/*' --bail=false typecheck || true",

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,43 +1,150 @@
 # @commercetools-nimbus/i18n
 
-This package contains all translation messages from the Nimbus design system.
+This package contains all translation messages from the Nimbus design system
+components. It's a **pure data package** that provides centralized
+internationalization support for accessibility labels, tooltips, and user-facing
+text across all Nimbus components.
 
-# fill all of this in
+## Package Type
 
-# add diagram
-
-# review Text intlMessage prop
-
-# preconstruct build?
-
-# i18n dist folder
-
-# add to changesets
-
-# automated prs?
-
-# order of operations
-
-# license?
-
-# aria-label guidelines/ best practices
+This is a **data-only package** - it contains no code, only translation files in
+multiple formats. It's designed to be consumed directly by importing JSON files.
 
 ## Supported Locales
 
+- **English (en)** - Default locale
+- **German (de)**
+- **Spanish (es)**
+- **French (fr-FR)**
+- **Portuguese (pt-BR)**
+
+## Installation
+
+```bash
+pnpm add @commercetools-nimbus/i18n
+# or
+npm install @commercetools-nimbus/i18n
+# or
+yarn add @commercetools-nimbus/i18n
+```
+
 ## Usage
+
+### Primary Usage: App-Kit Integration
+
+This package is primarily designed to be consumed by the **Merchant Center
+App-Kit**, which automatically loads and merges Nimbus translations with other
+system translations.
+
+## Message Keys Structure
+
+All translation keys follow the pattern: `Nimbus.{ComponentName}.{messageKey}`
+
+Examples:
+
+- `Nimbus.PasswordInput.show` - Show password button
+- `Nimbus.DatePicker.clearInput` - Clear input button
 
 ## Development
 
 ### Adding New Messages
 
-### Building
+1. Create or update a component's `.i18n.ts` file:
+
+```typescript
+// packages/nimbus/src/components/button/button.i18n.ts
+import { defineMessages } from "react-intl";
+
+export default defineMessages({
+  buttonLabel: {
+    id: "Nimbus.Button.buttonLabel",
+    description: "Label for the main action button",
+    defaultMessage: "Click me",
+  },
+});
+```
+
+2. Use the messages in your component:
+
+```typescript
+// packages/nimbus/src/components/button/button.tsx
+import { FormattedMessage } from 'react-intl';
+import messages from './button.i18n';
+
+export const Button = () => (
+  <button>
+    <FormattedMessage {...messages.buttonLabel} />
+  </button>
+);
+```
+
+### Extracting Messages
+
+Extract all messages from component files:
+
+```bash
+pnpm extract-intl
+```
+
+This scans all `.i18n.ts` files, updates `packages/i18n/data/core.json`, and
+also runs the `compile-i18n` script.
+
+### Compiling Messages
+
+Compile the raw JSON data into optimized AST format:
+
+```bash
+pnpm compile-i18n
+```
+
+This converts files in `data/` to optimized versions in `compiled-data/`.
+
+### Building Translation Data
+
+Compile the raw translation data into optimized format:
+
+```bash
+pnpm compile-i18n
+```
 
 ## File Structure
 
-## Return to:
+//TODO
 
-- date picker
+## Translation Workflow
+
+//TODO
+
+## Integration with App-Kit
+
+To add Nimbus translations to the Merchant Center App-Kit, update the
+`load-i18n.ts` file:
+
+//TODO
+
+## Best Practices
+
+### Accessibility Guidelines
+
+//TODO
+
+### Message Naming
+
+//TODO
 
 ```
 
+## Contributing
+
+//TODO
+# add diagram
+# review Text intlMessage prop
+# preconstruct build?
+# i18n dist folder
+# add to changesets
+# automated prs?
+# order of operations
+
+
+MIT
 ```

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -49,6 +49,17 @@ Examples:
 
 ### Adding New Messages
 
+TL;DR version:
+
+- Create a new `.i18n.ts` file in the component's directory and add the new
+  message(s) to it.
+- Be specific with the message description, these are used to help translators
+  understand the context of the message.
+- Run `pnpm extract-intl` to update the `core.json` file.
+- Test in Storybook to ensure the locale is working as expected.
+
+---
+
 1. Create or update a component's `.i18n.ts` file:
 
 ```typescript

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -80,32 +80,43 @@ export const Button = () => (
 
 ### Extracting Messages
 
-Extract all messages from component files:
+Extract all messages from component files and compile them:
 
 ```bash
 pnpm extract-intl
 ```
 
-This scans all `.i18n.ts` files, updates `packages/i18n/data/core.json`, and
-also runs the `compile-i18n` script.
+This command performs two operations in sequence:
 
-### Compiling Messages
+1. **Extracts** translation messages from all `.i18n.ts` files throughout the
+   codebase
+2. **Compiles** the extracted messages into optimized AST format for
+   distribution
 
-Compile the raw JSON data into optimized AST format:
+The process:
 
-```bash
-pnpm compile-i18n
-```
+- Scans all `.i18n.ts` files and updates `packages/i18n/data/core.json`
+- Converts files in `data/` to optimized versions in `compiled-data/`
 
-This converts files in `data/` to optimized versions in `compiled-data/`.
+> [!IMPORTANT]  
+> Run `extract-intl` before merging your changes so that Transifex knows about
+> new translation keys that need to be translated.
 
 ### Building Translation Data
 
-Compile the raw translation data into optimized format:
+The i18n package has its own build process that compiles translation data:
 
 ```bash
-pnpm compile-i18n
+pnpm --filter @commercetools-nimbus/i18n build
 ```
+
+This converts files in `data/` to optimized versions in `compiled-data/` for
+distribution.
+
+> [!NOTE]  
+> The i18n build process is automatically run during the main build process
+> (`pnpm build`) via `build:packages`, so compiled translation data is always
+> up-to-date in built packages.
 
 ## File Structure
 
@@ -113,7 +124,48 @@ pnpm compile-i18n
 
 ## Translation Workflow
 
-//TODO
+The i18n workflow involves two main scenarios: development (adding new keys) and
+building (compiling for distribution).
+
+### Development Workflow
+
+When developers add new translation keys to components:
+
+```mermaid
+
+    A[Developer adds .i18n.ts files] --> B[Run: pnpm extract-intl]
+    B --> C[Extract keys to core.json]
+    C --> D[Compile to compiled-data/]
+    D --> E[Commit changes]
+    E --> F[Transifex gets new keys]
+```
+
+### Build Workflow
+
+When building the project for distribution:
+
+```mermaid
+    A[Run: pnpm build] --> B[build:packages runs]
+    B --> C[i18n package build script]
+    C --> D[Compile existing data]
+    D --> E[Ready for distribution]
+```
+
+### Script Interaction
+
+| Script                 | Purpose            | When to Use                      | What it Does                                                                           |
+| ---------------------- | ------------------ | -------------------------------- | -------------------------------------------------------------------------------------- |
+| `extract-intl`         | Extract + Compile  | When adding new translation keys | 1. Scans `.i18n.ts` files<br>2. Updates `core.json`<br>3. Compiles to `compiled-data/` |
+| `build` (i18n package) | Compile only       | Automatically during build       | Compiles existing translation data                                                     |
+| `build:packages`       | Build all packages | During main build                | Runs `build` script in all packages including i18n                                     |
+
+### Key Points
+
+- **Extract workflow**: Use `extract-intl` when adding new translation keys
+- **Build workflow**: Compilation happens automatically during `pnpm build`
+- **No manual compilation**: The build system handles compilation automatically
+- **Transifex integration**: New keys are available for translation after
+  running `extract-intl`
 
 ## Integration with App-Kit
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -20,10 +20,7 @@
     "access": "public"
   },
   "sideEffects": false,
-  "main": "dist/commercetools-nimbus-i18n.cjs.js",
-  "module": "dist/commercetools-nimbus-i18n.esm.js",
   "files": [
-    "dist",
     "data",
     "compiled-data"
   ],

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -25,6 +25,6 @@
     "compiled-data"
   ],
   "scripts": {
-    "compile-data": "pnpm dlx @formatjs/cli compile-folder --format=transifex --ast data compiled-data"
+    "build": "pnpm dlx @formatjs/cli compile-folder --format=transifex --ast data compiled-data"
   }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commercetools-nimbus/i18n",
   "description": "All translation messages from the Nimbus design system.",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "bugs": "https://github.com/commercetools/nimbus/issues",
   "repository": {
     "type": "git",


### PR DESCRIPTION

**1.)** This PR introduces a new data-only package for Nimbus i18n translations, specifically designed for `mc-appkit` integration.

Taking a simpler approach than uikit... may/ may not work.

TL;DR This is to enable Nimbus components to display localized text in all MC applications.


Why package like this?
- Contains zero code - only translation JSON files in multiple formats (raw + compiled AST)
- No need for entrypoints, dependencies, preconstruct, etc
- Direct consumption by appkit, merge with other sources in `packages/i18n/src/load-i18n.ts`
- Tree-shakeable by nature


**2.)** Made a few changes to the i18n scripts


**3.)** Note that the README isn't really a part of this, but only a draft. Not sure if this is better kept here, or w/in the Nimbus package itself. tbd. 
