### PR TITLE
Compound components api reference for data table does not display well in docs. 

### DIFF
--- a/packages/nimbus/src/components/data-table/data-table.dev.mdx
+++ b/packages/nimbus/src/components/data-table/data-table.dev.mdx
@@ -1135,9 +1135,6 @@ type SortDescriptor = {
 };
 ```
 
-### DataTable.Manager API
-
-<PropsTable id="DataTableManager" />
 
 ## Testing your implementation
 

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.guidelines.mdx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.guidelines.mdx
@@ -96,11 +96,13 @@ const App = () => <Flex gap="200">
 >   areas, to avoid confusing the user.
 
 ```jsx-live
-const App = () => <Flex gap="200">
-  <Button colorPalette="primary" variant="solid">
-    <LoadingSpinner colorPalette="white" /> 
-    Remembering details...
-  </Button>
+const App = () => ( 
+  <Flex gap="200">
+    <Button colorPalette="primary" variant="solid">
+      <LoadingSpinner colorPalette="white" /> 
+      Remembering details...
+    </Button>
+  </Flex>
 )
 ```
 


### PR DESCRIPTION
Compound components api reference for data table does not render the individual subcomponents. This PR fixes it.  

Reference: https://github.com/commercetools/nimbus/pull/760#discussion_r2585313787