### PR TITLE
CRAFT 1880 | ensure changesets do not unexpectedly bump to major version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,6 @@
     ]
   ],
   "ignore": ["color-tokens", "blank-app", "docs"],
-  "updateInternalDependencies": "minor",
   "access": "restricted",
   "baseBranch": "main",
   "bumpVersionsWithWorkspaceProtocolOnly": false,

--- a/.changeset/true-tools-lick.md
+++ b/.changeset/true-tools-lick.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Update changeset configuration to prevent unnecessary major version bumps


### PR DESCRIPTION
This PR attempts to address the issue of unnecessary major version bumps due to changes in internal dependencies.

Changeset may be protecting consumers by forcing Nimbus to issue a breaking change because a peer dep has done the same. 
[Jira ticket](https://commercetools.atlassian.net/browse/CRAFT-1880)