### PR TITLE
feat(nimbus): restore sm size variant for Button

### DIFF
--- a/packages/nimbus/src/components/button/button.recipe.ts
+++ b/packages/nimbus/src/components/button/button.recipe.ts
@@ -58,17 +58,18 @@ export const buttonRecipe = defineRecipe({
           height: "500",
         },
       },
-      /* sm: {
+      sm: {
         h: "900",
         minW: "900",
         px: "350",
-        textStyle: "sm",
+        fontSize: "350",
+        lineHeight: "400",
         gap: "200",
         _icon: {
-          width: "400",
-          height: "400",
+          width: "500",
+          height: "500",
         },
-      }, */
+      },
       md: {
         h: "1000",
         minW: "1000",

--- a/packages/nimbus/src/components/button/button.stories.tsx
+++ b/packages/nimbus/src/components/button/button.stories.tsx
@@ -19,7 +19,7 @@ const sizes: ButtonProps["size"][] = [
   //"xl",
   //"lg",
   "md",
-  //"sm",
+  "sm",
   "xs",
   "2xs",
 ];


### PR DESCRIPTION
## Summary
- Re-enables the `sm` (small) size variant for the Button component
- Provides an intermediate size option between `xs` (extra-small) and `md` (medium)
- Updates Storybook stories to include the sm size in documentation

## Test plan
- [x] Build passes (`pnpm --filter @commercetools/nimbus build`)
- [x] All button story tests pass (12/12)
- [x] Visual verification in Storybook