### PR TITLE
fix(combobox): fix flaky AsyncMultiSelectCustomOptions test

### DIFF
--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -785,16 +785,11 @@ export const AsyncMultiSelectCustomOptions: Story = {
     });
 
     await step("Verify all tags can be removed", async () => {
-      // Remove AnotherCustom tag
-      const anotherCustomTag = canvas.queryByText("AnotherCustom");
-      if (anotherCustomTag) {
-        const removeButton = anotherCustomTag.parentElement?.querySelector(
-          '[aria-label*="Remove"]'
-        );
-        if (removeButton) {
-          await userEvent.click(removeButton);
-        }
-      }
+      // Remove AnotherCustom tag - use getByRole to fail fast if not found
+      const removeButton = canvas.getByRole("button", {
+        name: /remove tag anothercustom/i,
+      });
+      await userEvent.click(removeButton);
 
       // Verify it's removed
       await waitFor(


### PR DESCRIPTION
## Summary

Fixes the intermittently failing "Async Multi Select Custom Options" test in CI ([example failure](https://github.com/commercetools/nimbus/actions/runs/21662467627/job/62450058662)).

## Root Cause

The test used conditional logic that could silently skip the click action:

```typescript
const anotherCustomTag = canvas.queryByText("AnotherCustom");
if (anotherCustomTag) {
  const removeButton = anotherCustomTag.parentElement?.querySelector('[aria-label*="Remove"]');
  if (removeButton) {
    await userEvent.click(removeButton);
  }
}
```

**Why this is flaky:**
- `queryByText` returns `null` instead of throwing if element isn't found
- `querySelector` on `parentElement` could also return `null` due to timing
- If either condition failed, the click never happened
- The subsequent `waitFor` would timeout waiting for removal that was never triggered

## Fix

Replace with a direct role-based query that fails fast:

```typescript
const removeButton = canvas.getByRole("button", {
  name: /remove tag anothercustom/i,
});
await userEvent.click(removeButton);
```

**Why this is better:**
- `getByRole` throws immediately if the element doesn't exist (fail fast, no silent failures)
- Queries by accessible name (more reliable than DOM traversal)
- Follows the same pattern used elsewhere in the codebase (e.g., line 1247)

## Test plan

- [x] Ran the test 5 times locally - all passes
- [x] Build passes