### PR TITLE
feat(commands): add fix-security-alerts command

### DIFF
--- a/.claude/commands/github/fix-security-alerts.md
+++ b/.claude/commands/github/fix-security-alerts.md
@@ -233,6 +233,27 @@ git pull origin main
 git checkout -b security/fix-alerts-$(date +%Y-%m-%d)
 ```
 
+**Immediately after branch creation, verify you are on the new branch:**
+
+```bash
+git branch --show-current
+```
+
+**If branch creation fails** (e.g., branch already exists, checkout error): Stop
+immediately and report:
+
+```
+❌ Branch creation failed
+
+Could not create branch: security/fix-alerts-YYYY-MM-DD
+
+Reason: [specific error message from git]
+
+No changes were made. Please investigate the issue before re-running this command.
+```
+
+Exit without making any changes. Do NOT proceed to update dependencies.
+
 ### 5.2 Update Dependencies
 
 For each auto-fixable alert:
@@ -465,12 +486,24 @@ The PR is ready for review.
 | Peer dep conflict  | Move alert to "needs manual attention" with conflict details |
 | pnpm install fails | Rollback, report error, exit                                 |
 
+### Git Errors
+
+| Error                  | Response                                          |
+| ---------------------- | ------------------------------------------------- |
+| Branch creation fails  | Stop immediately, report error, exit (no changes) |
+| Branch already exists  | Stop, report conflict, let user investigate       |
+| Not on expected branch | Stop immediately, do NOT proceed with any changes |
+| Push fails             | Report error, branch remains local                |
+
 ---
 
 ## Important Constraints
 
 - You MUST verify GitHub CLI authentication before proceeding
 - You MUST check for clean working tree before making changes
+- You MUST verify the feature branch was created successfully before making any
+  changes
+- You MUST stop immediately if branch creation fails - do NOT proceed on main
 - You MUST present the full plan and wait for user approval
 - You MUST run all validation (lint, typecheck, test) before committing
 - You MUST rollback ALL changes if ANY validation fails (no partial fixes)


### PR DESCRIPTION
## Summary

- Adds a new Claude Code command (`/github:fix-security-alerts`) that automates the triage and remediation of Dependabot security alerts

## Features

The command provides a complete workflow for security alert management:

1. **Pre-flight checks**: Validates GitHub CLI auth, clean working tree, and current branch
2. **Alert fetching**: Retrieves open Dependabot alerts via GitHub API
3. **Analysis**: Categorizes alerts as auto-fixable or needing manual attention based on:
   - Patch availability
   - Direct vs transitive dependency
   - Major vs minor/patch version bump
   - Peer dependency conflicts
4. **Plan presentation**: Shows tables of fixes with severity, CVE, and version changes
5. **Execution**: Applies updates, runs full validation suite (lint, typecheck, test)
6. **PR creation**: Optionally pushes branch and creates PR with detailed summary
7. **Cleanup**: Closes superseded Dependabot PRs with comments

## Test plan

- [x] Run `/github:fix-security-alerts` on a repo with open Dependabot alerts
- [x] Verify pre-flight checks catch dirty working tree
- [x] Verify auto-fixable vs manual categorization is accurate
- [x] Verify validation failures trigger rollback
- [x] Verify PR creation includes proper CVE details