### PR TITLE
chore(nimbus): preserve polyfill in build

### DIFF
--- a/.changeset/curvy-ears-sit.md
+++ b/.changeset/curvy-ears-sit.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Fix missing window.matchMedia polyfill in built setup-jsdom-polyfills output  
+

--- a/packages/nimbus/src/test/setup-jsdom-polyfills.ts
+++ b/packages/nimbus/src/test/setup-jsdom-polyfills.ts
@@ -73,19 +73,19 @@ if (typeof globalThis.structuredClone !== "function") {
  * - Media query hooks (useMediaQuery)
  * - Breakpoint-based rendering
  */
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: (query: unknown) => ({
-    matches: false, // Default, can be overridden in tests
-    media: query,
-    onchange: null,
-    addListener: () => {}, // Deprecated but needed
-    removeListener: () => {}, // Deprecated but needed
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false, // Default, can be overridden in tests
+      media: query,
+      onchange: null,
+      addListener: () => {}, // Deprecated but needed
+      removeListener: () => {}, // Deprecated but needed
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}
 
 /**
  * Mock ResizeObserver


### PR DESCRIPTION
## Summary

I'd like to get this in and release a new version, as tree-shaking originally excluded this polyfill from the build.