### PR TITLE
fix: add explicit permissions to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       # Make sure to grab the latest version of the Playwright image
       # https://playwright.dev/docs/docker#pull-the-image


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the build-and-test workflow to resolve security scanning alert [#8](https://github.com/commercetools/nimbus/security/code-scanning/8) and follow GitHub Actions security best practices.

## Changes

- Added `permissions` block to the `build-and-test` job
- Set `contents: read` as the minimal required permission

## Rationale

The CodeQL security scanner flagged this workflow for missing explicit permissions. While the repository defaults are already restricted (created after Feb 2023), explicitly declaring permissions:

1. **Documents intent** - Makes it clear what access the workflow needs
2. **Defense in depth** - Protects against future repository setting changes
3. **Best practice** - Follows GitHub's security recommendations
4. **Sufficient** - The workflow only performs read operations:
   - Checkout code
   - Install dependencies (with caching)
   - Build packages
   - Run lint, typecheck, and tests

## Testing

The workflow will run automatically on this PR to validate the change works correctly.

## References

- Resolves: https://github.com/commercetools/nimbus/security/code-scanning/8
- [GitHub Docs: Controlling permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)