### PR TITLE
chore(ci): increase test timeout from 5 to 10 minutes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Run tests
         run: pnpm test
-        timeout-minutes: 5
+        timeout-minutes: 10


### PR DESCRIPTION
As we add more comprehensive test coverage with `.docs.spec.tsx` files, the test suite duration has grown. Current runs take ~5 minutes, so increasing to 10 minutes provides leeway for continued growth.