### PR TITLE
fix(docs): limit sidebar width

### DIFF
--- a/apps/docs/src/components/app-frame/app-frame.tsx
+++ b/apps/docs/src/components/app-frame/app-frame.tsx
@@ -164,7 +164,7 @@ function AppFrameMainContent({ children }: AppFrameMainContentProps) {
         },
       }}
     >
-      <Box maxWidth="80ch">{children}</Box>
+      <Box maxWidth="80ch" mx="auto">{children}</Box>
     </Box>
   );
 }


### PR DESCRIPTION
#### Summary

- Constrained side nav to 200-400px (is this the correct width?)
- Limited character width of main content to 80 chars
- Main content grows with browser width, min width 80 chars

**Limitation:** this is not "responsive" in any way, is this something we want to consider in the future?