### PR TITLE
fix(docs): remove duplicate TOC in sidebar

### DIFF
--- a/apps/docs/src/app.tsx
+++ b/apps/docs/src/app.tsx
@@ -70,22 +70,6 @@ function App() {
                 </Stack>
               </StickySidebar>
             </Flex>
-            <StickySidebar
-              width="8000"
-              borderLeft="solid-25"
-              borderColor="neutral.3"
-              flexShrink="0"
-              px="400"
-              pt="600"
-              id="sidebar-right"
-            >
-              <Stack gap="800">
-                <DevOnly>
-                  <DocumentMetaSettings />
-                </DevOnly>
-                <Toc />
-              </Stack>
-            </StickySidebar>
           </Flex>
         </>
       </NimbusProvider>


### PR DESCRIPTION
Removed the duplicate right sidebar component that was causing a second TOC to appear in the docs app. The duplicate sidebar was incorrectly placed outside the main flex container.

Fixes #606