### PR TITLE
fix(docs): add type guard

### DIFF
--- a/apps/docs/src/components/document-renderer/components/base-tags/blockquote.tsx
+++ b/apps/docs/src/components/document-renderer/components/base-tags/blockquote.tsx
@@ -44,21 +44,6 @@ const iconMapping = {
   WARNING: Warning,
   CAUTION: Error,
 };
-
-/**
- * Safely extracts text content from any React node type.
- * Handles strings, numbers, arrays, and React elements with children.
- */
-const getTextContent = (node: ReactNode): string => {
-  if (typeof node === "string") return node;
-  if (typeof node === "number") return String(node);
-  if (Array.isArray(node)) return node.map(getTextContent).join("");
-  if (isValidElement(node) && node.props.children) {
-    return getTextContent(node.props.children);
-  }
-  return "";
-};
-
 function cleanQuoteFlavor(input: string) {
   // Remove the brackets and exclamation mark
   const cleanKey = input.replace(/[[\]!]/g, "") as keyof typeof iconMapping;
@@ -97,30 +82,32 @@ export const Blockquote = (props: BlockquoteProps) => {
       if (!isParagraph) return;
 
       const firstChild = child.props.children[0];
-      const firstChildText = getTextContent(firstChild).trim();
+
+      // Type guard: ensure firstChild is a string before calling .trim()
+      if (typeof firstChild !== "string") return;
 
       switch (true) {
-        case firstChildText === "[!NOTE]":
+        case firstChild.trim() === "[!NOTE]":
           flavorProps = {
             colorPalette: "info",
           };
           break;
-        case firstChildText === "[!TIP]":
+        case firstChild.trim() === "[!TIP]":
           flavorProps = {
             colorPalette: "positive",
           };
           break;
-        case firstChildText === "[!IMPORTANT]":
+        case firstChild.trim() === "[!IMPORTANT]":
           flavorProps = {
             colorPalette: "primary",
           };
           break;
-        case firstChildText === "[!WARNING]":
+        case firstChild.trim() === "[!WARNING]":
           flavorProps = {
             colorPalette: "warning",
           };
           break;
-        case firstChildText === "[!CAUTION]":
+        case firstChild.trim() === "[!CAUTION]":
           flavorProps = {
             colorPalette: "critical",
           };
@@ -156,7 +143,11 @@ export const Blockquote = (props: BlockquoteProps) => {
 
         if (isParagraph) {
           const firstChild = child.props.children[0];
-          const firstChildText = getTextContent(firstChild).trim();
+
+          // Type guard: ensure firstChild is a string before calling .trim()
+          if (typeof firstChild !== "string") {
+            return child;
+          }
 
           if (
             [
@@ -165,7 +156,7 @@ export const Blockquote = (props: BlockquoteProps) => {
               "[!WARNING]",
               "[!CAUTION]",
               "[!TIP]",
-            ].includes(firstChildText)
+            ].includes(firstChild.trim())
           ) {
             // Get rid of first child
 
@@ -181,7 +172,7 @@ export const Blockquote = (props: BlockquoteProps) => {
                   fontSize="500"
                   asChild
                 >
-                  {cleanQuoteFlavor(firstChildText)}
+                  {cleanQuoteFlavor(firstChild.trim())}
                 </Box>,
                 ...Children.toArray(child.props.children.slice(2)),
               ],


### PR DESCRIPTION
## Summary

For some reason, some blockquotes in mdx files cause the page to crash because they parse to an object rather than a string. This PR adds some defensive programming to gracefully handle that situation.