### PR TITLE
fix(docs): preserve search query when clicking outside input

### DIFF
--- a/apps/docs/src/components/navigation/app-nav-bar/components/app-nav-bar-search/app-nav-bar-search.tsx
+++ b/apps/docs/src/components/navigation/app-nav-bar/components/app-nav-bar-search/app-nav-bar-search.tsx
@@ -80,6 +80,7 @@ export const AppNavBarSearch = () => {
               inputValue={query}
               onInputChange={setQuery}
               onSelectionChange={handleSelectionChange}
+              allowsCustomValue
             >
               <Flex alignItems="center" width="100%" py="400" pb="600">
                 <Box


### PR DESCRIPTION
Add allowsCustomValue prop to ComboBox to prevent React Aria from clearing the input value when focus is lost. This fixes the issue where clicking outside the search input (but inside the modal) would clear the query and make results non-clickable.

Fixes #595

Generated with [Claude Code](https://claude.ai/code)