### PR TITLE
CRAFT 1991 | use `#fff` for light mode `colors.bg` semantic token instead of `colors.neutral.1`

### DIFF
--- a/packages/nimbus/src/theme/semantic-tokens/colors.ts
+++ b/packages/nimbus/src/theme/semantic-tokens/colors.ts
@@ -4,7 +4,7 @@ import { themeTokens } from "@commercetools/nimbus-tokens";
 export const colors = defineSemanticTokens.colors({
   bg: {
     DEFAULT: {
-      value: "{colors.neutral.1}",
+      value: { _light: "#fff", _dark: "{colors.neutral.1}" },
     },
   },
   fg: {


### PR DESCRIPTION
As @misama-ct pointed out in [this comment that I somehow missed](https://github.com/commercetools/nimbus/pull/690/files#r2541800246), the bg color should be `#fff` to be consistent with the current MC.  This PR reverts `colors.bg._light`, but uses the correct color palette value for dark mode since the MC does not support dark mode and we should use the color palettes from the start when implementing it.

This pull request updates the default background color token in the theme configuration to improve light and dark mode support.

Theme improvements:

* In `packages/nimbus/src/theme/semantic-tokens/colors.ts`, the default background color token (`bg.DEFAULT.value`) now uses `#fff` for light mode and `{colors.neutral.1}` for dark mode, enhancing visual consistency across themes.