### PR TITLE
fix(button): filter additional react-aria handlers when forwarding

### DIFF
--- a/openspec/changes/archive/2026-01-21-filter-react-aria-event-props/proposal.md
+++ b/openspec/changes/archive/2026-01-21-filter-react-aria-event-props/proposal.md
@@ -1,0 +1,40 @@
+# Change: Filter React Aria Event Props in Button Component
+
+## Why
+
+The Button component's `shouldForwardProp` function currently only filters
+`onPress`, allowing other React Aria-specific event handlers like
+`onFocusChange`, `onHoverStart`, `onPressChange`, and others to leak through to
+the DOM. This causes "Unknown event handler property" warnings when the Button
+is used within Calendar/RangeCalendar components with multi-month displays,
+where React Aria's `ButtonContext` slots pass custom event handlers that are not
+valid DOM events.
+
+These warnings indicate:
+
+- Console noise in development and tests (developer experience issue)
+- Props leaking to DOM elements (violates separation of concerns)
+- Potential confusion when debugging unrelated issues
+
+## What Changes
+
+- Update `ButtonRoot` component's `shouldForwardProp` to filter ALL React
+  Aria-specific event handlers
+- Add comprehensive list of React Aria event props that should never reach the
+  DOM
+- Add unit test to verify React Aria event props are properly filtered
+- Verify existing Calendar and RangeCalendar tests pass without warnings
+
+## Impact
+
+- **Affected specs**: `nimbus-button`
+- **Affected code**:
+  - `packages/nimbus/src/components/button/button.slots.tsx` (modify filtering
+    logic)
+  - `packages/nimbus/src/components/button/button.spec.tsx` (add test)
+  - `packages/nimbus/src/components/calendar/calendar.docs.spec.tsx`
+    (verification)
+  - `packages/nimbus/src/components/range-calendar/range-calendar.docs.spec.tsx`
+    (verification)
+- **Breaking**: No - this is a bug fix that prevents props from reaching the DOM
+- **Dependencies**: None - isolated change to Button component

--- a/openspec/changes/archive/2026-01-21-filter-react-aria-event-props/specs/nimbus-button/spec.md
+++ b/openspec/changes/archive/2026-01-21-filter-react-aria-event-props/specs/nimbus-button/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Recipe-Based Styling
+
+The component SHALL use Chakra UI recipe per nimbus-core standards.
+
+#### Scenario: Recipe application
+
+- **WHEN** component renders
+- **THEN** SHALL apply button recipe from theme/recipes/button.ts
+- **AND** recipe SHALL be registered in theme configuration
+- **AND** SHALL support recipe props: variant, size, colorPalette
+
+#### Scenario: React Aria prop filtering
+
+- **WHEN** component receives React Aria-specific event props from ButtonContext
+  slots
+- **THEN** SHALL filter out all React Aria custom event handlers before
+  forwarding to DOM
+- **AND** SHALL prevent `onPress`, `onPressStart`, `onPressEnd`,
+  `onPressChange`, `onPressUp` from reaching DOM
+- **AND** SHALL prevent `onFocusChange` from reaching DOM
+- **AND** SHALL prevent `onHoverStart`, `onHoverEnd`, `onHoverChange` from
+  reaching DOM
+- **AND** SHALL prevent `onMoveStart`, `onMove`, `onMoveEnd` from reaching DOM
+- **AND** SHALL NOT emit "Unknown event handler property" warnings in React
+- **AND** SHALL allow standard DOM events (onClick, onFocus, onBlur, etc.) to
+  pass through

--- a/openspec/changes/archive/2026-01-21-filter-react-aria-event-props/tasks.md
+++ b/openspec/changes/archive/2026-01-21-filter-react-aria-event-props/tasks.md
@@ -1,0 +1,30 @@
+# Implementation Tasks
+
+## 1. Implementation
+
+- [x] 1.1 Update `button.slots.tsx` to add `REACT_ARIA_EVENT_PROPS` constant
+      listing all React Aria event handlers
+- [x] 1.2 Create `isReactAriaEventProp` helper function to check if a prop
+      matches any React Aria event pattern
+- [x] 1.3 Update `shouldForwardProp` logic in `ButtonRoot` to filter React Aria
+      event props using the new helper
+- [x] 1.4 Add comprehensive JSDoc comments explaining why these props must be
+      filtered
+
+## 2. Testing
+
+- [x] 2.1 Add unit test in `button.spec.tsx` that verifies React Aria event
+      props are filtered and do not cause warnings
+- [x] 2.2 Run Calendar tests to verify no "Unknown event handler property"
+      warnings
+- [x] 2.3 Run RangeCalendar tests to verify no "Unknown event handler property"
+      warnings
+- [x] 2.4 Run full Button test suite to ensure no regressions
+
+## 3. Validation
+
+- [x] 3.1 Build the nimbus package
+- [x] 3.2 Run all Storybook tests with no warnings
+- [x] 3.3 Verify console is clean when using Calendar/RangeCalendar with
+      multi-month display
+- [x] 3.4 Confirm all existing Button functionality still works (all tests pass)

--- a/openspec/specs/nimbus-button/spec.md
+++ b/openspec/specs/nimbus-button/spec.md
@@ -2,64 +2,75 @@
 
 ## Purpose
 
-The Button component provides an accessible, styled button element that follows nimbus-core standards. It supports multiple visual variants, sizes, colors, and interactive states while maintaining WCAG 2.1 AA accessibility compliance.
+The Button component provides an accessible, styled button element that follows
+nimbus-core standards. It supports multiple visual variants, sizes, colors, and
+interactive states while maintaining WCAG 2.1 AA accessibility compliance.
 
-**Component:** `Button`
-**Package:** `@commercetools/nimbus`
-**Type:** Single-slot component
-**React Aria:** Uses `Button` from react-aria-components
+**Component:** `Button` **Package:** `@commercetools/nimbus` **Type:**
+Single-slot component **React Aria:** Uses `Button` from react-aria-components
 
 ## Requirements
 
 ### Requirement: Button Variants
+
 The component SHALL support multiple visual variants.
 
 #### Scenario: Solid variant
+
 - **WHEN** variant="solid" is set (default)
 - **THEN** SHALL render with solid background color
 - **AND** SHALL use primary brand color by default
 - **AND** SHALL provide high contrast with white text
 
 #### Scenario: Outline variant
+
 - **WHEN** variant="outline" is set
 - **THEN** SHALL render with transparent background and border
 - **AND** SHALL use semantic color for border and text
 - **AND** SHALL show solid background on hover
 
 #### Scenario: Ghost variant
+
 - **WHEN** variant="ghost" is set
 - **THEN** SHALL render with transparent background and no border
 - **AND** SHALL show subtle background on hover
 - **AND** SHALL maintain text color visibility
 
 #### Scenario: Link variant
+
 - **WHEN** variant="link" is set
 - **THEN** SHALL render as text with underline
 - **AND** SHALL behave like a button (not anchor)
 - **AND** SHALL support all button interactions
 
 ### Requirement: Button Sizes
+
 The component SHALL support three size options.
 
 #### Scenario: Small size
+
 - **WHEN** size="sm" is set
 - **THEN** SHALL render with compact padding and smaller font
 - **AND** SHALL maintain minimum 44x44px touch target with padding/margin
 
 #### Scenario: Medium size
+
 - **WHEN** size="md" is set (default)
 - **THEN** SHALL render with standard padding and font size
 - **AND** SHALL provide comfortable touch and click target
 
 #### Scenario: Large size
+
 - **WHEN** size="lg" is set
 - **THEN** SHALL render with generous padding and larger font
 - **AND** SHALL be suitable for primary actions and hero sections
 
 ### Requirement: Semantic Colors
+
 The component SHALL support semantic color palettes.
 
 #### Scenario: Color variants
+
 - **WHEN** colorPalette prop is set
 - **THEN** SHALL accept: primary, neutral, info, positive, warning, critical
 - **AND** SHALL apply appropriate semantic colors from design tokens
@@ -67,9 +78,11 @@ The component SHALL support semantic color palettes.
 - **AND** SHALL support light and dark modes
 
 ### Requirement: Loading State
+
 The component SHALL support loading state with spinner.
 
 #### Scenario: Loading indication
+
 - **WHEN** loading={true} is set
 - **THEN** SHALL display LoadingSpinner component
 - **AND** SHALL disable button interactions
@@ -77,9 +90,11 @@ The component SHALL support loading state with spinner.
 - **AND** loadingText prop SHALL replace button text when provided
 
 ### Requirement: Disabled State
+
 The component SHALL support disabled state.
 
 #### Scenario: Disabled rendering
+
 - **WHEN** disabled={true} is set
 - **THEN** SHALL apply disabled styles (reduced opacity)
 - **AND** SHALL prevent click/keyboard interactions
@@ -87,46 +102,56 @@ The component SHALL support disabled state.
 - **AND** SHALL show not-allowed cursor
 
 ### Requirement: Click Handling
+
 The component SHALL handle click interactions.
 
 #### Scenario: Click event
+
 - **WHEN** user clicks button
 - **THEN** SHALL call onClick handler if provided
 - **AND** SHALL prevent multiple rapid clicks during loading
 - **AND** SHALL work with form submission when type="submit"
 
 ### Requirement: Keyboard Interaction
+
 The component SHALL support keyboard interactions per nimbus-core standards.
 
 #### Scenario: Enter and Space keys
+
 - **WHEN** button is focused and user presses Enter or Space
 - **THEN** SHALL trigger onClick handler
 - **AND** SHALL provide visual feedback (active state)
 - **AND** SHALL follow React Aria keyboard patterns
 
 ### Requirement: Icon Integration
+
 The component SHALL support icons from @commercetools/nimbus-icons.
 
 #### Scenario: Left icon
+
 - **WHEN** leftIcon prop is provided
 - **THEN** SHALL render icon before button text
 - **AND** SHALL apply appropriate spacing between icon and text
 
 #### Scenario: Right icon
+
 - **WHEN** rightIcon prop is provided
 - **THEN** SHALL render icon after button text
 - **AND** SHALL apply appropriate spacing between text and icon
 
 #### Scenario: Icon-only button
+
 - **WHEN** children is empty and icon is provided
 - **THEN** SHALL render as icon-only button
 - **AND** SHALL require aria-label for accessibility
 - **AND** SHOULD use IconButton component instead for better semantics
 
 ### Requirement: Polymorphic Rendering
+
 The component SHALL support rendering as different HTML elements.
 
 #### Scenario: Custom element
+
 - **WHEN** as prop is provided
 - **THEN** SHALL render as specified element (e.g., as="a" for link)
 - **AND** SHALL maintain button styling
@@ -134,50 +159,78 @@ The component SHALL support rendering as different HTML elements.
 - **AND** SHALL preserve button interactions
 
 ### Requirement: Form Button Types
+
 The component SHALL support form-related button types.
 
 #### Scenario: Submit button
+
 - **WHEN** type="submit" is set
 - **THEN** SHALL submit parent form on click
 - **AND** SHALL trigger form validation
 
 #### Scenario: Reset button
+
 - **WHEN** type="reset" is set
 - **THEN** SHALL reset parent form on click
 
 #### Scenario: Button type (default)
+
 - **WHEN** type="button" is set or no type specified
 - **THEN** SHALL NOT submit form
 - **AND** SHALL only trigger onClick handler
 
 ### Requirement: ARIA Attributes
-The component SHALL provide appropriate ARIA attributes per nimbus-core standards.
+
+The component SHALL provide appropriate ARIA attributes per nimbus-core
+standards.
 
 #### Scenario: Accessible name
+
 - **WHEN** button renders
 - **THEN** SHALL have accessible name from children text
 - **OR** SHALL use aria-label if provided
 - **AND** icon-only buttons SHALL require aria-label
 
 #### Scenario: State announcements
+
 - **WHEN** loading state changes
 - **THEN** SHALL announce to screen readers via aria-busy
 - **WHEN** disabled
 - **THEN** SHALL set aria-disabled="true"
 
 ### Requirement: Recipe-Based Styling
+
 The component SHALL use Chakra UI recipe per nimbus-core standards.
 
 #### Scenario: Recipe application
+
 - **WHEN** component renders
 - **THEN** SHALL apply button recipe from theme/recipes/button.ts
 - **AND** recipe SHALL be registered in theme configuration
 - **AND** SHALL support recipe props: variant, size, colorPalette
 
+#### Scenario: React Aria prop filtering
+
+- **WHEN** component receives React Aria-specific event props from ButtonContext
+  slots
+- **THEN** SHALL filter out all React Aria custom event handlers before
+  forwarding to DOM
+- **AND** SHALL prevent `onPress`, `onPressStart`, `onPressEnd`,
+  `onPressChange`, `onPressUp` from reaching DOM
+- **AND** SHALL prevent `onFocusChange` from reaching DOM
+- **AND** SHALL prevent `onHoverStart`, `onHoverEnd`, `onHoverChange` from
+  reaching DOM
+- **AND** SHALL prevent `onMoveStart`, `onMove`, `onMoveEnd` from reaching DOM
+- **AND** SHALL NOT emit "Unknown event handler property" warnings in React
+- **AND** SHALL allow standard DOM events (onClick, onFocus, onBlur, etc.) to
+  pass through
+
 ### Requirement: Custom Styling
+
 The component SHALL accept Chakra style props.
 
 #### Scenario: Style prop override
+
 - **WHEN** style props are provided
 - **THEN** SHALL accept all Chakra style props (padding, margin, width, etc.)
 - **AND** SHALL apply responsive style values

--- a/packages/nimbus/src/components/button/button.slots.tsx
+++ b/packages/nimbus/src/components/button/button.slots.tsx
@@ -4,6 +4,35 @@ import shouldForwardProp from "@emotion/is-prop-valid";
 import { system } from "@/theme";
 import type { ButtonRootSlotProps } from "./button.types";
 
+/**
+ * React Aria-specific event props that should NOT be forwarded to DOM elements.
+ * These are custom event handlers that React Aria uses internally but are not
+ * valid DOM event handlers.
+ *
+ * @see https://react-spectrum.adobe.com/react-aria/interactions.html
+ */
+const REACT_ARIA_EVENT_PROPS = [
+  "onPress",
+  "onPressStart",
+  "onPressEnd",
+  "onPressChange",
+  "onPressUp",
+  "onFocusChange",
+  "onHoverStart",
+  "onHoverEnd",
+  "onHoverChange",
+  "onMoveStart",
+  "onMove",
+  "onMoveEnd",
+];
+
+/**
+ * Checks if a prop is a React Aria-specific event handler that should not
+ * be forwarded to the DOM.
+ */
+const isReactAriaEventProp = (prop: string): boolean =>
+  REACT_ARIA_EVENT_PROPS.some((ariaProp) => prop.includes(ariaProp));
+
 const { withContext } = createRecipeContext({
   recipe: buttonRecipe,
 });
@@ -18,11 +47,17 @@ export const ButtonRoot = withContext<HTMLButtonElement, ButtonRootSlotProps>(
     defaultProps: {
       type: "button",
     },
-    /** make sure the `onPress` properties won't end up as attribute on the rendered DOM element */
+    /**
+     * Filter out React Aria-specific props that shouldn't reach the DOM.
+     * These props are consumed by useButton() but may still be present in
+     * contextProps from ButtonContext slots.
+     */
     shouldForwardProp(prop, variantKeys) {
       const chakraSfp =
         !variantKeys?.includes(prop) && !system.isValidProperty(prop);
-      return shouldForwardProp(prop) && chakraSfp && !prop.includes("onPress");
+      return (
+        shouldForwardProp(prop) && chakraSfp && !isReactAriaEventProp(prop)
+      );
     },
   }
 );

--- a/packages/nimbus/src/components/button/button.spec.tsx
+++ b/packages/nimbus/src/components/button/button.spec.tsx
@@ -166,4 +166,31 @@ describe("Button", () => {
       expect(buttonRef.current).toBe(button);
     });
   });
+
+  describe("DOM prop filtering", () => {
+    it("Does not forward React Aria event props to DOM", () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      render(
+        <Button.Context.Provider
+          value={{
+            onFocusChange: () => {},
+            onHoverStart: () => {},
+            onPressChange: () => {},
+          }}
+        >
+          <Button data-testid="test">Test</Button>
+        </Button.Context.Provider>
+      );
+
+      // Should not warn about unknown event handler properties
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Unknown event handler property")
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
### Problem                                                                  
                                                                           
  Button's `shouldForwardProp` only filtered `onPress`, allowing other React   
  Aria event handlers (`onFocusChange`, `onHoverStart`, etc.) to leak to the   
  DOM. This caused "Unknown event handler property" warnings when Button is
   used in Calendar/RangeCalendar with multi-month display.                
                                                                           
  ### Solution                                                                 
                                                                           
  Extended prop filtering to block all React Aria-specific event handlers  
  before they reach the DOM element.                                       
                                                                           
 ###  Changes                                                                  
                                                                           
  - button.slots.tsx: Added REACT_ARIA_EVENT_PROPS constant and            
  isReactAriaEventProp helper to filter all React Aria events              
  - button.spec.tsx: Added test verifying React Aria props are filtered and
   don't cause warnings                                                    
                                                                           
 ###  Impact                                                                   
                                                                           
  - ✅ Eliminates console warnings in Calendar/RangeCalendar tests         
  - ✅ Prevents non-DOM props from reaching the DOM                        
  - ✅ No breaking changes - all existing tests pass                    