### PR TITLE
chore(nimbus): allow styling in accordion components

### DIFF
--- a/packages/nimbus/src/components/accordion/accordion.stories.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.stories.tsx
@@ -197,3 +197,41 @@ export const DefaultExpandedKeys: Story = {
     });
   },
 };
+
+export const WithStyleProps: Story = {
+  render: () => (
+    <Accordion.Root>
+      <Accordion.Item
+        value="styled-item"
+        backgroundColor="warning.2"
+        padding="400"
+        margin="300"
+        borderRadius="md"
+        border="1px solid"
+        borderColor="warning.6"
+      >
+        <Accordion.Header
+          backgroundColor="info.5"
+          padding="300"
+          borderRadius="sm"
+          margin="200"
+        >
+          Item with Style Props
+        </Accordion.Header>
+        <Accordion.Content
+          padding="800"
+          fontWeight="500"
+          border="1px solid pink"
+        >
+          Content with custom styling using Chakra style props
+        </Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="normal-item">
+        <Accordion.Header>Normal Item (no style props)</Accordion.Header>
+        <Accordion.Content>
+          Normal content without custom styling
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion.Root>
+  ),
+};

--- a/packages/nimbus/src/components/accordion/accordion.types.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.types.tsx
@@ -1,4 +1,7 @@
-import type { RecipeVariantProps } from "@chakra-ui/react/styled-system";
+import type {
+  RecipeVariantProps,
+  HTMLChakraProps,
+} from "@chakra-ui/react/styled-system";
 import { accordionSlotRecipe } from "./accordion.recipe";
 import type { ReactNode, Ref } from "react";
 import type {
@@ -7,6 +10,20 @@ import type {
   DisclosurePanelProps as RaDisclosurePanelProps,
   ButtonProps as RaButtonProps,
 } from "react-aria-components";
+
+/**
+ * For use in components that use the polymorphic `as` and `asChild` props
+ * internally, but do not make them available to the consumer.
+ *
+ * Long rambling background:
+ * React-Aria's components cannot be configured to use `as` and `asChild` internally,
+ * and cannot be directly styled by chakra's styledSystem. Therefore components
+ * from `react-aria-components` should be wrapped in a chakra `withContext`
+ * root component to set the styles onto the `r-a-c` component using `asChild`.
+ * This means that we need to allow polymorphism internally, but should not
+ * allow it in the external props api since it would not work.
+ */
+type ExcludePolymorphicFromProps<T> = Omit<T, "as" | "asChild">;
 
 /**
  * Props for the Accordion Root component.
@@ -24,7 +41,10 @@ export interface AccordionRootProps
 /**
  * Props for individual Accordion Item components.
  */
-export interface AccordionItemProps extends RaDisclosureProps {
+export interface AccordionItemProps
+  extends ExcludePolymorphicFromProps<
+    RaDisclosureProps & HTMLChakraProps<"div">
+  > {
   /** The accordion item content (Header and Content components) */
   children: ReactNode;
   /** Unique value for this item (used for controlled state) */
@@ -37,7 +57,8 @@ export interface AccordionItemProps extends RaDisclosureProps {
  * Props for Accordion Header component.
  * Displays the clickable header that expands/collapses content.
  */
-export interface AccordionHeaderProps extends RaButtonProps {
+export interface AccordionHeaderProps
+  extends ExcludePolymorphicFromProps<RaButtonProps & HTMLChakraProps<"div">> {
   /** The header content to display */
   children: ReactNode;
   /** Ref to the header element */
@@ -48,7 +69,10 @@ export interface AccordionHeaderProps extends RaButtonProps {
  * Props for Accordion Content component.
  * Contains the collapsible content area.
  */
-export interface AccordionContentProps extends RaDisclosurePanelProps {
+export interface AccordionContentProps
+  extends ExcludePolymorphicFromProps<
+    RaDisclosurePanelProps & HTMLChakraProps<"div">
+  > {
   /** The content to display when expanded */
   children: ReactNode;
   /** Ref to the content element */

--- a/packages/nimbus/src/components/accordion/components/accordion-content.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-content.tsx
@@ -1,6 +1,7 @@
 import { AccordionPanelSlot } from "../accordion.slots";
 import { DisclosurePanel as RaDisclosurePanel } from "react-aria-components";
 import type { AccordionContentProps } from "../accordion.types";
+import { extractStyleProps } from "@/utils/extractStyleProps";
 
 // Create Content component
 export const AccordionContent = ({
@@ -8,9 +9,11 @@ export const AccordionContent = ({
   ref,
   ...props
 }: AccordionContentProps) => {
+  const [styleProps, restProps] = extractStyleProps(props);
+
   return (
-    <AccordionPanelSlot ref={ref} asChild>
-      <RaDisclosurePanel {...props}>{children}</RaDisclosurePanel>
+    <AccordionPanelSlot ref={ref} {...styleProps} asChild>
+      <RaDisclosurePanel {...restProps}>{children}</RaDisclosurePanel>
     </AccordionPanelSlot>
   );
 };

--- a/packages/nimbus/src/components/accordion/components/accordion-header.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-header.tsx
@@ -8,12 +8,14 @@ import { Flex } from "@/components";
 import { KeyboardArrowRight } from "@commercetools/nimbus-icons";
 import { Button as RaButton } from "react-aria-components";
 import type { AccordionHeaderProps } from "../accordion.types";
+import { extractStyleProps } from "@/utils/extractStyleProps";
 
 export const AccordionHeader = ({
   children,
   ref,
   ...props
 }: AccordionHeaderProps) => {
+  const [styleProps, restProps] = extractStyleProps(props);
   // Extract HeaderRightContent if present
   const headerContent = useMemo(() => {
     const main: React.ReactNode[] = [];
@@ -39,9 +41,10 @@ export const AccordionHeader = ({
       alignItems="center"
       borderBottom="solid-25"
       borderColor="neutral.4"
+      {...styleProps}
     >
       <AccordionTriggerSlot ref={ref} slot="trigger" asChild>
-        <RaButton {...props}>
+        <RaButton {...restProps}>
           <KeyboardArrowRight />
           <AccordionTitleSlot>{headerContent.main}</AccordionTitleSlot>
         </RaButton>

--- a/packages/nimbus/src/components/accordion/components/accordion-item.tsx
+++ b/packages/nimbus/src/components/accordion/components/accordion-item.tsx
@@ -1,6 +1,7 @@
 import { AccordionDisclosureSlot } from "../accordion.slots";
 import { Disclosure as RaDisclosure } from "react-aria-components";
 import type { AccordionItemProps } from "../accordion.types";
+import { extractStyleProps } from "@/utils/extractStyleProps";
 
 export const AccordionItem = ({
   children,
@@ -8,13 +9,19 @@ export const AccordionItem = ({
   ref,
   ...props
 }: AccordionItemProps) => {
+  const [styleProps, restProps] = extractStyleProps(props);
   const disclosureProps = {
-    ...props,
+    ...restProps,
     id: value, // React Aria uses id for the key
   };
 
   return (
-    <AccordionDisclosureSlot data-value={value} ref={ref} asChild>
+    <AccordionDisclosureSlot
+      data-value={value}
+      ref={ref}
+      {...styleProps}
+      asChild
+    >
       <RaDisclosure {...disclosureProps}>{children}</RaDisclosure>
     </AccordionDisclosureSlot>
   );


### PR DESCRIPTION
## Summary

This PR allows chakra styling to be forwarded to Accordion compound components. See the added Storybook story for an example.