### PR TITLE
CRAFT 2105 | data table pin row cell and tooltip text now render correctly in dark mode

### DIFF
--- a/.changeset/nine-wolves-allow.md
+++ b/.changeset/nine-wolves-allow.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": patch
+---
+
+DataTable "pin row" cell now renders dark background in dark mode. Tooltip now
+renders dark text on light background in dark mode.

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -47,7 +47,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           position: "sticky",
           right: 0,
           zIndex: 10,
-          backgroundColor: "white",
+          backgroundColor: "bg",
         },
       },
       "& .data-table-row": {
@@ -144,7 +144,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           left: "72px", // Width of selection column
         },
         "& [data-slot='pin-row-cell']": {
-          backgroundColor: "white",
+          backgroundColor: "bg",
           position: "sticky",
           clipPath: "inset(2px 2px 2px 0)",
         },

--- a/packages/nimbus/src/components/tooltip/tooltip.recipe.ts
+++ b/packages/nimbus/src/components/tooltip/tooltip.recipe.ts
@@ -10,7 +10,10 @@ export const tooltipRecipe = defineRecipe({
 
   // Base styles applied to all instances of the component
   base: {
-    color: "white",
+    // Tooltip styling is inverse of normal dark/light mode styling:
+    // light mode: dark bg / light text
+    // dark mode: light bg / dark text
+    color: "bg",
     textStyle: "xs",
     fontWeight: "400",
     background: "slate.12",


### PR DESCRIPTION
This pull request updates the `DataTable` and `Tooltip` components in the Nimbus design system to improve their appearance and accessibility in dark mode. The most significant changes ensure that pinned rows in the DataTable use the correct background color in dark mode, and that Tooltip text remains legible by inverting its color scheme appropriately.

**DataTable dark mode improvements:**

* Updated the pinned row cell and sticky column backgrounds to use the theme's `bg` color instead of hardcoded white, ensuring correct appearance in dark mode (`data-table.recipe.ts`). [[1]](diffhunk://#diff-303aa515c8d5ce49afc38c1a701296a87b1af9ee1fc3c76c11a72bda53514840L50-R50) [[2]](diffhunk://#diff-303aa515c8d5ce49afc38c1a701296a87b1af9ee1fc3c76c11a72bda53514840L147-R147)

**Tooltip dark mode improvements:**

* Changed the tooltip text color to use the theme's `bg` color, making tooltip text dark on a light background in dark mode and vice versa, for better accessibility (`tooltip.recipe.ts`).

**Documentation:**

* Added a changeset describing the DataTable and Tooltip dark mode improvements.