### PR TITLE
chore(docs): add search input design docs

### DIFF
--- a/packages/nimbus/src/components/search-input/search-input.mdx
+++ b/packages/nimbus/src/components/search-input/search-input.mdx
@@ -112,6 +112,11 @@ const App = () => (
 
 ```jsx-live
 const App = () => (
-  <SearchInput width="440px" placeholder="Please enter the name you are searching for" />
+  <SearchInput width="md" placeholder="Please enter the name you are searching for" />
 )
 ```
+
+
+## Properties
+
+<PropsTable id="SearchInput" />


### PR DESCRIPTION
Updates the SearchInput design docs according to [figma](https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=5011-2705&m=dev)

[ticket here](https://commercetools.atlassian.net/browse/CRAFT-1994)