### PR TITLE
chore(deps): update workspace dependencies to latest minor/patch versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,11 +32,11 @@ catalogs:
       specifier: 1.1.5
       version: 1.1.5
     '@types/react':
-      specifier: ^19.1.8
-      version: 19.1.8
+      specifier: ^19.1.16
+      version: 19.1.16
     '@types/react-dom':
-      specifier: ^19.1.6
-      version: 19.1.6
+      specifier: ^19.1.9
+      version: 19.1.9
     next-themes:
       specifier: ^0.4.6
       version: 0.4.6
@@ -251,10 +251,10 @@ importers:
         version: 9.36.0
       '@types/react':
         specifier: catalog:react
-        version: 19.1.8
+        version: 19.1.16
       '@types/react-dom':
         specifier: catalog:react
-        version: 19.1.6(@types/react@19.1.8)
+        version: 19.1.9(@types/react@19.1.16)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
         version: 4.1.0(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
@@ -290,7 +290,7 @@ importers:
         version: link:../../packages/nimbus-icons
       '@emotion/react':
         specifier: catalog:react
-        version: 11.14.0(@types/react@19.1.8)(react@19.1.0)
+        version: 11.14.0(@types/react@19.1.16)(react@19.1.0)
       '@internationalized/date':
         specifier: catalog:react
         version: 3.9.0
@@ -299,7 +299,7 @@ importers:
         version: 3.1.1
       '@mdx-js/react':
         specifier: ^3.1.1
-        version: 3.1.1(@types/react@19.1.8)(react@19.1.0)
+        version: 3.1.1(@types/react@19.1.16)(react@19.1.0)
       '@mdx-js/rollup':
         specifier: ^3.1.0
         version: 3.1.1(rollup@4.52.3)
@@ -341,7 +341,7 @@ importers:
         version: 4.0.3
       jotai:
         specifier: ^2.15.0
-        version: 2.15.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.8)(react@19.1.0)
+        version: 2.15.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.16)(react@19.1.0)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -411,10 +411,10 @@ importers:
         version: 4.17.20
       '@types/react':
         specifier: catalog:react
-        version: 19.1.8
+        version: 19.1.16
       '@types/react-dom':
         specifier: catalog:react
-        version: 19.1.6(@types/react@19.1.8)
+        version: 19.1.9(@types/react@19.1.16)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
         version: 4.1.0(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
@@ -468,7 +468,7 @@ importers:
     dependencies:
       '@chakra-ui/react':
         specifier: catalog:react
-        version: 3.27.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 3.27.0(@emotion/react@11.14.0(@types/react@19.1.16)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@emotion/is-prop-valid':
         specifier: catalog:react
         version: 1.4.0
@@ -517,7 +517,7 @@ importers:
     devDependencies:
       '@chakra-ui/cli':
         specifier: catalog:react
-        version: 3.27.0(@chakra-ui/react@3.27.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 3.27.0(@chakra-ui/react@3.27.0(@emotion/react@11.14.0(@types/react@19.1.16)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@commercetools/nimbus-icons':
         specifier: workspace:^
         version: link:../nimbus-icons
@@ -535,7 +535,7 @@ importers:
         version: 9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 9.1.9(@types/react@19.1.8)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+        version: 9.1.9(@types/react@19.1.16)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
         version: 9.1.9(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vitest@3.2.4)
@@ -544,7 +544,7 @@ importers:
         version: 9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.3)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       '@testing-library/react':
         specifier: catalog:tooling
-        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@testing-library/user-event':
         specifier: catalog:tooling
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -556,10 +556,10 @@ importers:
         version: 0.1.10
       '@types/react':
         specifier: catalog:react
-        version: 19.1.8
+        version: 19.1.16
       '@types/react-dom':
         specifier: catalog:react
-        version: 19.1.6(@types/react@19.1.8)
+        version: 19.1.9(@types/react@19.1.16)
       '@vitejs/plugin-react':
         specifier: catalog:tooling
         version: 5.0.4(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
@@ -629,7 +629,7 @@ importers:
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
       '@types/react':
         specifier: catalog:react
-        version: 19.1.8
+        version: 19.1.16
       react:
         specifier: catalog:react
         version: 19.1.0
@@ -2589,16 +2589,16 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react-dom@19.1.6':
-    resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
+  '@types/react-dom@19.1.9':
+    resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
       '@types/react': ^19.0.0
 
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
-  '@types/react@19.1.8':
-    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+  '@types/react@19.1.16':
+    resolution: {integrity: sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==}
 
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -6614,9 +6614,9 @@ snapshots:
       tough-cookie: 4.1.4
     optional: true
 
-  '@chakra-ui/cli@3.27.0(@chakra-ui/react@3.27.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@chakra-ui/cli@3.27.0(@chakra-ui/react@3.27.0(@emotion/react@11.14.0(@types/react@19.1.16)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@chakra-ui/react': 3.27.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/react': 3.27.0(@emotion/react@11.14.0(@types/react@19.1.16)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clack/prompts': 0.11.0
       '@pandacss/is-valid-prop': 0.54.0
       '@types/cli-table': 0.3.4
@@ -6640,11 +6640,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chakra-ui/react@3.27.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/react@3.27.0(@emotion/react@11.14.0(@types/react@19.1.16)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@ark-ui/react': 5.25.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
+      '@emotion/react': 11.14.0(@types/react@19.1.16)(react@19.1.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
       '@emotion/utils': 1.4.2
@@ -6856,7 +6856,7 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0)':
+  '@emotion/react@11.14.0(@types/react@19.1.16)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/babel-plugin': 11.13.5
@@ -6868,7 +6868,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 19.1.8
+      '@types/react': 19.1.16
     transitivePeerDependencies:
       - supports-color
 
@@ -7244,10 +7244,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/react@3.1.1(@types/react@19.1.8)(react@19.1.0)':
+  '@mdx-js/react@3.1.1(@types/react@19.1.16)(react@19.1.0)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.8
+      '@types/react': 19.1.16
       react: 19.1.0
 
   '@mdx-js/rollup@3.1.1(rollup@4.52.3)':
@@ -8600,9 +8600,9 @@ snapshots:
       axe-core: 4.10.2
       storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
 
-  '@storybook/addon-docs@9.1.9(@types/react@19.1.8)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
+  '@storybook/addon-docs@9.1.9(@types/react@19.1.16)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.1.16)(react@19.1.0)
       '@storybook/csf-plugin': 9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@storybook/react-dom-shim': 9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
@@ -8861,15 +8861,15 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
-      '@types/react': 19.1.8
-      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+      '@types/react': 19.1.16
+      '@types/react-dom': 19.1.9(@types/react@19.1.16)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -8973,9 +8973,9 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@19.1.8)':
+  '@types/hoist-non-react-statics@3.3.7(@types/react@19.1.16)':
     dependencies:
-      '@types/react': 19.1.8
+      '@types/react': 19.1.16
       hoist-non-react-statics: 3.3.2
 
   '@types/http-errors@2.0.4': {}
@@ -9014,15 +9014,15 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-dom@19.1.6(@types/react@19.1.8)':
+  '@types/react-dom@19.1.9(@types/react@19.1.16)':
     dependencies:
-      '@types/react': 19.1.8
+      '@types/react': 19.1.16
 
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
-      '@types/react': 19.1.8
+      '@types/react': 19.1.16
 
-  '@types/react@19.1.8':
+  '@types/react@19.1.16':
     dependencies:
       csstype: 3.1.3
 
@@ -11282,11 +11282,11 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jotai@2.15.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.8)(react@19.1.0):
+  jotai@2.15.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.16)(react@19.1.0):
     optionalDependencies:
       '@babel/core': 7.28.4
       '@babel/template': 7.27.2
-      '@types/react': 19.1.8
+      '@types/react': 19.1.16
       react: 19.1.0
 
   js-cookie@2.2.1: {}
@@ -12505,8 +12505,8 @@ snapshots:
       '@formatjs/ecma402-abstract': 2.3.4
       '@formatjs/icu-messageformat-parser': 2.11.2
       '@formatjs/intl': 3.1.6(typescript@5.9.2)
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.1.8)
-      '@types/react': 19.1.8
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.1.16)
+      '@types/react': 19.1.16
       hoist-non-react-statics: 3.3.2
       intl-messageformat: 10.7.16
       react: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,17 +63,17 @@ catalogs:
       specifier: ^2.8.12
       version: 2.8.12
     '@storybook/addon-a11y':
-      specifier: ^9.1.8
-      version: 9.1.8
+      specifier: ^9.1.9
+      version: 9.1.9
     '@storybook/addon-docs':
-      specifier: ^9.1.8
-      version: 9.1.8
+      specifier: ^9.1.9
+      version: 9.1.9
     '@storybook/addon-vitest':
-      specifier: ^9.1.8
-      version: 9.1.8
+      specifier: ^9.1.9
+      version: 9.1.9
     '@storybook/react-vite':
-      specifier: ^9.1.8
-      version: 9.1.8
+      specifier: ^9.1.9
+      version: 9.1.9
     '@testing-library/react':
       specifier: ^16.3.0
       version: 16.3.0
@@ -84,8 +84,8 @@ catalogs:
       specifier: ^5.0.4
       version: 5.0.4
     '@vitejs/plugin-react-swc':
-      specifier: ^4.0.1
-      version: 4.0.1
+      specifier: ^4.1.0
+      version: 4.1.0
     '@vitest/browser':
       specifier: ^3.2.4
       version: 3.2.4
@@ -93,8 +93,8 @@ catalogs:
       specifier: ^3.2.4
       version: 3.2.4
     '@vueless/storybook-dark-mode':
-      specifier: ^9.0.8
-      version: 9.0.8
+      specifier: ^9.0.9
+      version: 9.0.9
     eslint:
       specifier: ^9.36.0
       version: 9.36.0
@@ -111,14 +111,14 @@ catalogs:
       specifier: ^0.4.22
       version: 0.4.22
     eslint-plugin-storybook:
-      specifier: ^9.1.8
-      version: 9.1.8
+      specifier: ^9.1.9
+      version: 9.1.9
     glob:
       specifier: ^11.0.3
       version: 11.0.3
     globals:
-      specifier: ^16.3.0
-      version: 16.3.0
+      specifier: ^16.4.0
+      version: 16.4.0
     playwright:
       specifier: ^1.55.1
       version: 1.55.1
@@ -129,8 +129,8 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.0
     storybook:
-      specifier: ^9.1.8
-      version: 9.1.8
+      specifier: ^9.1.9
+      version: 9.1.9
     tsx:
       specifier: ^4.20.6
       version: 4.20.6
@@ -205,10 +205,10 @@ importers:
         version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.36.0))(eslint@9.36.0)(prettier@3.6.2)
       eslint-plugin-storybook:
         specifier: catalog:tooling
-        version: 9.1.8(eslint@9.36.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)
+        version: 9.1.9(eslint@9.36.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)
       globals:
         specifier: catalog:tooling
-        version: 16.3.0
+        version: 16.4.0
       playwright:
         specifier: catalog:tooling
         version: 1.55.1
@@ -257,7 +257,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.0.1(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+        version: 4.1.0(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       eslint:
         specifier: catalog:tooling
         version: 9.36.0
@@ -269,7 +269,7 @@ importers:
         version: 0.4.22(eslint@9.36.0)
       globals:
         specifier: catalog:tooling
-        version: 16.3.0
+        version: 16.4.0
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
@@ -417,7 +417,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.0.1(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+        version: 4.1.0(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       eslint:
         specifier: catalog:tooling
         version: 9.36.0
@@ -429,7 +429,7 @@ importers:
         version: 0.4.22(eslint@9.36.0)
       globals:
         specifier: catalog:tooling
-        version: 16.3.0
+        version: 16.4.0
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
@@ -532,16 +532,16 @@ importers:
         version: 1.1.5
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+        version: 9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 9.1.8(@types/react@19.1.8)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+        version: 9.1.9(@types/react@19.1.8)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
-        version: 9.1.8(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vitest@3.2.4)
+        version: 9.1.9(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vitest@3.2.4)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.3)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+        version: 9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.3)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       '@testing-library/react':
         specifier: catalog:tooling
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -571,7 +571,7 @@ importers:
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       '@vueless/storybook-dark-mode':
         specifier: catalog:tooling
-        version: 9.0.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 9.0.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       apca-w3:
         specifier: ^0.1.9
         version: 0.1.9
@@ -598,7 +598,7 @@ importers:
         version: 2.0.0
       storybook:
         specifier: catalog:tooling
-        version: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+        version: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       vite:
         specifier: catalog:tooling
         version: 7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)
@@ -2003,8 +2003,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@rolldown/pluginutils@1.0.0-beta.32':
-    resolution: {integrity: sha512-QReCdvxiUZAPkvp1xpAg62IeNzykOFA6syH2CnClif4YmALN1XKpB39XneL80008UbtMShthSVDKmrx05N1q/g==}
+  '@rolldown/pluginutils@1.0.0-beta.35':
+    resolution: {integrity: sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==}
 
   '@rolldown/pluginutils@1.0.0-beta.38':
     resolution: {integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==}
@@ -2188,22 +2188,22 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@storybook/addon-a11y@9.1.8':
-    resolution: {integrity: sha512-7I+Ll29aBwgAbpkNpK+BBJ+BmMCS7+Qe8fPh1n4701Hx7FB+laAx8UP+3kbmqCOwCvLU5JU5KJKgUMMGVE/Jww==}
+  '@storybook/addon-a11y@9.1.9':
+    resolution: {integrity: sha512-gkMbPqfnMkWjUBLCod/DKv3snIBBSv/BCQYDKIlf10AthZ3njO1tPvReNgPLGPzslI4EzkTo9NG6DKWY/VytDQ==}
     peerDependencies:
-      storybook: ^9.1.8
+      storybook: ^9.1.9
 
-  '@storybook/addon-docs@9.1.8':
-    resolution: {integrity: sha512-GVrNVEdNRRo6r1hawfgyy6x+HJqPx1oOHm0U0wz0SGAxgS/Xh6SQVZL+RDoh7NpXkNi1GbezVlT931UsHQTyvQ==}
+  '@storybook/addon-docs@9.1.9':
+    resolution: {integrity: sha512-76OHwsYCC6u8Nu5IUQ3E580BVnto6u4UgQC66inf+ot0+LI9fFPieg7fmcnQtYoFwiAyya3/JEwhY2GuFk7eMg==}
     peerDependencies:
-      storybook: ^9.1.8
+      storybook: ^9.1.9
 
-  '@storybook/addon-vitest@9.1.8':
-    resolution: {integrity: sha512-F1AgGpIuDxrGXErMRTfF9zUXvGSUgQPbAXggs74p9vz0855nlRMEny1cYY9BtktVr4JGyq+Mz2774hCt9HR3KQ==}
+  '@storybook/addon-vitest@9.1.9':
+    resolution: {integrity: sha512-PSfADYvJAjJZzNs1JvWKL3M4ao2BsoMI3Z/SrOG0jnFP/oNzBrjILOT5Gt5FXxbvByJN7Gi+Idp9iiWfXED6xA==}
     peerDependencies:
       '@vitest/browser': ^3.0.0
       '@vitest/runner': ^3.0.0
-      storybook: ^9.1.8
+      storybook: ^9.1.9
       vitest: ^3.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -2213,16 +2213,16 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@9.1.8':
-    resolution: {integrity: sha512-JjvBag0nM1N51O3VF5++op9Ly5OC8Q+y4PrWLgi2dKhMxJFs8fD9D4PeI/v41PUiQcI0suQxN9BoYoKn2QxUZw==}
+  '@storybook/builder-vite@9.1.9':
+    resolution: {integrity: sha512-tCQ2Bv07D0roTg6+c1dCrX6PmAwEpKkwX4eqq32vGYiQ0CTzWP1ivBUAzBvIIHD2FY/zLXzXSrDo/qtrQppCGw==}
     peerDependencies:
-      storybook: ^9.1.8
+      storybook: ^9.1.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/csf-plugin@9.1.8':
-    resolution: {integrity: sha512-KnrXPz87bn+8ZGkzFEBc7TT5HkWpR1Xz7ojxPclSvkKxTfzazuaw0JlOQMzJoI1+wHXDAIw/4MIsO8HEiaWyfQ==}
+  '@storybook/csf-plugin@9.1.9':
+    resolution: {integrity: sha512-8tMZaGqer9PkPl7xRD/d97pgzl6Aw5/rWH+q8fAA09bvjLllKOlytj3vTckGJ4DlkKKXGvxoECG/n35AbJOYIA==}
     peerDependencies:
-      storybook: ^9.1.8
+      storybook: ^9.1.9
 
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
@@ -2234,29 +2234,29 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/react-dom-shim@9.1.8':
-    resolution: {integrity: sha512-OepccjVZh/KQugTH8/RL2CIyf1g5Lwc5ESC8x8BH3iuYc82WMQBwMJzRI5EofQdirau63NGrqkWCgQASoVreEA==}
+  '@storybook/react-dom-shim@9.1.9':
+    resolution: {integrity: sha512-RFaB+N63XXEEo8l5INlvWnqxDUH7UGZ++MOsFsVUqfn7lAzxfR9HcJTGN3WOyIDBoS0vD3+LfnplqFyQU/anuw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.1.8
+      storybook: ^9.1.9
 
-  '@storybook/react-vite@9.1.8':
-    resolution: {integrity: sha512-DIxp76vcelyFOUJupeQEIHXDrSPP6KDXj6Z+Z9thS1HH7JY+OdGtcMLy4fbiD77Zyc8TV9RRZ1D33z2Ot/v9Vw==}
+  '@storybook/react-vite@9.1.9':
+    resolution: {integrity: sha512-k+wbLdM8963YkQmVSFEuigUfGZKEgUdA7tTazXGzkL65j0il93JbtFCso8spKePlgeQ2uD6RxbXUp+E3qLeRSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.1.8
+      storybook: ^9.1.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/react@9.1.8':
-    resolution: {integrity: sha512-EULkwHroJ4IDYcjIBj9VpGhaZ9E5b8LI84hlfBkJ9rnK44a/GrK1yFRIusukO58qTJSh2Y7zfAFKNuiaWh3Sfw==}
+  '@storybook/react@9.1.9':
+    resolution: {integrity: sha512-S06dZv8ebUmCrIP2GfIqD3g1F5LKBf0Lc1daSd2++2MI6i8zw8kZ8IAGg5bYrWb0nk56JHALCwXAzsGyRepEww==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.1.8
+      storybook: ^9.1.9
       typescript: ~5.9.2
     peerDependenciesMeta:
       typescript:
@@ -2645,37 +2645,15 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: ~5.9.2
 
-  '@typescript-eslint/project-service@8.42.0':
-    resolution: {integrity: sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: ~5.9.2
-
   '@typescript-eslint/project-service@8.45.0':
     resolution: {integrity: sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: ~5.9.2
 
-  '@typescript-eslint/scope-manager@8.42.0':
-    resolution: {integrity: sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.45.0':
     resolution: {integrity: sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.42.0':
-    resolution: {integrity: sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: ~5.9.2
-
-  '@typescript-eslint/tsconfig-utils@8.44.1':
-    resolution: {integrity: sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: ~5.9.2
 
   '@typescript-eslint/tsconfig-utils@8.45.0':
     resolution: {integrity: sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==}
@@ -2690,35 +2668,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: ~5.9.2
 
-  '@typescript-eslint/types@8.42.0':
-    resolution: {integrity: sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.44.1':
-    resolution: {integrity: sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.45.0':
     resolution: {integrity: sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.42.0':
-    resolution: {integrity: sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: ~5.9.2
 
   '@typescript-eslint/typescript-estree@8.45.0':
     resolution: {integrity: sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: ~5.9.2
-
-  '@typescript-eslint/utils@8.42.0':
-    resolution: {integrity: sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
       typescript: ~5.9.2
 
   '@typescript-eslint/utils@8.45.0':
@@ -2727,10 +2684,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: ~5.9.2
-
-  '@typescript-eslint/visitor-keys@8.42.0':
-    resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.45.0':
     resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
@@ -2744,8 +2697,8 @@ packages:
     engines: {node: '>=20.18 <=24.x'}
     os: [darwin, linux, win32]
 
-  '@vitejs/plugin-react-swc@4.0.1':
-    resolution: {integrity: sha512-NQhPjysi5duItyrMd5JWZFf2vNOuSMyw+EoZyTBDzk+DkfYD8WNrsUs09sELV2cr1P15nufsN25hsUBt4CKF9Q==}
+  '@vitejs/plugin-react-swc@4.1.0':
+    resolution: {integrity: sha512-Ff690TUck0Anlh7wdIcnsVMhofeEVgm44Y4OYdeeEEPSKyZHzDI9gfVBvySEhDfXtBp8tLCbfsVKPWEMEjq8/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
@@ -2838,8 +2791,8 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
-  '@vueless/storybook-dark-mode@9.0.8':
-    resolution: {integrity: sha512-VwYn0PnuZ4SIVZigU20FuUDadX++imsGP0w11CXchCjF6fqdrlEm4VrMCTF9tkh4U0ea2znl1ZYXAajUKyOJxw==}
+  '@vueless/storybook-dark-mode@9.0.9':
+    resolution: {integrity: sha512-wXy4O/qgqxiPywKgyXDxYgIyP5r0lBRes+uJCCcEtcpNVISzUFieNEojFGz32oSOLLTk6EGGgYiwwy82OH4ylg==}
     engines: {node: '>=20'}
 
   '@xobotyi/scrollbar-width@1.9.5':
@@ -3788,12 +3741,12 @@ packages:
     peerDependencies:
       eslint: '>=8.40'
 
-  eslint-plugin-storybook@9.1.8:
-    resolution: {integrity: sha512-mEn5EVc7DAEvuwKMqUrIYUFZQJiQD3i5egLi1UJERQm91mDOMr5RdC4hjUF3tNE+WxQYD7QzH2j1qf36ML7V3g==}
+  eslint-plugin-storybook@9.1.9:
+    resolution: {integrity: sha512-2ZxaIR3ZfsBP4vqrC6fsCKM8pCbgTLRcBUm69g1yiJBKAbIHU8nQSsD6gpEPO3YFdRayGqzxnvwwWcXwtm5f5Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       eslint: '>=8'
-      storybook: ^9.1.8
+      storybook: ^9.1.9
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -4126,8 +4079,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@16.3.0:
-    resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -5741,8 +5694,8 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
-  storybook@9.1.8:
-    resolution: {integrity: sha512-/iP+DvieJ6Mnixy4PFY/KXnhsg/IHIDlTbZqly3EDbveuhsCuIUELfGnj+QSRGf9C6v/f4sZf9sZ3r80ZnKuEA==}
+  storybook@9.1.9:
+    resolution: {integrity: sha512-KEazHA1iD2L8Fll+Kw9c/z0Pjv3Z+1GHYejmk+JlrIt+/mXDG2HVF7eelvk3tYCbuxqyuCL57pYhJUfkHwA6Fw==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -8483,7 +8436,7 @@ snapshots:
       '@react-types/shared': 3.32.0(react@19.1.0)
       react: 19.1.0
 
-  '@rolldown/pluginutils@1.0.0-beta.32': {}
+  '@rolldown/pluginutils@1.0.0-beta.35': {}
 
   '@rolldown/pluginutils@1.0.0-beta.38': {}
 
@@ -8641,31 +8594,31 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@storybook/addon-a11y@9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
+  '@storybook/addon-a11y@9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.2
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
 
-  '@storybook/addon-docs@9.1.8(@types/react@19.1.8)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
+  '@storybook/addon-docs@9.1.9(@types/react@19.1.8)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.1.8)(react@19.1.0)
-      '@storybook/csf-plugin': 9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+      '@storybook/csf-plugin': 9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@storybook/react-dom-shim': 9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+      '@storybook/react-dom-shim': 9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-vitest@9.1.8(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vitest@3.2.4)':
+  '@storybook/addon-vitest@9.1.9(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vitest@3.2.4)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prompts: 2.4.2
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       ts-dedent: 2.2.0
     optionalDependencies:
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(playwright@1.55.1)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@3.2.4)
@@ -8675,16 +8628,16 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))':
+  '@storybook/builder-vite@9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      '@storybook/csf-plugin': 9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       ts-dedent: 2.2.0
       vite: 7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)
 
-  '@storybook/csf-plugin@9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
+  '@storybook/csf-plugin@9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
     dependencies:
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -8694,25 +8647,25 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/react-dom-shim@9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
+  '@storybook/react-dom-shim@9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))':
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
 
-  '@storybook/react-vite@9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.3)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))':
+  '@storybook/react-vite@9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.52.3)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       '@rollup/pluginutils': 5.2.0(rollup@4.52.3)
-      '@storybook/builder-vite': 9.1.8(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
-      '@storybook/react': 9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)
+      '@storybook/builder-vite': 9.1.9(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      '@storybook/react': 9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)
       find-up: 7.0.0
       magic-string: 0.30.19
       react: 19.1.0
       react-docgen: 8.0.0
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
       tsconfig-paths: 4.2.0
       vite: 7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -8720,13 +8673,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)':
+  '@storybook/react@9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
+      '@storybook/react-dom-shim': 9.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
     optionalDependencies:
       typescript: 5.9.2
 
@@ -9134,15 +9087,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.42.0(typescript@5.9.2)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/types': 8.44.1
-      debug: 4.4.1
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/project-service@8.45.0(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.45.0(typescript@5.9.2)
@@ -9152,23 +9096,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.42.0':
-    dependencies:
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/visitor-keys': 8.42.0
-
   '@typescript-eslint/scope-manager@8.45.0':
     dependencies:
       '@typescript-eslint/types': 8.45.0
       '@typescript-eslint/visitor-keys': 8.45.0
-
-  '@typescript-eslint/tsconfig-utils@8.42.0(typescript@5.9.2)':
-    dependencies:
-      typescript: 5.9.2
-
-  '@typescript-eslint/tsconfig-utils@8.44.1(typescript@5.9.2)':
-    dependencies:
-      typescript: 5.9.2
 
   '@typescript-eslint/tsconfig-utils@8.45.0(typescript@5.9.2)':
     dependencies:
@@ -9186,27 +9117,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.42.0': {}
-
-  '@typescript-eslint/types@8.44.1': {}
-
   '@typescript-eslint/types@8.45.0': {}
-
-  '@typescript-eslint/typescript-estree@8.42.0(typescript@5.9.2)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.42.0(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/visitor-keys': 8.42.0
-      debug: 4.4.1
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.45.0(typescript@5.9.2)':
     dependencies:
@@ -9224,17 +9135,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.42.0(eslint@9.36.0)(typescript@5.9.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
-      '@typescript-eslint/scope-manager': 8.42.0
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.9.2)
-      eslint: 9.36.0
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/utils@8.45.0(eslint@9.36.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
@@ -9246,11 +9146,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.42.0':
-    dependencies:
-      '@typescript-eslint/types': 8.42.0
-      eslint-visitor-keys: 4.2.1
-
   '@typescript-eslint/visitor-keys@8.45.0':
     dependencies:
       '@typescript-eslint/types': 8.45.0
@@ -9260,9 +9155,9 @@ snapshots:
 
   '@visulima/boxen@2.0.2': {}
 
-  '@vitejs/plugin-react-swc@4.0.1(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))':
+  '@vitejs/plugin-react-swc@4.1.0(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.32
+      '@rolldown/pluginutils': 1.0.0-beta.35
       '@swc/core': 1.13.5
       vite: 7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -9408,7 +9303,7 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
-  '@vueless/storybook-dark-mode@9.0.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@vueless/storybook-dark-mode@9.0.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -10605,11 +10500,11 @@ snapshots:
     dependencies:
       eslint: 9.36.0
 
-  eslint-plugin-storybook@9.1.8(eslint@9.36.0)(storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2):
+  eslint-plugin-storybook@9.1.9(eslint@9.36.0)(storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)))(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/utils': 8.42.0(eslint@9.36.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0)(typescript@5.9.2)
       eslint: 9.36.0
-      storybook: 9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
+      storybook: 9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11022,7 +10917,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@16.3.0: {}
+  globals@16.4.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -13117,7 +13012,7 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  storybook@9.1.8(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)):
+  storybook@9.1.9(@testing-library/dom@10.4.0)(msw@2.7.0(@types/node@24.3.1)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.7(@types/node@24.3.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,8 +50,8 @@ catalogs:
     '@storybook/react-vite': ^9.1.9
     '@vueless/storybook-dark-mode': ^9.0.9
   react:
-    '@types/react': ^19.1.8
-    '@types/react-dom': ^19.1.6
+    '@types/react': ^19.1.16
+    '@types/react-dom': ^19.1.9
     react: ^19.0.0
     react-dom: ^19.0.0
     '@emotion/react': ^11.14.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalogMode: strict
 
 catalogs:
   tooling:
-    globals: ^16.3.0
+    globals: ^16.4.0
     glob: ^11.0.3
     typescript: ~5.9.2
     typescript-eslint: ^8.45.0
@@ -28,7 +28,7 @@ catalogs:
     prettier: ^3.6.2
     '@preconstruct/cli': ^2.8.12
     '@vitejs/plugin-react': ^5.0.4
-    '@vitejs/plugin-react-swc': ^4.0.1
+    '@vitejs/plugin-react-swc': ^4.1.0
     vite: ^7.1.7
     vite-bundle-analyzer: ^1.2.3
     vite-plugin-dts: ^4.5.4
@@ -42,13 +42,13 @@ catalogs:
     '@testing-library/react': ^16.3.0
     playwright: ^1.55.1
     vitest: ^3.2.4
-    storybook: ^9.1.8
-    eslint-plugin-storybook: ^9.1.8
-    '@storybook/addon-a11y': ^9.1.8
-    '@storybook/addon-docs': ^9.1.8
-    '@storybook/addon-vitest': ^9.1.8
-    '@storybook/react-vite': ^9.1.8
-    '@vueless/storybook-dark-mode': ^9.0.8
+    storybook: ^9.1.9
+    eslint-plugin-storybook: ^9.1.9
+    '@storybook/addon-a11y': ^9.1.9
+    '@storybook/addon-docs': ^9.1.9
+    '@storybook/addon-vitest': ^9.1.9
+    '@storybook/react-vite': ^9.1.9
+    '@vueless/storybook-dark-mode': ^9.0.9
   react:
     '@types/react': ^19.1.8
     '@types/react-dom': ^19.1.6


### PR DESCRIPTION
## Summary

This PR updates workspace catalog dependencies to their latest minor and patch versions while maintaining compatibility and respecting version constraints.

## 🔧 Tooling Dependencies Updated

**Build & Development Tools:**
- `globals`: 16.3.0 → 16.4.0 (minor)
- `@vitejs/plugin-react-swc`: 4.0.1 → 4.1.0 (minor)

**Storybook Ecosystem (9.1.8 → 9.1.9):**
- `storybook`
- `eslint-plugin-storybook`
- `@storybook/addon-a11y`
- `@storybook/addon-docs`
- `@storybook/addon-vitest`
- `@storybook/react-vite`
- `@vueless/storybook-dark-mode`: 9.0.8 → 9.0.9

**Additional Lockfile Updates:**
- `tsx`: 4.20.5 → 4.20.6 (patch)
- `typescript-eslint`: 8.44.1 → 8.45.0 (minor)

## ⚛️ React Ecosystem Updates

**Type Definitions:**
- `@types/react`: 19.1.8 → 19.1.16 (patch)
- `@types/react-dom`: 19.1.6 → 19.1.9 (patch)

**⚠️ Important: React Core Frozen**

React and React-DOM remain at **19.0.0** by design. As a UI library consumed by other applications, we must allow consumers to control their React version. Only TypeScript type definitions were updated.

## 📊 Update Strategy

Dependencies were updated in risk-ordered groups with validation checkpoints:

1. **Tooling Group** (lowest risk): Build tools, linters, test frameworks
2. **React Types** (controlled): Only `@types/*` packages updated

Each group was:
- ✅ Updated independently
- ✅ Verified with `pnpm build:packages`
- ✅ Tested with full suite (478 tests passed)
- ✅ Committed as checkpoint

## 🧪 Testing

- ✅ **Build integrity verified**: `pnpm build:packages` passes
- ✅ **Full test suite passes**: `pnpm test` (478 tests, all passed)
- ✅ **Complete build passes**: `pnpm build` (includes docs)
- ✅ **No breaking changes detected**

## 📦 Packages Skipped

**Major version updates (requires manual review):**
- None in this update cycle

**Frozen by constraint:**
- `react`: 19.0.0 (consumers control version)
- `react-dom`: 19.0.0 (consumers control version)
- `@emotion/react`: 11.14.0 (already latest)
- `@chakra-ui/*`: 3.27.0 (already latest)
- All React Aria packages (already latest)

## 📝 Summary

- ✅ **11 packages updated** (9 tooling, 2 React types)
- ✅ **0 packages skipped** (major versions)
- ✅ **0 packages failed**
- ✅ **100% test pass rate** (478/478 tests)

## 🔍 Review Notes

This is a low-risk update focused on:
1. **Patch updates** to Storybook ecosystem for bug fixes
2. **Minor updates** to build tooling for new features
3. **Type definition updates** for improved TypeScript support

All changes are backward compatible within semver constraints.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)