### PR TITLE
chore(docs): create `Kbd` component eng docs

### DIFF
--- a/packages/nimbus/src/components/kbd/kbd.dev.mdx
+++ b/packages/nimbus/src/components/kbd/kbd.dev.mdx
@@ -333,7 +333,3 @@ describe('Kbd in instructions', () => {
   });
 });
 ```
-
-## Resources
-
-- [Storybook](link-tbd)


### PR DESCRIPTION
This PR creates the `Kbd` component engineering docs. Note: No storybook link exists for this component so the Resources section was removed.