### PR TITLE
CRAFT 1824 | add patterns to entrypoint chunks in vite.config.ts

### DIFF
--- a/.changeset/chatty-jobs-unite.md
+++ b/.changeset/chatty-jobs-unite.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Add patterns directory to package entrypoint

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -14,8 +14,10 @@ import { analyzer } from "vite-bundle-analyzer";
 const createEntries = async () => {
   // Only index files are turned into entrypoints, as we don't want to include test files, storybook stories, etc.
   const entries = new Map<string, string>();
-  // Build a glob containing each index.ts file in src/components
-  const componentEntryPoints = await glob("src/components/**/index.ts");
+  // Build a glob containing each index.ts file in src/components or src/patterns
+  const componentEntryPoints = await glob(
+    "src/{components,patterns}/**/index.ts"
+  );
   // Declare an entrypoint for each component's index file. This enables consuming applications to only bundle the components imported into their app, instead of requiring that consumers bundle all components if they use any component.
   for (const file of componentEntryPoints) {
     // Get the name of the folder containing the index file to maintain semi-unique file/entrypoint names


### PR DESCRIPTION
This pull request updates the entrypoint discovery logic in the Vite configuration to improve how components are bundled. The main change is expanding the scope to include both `src/components` and `src/patterns` directories, making it easier for consuming applications to selectively bundle components and patterns.

Entrypoint discovery improvements:

* Updated the glob pattern in `vite.config.ts` to include `index.ts` files from both `src/components` and `src/patterns`, allowing entrypoints to be created for patterns as well as components.