### PR TITLE
chore(docs): update component documentation titles for consistency

### DIFF
--- a/packages/nimbus/src/components/combobox/combobox.mdx
+++ b/packages/nimbus/src/components/combobox/combobox.mdx
@@ -12,7 +12,7 @@ tags:
   - component
 ---
 
-# ComboBox input
+# ComboBox
 
 A combobox is an input that combines a text field with a pop-up list of options. It allows users to select a value from a predefined list or enter their own custom value.
 

--- a/packages/nimbus/src/components/select/select.mdx
+++ b/packages/nimbus/src/components/select/select.mdx
@@ -9,7 +9,7 @@ order: 999
 menu:
   - Components
   - Inputs
-  - Select
+  - Select input
 tags:
   - component
 figmaLink: >-

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
@@ -9,14 +9,14 @@ order: 999
 menu:
   - Components
   - Inputs
-  - ToggleButtonGroup
+  - Toggle button group
 tags:
   - component
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=2693-2416&m=dev
 ---
 
-# Button Group
+# Toggle button group
 
 A set of closely related, mutually exclusive or complementary actions that are important enough to be displayed directly in the interface for quick access.
 


### PR DESCRIPTION
This PR ensures Component naming is consistent b/w the nav bar and the docs (eg, currently Select is in nav bar, but Select input in the docs)

Key places that seemed to need this change: 

* Renamed "ComboBox input" to "ComboBox" for clarity.
* Updated "Select" to "Select input" for better specificity.
* Changed "ToggleButtonGroup" to "Toggle button group" to enhance readability.