### PR TITLE
fix(changesets): remove ignored nimbus-i18n package from changesets

### DIFF
--- a/.changeset/brave-frogs-report.md
+++ b/.changeset/brave-frogs-report.md
@@ -1,5 +1,0 @@
----
-"@commercetools/nimbus-i18n": patch
----
-
-Add additional en datatable strings

--- a/.changeset/salty-meals-bet.md
+++ b/.changeset/salty-meals-bet.md
@@ -1,7 +1,5 @@
 ---
 "@commercetools/nimbus": minor
-"@commercetools/nimbus-i18n": minor
 ---
 
-Update Combobox to new context-based architecture and add missing features,
-update i18n strings.
+Update Combobox to new context-based architecture and add missing features.

--- a/.changeset/shy-seals-mix.md
+++ b/.changeset/shy-seals-mix.md
@@ -1,5 +1,0 @@
----
-"@commercetools/nimbus-i18n": patch
----
-
-Add compiled Spanish strings


### PR DESCRIPTION
## Summary
- Remove `@commercetools/nimbus-i18n` from salty-meals-bet changeset
- Delete brave-frogs-report changeset (only referenced ignored package)
- Delete shy-seals-mix changeset (only referenced ignored package)

## Problem
The release job was failing with:
```
🦋  error Error: Found mixed changeset salty-meals-bet
🦋  error Found ignored packages: @commercetools/nimbus-i18n
🦋  error Found not ignored packages: @commercetools/nimbus
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
```

## Solution
According to `.changeset/config.json`, `@commercetools/nimbus-i18n` is in the ignored packages list. Changesets doesn't allow mixing ignored and non-ignored packages in a single changeset.

Removed the ignored package from the mixed changeset and deleted changesets that only referenced ignored packages.

## Test plan
- [x] Changeset version command should now succeed in CI
- [x] No more "mixed changeset" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)