### PR TITLE
chore(patterns): actually export the patterns

### DIFF
--- a/packages/nimbus/src/index.ts
+++ b/packages/nimbus/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./components";
 export * from "./hooks";
+export * from "./patterns";
 export * from "./theme";
 export * from "./type-utils";


### PR DESCRIPTION
This PR simply exports the new patterns directory, which was left out of [this](https://github.com/commercetools/nimbus/pull/510) work