### PR TITLE
CRAFT-1757: fix(select): fix Select components' ClearButton

### DIFF
--- a/packages/nimbus/src/components/select/components/select.clear-button.tsx
+++ b/packages/nimbus/src/components/select/components/select.clear-button.tsx
@@ -21,12 +21,13 @@ export const SelectClearButton = () => {
   return (
     <ClearPressResponder>
       <IconButton
-        pointerEvents="all"
         size="2xs"
+        slot={null}
         variant="ghost"
         aria-label={intl.formatMessage(messages.clearSelection)}
         aria-labelledby=""
         onPress={onPressRequest}
+        pointerEvents="all"
       >
         <CloseIcon />
       </IconButton>

--- a/packages/nimbus/src/components/select/components/select.option-group.tsx
+++ b/packages/nimbus/src/components/select/components/select.option-group.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
-
+import { extractStyleProps } from "@/utils/extractStyleProps";
+import { chakra } from "@chakra-ui/react/styled-system";
 import {
   ListBoxSection as RaListBoxSection,
   Header as RaHeader,
@@ -12,6 +13,7 @@ export const SelectOptionGroup = <T extends object>(
   props: SelectOptionGroupProps<T> & { ref?: React.Ref<HTMLDivElement> }
 ) => {
   const { ref, label, items, children, ...restProps } = props;
+  const [styleProps, functionalProps] = extractStyleProps(restProps);
 
   // Validate that children is a function when items is provided
   if (items && typeof children !== "function") {
@@ -21,24 +23,26 @@ export const SelectOptionGroup = <T extends object>(
   }
 
   return (
-    <RaListBoxSection ref={ref} {...restProps}>
-      <SelectOptionGroupSlot asChild>
-        <RaHeader>{label}</RaHeader>
-      </SelectOptionGroupSlot>
+    <chakra.div {...styleProps} asChild>
+      <RaListBoxSection ref={ref} {...functionalProps}>
+        <SelectOptionGroupSlot asChild>
+          <RaHeader>{label}</RaHeader>
+        </SelectOptionGroupSlot>
 
-      {items ? (
-        <Collection items={items}>
-          {(item: T) => {
-            if (typeof children === "function") {
-              return children(item);
-            }
-            return null;
-          }}
-        </Collection>
-      ) : (
-        (children as ReactNode)
-      )}
-    </RaListBoxSection>
+        {items ? (
+          <Collection items={items}>
+            {(item: T) => {
+              if (typeof children === "function") {
+                return children(item);
+              }
+              return null;
+            }}
+          </Collection>
+        ) : (
+          (children as ReactNode)
+        )}
+      </RaListBoxSection>
+    </chakra.div>
   );
 };
 

--- a/packages/nimbus/src/components/select/components/select.option.tsx
+++ b/packages/nimbus/src/components/select/components/select.option.tsx
@@ -1,14 +1,17 @@
 import { ListBoxItem as RaListBoxItem } from "react-aria-components";
 import { SelectOptionSlot } from "./../select.slots";
 import type { SelectOptionProps } from "../select.types";
+import { extractStyleProps } from "@/utils/extractStyleProps";
 
 export const SelectOption = <T extends object>({
   ref,
   ...restProps
-}: SelectOptionProps<T> & { ref?: React.Ref<HTMLDivElement> }) => {
+}: SelectOptionProps<T>) => {
+  const [styleProps, functionalProps] = extractStyleProps(restProps);
+
   return (
-    <SelectOptionSlot asChild ref={ref}>
-      <RaListBoxItem {...restProps} />
+    <SelectOptionSlot asChild {...styleProps}>
+      <RaListBoxItem ref={ref} {...functionalProps} />
     </SelectOptionSlot>
   );
 };

--- a/packages/nimbus/src/components/select/components/select.root.tsx
+++ b/packages/nimbus/src/components/select/components/select.root.tsx
@@ -83,7 +83,7 @@ export const SelectRoot = function SelectRoot({
               </Flex>
             )}
 
-            <Flex my="auto" w="600" h="600" pointerEvents="none">
+            <Flex my="auto" w="600" h="600">
               <Box color="neutral.9" asChild m="auto" w="400" h="400">
                 {isLoading ? (
                   <Box asChild animation="spin" animationDuration="slowest">

--- a/packages/nimbus/src/components/select/select.stories.tsx
+++ b/packages/nimbus/src/components/select/select.stories.tsx
@@ -4,7 +4,7 @@ import { Text, Stack, Box, Icon } from "@/components";
 import type { Key } from "react-aria";
 import { useState } from "react";
 import { type SelectRootProps } from "./select.types";
-import { userEvent, within, expect, fn } from "storybook/test";
+import { userEvent, within, expect, fn, waitFor } from "storybook/test";
 import { AddReaction, Search, Visibility } from "@commercetools/nimbus-icons";
 
 import { useAsyncList } from "react-stately";
@@ -358,6 +358,44 @@ export const Clearable: Story = {
           '[aria-label="Clear selection"]'
         );
         await expect(clearButton).not.toBeInTheDocument();
+      }
+    );
+
+    await step(
+      "Keyboard navigation to clear button clears the selection",
+      async () => {
+        const clearableSelect = canvas.getByTestId("clearable-select");
+        const selectButton = clearableSelect.querySelector("button");
+
+        // Verify initial selection
+        await expect(selectButton).toHaveTextContent("Apple");
+
+        // Find and activate the clear button with keyboard
+        const clearButton = clearableSelect.querySelector(
+          '[aria-label="Clear selection"]'
+        ) as HTMLElement;
+
+        // Use type to properly simulate keyboard interaction (handles focus + keypress)
+        await userEvent.type(clearButton, "{Enter}");
+
+        // Wait for the selection to be cleared
+        await waitFor(
+          () => {
+            expect(selectButton).toHaveTextContent("Select an item");
+          },
+          { timeout: 1000 }
+        );
+
+        // Verify clear button disappears after clearing (it only renders when there's a selection)
+        await waitFor(
+          () => {
+            const clearButtonAfter = clearableSelect.querySelector(
+              '[aria-label="Clear selection"]'
+            );
+            expect(clearButtonAfter).not.toBeInTheDocument();
+          },
+          { timeout: 1000 }
+        );
       }
     );
   },

--- a/packages/nimbus/src/components/select/select.types.tsx
+++ b/packages/nimbus/src/components/select/select.types.tsx
@@ -48,7 +48,12 @@ export interface SelectOptionProps<T>
       | "onMouseDown"
       | "onMouseUp"
     >,
-    Omit<SelectOptionSlotProps, keyof RaListBoxItemProps<T>> {}
+    Omit<SelectOptionSlotProps, keyof RaListBoxItemProps<T>> {
+  /**
+   * React ref to be forwarded to the option element
+   */
+  ref?: React.Ref<HTMLDivElement>;
+}
 
 export interface SelectOptionGroupProps<T>
   extends RaListBoxSectionProps<T>,


### PR DESCRIPTION
TBD

- Added a `ref` prop to `SelectOptionProps` for better element reference handling.
- Updated `SelectClearButton` to use `slot={null}` for improved event handling.
- Refactored `SelectOptionGroup` to utilize `extractStyleProps` for style management.
- Modified `SelectOption` to separate style and functional props, enhancing flexibility.
- Cleaned up `SelectRoot` component layout for better structure and readability.