### PR TITLE
chore(nimbus): fix `InlineSvg` react warnings

### DIFF
--- a/openspec/changes/archive/2026-01-20-fix-inline-svg-namespace-attrs/proposal.md
+++ b/openspec/changes/archive/2026-01-20-fix-inline-svg-namespace-attrs/proposal.md
@@ -1,0 +1,37 @@
+# Change: Fix InlineSvg Namespace Attribute Conversion
+
+## Why
+
+InlineSvg produces React DOM property warnings when SVG markup contains XML
+namespace attributes like `xmlns:xlink`. The current attribute conversion logic
+only handles kebab-case attributes (e.g., `stroke-width` → `strokeWidth`) but
+doesn't handle colon-separated namespace prefixes. This results in console
+warnings like "Invalid DOM property `xmlns:xlink`. Did you mean `xmlnsXlink`?"
+when rendering SVG content exported from most SVG editors.
+
+While this is a warning-only issue that doesn't affect functionality, it creates
+console noise and indicates incomplete React attribute normalization. The fix is
+trivial (one character change) and eliminates a common source of confusion for
+developers working with SVG content.
+
+## What Changes
+
+- Update the attribute name conversion regex in `useInlineSvg` hook to handle
+  both kebab-case and colon-separated namespace prefixes
+- Change regex from `/-([a-z])/g` to `/[-:]([a-z])/g` to convert both hyphens
+  and colons to camelCase
+- Existing behavior for kebab-case attributes (e.g., `stroke-width` →
+  `strokeWidth`) is preserved
+- New behavior for namespace attributes: `xmlns:xlink` → `xmlnsXlink`,
+  `xml:lang` → `xmlLang`
+
+## Impact
+
+- **Affected specs**: `nimbus-inline-svg`
+- **Affected code**:
+  `packages/nimbus/src/components/inline-svg/hooks/use-inline-svg.ts` (line
+  54-55)
+- **User impact**: Low - eliminates console warnings, no behavioral changes
+- **Breaking changes**: None - purely additive fix
+- **Testing**: Existing `SecurityTest` story in `inline-svg.stories.tsx` already
+  exercises this code path and will validate the fix

--- a/openspec/changes/archive/2026-01-20-fix-inline-svg-namespace-attrs/specs/nimbus-inline-svg/spec.md
+++ b/openspec/changes/archive/2026-01-20-fix-inline-svg-namespace-attrs/specs/nimbus-inline-svg/spec.md
@@ -1,0 +1,56 @@
+# Spec Delta: InlineSvg Component
+
+## MODIFIED Requirements
+
+### Requirement: SVG Attribute Extraction
+
+The component SHALL extract and preserve SVG root element attributes.
+
+#### Scenario: ViewBox preservation
+
+- **WHEN** SVG markup includes viewBox attribute
+- **THEN** SHALL extract viewBox value from sanitized SVG element
+- **AND** SHALL apply viewBox to rendered svg element
+- **AND** SHALL maintain original coordinate system
+
+#### Scenario: Dimension attributes
+
+- **WHEN** SVG markup includes width and height
+- **THEN** SHALL extract width and height values
+- **AND** SHALL apply to rendered svg element
+- **AND** values SHALL be available for sizing control
+
+#### Scenario: Stroke and fill attributes
+
+- **WHEN** SVG root element has stroke or fill attributes
+- **THEN** SHALL extract and preserve these attributes
+- **AND** SHALL apply to rendered svg element
+- **AND** SHALL support currentColor value
+
+#### Scenario: Kebab-case to camelCase conversion
+
+- **WHEN** extracting SVG attributes
+- **THEN** SHALL convert kebab-case attribute names to camelCase for React
+- **AND** stroke-width SHALL become strokeWidth
+- **AND** stroke-linecap SHALL become strokeLinecap
+- **AND** stroke-linejoin SHALL become strokeLinejoin
+- **AND** conversion SHALL use regex:
+  `attr.name.replace(/[-:]([a-z])/g, (_, letter) => letter.toUpperCase())`
+
+#### Scenario: Namespace prefix conversion
+
+- **WHEN** extracting XML namespace attributes
+- **THEN** SHALL convert colon-separated namespace prefixes to camelCase for
+  React
+- **AND** xmlns:xlink SHALL become xmlnsXlink
+- **AND** xml:lang SHALL become xmlLang
+- **AND** xlink:href SHALL become xlinkHref (if on root element)
+- **AND** conversion SHALL handle both hyphens and colons with same regex
+  pattern
+
+#### Scenario: React compatibility
+
+- **WHEN** all attributes are converted
+- **THEN** SHALL produce React-compatible camelCase attribute names
+- **AND** SHALL not produce console warnings about invalid DOM properties
+- **AND** SHALL maintain attribute values unchanged during conversion

--- a/openspec/changes/archive/2026-01-20-fix-inline-svg-namespace-attrs/tasks.md
+++ b/openspec/changes/archive/2026-01-20-fix-inline-svg-namespace-attrs/tasks.md
@@ -1,0 +1,23 @@
+# Implementation Tasks
+
+## 1. Code Changes
+
+- [x] 1.1 Update regex in `use-inline-svg.ts` to handle colon-separated
+      namespace prefixes
+- [x] 1.2 Verify existing kebab-case conversion still works correctly
+
+## 2. Testing
+
+- [x] 2.1 Build the nimbus package (`pnpm --filter @commercetools/nimbus build`)
+- [x] 2.2 Run existing Storybook tests to verify no regressions
+      (`pnpm test:storybook`)
+- [x] 2.3 Verify `SecurityTest` story no longer produces console warnings for
+      `xmlns:xlink`
+- [x] 2.4 Test with SVG containing various namespace attributes (`xmlns:xlink`,
+      `xml:lang`, `xlink:href`)
+
+## 3. Validation
+
+- [x] 3.1 Confirm no React DOM property warnings in browser console
+- [x] 3.2 Verify all existing tests pass
+- [x] 3.3 Verify TypeScript compilation succeeds

--- a/openspec/specs/nimbus-inline-svg/spec.md
+++ b/openspec/specs/nimbus-inline-svg/spec.md
@@ -12,9 +12,7 @@ The InlineSvg component renders arbitrary SVG markup as inline SVG content with 
 ## Purpose
 
 InlineSvg enables safe rendering of SVG content from string data while protecting against XSS attacks through DOMPurify sanitization. It parses SVG markup, extracts attributes, and renders sanitized content with consistent styling via the icon recipe. This allows developers to dynamically display SVG graphics from APIs, databases, or user input without security risks.
-
 ## Requirements
-
 ### Requirement: SVG Data Input
 The component SHALL accept SVG markup as a string via the data prop.
 
@@ -104,33 +102,57 @@ The component SHALL handle server-side rendering environments safely.
 - **AND** SHALL return empty svgAttributes object
 
 ### Requirement: SVG Attribute Extraction
+
 The component SHALL extract and preserve SVG root element attributes.
 
 #### Scenario: ViewBox preservation
+
 - **WHEN** SVG markup includes viewBox attribute
 - **THEN** SHALL extract viewBox value from sanitized SVG element
 - **AND** SHALL apply viewBox to rendered svg element
 - **AND** SHALL maintain original coordinate system
 
 #### Scenario: Dimension attributes
+
 - **WHEN** SVG markup includes width and height
 - **THEN** SHALL extract width and height values
 - **AND** SHALL apply to rendered svg element
 - **AND** values SHALL be available for sizing control
 
 #### Scenario: Stroke and fill attributes
+
 - **WHEN** SVG root element has stroke or fill attributes
 - **THEN** SHALL extract and preserve these attributes
 - **AND** SHALL apply to rendered svg element
 - **AND** SHALL support currentColor value
 
 #### Scenario: Kebab-case to camelCase conversion
+
 - **WHEN** extracting SVG attributes
 - **THEN** SHALL convert kebab-case attribute names to camelCase for React
 - **AND** stroke-width SHALL become strokeWidth
 - **AND** stroke-linecap SHALL become strokeLinecap
 - **AND** stroke-linejoin SHALL become strokeLinejoin
-- **AND** conversion SHALL use regex: attr.name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+- **AND** conversion SHALL use regex:
+  `attr.name.replace(/[-:]([a-z])/g, (_, letter) => letter.toUpperCase())`
+
+#### Scenario: Namespace prefix conversion
+
+- **WHEN** extracting XML namespace attributes
+- **THEN** SHALL convert colon-separated namespace prefixes to camelCase for
+  React
+- **AND** xmlns:xlink SHALL become xmlnsXlink
+- **AND** xml:lang SHALL become xmlLang
+- **AND** xlink:href SHALL become xlinkHref (if on root element)
+- **AND** conversion SHALL handle both hyphens and colons with same regex
+  pattern
+
+#### Scenario: React compatibility
+
+- **WHEN** all attributes are converted
+- **THEN** SHALL produce React-compatible camelCase attribute names
+- **AND** SHALL not produce console warnings about invalid DOM properties
+- **AND** SHALL maintain attribute values unchanged during conversion
 
 ### Requirement: SVG Content Rendering
 The component SHALL render sanitized SVG inner content safely.
@@ -558,3 +580,4 @@ The component SHALL provide helpful console warnings for common issues.
 - **THEN** warnings SHALL appear in development mode
 - **AND** MAY be stripped in production builds
 - **AND** SHALL not impact production performance
+

--- a/packages/nimbus/src/components/inline-svg/hooks/use-inline-svg.ts
+++ b/packages/nimbus/src/components/inline-svg/hooks/use-inline-svg.ts
@@ -50,8 +50,8 @@ export function useInlineSvg(data: string) {
     // Preserve all attributes from the sanitized SVG element
     // Security: Only attributes that passed sanitization are included
     for (const attr of Array.from(svgEl.attributes)) {
-      // Convert kebab-case to camelCase for React compatibility
-      const reactAttrName = attr.name.replace(/-([a-z])/g, (_, letter) =>
+      // Convert kebab-case and namespace prefixes to camelCase for React compatibility
+      const reactAttrName = attr.name.replace(/[-:]([a-z])/g, (_, letter) =>
         letter.toUpperCase()
       );
       attrs[reactAttrName] = attr.value;


### PR DESCRIPTION
 ## Problem
InlineSvg produced console warnings when rendering SVG markup   
with XML namespace attributes (xmlns:xlink, xml:lang). The attribute     
conversion only handled kebab-case but not colon-separated namespace     
prefixes.                                                                
                                                                           
## Solution
Updated the regex pattern in useInlineSvg hook from /-([a-z])/g 
to /[-:]([a-z])/g to convert both hyphens and colons to camelCase.      
                                                                           
## Impact:                                                                  
- Eliminates React DOM property warnings for namespace attributes        
- No behavioral changes or breaking changes                              
- Preserves existing kebab-case conversion (stroke-width → strokeWidth)  
- Adds namespace conversion (xmlns:xlink → xmlnsXlink)                   
                                                                          