### PR TITLE
docs: add comprehensive documentation for React component types and API

### DIFF
--- a/.claude/commands/document-types.md
+++ b/.claude/commands/document-types.md
@@ -1,0 +1,301 @@
+---
+description: Creates or updates a components typescript types documentation
+---
+
+You are an expert React/TypeScript documentation generator for the Nimbus design
+system. Your purpose is to analyze React components and generate comprehensive,
+well-structured API documentation in Markdown after ultrathinking about
+everything.
+
+Your primary task is to take a React component name as input, inspect its
+exports to determine if it's a single component or a namespace with
+sub-components, and then create or update a corresponding `.types.md` file that
+documents its API (props, types, defaults).
+
+---
+
+## Workflow
+
+1.  **Receive Input:** You will be given a single string representing the name
+    of a React component (e.g., `Dialog`, `Button`, `Menu`).
+
+2.  **Determine Filename:** Based on the input `ComponentName`, the output
+    filename must be the kebab-case version of the name, ending with
+    `.types.md`.
+    - `Dialog` -> `dialog.types.md`
+    - `Button` -> `button.types.md`
+    - `Menu` -> `menu.types.md`
+
+3.  **Analyze Component Structure:**
+    - Locate the component's `.types.ts` file in
+      `packages/nimbus/src/components/{component-name}/{component-name}.types.ts`
+    - Locate the component's `.slots.tsx` file in
+      `packages/nimbus/src/components/{component-name}/{component-name}.slots.tsx`
+      (if it exists)
+    - **Identify the Export Structure:**
+      - **A) Single Component:** A standard React component exported directly
+        (e.g., `Button`)
+      - **B) Compound Component:** An object that acts as a namespace containing
+        multiple sub-components (e.g., `Dialog.Root`, `Dialog.Trigger`,
+        `Dialog.Content`)
+
+4.  **Determine Style Props Support:**
+    - Check if the component's props interface extends a slot props type (e.g.,
+      `DialogTriggerSlotProps`, `ButtonRootProps`)
+    - If it extends a slot props type that is defined as
+      `HTMLChakraProps<element>`, the component **supports Chakra UI style
+      props**
+    - Note this in the documentation for each component/sub-component
+
+5.  **Generate Documentation Content:**
+    - For **every** component and sub-component identified, extract its props
+    - Categorize props into three separate tables:
+      1. **Configuration Props:** All props that are NOT events and NOT
+         accessibility-related
+      2. **Event Props:** Props starting with `on` (e.g., `onClick`,
+         `onOpenChange`)
+      3. **Accessibility Props:** Props related to ARIA or accessibility (e.g.,
+         `aria-label`, `isDisabled`)
+    - Extract TypeScript types, whether props are required, descriptions from
+      JSDoc comments, and default values
+    - Structure the documentation by starting with the root component, followed
+      by each sub-component in logical order
+
+6.  **Format the Output File:**
+    - Create or update the target markdown file (`component-name.types.md`)
+    - If the file exists, overwrite it entirely with the newly generated,
+      correctly formatted content
+    - The file must start with a level 1 heading: `# [ComponentName] API`
+    - **For compound components only:** After the main heading, add a
+      "Components" section with an unordered list linking to each sub-component
+      (e.g., `- [Dialog.Root](#dialogroot)`,
+      `- [Dialog.Trigger](#dialogtrigger)`)
+    - Each component and sub-component must have its own section with:
+      - Level 2 heading: `## [ComponentName]` or
+        `## [ComponentName.SubComponent]`
+      - A note about style props support if applicable
+      - Three separate tables (Configuration, Events, Accessibility) with their
+        respective props
+
+---
+
+## Formatting Rules
+
+### Style Props Support
+
+For each component/sub-component section, include a note about style props
+support:
+
+```markdown
+## Dialog.Trigger
+
+Supports style-props: ✅
+```
+
+or
+
+```markdown
+## Button
+
+Supports style-props: ✅
+```
+
+If a component does NOT support style props (doesn't extend a slot props type):
+
+```markdown
+## CustomComponent
+
+Supports style-props: ❌
+```
+
+### Table Categories
+
+Each component section should have up to three tables:
+
+1. **Props**
+2. **Event Props** (if any event handlers exist)
+3. **Accessibility Props** (if any accessibility-related props exist)
+
+If a category has no props, omit that table.
+
+### Table Header
+
+All tables must use this exact header format:
+
+```
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+```
+
+### Prop Column
+
+- List the name of the prop
+- If the prop is **required**, append an asterisk (`*`) to its name (e.g.,
+  `children*`)
+
+### Type / Description Column
+
+- Start with the TypeScript type, formatted as inline code (e.g.,
+  `` `string` ``, `` `React.ReactNode` ``)
+- For union types, provide clear representation (e.g.,
+  `` `'small' | 'medium' | 'large'` ``)
+- For function types, show the signature (e.g.,
+  `` `(isOpen: boolean) => void` ``)
+- Follow the type with a clear, concise description extracted from JSDoc
+  comments
+- If the JSDoc has an `@default` tag, don't repeat it in the description
+
+### Default Column
+
+- State the default value of the prop
+- If the value is a string, enclose it in backticks (e.g., `` `'medium'` ``)
+- If there is no default value, use a hyphen (`-`)
+- Extract default values from `@default` JSDoc tags
+
+### Prop Categorization Rules
+
+**Configuration Props:**
+
+- Regular component props (variant, size, children, etc.)
+- State props (isOpen, defaultOpen, value, etc.)
+- Ref props
+- NOT event handlers (on\*)
+- NOT accessibility props
+
+**Event Props:**
+
+- Any prop starting with `on` (onClick, onChange, onOpenChange, etc.)
+
+**Accessibility Props:**
+
+- Props starting with `aria-`
+- Props like `isDisabled`, `isReadOnly`
+- Props related to keyboard navigation or screen readers
+
+---
+
+## Example Scenario
+
+**Input:** `Dialog`
+
+**Expected Output File (`dialog.types.md`):**
+
+```markdown
+# Dialog API
+
+## Components
+
+- [Dialog.Root](#dialogroot)
+- [Dialog.Trigger](#dialogtrigger)
+- [Dialog.Content](#dialogcontent)
+- [Dialog.CloseTrigger](#dialogclosetrigger)
+
+---
+
+## Dialog.Root
+
+Supports style-props: ✅
+
+### Configuration Props
+
+| Prop                         | Type / Description                                                                                              | Default |
+| :--------------------------- | :-------------------------------------------------------------------------------------------------------------- | :------ |
+| children\*                   | `React.ReactNode` <br> The children components (Trigger, Content, etc.)                                         | -       |
+| isOpen                       | `boolean` <br> Whether the dialog is open (controlled mode)                                                     | -       |
+| defaultOpen                  | `boolean` <br> Whether the dialog is open by default (uncontrolled mode)                                        | `false` |
+| isDismissable                | `boolean` <br> Whether the dialog can be dismissed by clicking the backdrop or pressing Escape                  | `true`  |
+| isKeyboardDismissDisabled    | `boolean` <br> Whether keyboard dismissal (Escape key) is disabled                                              | `false` |
+| shouldCloseOnInteractOutside | `(event: Event) => boolean` <br> Function to determine whether the dialog should close when interacting outside | -       |
+
+### Event Props
+
+| Prop         | Type / Description                                                                 | Default |
+| :----------- | :--------------------------------------------------------------------------------- | :------ |
+| onOpenChange | `(isOpen: boolean) => void` <br> Callback fired when the dialog open state changes | -       |
+
+### Accessibility Props
+
+| Prop       | Type / Description                                                                                            | Default |
+| :--------- | :------------------------------------------------------------------------------------------------------------ | :------ |
+| aria-label | `string` <br> A title for the dialog, optional as long as Dialog.Title is used or a Heading with slot="title" | -       |
+
+---
+
+## Dialog.Trigger
+
+Supports style-props: ✅
+
+### Configuration Props
+
+| Prop       | Type / Description                                                                         | Default |
+| :--------- | :----------------------------------------------------------------------------------------- | :------ |
+| children\* | `React.ReactNode` <br> The trigger content                                                 | -       |
+| asChild    | `boolean` <br> Whether to render as a child element (use children directly as the trigger) | `false` |
+| ref        | `React.RefObject<HTMLButtonElement>` <br> The ref to the trigger html-button               | -       |
+
+### Accessibility Props
+
+| Prop       | Type / Description                             | Default |
+| :--------- | :--------------------------------------------- | :------ |
+| isDisabled | `boolean` <br> Whether the trigger is disabled | `false` |
+
+---
+
+## Dialog.Content
+
+Supports style-props: ✅
+
+### Configuration Props
+
+| Prop       | Type / Description                                                   | Default |
+| :--------- | :------------------------------------------------------------------- | :------ |
+| children\* | `React.ReactNode` <br> The dialog content                            | -       |
+| ref        | `React.RefObject<HTMLDivElement>` <br> The ref to the dialog content | -       |
+
+---
+
+## Dialog.CloseTrigger
+
+Supports style-props: ✅
+
+### Accessibility Props
+
+| Prop       | Type / Description                                  | Default          |
+| :--------- | :-------------------------------------------------- | :--------------- |
+| aria-label | `string` <br> Accessible label for the close button | `"Close dialog"` |
+```
+
+---
+
+## Important Notes
+
+- **Always check for slot props inheritance:** If a props interface extends a
+  slot props type (like `DialogTriggerSlotProps`, `ButtonRootProps`, etc.), the
+  component supports style props
+- **Extract JSDoc comments:** Use the JSDoc comments from the `.types.ts` file
+  for descriptions and default values
+- **Handle recipe variants:** Components extending
+  `RecipeVariantProps<typeof recipe>` support variant props (size, variant,
+  tone, etc.) which should be documented
+- **Omit style props list:** Do NOT list individual Chakra UI style props - just
+  note that they are supported
+- **Handle complex types:** For types imported from React Aria or other
+  libraries, show the simplified version in the table
+- **Categorize carefully:** Make sure props are in the correct table
+  (Configuration vs Events vs Accessibility)
+- **Order matters:** List Configuration props first, then Events, then
+  Accessibility
+
+---
+
+## Execution Steps
+
+1. Read the component's `.types.ts` file
+2. Read the component's `.slots.tsx` file (if it exists)
+3. Identify all exported props interfaces
+4. For each interface:
+   - Determine if it extends slot props (for style props support)
+   - Categorize each prop into Configuration/Events/Accessibility
+   - Extract type information, descriptions, and defaults
+5. Generate the markdown file with proper formatting
+6. Write the file to the component directory

--- a/packages/nimbus/src/components/accordion/accordion.types.md
+++ b/packages/nimbus/src/components/accordion/accordion.types.md
@@ -1,0 +1,140 @@
+# Accordion API
+
+## Components
+
+- [Accordion.Root](#accordionroot)
+- [Accordion.Item](#accordionitem)
+- [Accordion.Header](#accordionheader)
+- [Accordion.Content](#accordioncontent)
+- [Accordion.HeaderRightContent](#accordionheaderrightcontent)
+
+---
+
+## Accordion.Root
+
+Supports style-props: ✅
+
+Controls the overall accordion container and behavior.
+
+### Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `ReactNode` <br> The accordion items to display | - |
+| ref | `Ref<HTMLDivElement>` <br> Ref to the root element | - |
+| allowsMultipleExpanded | `boolean` <br> Whether multiple items can be expanded simultaneously | `false` |
+| defaultExpandedKeys | `Iterable<Key>` <br> Default expanded items in uncontrolled mode | - |
+| expandedKeys | `Iterable<Key>` <br> Controlled expanded items state | - |
+
+### Event Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| onExpandedChange | `(keys: Set<Key>) => void` <br> Callback fired when expansion state changes | - |
+
+### Accessibility Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| isDisabled | `boolean` <br> Disables all accordion items | `false` |
+
+---
+
+## Accordion.Item
+
+Supports style-props: ✅
+
+Individual accordion item component that contains Header and Content.
+
+### Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `ReactNode` <br> The accordion item content (Header and Content components) | - |
+| value | `string` <br> Unique value for this item (used for controlled state) | - |
+| ref | `Ref<HTMLDivElement>` <br> Ref to the item element | - |
+| defaultExpanded | `boolean` <br> Default expansion state in uncontrolled mode | `false` |
+| isExpanded | `boolean` <br> Controlled expansion state | - |
+
+### Event Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| onExpandedChange | `(isExpanded: boolean) => void` <br> Callback fired when item expansion state changes | - |
+
+### Accessibility Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| isDisabled | `boolean` <br> Disables this accordion item | `false` |
+
+---
+
+## Accordion.Header
+
+Supports style-props: ✅
+
+Displays the clickable header that expands/collapses content.
+
+### Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `ReactNode` <br> The header content to display | - |
+| ref | `Ref<HTMLButtonElement>` <br> Ref to the header element | - |
+| autoFocus | `boolean` <br> Whether the header button should automatically receive focus | `false` |
+| type | `'button' \| 'submit' \| 'reset'` <br> The button type attribute | `'button'` |
+| excludeFromTabOrder | `boolean` <br> Excludes the header button from keyboard tab order | `false` |
+
+### Event Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| onPress | `(e: PressEvent) => void` <br> Handler called when the header is pressed | - |
+| onPressStart | `(e: PressEvent) => void` <br> Handler called when press interaction starts | - |
+| onPressEnd | `(e: PressEvent) => void` <br> Handler called when press interaction ends | - |
+| onPressChange | `(isPressed: boolean) => void` <br> Handler called when press state changes | - |
+| onPressUp | `(e: PressEvent) => void` <br> Handler called when press is released | - |
+| onFocus | `(e: FocusEvent) => void` <br> Handler called when header receives focus | - |
+| onBlur | `(e: FocusEvent) => void` <br> Handler called when header loses focus | - |
+| onKeyDown | `(e: KeyboardEvent) => void` <br> Handler called for key down events | - |
+| onKeyUp | `(e: KeyboardEvent) => void` <br> Handler called for key up events | - |
+
+### Accessibility Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| isDisabled | `boolean` <br> Disables the header button | `false` |
+| aria-label | `string` <br> Accessible label for the header button | - |
+| aria-labelledby | `string` <br> ID of element that labels the header button | - |
+| aria-describedby | `string` <br> ID of element that describes the header button | - |
+| aria-details | `string` <br> ID of element providing additional details | - |
+
+---
+
+## Accordion.Content
+
+Supports style-props: ✅
+
+Contains the collapsible content area that expands/collapses.
+
+### Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `ReactNode` <br> The content to display when expanded | - |
+| ref | `Ref<HTMLDivElement>` <br> Ref to the content element | - |
+
+---
+
+## Accordion.HeaderRightContent
+
+Supports style-props: ✅
+
+Slot component for displaying additional content on the right side of the accordion header.
+
+### Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children | `ReactNode` <br> Content to display on the right side of the header | - |

--- a/packages/nimbus/src/components/dialog/dialog.types.md
+++ b/packages/nimbus/src/components/dialog/dialog.types.md
@@ -1,0 +1,156 @@
+# Dialog API
+
+## Components
+
+- [Dialog.Root](#dialogroot)
+- [Dialog.Trigger](#dialogtrigger)
+- [Dialog.Content](#dialogcontent)
+- [Dialog.Header](#dialogheader)
+- [Dialog.Body](#dialogbody)
+- [Dialog.Footer](#dialogfooter)
+- [Dialog.Title](#dialogtitle)
+- [Dialog.CloseTrigger](#dialogclosetrigger)
+
+---
+
+## Dialog.Root
+
+Supports style-props: ✅
+
+The root component that provides context and state management for the dialog. Uses React Aria's DialogTrigger for accessibility and state management. This component handles configuration through recipe variants that are passed down to child components via context.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The children components (Trigger, Content, etc.) | - |
+| isOpen | `boolean` <br> Whether the dialog is open (controlled mode) | - |
+| defaultOpen | `boolean` <br> Whether the dialog is open by default (uncontrolled mode) | `false` |
+| isDismissable | `boolean` <br> Whether the dialog can be dismissed by clicking the backdrop or pressing Escape. If true, clicking outside the dialog or pressing Escape will close it. | `true` |
+| isKeyboardDismissDisabled | `boolean` <br> Whether keyboard dismissal (Escape key) is disabled. If true, pressing Escape will NOT close the dialog. | `false` |
+| shouldCloseOnInteractOutside | `(event: Event) => boolean` <br> Function to determine whether the dialog should close when interacting outside. Receives the event and returns true to allow closing, false to prevent. | - |
+| size | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` <br> Size variant for the dialog | - |
+| placement | `'center' \| 'top' \| 'bottom'` <br> Placement variant for the dialog position | - |
+
+### Event Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| onOpenChange | `(isOpen: boolean) => void` <br> Callback fired when the dialog open state changes | - |
+
+### Accessibility Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| aria-label | `string` <br> A Title for the dialog, optional, as long as the Dialog.Title component is used or there is a Heading component used inside the Dialog with a `slot`-property set to `title`. | - |
+
+---
+
+## Dialog.Trigger
+
+Supports style-props: ✅
+
+The trigger element that opens the dialog when activated.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The trigger content | - |
+| asChild | `boolean` <br> Whether to render as a child element (use children directly as the trigger) | `false` |
+| ref | `React.RefObject<HTMLButtonElement>` <br> The ref to the trigger html-button | - |
+
+### Accessibility Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| isDisabled | `boolean` <br> Whether the trigger is disabled | `false` |
+
+---
+
+## Dialog.Content
+
+Supports style-props: ✅
+
+The main dialog content container that wraps the React Aria Dialog and Modal. Configuration (size, placement, etc.) is inherited from Dialog.Root via context.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The dialog content | - |
+| ref | `React.RefObject<HTMLDivElement>` <br> The ref to the dialog content | - |
+
+---
+
+## Dialog.Header
+
+Supports style-props: ✅
+
+The header section of the dialog content.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The header content | - |
+| ref | `React.Ref<HTMLElement>` <br> The ref to the dialog header | - |
+
+---
+
+## Dialog.Body
+
+Supports style-props: ✅
+
+The main body content section of the dialog.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The body content | - |
+| ref | `React.Ref<HTMLDivElement>` <br> The ref to the dialog body | - |
+
+---
+
+## Dialog.Footer
+
+Supports style-props: ✅
+
+The footer section of the dialog, typically containing action buttons.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The footer content (usually buttons) | - |
+| ref | `React.Ref<HTMLElement>` <br> The ref to the dialog footer | - |
+
+---
+
+## Dialog.Title
+
+Supports style-props: ✅
+
+The accessible title element for the dialog.
+
+### Configuration Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| children* | `React.ReactNode` <br> The title text | - |
+| ref | `React.Ref<HTMLHeadingElement>` <br> The ref to the dialog title | - |
+
+---
+
+## Dialog.CloseTrigger
+
+Supports style-props: ✅
+
+A button that closes the dialog when activated. Displays an IconButton with an X icon by default.
+
+### Accessibility Props
+
+| Prop | Type / Description | Default |
+| :--- | :--- | :--- |
+| aria-label | `string` <br> Accessible label for the close button | `"Close dialog"` |


### PR DESCRIPTION
This PR contains a claude slash-command for extracting the typescript types of a react component and documenting them in a corresponding markdown file + 2 examples for how such generated files look like.

Within claude code you'd just prompt `/document-types ComponentName` and if everything goes well, a `component-name.types.md` file is being generated.

(This is some sort of semi-automatic fallback-solution in case we can not get `react-docgen` to reliably parse our component types.)