### PR TITLE
chore(docs): create `Tabs` design docs

### DIFF
--- a/packages/nimbus/src/components/tabs/tabs.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.mdx
@@ -26,7 +26,7 @@ Tabs are a navigational component used to organize and switch between different 
 
 ### Resources
 
-Deep dive on details and access design library.
+Deep dive into implementation details and access the Nimbus design library.
 
 [Figma library](https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=8571-34966&m=dev)
 [React Aria Docs](https://react-spectrum.adobe.com/react-aria/Tabs.html)

--- a/packages/nimbus/src/components/tabs/tabs.recipe.ts
+++ b/packages/nimbus/src/components/tabs/tabs.recipe.ts
@@ -146,11 +146,28 @@ export const tabsSlotRecipe = defineSlotRecipe({
         },
       },
     },
-    // Line + Vertical + Start (tabs on left, border on left)
+    // Line + Vertical + Start (tabs on left, border on right between tabs and content)
     {
       variant: "line",
       orientation: "vertical",
       placement: "start",
+      css: {
+        list: {
+          boxShadow: "1px 0 0 0 {colors.neutral.6}",
+        },
+        tab: {
+          boxShadow: "2px 0 0 0 transparent",
+          _selected: {
+            boxShadow: "2px 0 0 0 {colors.primary.9}",
+          },
+        },
+      },
+    },
+    // Line + Vertical + End (tabs on right, border on left between tabs and content)
+    {
+      variant: "line",
+      orientation: "vertical",
+      placement: "end",
       css: {
         list: {
           boxShadow: "-1px 0 0 0 {colors.neutral.6}",
@@ -159,26 +176,6 @@ export const tabsSlotRecipe = defineSlotRecipe({
           boxShadow: "-2px 0 0 0 transparent",
           _selected: {
             boxShadow: "-2px 0 0 0 {colors.primary.9}",
-          },
-        },
-      },
-    },
-    // Line + Vertical + End (tabs on right, border on right)
-    {
-      variant: "line",
-      orientation: "vertical",
-      placement: "end",
-      css: {
-        root: {
-          flexDirection: "row-reverse",
-        },
-        list: {
-          boxShadow: "1px 0 0 0 {colors.neutral.6}",
-        },
-        tab: {
-          boxShadow: "2px 0 0 0 transparent",
-          _selected: {
-            boxShadow: "2px 0 0 0 {colors.primary.9}",
           },
         },
       },

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -350,8 +350,7 @@ export const VerticalPlacement: Story = {
             Vertical - Placement Start (Default)
           </Heading>
           <Text color="neutral.11" mb="400">
-            Tabs on the left, panels on the right. Border indicator on the left
-            side.
+            Tabs on the left, panels on the right.
           </Text>
           <Box data-testid="vertical-placement-start">
             <Tabs.Root
@@ -368,8 +367,7 @@ export const VerticalPlacement: Story = {
             Vertical - Placement End
           </Heading>
           <Text color="neutral.11" mb="400">
-            Tabs on the right, panels on the left. Border indicator on the right
-            side.
+            Tabs on the right, panels on the left.
           </Text>
           <Box data-testid="vertical-placement-end">
             <Tabs.Root


### PR DESCRIPTION
## Summary

Does what the title says. [Figma here](https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=4431-8550&m=dev)

This PR also fixes a bug in which, for vertical tabs, the `placement="end"` prop did not set the tab panels to the left (they stayed on the right). It adds a Storybook story to document it.