### PR TITLE
fix(docs): clear search results on input blur

### DIFF
--- a/apps/docs/src/components/navigation/app-nav-bar/components/app-nav-bar-search/app-nav-bar-search.tsx
+++ b/apps/docs/src/components/navigation/app-nav-bar/components/app-nav-bar-search/app-nav-bar-search.tsx
@@ -98,7 +98,11 @@ export const AppNavBarSearch = () => {
                   asChild
                 >
                   {/** TODO: TextInput should actually work here, try again once it's fixed*/}
-                  <Input autoFocus placeholder="Type to search..." />
+                  <Input
+                    autoFocus
+                    placeholder="Type to search..."
+                    onBlur={() => setQuery("")}
+                  />
                 </Box>
               </Flex>
               <Box mx="-600">


### PR DESCRIPTION
Clear search query when input loses focus without selection to prevent stale results from displaying. This fixes the edge case where results remain visible but non-functional after blurring the input.

Fixes #593

Generated with [Claude Code](https://claude.ai/code)