### PR TITLE
Clean up: colorPalette

### DIFF
--- a/packages/nimbus/src/components/data-table/components/data-table.layout-settings-panel.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.layout-settings-panel.tsx
@@ -97,7 +97,7 @@ export const LayoutSettingsPanel = ({
         <Toolbar orientation="horizontal" variant="outline" size="xs" w="full">
           <ToggleButtonGroup.Root
             w="full"
-            tone="primary"
+            colorPalette="primary"
             selectedKeys={[rowDensity]}
             onSelectionChange={handleRowDensityChange}
             aria-label={formatMessage(messages.RowDensityAriaLabel)}

--- a/packages/nimbus/src/components/data-table/components/data-table.manager.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.manager.tsx
@@ -156,7 +156,7 @@ export const DataTableManager = () => {
         </Tooltip.Content>
         <IconButton
           variant="ghost"
-          tone="primary"
+          colorPalette="primary"
           size="xs"
           aria-label={formatMessage(messages.settings)}
           onClick={() => setIsOpen(true)}

--- a/packages/nimbus/src/components/data-table/components/data-table.visible-columns-panel.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.visible-columns-panel.tsx
@@ -224,7 +224,7 @@ export const VisibleColumnsPanel = ({
       <Box>
         <Button
           variant="ghost"
-          tone="primary"
+          colorPalette="primary"
           size="xs"
           onClick={handleResetColumns}
           aria-label={formatMessage(messages.reset)}


### PR DESCRIPTION
This PR removes additional instances of `tone` (replacing them with `colorPalette`) from DataTable implementation.