### PR TITLE
Craft 1742 | a11y updates

### DIFF
--- a/packages/nimbus/src/components/money-input/money-input.i18n.ts
+++ b/packages/nimbus/src/components/money-input/money-input.i18n.ts
@@ -1,10 +1,15 @@
 import { defineMessages } from "react-intl";
 
 export default defineMessages({
-  currencySelection: {
-    id: "Nimbus.MoneyInput.currencySelection",
+  currencySelectLabel: {
+    id: "Nimbus.MoneyInput.currencySelectLabel",
     description: "aria-label for currency selection dropdown",
-    defaultMessage: "Currency selection",
+    defaultMessage: "Currency",
+  },
+  amountInputLabel: {
+    id: "Nimbus.MoneyInput.amountInputLabel",
+    description: "aria-label for amount input",
+    defaultMessage: "Amount",
   },
   highPrecisionPrice: {
     id: "Nimbus.MoneyInput.highPrecisionPrice",

--- a/packages/nimbus/src/components/money-input/money-input.recipe.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.recipe.tsx
@@ -15,18 +15,12 @@ export const moneyInputRecipe = defineSlotRecipe({
       width: "full",
       position: "relative",
       fontFamily: "inherit",
-      "--trigger-border-color": "colors.neutral.7",
-      "--trigger-border-width": "sizes.25",
       "& .nimbus-select__trigger": {
         width: "2800",
         borderRightRadius: "0",
         // Show all but the right shadow
         boxShadow:
-          "inset 0 var(--trigger-border-width) 0 0 var(--trigger-border-color), inset 0 calc(var(--trigger-border-width) * -1) 0 0 var(--trigger-border-color), inset var(--trigger-border-width) 0 0 0 var(--trigger-border-color)",
-      },
-      "& .nimbus-select__root[data-invalid='true']": {
-        "--trigger-border-color": "colors.critical.7",
-        "--trigger-border-width": "sizes.50",
+          "inset 0 1px 0 0 {colors.neutral.7}, inset 0 -1px 0 0 {colors.neutral.7}, inset 1px 0 0 0 {colors.neutral.7}",
       },
       "& .nimbus-number-input__root > input": {
         borderLeftRadius: "0",

--- a/packages/nimbus/src/components/money-input/money-input.recipe.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.recipe.tsx
@@ -33,7 +33,7 @@ export const moneyInputRecipe = defineSlotRecipe({
     },
     currencySelect: {
       // Ensure focus ring is visible above amount input
-      "& [data-focused='true']": {
+      _focusWithin: {
         zIndex: 2,
       },
     },
@@ -49,7 +49,7 @@ export const moneyInputRecipe = defineSlotRecipe({
     },
     amountInput: {
       // Ensure focus ring is visible above currency select
-      "& [data-has-focus='true']": {
+      _focusWithin: {
         zIndex: 2,
       },
     },

--- a/packages/nimbus/src/components/money-input/money-input.recipe.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.recipe.tsx
@@ -15,12 +15,18 @@ export const moneyInputRecipe = defineSlotRecipe({
       width: "full",
       position: "relative",
       fontFamily: "inherit",
+      "--trigger-border-color": "colors.neutral.7",
+      "--trigger-border-width": "sizes.25",
       "& .nimbus-select__trigger": {
         width: "2800",
         borderRightRadius: "0",
         // Show all but the right shadow
         boxShadow:
-          "inset 0 1px 0 0 {colors.neutral.7}, inset 0 -1px 0 0 {colors.neutral.7}, inset 1px 0 0 0 {colors.neutral.7}",
+          "inset 0 var(--trigger-border-width) 0 0 var(--trigger-border-color), inset 0 calc(var(--trigger-border-width) * -1) 0 0 var(--trigger-border-color), inset var(--trigger-border-width) 0 0 0 var(--trigger-border-color)",
+      },
+      "& .nimbus-select__root[data-invalid='true']": {
+        "--trigger-border-color": "colors.critical.7",
+        "--trigger-border-width": "sizes.50",
       },
       "& .nimbus-number-input__root > input": {
         borderLeftRadius: "0",

--- a/packages/nimbus/src/components/money-input/money-input.slots.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.slots.tsx
@@ -1,4 +1,5 @@
 import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
+import { Group } from "@/components";
 import type {
   MoneyInputRootSlotProps,
   MoneyInputContainerSlotProps,
@@ -16,7 +17,7 @@ const { withProvider, withContext } = createSlotRecipeContext({
 export const MoneyInputRootSlot = withProvider<
   HTMLDivElement,
   MoneyInputRootSlotProps
->("div", "root");
+>(Group, "root");
 
 export const MoneyInputContainerSlot = withContext<
   HTMLDivElement,

--- a/packages/nimbus/src/components/money-input/money-input.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.tsx
@@ -296,6 +296,7 @@ export const MoneyInputComponent = (props: MoneyInputProps) => {
               onBlur={handleCurrencyBlur}
               isDisabled={isCurrencyInputDisabled || isDisabled || isReadOnly}
               isClearable={false}
+              isInvalid={isInvalid}
               placeholder=""
               aria-label={intl.formatMessage(messages.currencySelectLabel)}
               size={size}

--- a/packages/nimbus/src/components/money-input/money-input.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.tsx
@@ -1,7 +1,6 @@
-import { useRef, useCallback, useMemo } from "react";
-import { mergeRefs } from "@chakra-ui/react";
+import { useCallback, useMemo } from "react";
 import { useSlotRecipe } from "@chakra-ui/react/styled-system";
-import { useId, useLocale, useObjectRef } from "react-aria";
+import { useId, useLocale } from "react-aria";
 import { useIntl, FormattedMessage } from "react-intl";
 import {
   NumberInput,
@@ -134,11 +133,11 @@ export const MoneyInputComponent = (props: MoneyInputProps) => {
   const { locale } = useLocale();
   const intl = useIntl();
 
-  // State management
-  const hasNoCurrencies = !currencies || currencies.length === 0;
-
   // Convert string value to number for NumberInput
   const numericValue = value.amount ? parseFloat(value.amount) : undefined;
+
+  // Detect whether the currency select or currency label should display
+  const hasNoCurrencies = !currencies || currencies.length === 0;
 
   // High precision detection using raw input value - default to en if locale is not provided
   const isCurrentlyHighPrecision = isHighPrecision(value, locale || "en");
@@ -156,10 +155,6 @@ export const MoneyInputComponent = (props: MoneyInputProps) => {
       style: "decimal", // Use decimal to avoid currency symbol conflicts
     };
   }, [value.currencyCode, locale]);
-
-  // Refs
-  const localRef = useRef<HTMLInputElement>(null);
-  const ref = useObjectRef(mergeRefs(localRef, null));
 
   // Recipe setup
   const recipe = useSlotRecipe({ recipe: moneyInputRecipe });
@@ -296,7 +291,6 @@ export const MoneyInputComponent = (props: MoneyInputProps) => {
               onBlur={handleCurrencyBlur}
               isDisabled={isCurrencyInputDisabled || isDisabled || isReadOnly}
               isClearable={false}
-              isInvalid={isInvalid}
               placeholder=""
               aria-label={intl.formatMessage(messages.currencySelectLabel)}
               size={size}
@@ -314,7 +308,6 @@ export const MoneyInputComponent = (props: MoneyInputProps) => {
 
         {/* Amount Input - NumberInput handles live user interaction */}
         <MoneyInputAmountInputSlot
-          ref={ref}
           data-has-high-precision={
             hasHighPrecisionBadge && isCurrentlyHighPrecision
           }

--- a/packages/nimbus/src/components/money-input/money-input.types.ts
+++ b/packages/nimbus/src/components/money-input/money-input.types.ts
@@ -3,6 +3,7 @@ import type {
   RecipeVariantProps,
   UnstyledProp,
 } from "@chakra-ui/react/styled-system";
+import type { GroupProps } from "@/components";
 import type { TValue, TCurrencyCode } from "./utils";
 import type { moneyInputRecipe } from "./money-input.recipe";
 
@@ -16,7 +17,8 @@ export interface MoneyInputSlotRecipeProps
 export type MoneyInputRootSlotProps = HTMLChakraProps<
   "div",
   MoneyInputSlotRecipeProps
->;
+> &
+  GroupProps;
 export type MoneyInputContainerSlotProps = HTMLChakraProps<
   "div",
   MoneyInputSlotRecipeProps

--- a/packages/nimbus/src/components/money-input/utils/static-methods.ts
+++ b/packages/nimbus/src/components/money-input/utils/static-methods.ts
@@ -12,6 +12,13 @@ const has = (obj: Record<string, unknown>, key: string): boolean => {
 };
 
 // Static method implementations - preserve exact logic from UI Kit
+export function getMoneyGroupAttribute(
+  attr?: string,
+  inputType?: string
+): string | undefined {
+  return attr && inputType ? `${attr}.${inputType}` : undefined;
+}
+
 export const transformFormInputToMoneyValue = (value: TValue, locale: string) =>
   parseStringToMoneyValue(
     typeof value.amount === "string" ? value.amount.trim() : "",

--- a/packages/nimbus/src/components/number-input/number-input.slots.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.slots.tsx
@@ -4,7 +4,11 @@ import {
   type UnstyledProp,
   createSlotRecipeContext,
 } from "@chakra-ui/react/styled-system";
-import { Button as RaButton } from "react-aria-components";
+import {
+  Button as RaButton,
+  Input as RaInput,
+  type InputProps as RaInputProps,
+} from "react-aria-components";
 import type { AriaButtonProps } from "react-aria";
 
 import { numberInputRecipe } from "./number-input.recipe";
@@ -16,12 +20,15 @@ export interface NumberInputRecipeProps
 export type NumberInputRootSlotProps = HTMLChakraProps<
   "div",
   NumberInputRecipeProps
->;
+> & {
+  name?: string;
+};
 
 export type NumberInputInputSlotProps = HTMLChakraProps<
   "input",
   NumberInputRecipeProps
->;
+> &
+  RaInputProps;
 
 export type NumberInputIncrementButtonSlotProps = HTMLChakraProps<
   "button",
@@ -55,7 +62,7 @@ export const NumberInputRootSlot = withProvider<
 export const NumberInputInputSlot = withContext<
   HTMLInputElement,
   NumberInputInputSlotProps
->("input", "input");
+>(RaInput, "input");
 
 /**
  * Increment button slot for NumberInput component.

--- a/packages/nimbus/src/components/number-input/number-input.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.tsx
@@ -58,12 +58,18 @@ export const NumberInput = (props: NumberInputProps) => {
   };
 
   return (
-    <NumberInputRootSlot {...recipeProps} {...styleProps} size={size}>
+    <NumberInputRootSlot
+      {...recipeProps}
+      {...styleProps}
+      size={size}
+      className={props?.className as string}
+    >
       <NumberInputInputSlot
         ref={ref}
         {...inputProps}
         {...stateProps}
-        size={size}
+        // https://github.com/adobe/react-spectrum/issues/4744
+        name={props.name}
       />
       <Box
         position="absolute"


### PR DESCRIPTION
This pull request refactors the `MoneyInput` component and its stories to improve accessibility, consistency, and maintainability. The changes focus on using more semantic ARIA roles and labels, aligning test queries with accessibility best practices, and cleaning up component internals. The most important changes are outlined below.

**Accessibility and ARIA improvements:**

* Replaced test IDs and placeholder-based queries in Storybook stories with ARIA roles and accessible names, ensuring all test interactions use `getByRole` or `getByLabelText` for elements like currency select, amount input, and high precision badges. This aligns the component and its tests with accessibility standards. [[1]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL101-R124) [[2]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL194-R205) [[3]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL217-R229) [[4]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL248-R260) [[5]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL308-R319) [[6]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL327-R347) [[7]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL344-R384) [[8]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL416-R436) [[9]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL506-R526) [[10]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL522-R546) [[11]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL532-R560) [[12]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL542-R578) [[13]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL1216-R1257) [[14]](diffhunk://#diff-f00f2285d317b126da13211c6b022d4d71f88d0ba3d3fed804cd7cdc9907869fL1234-R1278)

* Updated i18n message keys and default messages for ARIA labels, introducing `currencySelectLabel` and `amountInputLabel` for improved clarity and consistency in accessibility labeling.

**Component and slot structure updates:**

* Changed `MoneyInputRootSlot` to use the `Group` component instead of a plain `div`, improving semantics and grouping for accessibility.

* Cleaned up unused state and ref logic in the main component, simplifying focus management and ID generation by relying on `useId` and removing unnecessary hooks. [[1]](diffhunk://#diff-751ad90e059b6dc22ab954bdb39455592632e096f59bb2eb6ce99708b33aea11L1-R3) [[2]](diffhunk://#diff-751ad90e059b6dc22ab954bdb39455592632e096f59bb2eb6ce99708b33aea11L106-R106) [[3]](diffhunk://#diff-751ad90e059b6dc22ab954bdb39455592632e096f59bb2eb6ce99708b33aea11L125-R141)

**Styling and recipe improvements:**

* Updated focus ring styling in the slot recipe to use Chakra's `_focusWithin` pseudo-class instead of custom data attributes, making the styling more robust and idiomatic. [[1]](diffhunk://#diff-bbd9eba2517fc1715963a31f42e83c301bca0504c9e30757d7843a075c1c9c75L36-R36) [[2]](diffhunk://#diff-bbd9eba2517fc1715963a31f42e83c301bca0504c9e30757d7843a075c1c9c75L52-R52)

**Testing and static method coverage:**

* Added tests for static methods `getAmountInputId` and `getCurrencyDropdownId` to ensure correct ID generation and coverage.

These changes collectively make the `MoneyInput` component more accessible, easier to test, and more maintainable for future development.