### PR TITLE
chore(nimbus): create `Text` and `Heading` engineering docs

### DIFF
--- a/packages/nimbus/src/components/heading/heading.dev.mdx
+++ b/packages/nimbus/src/components/heading/heading.dev.mdx
@@ -1,0 +1,138 @@
+---
+title: Heading Component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import { Heading, type HeadingProps } from '@commercetools/nimbus';
+```
+
+### Basic usage
+
+The simplest implementation renders a heading with the default xl size:
+
+```jsx-live-dev
+const App = () => (
+  <Heading>Welcome to Nimbus</Heading>
+)
+```
+
+## Usage examples
+
+### Size options
+
+The Heading component provides 11 size variants (xs through 7xl) to establish clear typographic hierarchy:
+
+```jsx-live-dev
+const App = () => (
+  <Stack direction="column" gap="400">
+    <Heading size="xs">Extra Small Heading (xs)</Heading>
+    <Heading size="sm">Small Heading (sm)</Heading>
+    <Heading size="md">Medium Heading (md)</Heading>
+    <Heading size="lg">Large Heading (lg)</Heading>
+    <Heading size="xl">Extra Large Heading (xl - default)</Heading>
+    <Heading size="2xl">2XL Heading</Heading>
+    <Heading size="3xl">3XL Heading</Heading>
+    <Heading size="4xl">4XL Heading</Heading>
+    <Heading size="5xl">5XL Heading</Heading>
+    <Heading size="6xl">6XL Heading</Heading>
+    <Heading size="7xl">7XL Heading</Heading>
+  </Stack>
+)
+```
+
+### Semantic HTML levels
+
+Use the `as` prop to render the appropriate semantic HTML heading element (h1-h6):
+
+```jsx-live-dev
+const App = () => (
+  <Stack direction="column" gap="400">
+    <Heading as="h1" size="4xl">Page Title (h1)</Heading>
+    <Heading as="h2" size="2xl">Section Heading (h2)</Heading>
+    <Heading as="h3" size="xl">Subsection Heading (h3)</Heading>
+    <Heading as="h4" size="lg">Card Title (h4)</Heading>
+    <Heading as="h5" size="md">Minor Heading (h5)</Heading>
+    <Heading as="h6" size="sm">Smallest Heading (h6)</Heading>
+  </Stack>
+)
+```
+
+**Best practice:** Match visual hierarchy (size) with semantic hierarchy (h1-h6) for optimal accessibility. Use h1 for main page titles, h2 for major sections, and so on.
+
+### Custom styling
+
+The Heading component supports Chakra UI style props for additional customization:
+
+```jsx-live-dev
+const App = () => (
+  <Stack direction="column" gap="400">
+    <Heading size="2xl" color="primary.11">
+      Primary Color Heading
+    </Heading>
+    <Heading size="xl" marginTop="600" marginBottom="400">
+      Heading with Custom Margins
+    </Heading>
+    <Heading size="lg" fontWeight="400">
+      Lighter Weight Heading
+    </Heading>
+    <Heading size="md" textAlign="center">
+      Center-Aligned Heading
+    </Heading>
+  </Stack>
+)
+```
+
+## Component requirements
+
+### Accessibility
+
+The Heading component provides semantic HTML heading elements for proper document structure. Screen readers use heading levels to navigate content and understand page hierarchy.
+
+**Heading level best practices:**
+- Use heading levels sequentially (don't skip levels)
+- Typically one h1 per page (the main title)
+- Use h2-h6 to create logical content hierarchy
+- Visual size (size prop) can differ from semantic level (as prop)
+
+If your use case requires tracking and analytics for this component, it is good practice to add a **persistent**, **unique** id to the component:
+
+```tsx
+const PERSISTENT_ID = "example-heading-id";
+
+export const Example = () => (
+  <Heading id={PERSISTENT_ID}>Analytics-Tracked Heading</Heading>
+);
+```
+
+#### Keyboard navigation
+
+As a non-interactive display component, Heading does not require keyboard interaction. However, screen reader users can navigate between headings using keyboard shortcuts (typically H key) to quickly scan page structure.
+
+## API reference
+
+<PropsTable id="Heading" />
+
+The Heading component extends Chakra UI's Heading component and accepts all style props including:
+
+- Typography: `size`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`
+- Color: `color`, `colorPalette`
+- Layout: `display`, `width`, `maxWidth`
+- Spacing: `margin`, `padding`, `gap`
+- Text formatting: `textAlign`, `textTransform`, `textDecoration`
+
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using Heading within your application. As the component's internal functionality is already tested by Nimbus, these patterns help you verify your integration and application-specific logic.
+
+{{docs-tests: heading.docs.spec.tsx}}
+
+## Resources
+
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-heading--docs)
+- [Text Component](../components/typography/text) - Related typography component

--- a/packages/nimbus/src/components/heading/heading.docs.spec.tsx
+++ b/packages/nimbus/src/components/heading/heading.docs.spec.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Heading, NimbusProvider } from "@commercetools/nimbus";
+
+/**
+ * @docs-section basic-rendering
+ * @docs-title Basic Rendering Tests
+ * @docs-description Verify the heading component renders with expected content
+ * @docs-order 1
+ */
+describe("Heading - Basic rendering", () => {
+  it("renders heading with text content", () => {
+    render(
+      <NimbusProvider>
+        <Heading>Welcome to Dashboard</Heading>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Welcome to Dashboard" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders with default h2 semantic level", () => {
+    render(
+      <NimbusProvider>
+        <Heading>Default Heading</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", { name: "Default Heading" });
+    expect(heading.tagName).toBe("H2");
+  });
+});
+
+/**
+ * @docs-section size-variants
+ * @docs-title Size Variant Tests
+ * @docs-description Test different size variants to ensure proper rendering
+ * @docs-order 2
+ */
+describe("Heading - Size variants", () => {
+  it("renders with small size", () => {
+    render(
+      <NimbusProvider>
+        <Heading size="sm">Small Heading</Heading>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Small Heading" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders with extra large size", () => {
+    render(
+      <NimbusProvider>
+        <Heading size="xl">Extra Large Heading</Heading>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Extra Large Heading" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders with 5xl size", () => {
+    render(
+      <NimbusProvider>
+        <Heading size="5xl">Massive Heading</Heading>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Massive Heading" })
+    ).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section semantic-levels
+ * @docs-title Semantic HTML Level Tests
+ * @docs-description Test heading semantic levels for proper document structure
+ * @docs-order 3
+ */
+describe("Heading - Semantic levels", () => {
+  it("renders as h1 when specified", () => {
+    render(
+      <NimbusProvider>
+        <Heading as="h1">Page Title</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Page Title",
+    });
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe("H1");
+  });
+
+  it("renders as h3 when specified", () => {
+    render(
+      <NimbusProvider>
+        <Heading as="h3">Subsection Title</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", {
+      level: 3,
+      name: "Subsection Title",
+    });
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe("H3");
+  });
+
+  it("renders as h6 when specified", () => {
+    render(
+      <NimbusProvider>
+        <Heading as="h6">Minor Heading</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", {
+      level: 6,
+      name: "Minor Heading",
+    });
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe("H6");
+  });
+});
+
+/**
+ * @docs-section style-props
+ * @docs-title Style Props Tests
+ * @docs-description Test that style props are properly applied
+ * @docs-order 4
+ */
+describe("Heading - Style props", () => {
+  it("applies custom id for analytics tracking", () => {
+    const PERSISTENT_ID = "dashboard-title";
+
+    render(
+      <NimbusProvider>
+        <Heading id={PERSISTENT_ID}>Dashboard</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", { name: "Dashboard" });
+    expect(heading).toHaveAttribute("id", PERSISTENT_ID);
+  });
+
+  it("applies className for custom styling", () => {
+    render(
+      <NimbusProvider>
+        <Heading className="custom-heading">Styled Heading</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", { name: "Styled Heading" });
+    expect(heading).toHaveClass("custom-heading");
+  });
+});
+
+/**
+ * @docs-section accessibility
+ * @docs-title Accessibility Tests
+ * @docs-description Verify heading accessibility features
+ * @docs-order 5
+ */
+describe("Heading - Accessibility", () => {
+  it("provides accessible heading role", () => {
+    render(
+      <NimbusProvider>
+        <Heading>Accessible Heading</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading");
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveAccessibleName("Accessible Heading");
+  });
+
+  it("supports aria-label for screen readers", () => {
+    render(
+      <NimbusProvider>
+        <Heading aria-label="Dashboard Overview">Dashboard</Heading>
+      </NimbusProvider>
+    );
+
+    const heading = screen.getByRole("heading", { name: "Dashboard Overview" });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it("maintains proper heading hierarchy", () => {
+    render(
+      <NimbusProvider>
+        <div>
+          <Heading as="h1">Main Title</Heading>
+          <Heading as="h2">Section Title</Heading>
+          <Heading as="h3">Subsection Title</Heading>
+        </div>
+      </NimbusProvider>
+    );
+
+    const h1 = screen.getByRole("heading", { level: 1 });
+    const h2 = screen.getByRole("heading", { level: 2 });
+    const h3 = screen.getByRole("heading", { level: 3 });
+
+    expect(h1).toBeInTheDocument();
+    expect(h2).toBeInTheDocument();
+    expect(h3).toBeInTheDocument();
+  });
+});

--- a/packages/nimbus/src/components/text/text.dev.mdx
+++ b/packages/nimbus/src/components/text/text.dev.mdx
@@ -1,0 +1,172 @@
+---
+title: Text Component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import { Text, type TextProps } from '@commercetools/nimbus';
+```
+
+### Basic usage
+
+The simplest implementation renders a paragraph element with default styling:
+
+```jsx-live-dev
+const App = () => {
+  return <Text>This is basic text content.</Text>;
+};
+```
+
+## Usage examples
+
+### Typography scale
+
+The `textStyle` prop applies predefined typography styles from the design system. These styles include font-size, line-height, and letter-spacing optimized for readability:
+
+```jsx-live-dev
+const App = () => {
+  return (
+    <Stack direction="column" gap="400">
+      <Text textStyle="md">Paragraph md - Primary body text, long descriptions</Text>
+      <Text textStyle="sm">Paragraph sm - Secondary text, metadata, table content</Text>
+      <Text textStyle="xs">Paragraph xs - Tertiary content, small notes, timestamps</Text>
+      <Text textStyle="caption">CAPTION - Specialized metadata with letter spacing</Text>
+    </Stack>
+  );
+};
+```
+
+### Semantic color tones
+
+Use semantic color tokens to convey meaning and maintain consistent contrast ratios. All colored text uses step 11 of the color scale for accessibility:
+
+```jsx-live-dev
+const App = () => {
+  return (
+    <Stack direction="column" gap="400">
+      <Text color="fg">Default - Standard body text</Text>
+      <Text color="fg.subtle">Secondary - Helper text and metadata</Text>
+      <Text color="primary.11">Primary - Links and branded messages</Text>
+      <Text color="info.11">Info - System messages and non-critical feedback</Text>
+      <Text color="positive.11">Positive - Success states and confirmations</Text>
+      <Text color="warning.11">Warning - Cautions and items requiring review</Text>
+      <Text color="critical.11">Critical - Errors and destructive actions</Text>
+    </Stack>
+  );
+};
+```
+
+### Polymorphic rendering
+
+Use the `as` prop to render Text as different HTML elements while maintaining the same styling API. This is essential for semantic HTML and accessibility:
+
+```jsx-live-dev
+const App = () => {
+  return (
+    <Stack direction="column" gap="400">
+      <Text as="p">Renders as paragraph (default)</Text>
+      <Text as="span">Renders as inline span</Text>
+      <Text as="div">Renders as div block</Text>
+      <Text as="label" htmlFor="example-input">
+        Renders as form label
+      </Text>
+      <Text as="strong" fontWeight="700">
+        Renders as strong (bold)
+      </Text>
+      <Text as="em" fontStyle="italic">
+        Renders as emphasis (italic)
+      </Text>
+    </Stack>
+  );
+};
+```
+
+### Custom styling
+
+Text supports all Chakra UI style props, allowing you to customize typography beyond the predefined styles:
+
+```jsx-live-dev
+const App = () => {
+  return (
+    <Stack direction="column" gap="400">
+      <Text fontSize="450" fontWeight="600" lineHeight="1.4">
+        Custom font size and weight
+      </Text>
+      <Text letterSpacing="2px" textTransform="uppercase">
+        Custom letter spacing
+      </Text>
+      <Text textDecoration="underline" textDecorationStyle="dashed">
+        Custom text decoration
+      </Text>
+      <Text
+        maxWidth="300px"
+        overflow="hidden"
+        textOverflow="ellipsis"
+        whiteSpace="nowrap"
+      >
+        This text will truncate with an ellipsis when it exceeds the maximum width
+      </Text>
+    </Stack>
+  );
+};
+```
+
+## Component requirements
+
+### Accessibility
+
+The Text component provides semantic HTML text rendering. Use appropriate elements via the `as` prop to maintain document structure.
+
+**Semantic HTML best practices:**
+- Use `<p>` (default) for paragraphs
+- Use `<span>` for inline text
+- Use `<label>` for form field labels with `htmlFor` attribute
+- Use `<strong>` or `<em>` for emphasis
+- Avoid using `<div>` for text unless necessary for layout
+
+**Contrast requirements:**
+When using colored text, always use step 11 of the color scale (e.g., `primary.11`, `critical.11`) to ensure WCAG AA contrast ratios (4.5:1 minimum) against light backgrounds.
+
+If your use case requires tracking and analytics for this component, it is good practice to add a **persistent**, **unique** id to the component:
+
+```tsx
+const PERSISTENT_ID = "product-description-text";
+
+export const ProductDescription = () => (
+  <Text id={PERSISTENT_ID} textStyle="md">
+    Product details and specifications
+  </Text>
+);
+```
+
+#### Keyboard navigation
+
+As a non-interactive display component, Text does not require keyboard interaction.
+
+## API reference
+
+<PropsTable id="Text" />
+
+The Text component extends Chakra UI's Text component and accepts all style props including:
+
+- Typography: `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `textStyle`
+- Color: `color`, `colorPalette`
+- Layout: `display`, `width`, `maxWidth`, `overflow`
+- Spacing: `margin`, `padding`, `gap`
+- Text formatting: `textAlign`, `textTransform`, `textDecoration`, `whiteSpace`, `textOverflow`
+
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using Text within your application. As the component's internal functionality is already tested by Nimbus, these patterns help you verify your integration and application-specific logic.
+
+{{docs-tests: text.docs.spec.tsx}}
+
+## Resources
+
+- [Chakra UI Text Documentation](https://www.chakra-ui.com/docs/components/text)
+- [Heading Component](../components/typography/heading) - Related typography component

--- a/packages/nimbus/src/components/text/text.docs.spec.tsx
+++ b/packages/nimbus/src/components/text/text.docs.spec.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Text, NimbusProvider } from "@commercetools/nimbus";
+
+/**
+ * @docs-section basic-rendering
+ * @docs-title Basic Rendering
+ * @docs-description Verify that Text renders correctly with different content types
+ * @docs-order 1
+ */
+describe("Text - Basic rendering", () => {
+  it("renders text content", () => {
+    render(
+      <NimbusProvider>
+        <Text>Hello World</Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("renders with custom id for tracking", () => {
+    const PERSISTENT_ID = "product-description-text";
+
+    render(
+      <NimbusProvider>
+        <Text id={PERSISTENT_ID}>Product description</Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Product description")).toHaveAttribute(
+      "id",
+      PERSISTENT_ID
+    );
+  });
+
+  it("renders children elements", () => {
+    render(
+      <NimbusProvider>
+        <Text>
+          Text with <strong>bold</strong> and <em>italic</em> content
+        </Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText(/Text with/)).toBeInTheDocument();
+    expect(screen.getByText("bold")).toBeInTheDocument();
+    expect(screen.getByText("italic")).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section typography-scale
+ * @docs-title Typography Scale
+ * @docs-description Test different textStyle variants
+ * @docs-order 2
+ */
+describe("Text - Typography scale", () => {
+  it("applies textStyle variants", () => {
+    const { rerender } = render(
+      <NimbusProvider>
+        <Text textStyle="md" data-testid="text-element">
+          Medium text
+        </Text>
+      </NimbusProvider>
+    );
+
+    const textElement = screen.getByTestId("text-element");
+    expect(textElement).toBeInTheDocument();
+
+    // Test different textStyle values
+    const textStyles = ["sm", "xs", "caption"] as const;
+    textStyles.forEach((style) => {
+      rerender(
+        <NimbusProvider>
+          <Text textStyle={style} data-testid="text-element">
+            {style} text
+          </Text>
+        </NimbusProvider>
+      );
+      expect(screen.getByTestId("text-element")).toBeInTheDocument();
+    });
+  });
+
+  it("combines textStyle with custom overrides", () => {
+    render(
+      <NimbusProvider>
+        <Text textStyle="sm" fontWeight="700">
+          Bold small text
+        </Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Bold small text")).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section semantic-colors
+ * @docs-title Semantic Colors
+ * @docs-description Test semantic color application
+ * @docs-order 3
+ */
+describe("Text - Semantic colors", () => {
+  it("applies semantic color tokens", () => {
+    const colors = [
+      { color: "fg", label: "Default text" },
+      { color: "fg.subtle", label: "Secondary text" },
+      { color: "primary.11", label: "Primary text" },
+      { color: "info.11", label: "Info text" },
+      { color: "positive.11", label: "Success text" },
+      { color: "warning.11", label: "Warning text" },
+      { color: "critical.11", label: "Error text" },
+    ] as const;
+
+    render(
+      <NimbusProvider>
+        {colors.map(({ color, label }) => (
+          <Text key={color} color={color}>
+            {label}
+          </Text>
+        ))}
+      </NimbusProvider>
+    );
+
+    colors.forEach(({ label }) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it("maintains contrast with colored text", () => {
+    render(
+      <NimbusProvider>
+        <Text color="critical.11">Error message</Text>
+      </NimbusProvider>
+    );
+
+    const errorText = screen.getByText("Error message");
+    expect(errorText).toBeInTheDocument();
+    // In a real application, you would verify the actual computed color
+    // meets WCAG contrast requirements against the background
+  });
+});
+
+/**
+ * @docs-section polymorphic-rendering
+ * @docs-title Polymorphic Rendering
+ * @docs-description Test rendering as different HTML elements
+ * @docs-order 4
+ */
+describe("Text - Polymorphic rendering", () => {
+  it("renders as paragraph by default", () => {
+    const { container } = render(
+      <NimbusProvider>
+        <Text>Default paragraph</Text>
+      </NimbusProvider>
+    );
+
+    const paragraph = container.querySelector("p");
+    expect(paragraph).toBeInTheDocument();
+    expect(paragraph).toHaveTextContent("Default paragraph");
+  });
+
+  it("renders as span when specified", () => {
+    const { container } = render(
+      <NimbusProvider>
+        <Text as="span">Inline text</Text>
+      </NimbusProvider>
+    );
+
+    const span = container.querySelector("span");
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveTextContent("Inline text");
+  });
+
+  it("renders as label with htmlFor attribute", () => {
+    render(
+      <NimbusProvider>
+        {/* @ts-expect-error - TypeScript doesn't infer element-specific props with polymorphic as prop */}
+        <Text as="label" htmlFor="email-input">
+          Email Address
+        </Text>
+      </NimbusProvider>
+    );
+
+    const label = screen.getByText("Email Address");
+    expect(label.tagName).toBe("LABEL");
+    expect(label).toHaveAttribute("for", "email-input");
+  });
+
+  it("renders as div for layout purposes", () => {
+    render(
+      <NimbusProvider>
+        <Text as="div">Block text</Text>
+      </NimbusProvider>
+    );
+
+    const text = screen.getByText("Block text");
+    expect(text).toBeInTheDocument();
+    expect(text.tagName).toBe("DIV");
+  });
+});
+
+/**
+ * @docs-section custom-styling
+ * @docs-title Custom Styling
+ * @docs-description Test custom style prop application
+ * @docs-order 5
+ */
+describe("Text - Custom styling", () => {
+  it("applies custom typography styles", () => {
+    render(
+      <NimbusProvider>
+        <Text fontSize="450" fontWeight="600" letterSpacing="2px">
+          Custom styled text
+        </Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Custom styled text")).toBeInTheDocument();
+  });
+
+  it("applies truncation styles", () => {
+    render(
+      <NimbusProvider>
+        <Text
+          maxWidth="200px"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+        >
+          This is a very long text that should be truncated
+        </Text>
+      </NimbusProvider>
+    );
+
+    const text = screen.getByText(/This is a very long text/);
+    expect(text).toBeInTheDocument();
+  });
+
+  it("applies text transformation", () => {
+    render(
+      <NimbusProvider>
+        <Text textTransform="uppercase">uppercase text</Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("uppercase text")).toBeInTheDocument();
+  });
+
+  it("applies responsive styles", () => {
+    render(
+      <NimbusProvider>
+        <Text fontSize={{ base: "350", md: "400", lg: "450" }}>
+          Responsive text
+        </Text>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Responsive text")).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section accessibility
+ * @docs-title Accessibility
+ * @docs-description Verify semantic HTML and accessibility features
+ * @docs-order 6
+ */
+describe("Text - Accessibility", () => {
+  it("maintains semantic structure with as prop", () => {
+    const { container } = render(
+      <NimbusProvider>
+        <Text as="strong">Important text</Text>
+      </NimbusProvider>
+    );
+
+    const strong = container.querySelector("strong");
+    expect(strong).toBeInTheDocument();
+    expect(strong).toHaveTextContent("Important text");
+  });
+
+  it("associates label with form control", () => {
+    render(
+      <NimbusProvider>
+        {/* @ts-expect-error - TypeScript doesn't infer element-specific props with polymorphic as prop */}
+        <Text as="label" htmlFor="username">
+          Username
+        </Text>
+        <input id="username" type="text" />
+      </NimbusProvider>
+    );
+
+    const label = screen.getByText("Username");
+    const input = screen.getByRole("textbox");
+
+    expect(label).toHaveAttribute("for", "username");
+    expect(input).toHaveAttribute("id", "username");
+  });
+
+  it("supports title attribute for truncated text", () => {
+    const longText = "This is a very long text that will be truncated";
+
+    render(
+      <NimbusProvider>
+        <Text
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+          title={longText}
+        >
+          {longText}
+        </Text>
+      </NimbusProvider>
+    );
+
+    const text = screen.getByText(longText);
+    expect(text).toHaveAttribute("title", longText);
+  });
+});


### PR DESCRIPTION
The `Heading` component overview links to `Text`, as these two components have a high amount of overlap.

The engineering docs here have a lot of redundancy, hence the reason this PR is a two-for-one.