### PR TITLE
fix(docs): use SimpleGrid for category overview to prevent focus ring clipping

### DIFF
--- a/apps/docs/src/components/document-renderer/components/category-overview/category-overview.tsx
+++ b/apps/docs/src/components/document-renderer/components/category-overview/category-overview.tsx
@@ -133,7 +133,12 @@ const CategoryOverviewContent: FC<{ variant?: string }> = ({ variant }) => {
       <SimpleGrid columns={3} gap="200">
         {sortedDocs.map((doc) => (
           <Link key={doc.path} textDecoration="none" href={doc.path}>
-            <Card.Root cardPadding="md" borderStyle="none" width="full">
+            <Card.Root
+              _hover={{ bg: "colorPalette.2" }}
+              cardPadding="md"
+              borderStyle="none"
+              width="full"
+            >
               <Card.Content>
                 <Stack>
                   <Box color="primary.11" textStyle="5xl" mb="200">


### PR DESCRIPTION
Fixes [CRAFT-1898](https://commercetools.atlassian.net/browse/CRAFT-1898) (The focus ring itself is cut off for most instances):

<img width="684" height="769" alt="image" src="https://github.com/user-attachments/assets/9ddef833-1e72-4b75-9ada-48d646cf7d86" /> 


## Summary
- Replace `Stack` with `SimpleGrid` in the non-list variant of CategoryOverview
- The `gap="200"` between grid items ensures focus outlines aren't cut off by adjacent cards
- Simplifies markup by removing unnecessary wrapper `Box` elements

## Test plan
- [x] Navigate to a category overview page in the docs
- [x] Tab through the cards and verify focus rings are fully visible
- [ ] Verify the 3-column grid layout displays correctly

## Before

<img width="688" height="707" alt="image" src="https://github.com/user-attachments/assets/d49e518b-1f10-42be-afba-8bb6c5ecde67" />


[CRAFT-1898]: https://commercetools.atlassian.net/browse/CRAFT-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ