### PR TITLE
CRAFT 1806 | ensure storybook nav shows stories in alpha order and containers in logical order

### DIFF
--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -17,6 +17,7 @@ variations, test interactions, and ensure accessibility compliance.
 - Test interactive behavior with play functions
 - Validate accessibility
 - Provide usage examples
+- Use a StartCase value for meta.title
 
 ## File Structure
 

--- a/packages/nimbus/.storybook/preview.tsx
+++ b/packages/nimbus/.storybook/preview.tsx
@@ -50,6 +50,12 @@ const preview: Preview = {
     docs: {
       container: CustomDocsContainer,
     },
+    options: {
+      /* @see https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#sorting-stories **/
+      storySort: {
+        order: ["Components", "Patterns", "Utils", "Hooks"],
+      },
+    },
   },
   tags: ["autodocs", "a11y-test"],
   decorators: [

--- a/packages/nimbus/src/components/accordion/accordion.stories.tsx
+++ b/packages/nimbus/src/components/accordion/accordion.stories.tsx
@@ -4,7 +4,7 @@ import { Avatar, Button, Checkbox, Flex } from "@/components";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
 const meta: Meta<typeof Accordion.Root> = {
-  title: "components/Accordion",
+  title: "Components/Accordion",
   component: Accordion.Root,
 };
 

--- a/packages/nimbus/src/components/alert/alert.stories.tsx
+++ b/packages/nimbus/src/components/alert/alert.stories.tsx
@@ -14,7 +14,7 @@ const variants: AlertProps["variant"][] = ["flat", "outlined"];
  * - component: references the component being documented
  */
 const meta: Meta<typeof Alert.Root> = {
-  title: "components/Alert",
+  title: "Components/Alert",
   component: Alert.Root,
 };
 

--- a/packages/nimbus/src/components/avatar/avatar.stories.tsx
+++ b/packages/nimbus/src/components/avatar/avatar.stories.tsx
@@ -10,7 +10,7 @@ import { Button, Stack } from "@/components";
  * - component: references the component being documented
  */
 const meta: Meta<typeof Avatar> = {
-  title: "components/Avatar",
+  title: "Components/Avatar",
   component: Avatar,
 };
 

--- a/packages/nimbus/src/components/badge/badge.stories.tsx
+++ b/packages/nimbus/src/components/badge/badge.stories.tsx
@@ -16,7 +16,7 @@ const colors: Array<
  * - component: references the component being documented
  */
 const meta: Meta<typeof Badge> = {
-  title: "components/Badge",
+  title: "Components/Badge",
   component: Badge,
 };
 

--- a/packages/nimbus/src/components/button/button.stories.tsx
+++ b/packages/nimbus/src/components/button/button.stories.tsx
@@ -7,7 +7,7 @@ import { ArrowRight as DemoIcon } from "@commercetools/nimbus-icons";
 import { createRef, useState } from "react";
 
 const meta: Meta<typeof Button> = {
-  title: "components/Buttons/Button",
+  title: "Components/Buttons/Button",
   component: Button,
 };
 

--- a/packages/nimbus/src/components/card/card.stories.tsx
+++ b/packages/nimbus/src/components/card/card.stories.tsx
@@ -10,7 +10,7 @@ const borderStyles: CardProps["borderStyle"][] = ["none", "outlined"];
 const backgroundStyles: CardProps["backgroundStyle"][] = ["default", "muted"];
 
 const meta: Meta<typeof Card.Root> = {
-  title: "components/Card",
+  title: "Components/Card",
   component: Card.Root,
 };
 

--- a/packages/nimbus/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { Stack } from "@/components";
 import { userEvent, within, expect, fn } from "storybook/test";
 
 const meta: Meta<typeof Checkbox> = {
-  title: "components/Checkbox",
+  title: "Components/Checkbox",
   component: Checkbox,
 };
 

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -30,7 +30,7 @@ import { AddReaction, Search } from "@commercetools/nimbus-icons";
  * - component: references the component being documented
  */
 const meta: Meta<typeof ComboBox.Root> = {
-  title: "components/ComboBox",
+  title: "Components/ComboBox",
   component: ComboBox.Root,
 };
 

--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -375,7 +375,7 @@ const DataTableWithModals = ({
  * - component: references the component being documented
  */
 const meta: Meta<object> = {
-  title: "components/DataTable",
+  title: "Components/DataTable",
   component: DataTable,
 };
 

--- a/packages/nimbus/src/components/dialog/dialog.stories.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components";
 
 const meta: Meta<typeof Dialog.Root> = {
-  title: "components/Overlay/Dialog",
+  title: "Components/Overlay/Dialog",
   component: Dialog.Root,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
+++ b/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
@@ -41,7 +41,7 @@ async function dragItem(
 }
 
 const meta: Meta<typeof DraggableList.Root> = {
-  title: "components/DraggableList",
+  title: "Components/DraggableList",
   tags: ["autodocs"],
 };
 

--- a/packages/nimbus/src/components/drawer/drawer.stories.tsx
+++ b/packages/nimbus/src/components/drawer/drawer.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components";
 
 const meta: Meta<typeof Drawer.Root> = {
-  title: "components/Overlay/Drawer",
+  title: "Components/Overlay/Drawer",
   component: Drawer.Root,
   tags: ["autodocs"],
   argTypes: {

--- a/packages/nimbus/src/components/field-errors/field-errors.stories.tsx
+++ b/packages/nimbus/src/components/field-errors/field-errors.stories.tsx
@@ -8,7 +8,7 @@ import { userEvent, within, expect } from "storybook/test";
  * Storybook metadata configuration
  */
 const meta: Meta<typeof FieldErrors> = {
-  title: "components/FieldErrors",
+  title: "Components/FieldErrors",
   component: FieldErrors,
   parameters: {
     docs: {

--- a/packages/nimbus/src/components/form-field/form-field.stories.tsx
+++ b/packages/nimbus/src/components/form-field/form-field.stories.tsx
@@ -4,7 +4,7 @@ import { Box, TextInput, Select, Stack } from "@/components";
 import { userEvent, within, expect } from "storybook/test";
 
 const meta: Meta<typeof FormField.Root> = {
-  title: "components/FormField",
+  title: "Components/FormField",
   component: FormField.Root,
   argTypes: {
     direction: {

--- a/packages/nimbus/src/components/grid/grid.stories.tsx
+++ b/packages/nimbus/src/components/grid/grid.stories.tsx
@@ -9,7 +9,7 @@ import { within, expect } from "storybook/test";
  * - component: references the component being documented
  */
 const meta: Meta<typeof Grid> = {
-  title: "components/Grid",
+  title: "Components/Grid",
   component: Grid,
 };
 

--- a/packages/nimbus/src/components/group/group.stories.tsx
+++ b/packages/nimbus/src/components/group/group.stories.tsx
@@ -10,7 +10,7 @@ import { within, expect } from "storybook/test";
  * - component: references the component being documented
  */
 const meta: Meta<typeof Group> = {
-  title: "components/Group",
+  title: "Components/Group",
   component: Group,
 };
 

--- a/packages/nimbus/src/components/icon-button/icon-button.stories.tsx
+++ b/packages/nimbus/src/components/icon-button/icon-button.stories.tsx
@@ -7,7 +7,7 @@ import { createRef } from "react";
 import { expect, fn, within, userEvent } from "storybook/test";
 
 const meta: Meta<typeof IconButton> = {
-  title: "components/Buttons/IconButton",
+  title: "Components/Buttons/IconButton",
   component: IconButton,
 };
 

--- a/packages/nimbus/src/components/icon-toggle-button/icon-toggle-button.stories.tsx
+++ b/packages/nimbus/src/components/icon-toggle-button/icon-toggle-button.stories.tsx
@@ -6,7 +6,7 @@ import { ThumbUp, Star, Bookmark } from "@commercetools/nimbus-icons";
 import { useState } from "react";
 
 const meta: Meta<typeof IconToggleButton> = {
-  title: "components/Buttons/IconToggleButton",
+  title: "Components/Buttons/IconToggleButton",
   component: IconToggleButton,
 };
 

--- a/packages/nimbus/src/components/icon/icon.stories.tsx
+++ b/packages/nimbus/src/components/icon/icon.stories.tsx
@@ -11,7 +11,7 @@ import { within, expect } from "storybook/test";
  * - component: references the component being documented
  */
 const meta: Meta<typeof Icon> = {
-  title: "components/Icon",
+  title: "Components/Icon",
   component: Icon,
 };
 

--- a/packages/nimbus/src/components/link/link.stories.tsx
+++ b/packages/nimbus/src/components/link/link.stories.tsx
@@ -12,7 +12,7 @@ const fontColors: LinkProps["fontColor"][] = ["primary", "inherit"];
  * The Link component allows a user to navigate to a different page or resource.
  */
 const meta: Meta<typeof Link> = {
-  title: "components/Link",
+  title: "Components/Link",
   component: Link,
 };
 

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.stories.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.stories.tsx
@@ -10,7 +10,7 @@ const sizes: LoadingSpinnerProps["size"][] = ["lg", "md", "sm", "xs", "2xs"];
 const tones: LoadingSpinnerProps["tone"][] = ["primary", "white"];
 
 const meta: Meta<typeof LoadingSpinner> = {
-  title: "components/LoadingSpinner",
+  title: "Components/LoadingSpinner",
   component: LoadingSpinner,
 };
 

--- a/packages/nimbus/src/components/localized-field/localized-field.stories.tsx
+++ b/packages/nimbus/src/components/localized-field/localized-field.stories.tsx
@@ -43,7 +43,7 @@ import {
 import { LocalizedFieldStoryComponent } from "./utils/localized-field.story-component";
 
 const meta: Meta<typeof LocalizedField> = {
-  title: "components/LocalizedField",
+  title: "Components/LocalizedField",
   component: LocalizedField,
   parameters: {
     a11y: {

--- a/packages/nimbus/src/components/menu/menu.stories.tsx
+++ b/packages/nimbus/src/components/menu/menu.stories.tsx
@@ -50,7 +50,7 @@ import {
 } from "@commercetools/nimbus-icons";
 
 const meta: Meta<typeof Menu.Root> = {
-  title: "components/Menu",
+  title: "Components/Menu",
   component: Menu.Root,
   parameters: {},
   tags: ["autodocs"],

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.stories.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.stories.tsx
@@ -7,7 +7,7 @@ import { Box, Stack, Text, FormField, Icon, IconButton } from "@/components";
 import { AddReaction, Search, AddBox } from "@commercetools/nimbus-icons";
 
 const meta: Meta<typeof MultilineTextInput> = {
-  title: "components/MultilineTextInput",
+  title: "Components/MultilineTextInput",
   component: MultilineTextInput,
 };
 

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.stories.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.stories.tsx
@@ -9,7 +9,7 @@ import type { DateValue } from "react-aria";
 import type { NimbusRouterConfig } from "./nimbus-provider.types";
 
 const meta: Meta<typeof NimbusProvider> = {
-  title: "components/NimbusProvider",
+  title: "Components/NimbusProvider",
   component: NimbusProvider,
 };
 

--- a/packages/nimbus/src/components/number-input/number-input.stories.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "@commercetools/nimbus-icons";
 
 const meta: Meta<typeof NumberInput> = {
-  title: "components/NumberInput",
+  title: "Components/NumberInput",
   component: NumberInput,
 };
 

--- a/packages/nimbus/src/components/pagination/pagination.stories.tsx
+++ b/packages/nimbus/src/components/pagination/pagination.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { Stack, Box, Text } from "@/components";
 
 const meta: Meta<typeof Pagination> = {
-  title: "components/Pagination",
+  title: "Components/Pagination",
   component: Pagination,
 
   argTypes: {

--- a/packages/nimbus/src/components/progress-bar/progress-bar.stories.tsx
+++ b/packages/nimbus/src/components/progress-bar/progress-bar.stories.tsx
@@ -20,7 +20,7 @@ const colors: Array<
  * - component: references the component being documented
  */
 const meta: Meta<typeof ProgressBar> = {
-  title: "components/ProgressBar",
+  title: "Components/ProgressBar",
   component: ProgressBar,
 };
 

--- a/packages/nimbus/src/components/radio-input/radio-input.stories.tsx
+++ b/packages/nimbus/src/components/radio-input/radio-input.stories.tsx
@@ -11,7 +11,7 @@ import { FormField } from "@/components/form-field";
  * - component: references the component being documented
  */
 const meta: Meta<typeof RadioInput.Root> = {
-  title: "components/RadioInput",
+  title: "Components/RadioInput",
   component: RadioInput.Root,
 };
 

--- a/packages/nimbus/src/components/search-input/search-input.stories.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.stories.tsx
@@ -5,7 +5,7 @@ import { userEvent, within, expect, fn, waitFor } from "storybook/test";
 import { Box, Stack, Text, FormField } from "@/components";
 
 const meta: Meta<typeof SearchInput> = {
-  title: "components/SearchInput",
+  title: "Components/SearchInput",
   component: SearchInput,
 };
 

--- a/packages/nimbus/src/components/select/select.stories.tsx
+++ b/packages/nimbus/src/components/select/select.stories.tsx
@@ -13,7 +13,7 @@ import { useAsyncList } from "react-stately";
  * Storybook metadata configuration
  */
 const meta: Meta<typeof Select.Root> = {
-  title: "components/Select",
+  title: "Components/Select",
   component: Select.Root,
 };
 

--- a/packages/nimbus/src/components/separator/separator.stories.tsx
+++ b/packages/nimbus/src/components/separator/separator.stories.tsx
@@ -4,7 +4,7 @@ import { Box, Stack } from "@/components";
 import { within, expect } from "storybook/test";
 
 const meta: Meta<typeof Separator> = {
-  title: "components/Separator",
+  title: "Components/Separator",
   component: Separator,
 };
 

--- a/packages/nimbus/src/components/simple-grid/simple-grid.stories.tsx
+++ b/packages/nimbus/src/components/simple-grid/simple-grid.stories.tsx
@@ -9,7 +9,7 @@ import { within, expect } from "storybook/test";
  * - component: references the component being documented
  */
 const meta: Meta<typeof SimpleGrid> = {
-  title: "components/SimpleGrid",
+  title: "Components/SimpleGrid",
   component: SimpleGrid,
 };
 

--- a/packages/nimbus/src/components/split-button/split-button.stories.tsx
+++ b/packages/nimbus/src/components/split-button/split-button.stories.tsx
@@ -6,7 +6,7 @@ import { Menu } from "@/components/menu";
 import { Save, Edit, Share } from "@commercetools/nimbus-icons";
 
 const meta: Meta<typeof SplitButton> = {
-  title: "components/Buttons/SplitButton",
+  title: "Components/Buttons/SplitButton",
   component: SplitButton,
   parameters: {},
   tags: ["autodocs"],

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -10,7 +10,7 @@ import { Box } from "../box";
  * - component: references the component being documented
  */
 const meta: Meta<typeof Tabs.Root> = {
-  title: "components/Tabs",
+  title: "Components/Tabs",
   component: Tabs.Root,
   argTypes: {
     orientation: {

--- a/packages/nimbus/src/components/tag-group/tag-group.stories.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.stories.tsx
@@ -13,7 +13,7 @@ import { TagGroup } from "./tag-group";
  * - component: references the component being documented
  */
 const meta: Meta<typeof TagGroup.Root> = {
-  title: "components/TagGroup",
+  title: "Components/TagGroup",
   component: TagGroup.Root,
 };
 

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "@commercetools/nimbus-icons";
 
 const meta: Meta<typeof TextInput> = {
-  title: "components/TextInput",
+  title: "Components/TextInput",
   component: TextInput,
 };
 

--- a/packages/nimbus/src/components/time-input/time-input.stories.tsx
+++ b/packages/nimbus/src/components/time-input/time-input.stories.tsx
@@ -32,7 +32,7 @@ const inventionOfTheInternet = parseZonedDateTime(
  * - component: references the component being documented
  */
 const meta: Meta<typeof TimeInput> = {
-  title: "components/TimeInput",
+  title: "Components/TimeInput",
   component: TimeInput,
 };
 

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.stories.tsx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.stories.tsx
@@ -8,7 +8,7 @@ import { SentimentSatisfied as DemoIcon } from "@commercetools/nimbus-icons";
  * Storybook metadata configuration
  */
 const meta: Meta<typeof ToggleButtonGroup.Root> = {
-  title: "components/Buttons/ToggleButtonGroup",
+  title: "Components/Buttons/ToggleButtonGroup",
   component: ToggleButtonGroup.Root,
 };
 

--- a/packages/nimbus/src/components/toggle-button/toggle-button.stories.tsx
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.stories.tsx
@@ -6,7 +6,7 @@ import { ThumbUp, Star, Bookmark } from "@commercetools/nimbus-icons";
 import { useState, createRef } from "react";
 
 const meta: Meta<typeof ToggleButton> = {
-  title: "components/Buttons/ToggleButton",
+  title: "Components/Buttons/ToggleButton",
   component: ToggleButton,
 };
 

--- a/packages/nimbus/src/components/toolbar/toolbar.stories.tsx
+++ b/packages/nimbus/src/components/toolbar/toolbar.stories.tsx
@@ -38,7 +38,7 @@ import {
 import { useState } from "react";
 
 const meta: Meta<typeof Toolbar> = {
-  title: "Components / Toolbar",
+  title: "Components/Toolbar",
   component: Toolbar,
   argTypes: {
     orientation: {

--- a/packages/nimbus/src/components/tooltip/make-element-focusable.stories.tsx
+++ b/packages/nimbus/src/components/tooltip/make-element-focusable.stories.tsx
@@ -4,7 +4,7 @@ import { within, expect } from "storybook/test";
 import { Tooltip, MakeElementFocusable } from "@/components";
 
 const meta: Meta<typeof MakeElementFocusable> = {
-  title: "components/Tooltip/MakeElementFocusable",
+  title: "Components/Tooltip/MakeElementFocusable",
   component: MakeElementFocusable,
   render: (args) => (
     <Tooltip.Root delay={0} closeDelay={0}>

--- a/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
@@ -20,7 +20,7 @@ const placements = {
 const allPlacements = Object.values(placements).flatMap((x) => x);
 
 const meta: Meta<typeof Tooltip.Content> = {
-  title: "components/tooltip/Tooltip",
+  title: "Components/Tooltip/Tooltip",
   component: Tooltip.Content,
   argTypes: {
     placement: {

--- a/packages/nimbus/src/components/visually-hidden/visually-hidden.stories.tsx
+++ b/packages/nimbus/src/components/visually-hidden/visually-hidden.stories.tsx
@@ -21,7 +21,7 @@ const invisibleCssProps = {
  * Makes it visible if focused.
  */
 const meta: Meta<typeof VisuallyHidden> = {
-  title: "utils/VisuallyHidden",
+  title: "Utils/VisuallyHidden",
   component: VisuallyHidden,
 };
 

--- a/packages/nimbus/src/hooks/use-hotkeys/use-hotkeys.stories.tsx
+++ b/packages/nimbus/src/hooks/use-hotkeys/use-hotkeys.stories.tsx
@@ -27,7 +27,7 @@ const UseHotkeysDemo = ({
 };
 
 const meta: Meta<typeof UseHotkeysDemo> = {
-  title: "Hooks/useHotkeys",
+  title: "Hooks/UseHotkeys",
   component: UseHotkeysDemo,
   parameters: {
     layout: "centered",


### PR DESCRIPTION
This pull request standardizes the Storybook story titles across the codebase to use StartCase (e.g., "Components/Accordion" instead of "components/Accordion") for improved consistency and organization. Additionally, it introduces a custom sorting order for Storybook stories to enhance navigation in the Storybook UI. Documentation has also been updated to reflect this new convention.

**Storybook Title Standardization:**

* Updated the `title` property in the `meta` objects of all component story files in `packages/nimbus/src/components/` to use StartCase, such as changing `"components/Accordion"` to `"Components/Accordion"`. This affects stories for Accordion, Alert, Avatar, Badge, Button, Card, Checkbox, ComboBox, DataTable, Dialog, Drawer, DraggableList, FieldErrors, FormField, Grid, Group, IconButton, and IconToggleButton. [[1]](diffhunk://#diff-8ea0499167f94bb341d65c81d58aa0a72c518a7f4401f896c810d937d05af5ccL7-R7) [[2]](diffhunk://#diff-fe2f233af98ba26ed90dcdb4cd836ffafe96d206a699c6ae4c9ccaa4db36a2d7L17-R17) [[3]](diffhunk://#diff-374ff6c63885fdcb694fc8a63b1ba362d992e6c6e1dbf4a3001e10b0382e8ed5L13-R13) [[4]](diffhunk://#diff-ea0b9e33b2ca4dd81192feeb7ba2ba5fb412a554bbff7d00b5e0c3410f777554L19-R19) [[5]](diffhunk://#diff-6fd32995bafa732d4adad4ea37a1678e0da28efd5ca2f1a413556ee326940919L10-R10) [[6]](diffhunk://#diff-01b542ea13f5b4a56f1a6c805ee007f7a7caeeb03fffd09896379b0881089540L13-R13) [[7]](diffhunk://#diff-509826dd4140608a5aa56fc1c240c91b76b7165009fc602e8c61c87092ed02d7L7-R7) [[8]](diffhunk://#diff-998be31bb0fcce1c68dcbd9f0dea00d737fd57a110861dcbeb73bb1502e3a575L33-R33) [[9]](diffhunk://#diff-032bd12ecfa8eca3fd5f75eb8af7cc1d03b73321a6a9b0dfeadc79e0fae727daL378-R378) [[10]](diffhunk://#diff-49e5e7e0274903acb6fa96e15a7df12842571c16ea7a87ad8960e0f90d3d5806L20-R20) [[11]](diffhunk://#diff-6b7d87c00c7a7c918feb2f722a86c679367f0611a95e311b3afe000e3eaad4f1L20-R20) [[12]](diffhunk://#diff-b9736e8fa39d4839aa44b2ae22125f26f5a9e74804699754c7fc022e293482e7L44-R44) [[13]](diffhunk://#diff-97045835feafd703c8966f58a2c17658a0531ebf87ad0d26297ececa28a626ceL11-R11) [[14]](diffhunk://#diff-801aa339c11cdbf14ab99d01cd8b0eca4ff253079d30e728cd58bc78adaa2eaeL7-R7) [[15]](diffhunk://#diff-da0d534f4a58b7232d10f038d89736091d2174227ee6fbd9422543566ed52a89L12-R12) [[16]](diffhunk://#diff-afa2328f42d12ddbb865e352571f9b52e2599e898fb6eb18d0316dd9a34f03d5L13-R13) [[17]](diffhunk://#diff-6fe47fdd16646ebdb9c696e0614e2d515ecb3c44d433911d425b7dcfb3ccb995L10-R10) [[18]](diffhunk://#diff-f2b761c00187025fd16d15c3ad07f1df97d72a3d9163690c47c3cab307904786L9-R9)

**Storybook Configuration Improvements:**

* Added a custom `storySort` order in `.storybook/preview.tsx` to group stories as "Components", "Patterns", "Utils", and "Hooks" for better navigation and discoverability in Storybook.

**Documentation Updates:**

* Updated documentation in `docs/file-type-guidelines/stories.md` to instruct using a StartCase value for `meta.title` in stories.

Storybook nav on current `main` (not in alpha order):
<img width="322" height="1216" alt="Screenshot 2025-10-15 at 12 11 28 PM" src="https://github.com/user-attachments/assets/acb9151a-f944-472e-9d2b-a34fc88a94d2" />

Storybook nav on this branch (is in alpha order):
<img width="290" height="1250" alt="Screenshot 2025-10-15 at 12 23 18 PM" src="https://github.com/user-attachments/assets/fd4fb7c3-7999-41db-a7d1-bd5a7c330dbd" />
