### PR TITLE
chore(docs): add TagGroup engineering docs

### DIFF
--- a/packages/nimbus/src/components/tag-group/tag-group.dev.mdx
+++ b/packages/nimbus/src/components/tag-group/tag-group.dev.mdx
@@ -125,18 +125,18 @@ const App = () => (
         <TagGroup.Tag colorPalette="red" backgroundColor="colorPalette.9" color="colorPalette.contrast">
           Red
         </TagGroup.Tag>
-        <TagGroup.Tag colorPalette="red" backgroundColor="colorPalette.3">
+        <TagGroup.Tag colorPalette="critical" backgroundColor="colorPalette.3" color="colorPalette.11">
           Error
         </TagGroup.Tag>
       </TagGroup.TagList>
     </TagGroup.Root>
 
-    <TagGroup.Root aria-label="Purple tags">
+    <TagGroup.Root aria-label="Green tags">
       <TagGroup.TagList>
-        <TagGroup.Tag colorPalette="purple" backgroundColor="colorPalette.8" color="colorPalette.12">
-          Purple
+        <TagGroup.Tag colorPalette="green" backgroundColor="colorPalette.8" color="colorPalette.12">
+          Green
         </TagGroup.Tag>
-        <TagGroup.Tag colorPalette="purple" backgroundColor="colorPalette.4" color="colorPalette.11">
+        <TagGroup.Tag colorPalette="green" backgroundColor="colorPalette.4" color="colorPalette.11">
           Accent
         </TagGroup.Tag>
       </TagGroup.TagList>


### PR DESCRIPTION
Creates engineering docs for the `TagGroup` component.