### PR TITLE
Craft 1880 release workflow updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           version: pnpm changeset:version-and-format
           commit: "ci(changesets): version packages"
           title: "ci(changesets): version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           SKIP_POSTINSTALL_DEV_SETUP: true


### PR DESCRIPTION
Relates to [this error](https://github.com/commercetools/nimbus/actions/runs/19042308836/job/54382105195#step:7:27) we encountered in the release workflow; the removed lines are not supported in the [latest version](https://github.com/commercetools/nimbus/actions/runs/19042308836/job/54382105195#step:7:27) of the action.

_Some background:_

- The release workflow was sometimes failing
- One of the reasons we found was that it doesn't always understand that there is an existing Version Packages PR that is open - when it tries to create one, an error is thrown because there's already a PR with that name
- I opted to use the latest version of the changesets/action which is 1.5.3, which notes that this issue was addressed 
- What I didn't notice is that the lines I'm removing (in this PR) from the release workflow were only supported by the old version, and they throw their own errors.

Still unclear:
Do we still get 'versioned' releases that are correctly numbered?
We may need `createGithubReleases: true` in the workflow - [the docs say](https://github.com/changesets/action?tab=readme-ov-file#inputs) that it defaults to true, but it's unclear if it can simply be removed.