### PR TITLE
fix: card backgrounds in dark mode

### DIFF
--- a/.changeset/pink-poems-change.md
+++ b/.changeset/pink-poems-change.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/nimbus": patch
+---
+
+fix an issue with card backgrounds in dark-mode

--- a/apps/docs/src/components/document-renderer/components/frontpage/frontpage.tsx
+++ b/apps/docs/src/components/document-renderer/components/frontpage/frontpage.tsx
@@ -39,7 +39,7 @@ const links = [
 export const Frontpage = () => {
   return (
     <Stack gap="400">
-      <Card.Root borderStyle="outlined" cardPadding="md" elevation="elevated">
+      <Card.Root borderStyle="outlined">
         <Flex direction="column" width="100%" align="center" py="800">
           <Heading size="7xl" m="auto" letterSpacing={"-.025em"}>
             Nimbus
@@ -62,7 +62,7 @@ export const Frontpage = () => {
             href={link.href?.substring(1)}
             textDecoration="none"
           >
-            <Card.Root borderStyle="outlined" cardPadding="lg" width="full">
+            <Card.Root borderStyle="outlined" width="full">
               <Card.Content>
                 <Stack direction="row" gap="400" alignItems="center">
                   <Box>

--- a/packages/nimbus/src/components/card/card.recipe.ts
+++ b/packages/nimbus/src/components/card/card.recipe.ts
@@ -58,7 +58,7 @@ export const cardRecipe = defineSlotRecipe({
     backgroundStyle: {
       default: {
         root: {
-          backgroundColor: "colorPalette.contrast",
+          backgroundColor: "bg",
         },
       },
       muted: {


### PR DESCRIPTION

<img width="1009" height="937" alt="image" src="https://github.com/user-attachments/assets/78577cd9-0d9a-47bf-9b83-90212c28ccb6" />


## Summary
- Fixes card background color issues in dark mode by using the correct semantic token
- Updates frontpage to remove unnecessary cardPadding props

## Changes
- Changed `card.recipe.ts` background from `colorPalette.contrast` to `bg` token
- Removed `cardPadding` props from frontpage Card components