### PR TITLE
CRAFT-1899: fix(date-range-picker): restore ghost variant styling

### DIFF
--- a/.changeset/fix-date-range-picker-ghost-variant.md
+++ b/.changeset/fix-date-range-picker-ghost-variant.md
@@ -1,5 +1,0 @@
----
-"@commercetools/nimbus": patch
----
-
-fix(DateRangePicker): restore ghost variant styling by moving border properties to solid variant

--- a/.changeset/quiet-ghosts-appear.md
+++ b/.changeset/quiet-ghosts-appear.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/nimbus": patch
+---
+
+fix(DateRangePicker): restore ghost variant styling


### PR DESCRIPTION
## Summary
- Fixed ghost variant not showing transparent background (looked identical to solid variant)
- Moved `--border-width`, `--border-color`, and `bg` from `base.group` to `variants.variant.solid.group`
- Ghost variant now correctly has no border, matching the pattern used by `DateInput`

## Root Cause
The border CSS variables were defined in the base group styles, which meant they were always applied regardless of variant. The `ghost` variant only overrode `bg: "transparent"` but the border shadow was still rendered.

## Test plan
- [x] All 16 DateRangePicker tests pass
- [x] Visual verification in Storybook confirms ghost variant now has no border