### PR TITLE
CRAFT 2106 | ensure button event handlers only fire once, deprecate onClick prop in react-aria based components

### DIFF
--- a/.changeset/eighty-bugs-smile.md
+++ b/.changeset/eighty-bugs-smile.md
@@ -2,4 +2,7 @@
 "@commercetools/nimbus": patch
 ---
 
-Ensure onClick and other event handlers are only called once in Button
+Ensure onClick and other event handlers are only called once in Button.
+
+Add deprecation directive for `onClick` prop passed to React-Aria based
+components directing user to use `onPress` instead

--- a/packages/nimbus/src/components/accordion/accordion.types.ts
+++ b/packages/nimbus/src/components/accordion/accordion.types.ts
@@ -7,7 +7,10 @@ import type {
   ButtonProps as RaButtonProps,
 } from "react-aria-components";
 // TODO: this needs to be an @/ import
-import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  OmitInternalProps,
+  DeprecateOnClick,
+} from "../../type-utils/omit-props";
 
 // ============================================================
 // RECIPE PROPS
@@ -58,14 +61,14 @@ export type AccordionItemProps = OmitInternalProps<
  * Props for the Accordion.Header component.
  * Displays the clickable header that expands/collapses content.
  */
-export type AccordionHeaderProps = OmitInternalProps<
-  RaButtonProps & HTMLChakraProps<"div">
-> & {
-  /** The header content to display */
-  children: ReactNode;
-  /** Ref to the header element */
-  ref?: Ref<HTMLButtonElement>;
-};
+export type AccordionHeaderProps = DeprecateOnClick<
+  OmitInternalProps<RaButtonProps & HTMLChakraProps<"div">> & {
+    /** The header content to display */
+    children: ReactNode;
+    /** Ref to the header element */
+    ref?: Ref<HTMLButtonElement>;
+  }
+>;
 
 /**
  * Props for the Accordion.Content component.

--- a/packages/nimbus/src/components/button/button.stories.tsx
+++ b/packages/nimbus/src/components/button/button.stories.tsx
@@ -358,6 +358,8 @@ export const EventHandlersFireOnce: Story = {
     onPress: fn(),
     onFocus: fn(),
     onBlur: fn(),
+    onKeyDown: fn(),
+    onPointerDown: fn(),
     children: "Click Me",
     ["data-testid"]: "event-test",
   },
@@ -378,6 +380,10 @@ export const EventHandlersFireOnce: Story = {
       await expect(args.onFocus).toHaveBeenCalledTimes(1);
     });
 
+    await step("onPointerDown fires exactly once per click", async () => {
+      await expect(args.onPointerDown).toHaveBeenCalledTimes(1);
+    });
+
     await step("onBlur fires exactly once after blur", async () => {
       await userEvent.tab(); // move focus away
       await expect(args.onBlur).toHaveBeenCalledTimes(1);
@@ -389,8 +395,18 @@ export const EventHandlersFireOnce: Story = {
         await userEvent.click(button);
         await expect(args.onClick).toHaveBeenCalledTimes(2);
         await expect(args.onPress).toHaveBeenCalledTimes(2);
+        await expect(args.onPointerDown).toHaveBeenCalledTimes(2);
       }
     );
+
+    await step("onKeyDown fires exactly once per keypress", async () => {
+      // onKeyDown accumulated calls from earlier interactions (tab, etc.)
+      const countBefore = (args.onKeyDown as ReturnType<typeof fn>).mock.calls
+        .length;
+      button.focus();
+      await userEvent.keyboard("{Enter}");
+      await expect(args.onKeyDown).toHaveBeenCalledTimes(countBefore + 1);
+    });
   },
 };
 

--- a/packages/nimbus/src/components/button/button.tsx
+++ b/packages/nimbus/src/components/button/button.tsx
@@ -36,68 +36,78 @@ const ButtonComponent = (props: ButtonProps) => {
   // Components like CollapsibleMotion.Trigger pass `disabled` via asChild.
   const isDisabled = contextProps.isDisabled ?? contextProps.disabled;
 
-  // Prevent double-firing of onClick while ensuring it fires even when a
-  // parent blocks pointerdown (e.g., DataTable row capture handlers).
+  // Prevent double-firing of wrapped event handlers (onClick, onFocus, onBlur).
   //
-  // usePress (inside useButton) wraps onClick via triggerClick. When
-  // mergeProps chains both contextProps.onClick and buttonProps.onClick,
-  // onClick fires twice. Simply filtering contextProps.onClick breaks when
-  // pointerdown is blocked because usePress never starts a press sequence
-  // and triggerClick is never called.
+  // useButton internally wraps these handlers: usePress wraps onClick via
+  // triggerClick, and useFocusable wraps onFocus/onBlur via useFocus.
+  // When mergeProps chains both the context handler and the useButton-processed
+  // handler, they fire twice for the same native event.
   //
-  // Solution: wrap onClick so it deduplicates per native event. The same
-  // wrapper is passed to useButton (for keyboard support via triggerClick /
-  // triggerSyntheticClick) AND merged into componentProps as a fallback.
-  // The first invocation per native event fires; subsequent calls (from
-  // mergeProps chaining) are no-ops.
-  const handledClicksRef = useRef(new WeakSet<Event>());
-  const { onClick: contextOnClick, ...contextPropsWithoutOnClick } =
-    contextProps;
+  // Solution: wrap each handler so it deduplicates per native event using a
+  // WeakSet. The deduped wrapper is passed to useButton (so the internal
+  // wrapping works for keyboard activation, etc.) AND merged into
+  // componentProps as a fallback (for cases where usePress can't fire, e.g.
+  // when pointerdown is blocked by a parent capture handler).
+  //
+  // Independent handlers (onKeyDown, onPointerDown, etc.) are NOT wrapped by
+  // useButton internals — usePress creates its own separate handlers for those.
+  // They chain naturally via mergeProps, which is the correct behavior.
+  const handledEventsRef = useRef(new WeakSet<Event>());
 
-  /** How it works:                                                                                                                                         
-  - dedupedOnClick wraps the original onClick with a WeakSet check on e.nativeEvent                                                                     
-  - It's passed to useButton → usePress uses it for triggerClick (pointer) and triggerSyntheticClick (keyboard)                                         
-  - It's also in componentProps as a fallback (via the third mergeProps arg)
-  - Normal click: usePress calls triggerClick → dedupedOnClick fires, adds to WeakSet → mergeProps chain calls it again → already in WeakSet, skips
-  - Blocked pointerdown: usePress doesn't call triggerClick → mergeProps chain calls dedupedOnClick → not in WeakSet, fires
-  - Keyboard: triggerSyntheticClick creates a new MouseEvent → dedupedOnClick fires → no native click event → no second call */
-  const dedupedOnClick = useMemo(
-    () =>
-      contextOnClick
-        ? (...args: Parameters<typeof contextOnClick>) => {
-            const e = args[0];
-            if (handledClicksRef.current.has(e.nativeEvent)) return;
-            handledClicksRef.current.add(e.nativeEvent);
-            contextOnClick(...args);
-          }
-        : undefined,
-    [contextOnClick]
-  );
+  const {
+    onClick: contextOnClick,
+    onFocus: contextOnFocus,
+    onBlur: contextOnBlur,
+    onKeyDown: contextOnKeyDown,
+    onKeyUp: contextOnKeyUp,
+    ...contextPropsWithoutWrapped
+  } = contextProps;
+
+  // Generic dedup helper: wraps a handler so it only fires once per native event
+  const useDedupedHandler = <T extends (...args: never[]) => void>(
+    handler: T | undefined
+  ) =>
+    useMemo(
+      () =>
+        handler
+          ? (((...args: Parameters<T>) => {
+              const e = args[0] as React.SyntheticEvent;
+              if (handledEventsRef.current.has(e.nativeEvent)) return;
+              handledEventsRef.current.add(e.nativeEvent);
+              handler(...args);
+            }) as T)
+          : undefined,
+      [handler]
+    );
+
+  const dedupedOnClick = useDedupedHandler(contextOnClick);
+  const dedupedOnFocus = useDedupedHandler(contextOnFocus);
+  const dedupedOnBlur = useDedupedHandler(contextOnBlur);
+  const dedupedOnKeyDown = useDedupedHandler(contextOnKeyDown);
+  const dedupedOnKeyUp = useDedupedHandler(contextOnKeyUp);
 
   const { buttonProps } = useButton(
     {
-      ...contextPropsWithoutOnClick,
+      ...contextPropsWithoutWrapped,
       onClick: dedupedOnClick,
+      onFocus: dedupedOnFocus,
+      onBlur: dedupedOnBlur,
+      onKeyDown: dedupedOnKeyDown,
+      onKeyUp: dedupedOnKeyUp,
       isDisabled,
       elementType,
     },
     contextRef
   );
 
-  // Strip props from contextProps that useButton already returns in buttonProps
-  // to prevent double-firing of event handlers (onKeyDown, etc.)
-  // while preserving non-standard props (Chakra style props, etc.) that
-  // useButton's filterDOMProps strips out.
-  const passthroughContextProps = Object.fromEntries(
-    Object.entries(contextPropsWithoutOnClick).filter(
-      ([key]) => !(key in buttonProps)
-    )
-  );
-
-  const componentProps = mergeProps(passthroughContextProps, buttonProps, {
+  const componentProps = mergeProps(contextPropsWithoutWrapped, buttonProps, {
     as,
     asChild,
     onClick: dedupedOnClick,
+    onFocus: dedupedOnFocus,
+    onBlur: dedupedOnBlur,
+    onKeyDown: dedupedOnKeyDown,
+    onKeyUp: dedupedOnKeyUp,
     /**
      * In case `slot` was null, the `useContextProps` hook already
      * processed it at this point, so it's safe to not attach it

--- a/packages/nimbus/src/components/button/button.types.ts
+++ b/packages/nimbus/src/components/button/button.types.ts
@@ -4,7 +4,7 @@ import type {
   RecipeProps,
   UnstyledProp,
 } from "@chakra-ui/react";
-import type { SemanticPalettesOnly } from "@/type-utils";
+import type { SemanticPalettesOnly, DeprecateOnClick } from "@/type-utils";
 
 // ============================================================
 // RECIPE PROPS
@@ -42,18 +42,20 @@ export type ButtonRootSlotProps = Omit<
 // MAIN PROPS
 // ============================================================
 
-export type ButtonProps = Omit<ButtonRootSlotProps, keyof RaButtonProps> &
-  RaButtonProps & {
-    /**
-     * Data attributes for testing or custom metadata
-     */
-    [key: `data-${string}`]: unknown;
-    /**
-     * Slot name for React Aria Components composition
-     */
-    slot?: string | null | undefined;
-    /**
-     * Ref forwarding to the button element
-     */
-    ref?: React.Ref<HTMLButtonElement>;
-  };
+export type ButtonProps = DeprecateOnClick<
+  Omit<ButtonRootSlotProps, keyof RaButtonProps> &
+    RaButtonProps & {
+      /**
+       * Data attributes for testing or custom metadata
+       */
+      [key: `data-${string}`]: unknown;
+      /**
+       * Slot name for React Aria Components composition
+       */
+      slot?: string | null | undefined;
+      /**
+       * Ref forwarding to the button element
+       */
+      ref?: React.Ref<HTMLButtonElement>;
+    }
+>;

--- a/packages/nimbus/src/components/link/link.types.tsx
+++ b/packages/nimbus/src/components/link/link.types.tsx
@@ -4,6 +4,7 @@ import type {
   UnstyledProp,
 } from "@chakra-ui/react";
 import type { AriaLinkOptions } from "react-aria";
+import type { DeprecateOnClick } from "@/type-utils";
 
 // ============================================================
 // RECIPE PROPS
@@ -42,13 +43,15 @@ type LinkVariantProps = Omit<
 // MAIN PROPS
 // ============================================================
 
-export type LinkProps = LinkVariantProps & {
-  /**
-   * Content to display inside the link
-   */
-  children?: React.ReactNode;
-  /**
-   * Ref forwarding to the anchor element
-   */
-  ref?: React.Ref<HTMLAnchorElement>;
-};
+export type LinkProps = DeprecateOnClick<
+  LinkVariantProps & {
+    /**
+     * Content to display inside the link
+     */
+    children?: React.ReactNode;
+    /**
+     * Ref forwarding to the anchor element
+     */
+    ref?: React.Ref<HTMLAnchorElement>;
+  }
+>;

--- a/packages/nimbus/src/components/menu/menu.types.ts
+++ b/packages/nimbus/src/components/menu/menu.types.ts
@@ -9,7 +9,10 @@ import type {
   SubmenuTriggerProps as RaSubmenuTriggerProps,
 } from "react-aria-components";
 import type { HTMLChakraProps, SlotRecipeProps } from "@chakra-ui/react";
-import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  OmitInternalProps,
+  DeprecateOnClick,
+} from "../../type-utils/omit-props";
 
 // ============================================================
 // RECIPE PROPS
@@ -62,18 +65,17 @@ export type MenuRootProps = Omit<RaMenuTriggerProps, "trigger" | "children"> &
   };
 
 // Menu trigger component
-export type MenuTriggerProps = OmitInternalProps<
-  MenuTriggerSlotProps,
-  keyof RaButtonProps
-> &
-  RaButtonProps & {
-    /**
-     * When true, the trigger will not render its own button element.
-     * Instead, it will pass props to its child element.
-     */
-    asChild?: boolean;
-    ref?: Ref<HTMLButtonElement>;
-  };
+export type MenuTriggerProps = DeprecateOnClick<
+  OmitInternalProps<MenuTriggerSlotProps, keyof RaButtonProps> &
+    RaButtonProps & {
+      /**
+       * When true, the trigger will not render its own button element.
+       * Instead, it will pass props to its child element.
+       */
+      asChild?: boolean;
+      ref?: Ref<HTMLButtonElement>;
+    }
+>;
 
 // Menu content/popover component
 export type MenuContentProps = {

--- a/packages/nimbus/src/components/number-input/number-input.types.ts
+++ b/packages/nimbus/src/components/number-input/number-input.types.ts
@@ -8,7 +8,10 @@ import type {
   AriaButtonProps as RaButtonProps,
   AriaNumberFieldProps as RaNumberFieldProps,
 } from "react-aria";
-import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  OmitInternalProps,
+  DeprecateOnClick,
+} from "../../type-utils/omit-props";
 
 // ============================================================
 // RECIPE PROPS
@@ -54,17 +57,13 @@ export type NumberInputInputSlotProps = HTMLChakraProps<
 > &
   RaInputProps;
 
-export type NumberInputIncrementButtonSlotProps = HTMLChakraProps<
-  "button",
-  NumberInputRecipeProps
-> &
-  RaButtonProps;
+export type NumberInputIncrementButtonSlotProps = DeprecateOnClick<
+  HTMLChakraProps<"button", NumberInputRecipeProps> & RaButtonProps
+>;
 
-export type NumberInputDecrementButtonSlotProps = HTMLChakraProps<
-  "button",
-  NumberInputRecipeProps
-> &
-  RaButtonProps;
+export type NumberInputDecrementButtonSlotProps = DeprecateOnClick<
+  HTMLChakraProps<"button", NumberInputRecipeProps> & RaButtonProps
+>;
 
 // ============================================================
 // HELPER TYPES

--- a/packages/nimbus/src/components/toggle-button/toggle-button.types.ts
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.types.ts
@@ -1,6 +1,6 @@
 import type { HTMLChakraProps, RecipeProps } from "@chakra-ui/react";
 import type { ToggleButtonProps as RaToggleButtonProps } from "react-aria-components";
-import type { SemanticPalettesOnly } from "@/type-utils";
+import type { SemanticPalettesOnly, DeprecateOnClick } from "@/type-utils";
 
 // ============================================================
 // RECIPE PROPS
@@ -43,13 +43,12 @@ type ExcludedProps = "css" | "colorScheme" | "recipe" | "as" | "asChild";
 // MAIN PROPS
 // ============================================================
 
-export type ToggleButtonProps = Omit<
-  ToggleButtonRootSlotProps,
-  keyof RaToggleButtonProps | ExcludedProps
-> &
-  RaToggleButtonProps & {
-    /**
-     * Ref forwarding to the button element
-     */
-    ref?: React.Ref<HTMLButtonElement>;
-  };
+export type ToggleButtonProps = DeprecateOnClick<
+  Omit<ToggleButtonRootSlotProps, keyof RaToggleButtonProps | ExcludedProps> &
+    RaToggleButtonProps & {
+      /**
+       * Ref forwarding to the button element
+       */
+      ref?: React.Ref<HTMLButtonElement>;
+    }
+>;

--- a/packages/nimbus/src/type-utils/omit-props.ts
+++ b/packages/nimbus/src/type-utils/omit-props.ts
@@ -20,3 +20,27 @@ export type OmitInternalProps<
   T,
   AdditionalExclusions extends string = never,
 > = Omit<T, "as" | "asChild" | "elementType" | "css" | AdditionalExclusions>;
+
+/**
+ * Replaces the `onClick` prop in `T` with a `@deprecated` version that
+ * preserves the original type signature but shows a deprecation warning in IDEs.
+ *
+ * React Aria's `onPress` should be used instead of `onClick` because it
+ * provides consistent behavior across pointer, keyboard, and virtual click
+ * interactions with additional event metadata.
+ *
+ * **Usage:** Apply to any component props type that inherits `onClick` from
+ * React Aria (`AriaButtonProps`, `AriaLinkOptions`, `PressEvents`, etc.).
+ */
+export type DeprecateOnClick<T> = Omit<T, "onClick"> &
+  ("onClick" extends keyof T
+    ? {
+        /**
+         * @deprecated Use `onPress` instead. `onClick` is an alias provided
+         * for compatibility but `onPress` offers better cross-interaction
+         * support (pointer, keyboard, screen reader).
+         */
+        onClick?: T["onClick"];
+      }
+    : // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+      {});


### PR DESCRIPTION
This pull request addresses a double-firing bug with event handlers in the `Button` component and introduces a deprecation warning for the `onClick` prop across several components, guiding users to use `onPress` instead. It also adds comprehensive tests to ensure event handlers are only called once per interaction and updates type definitions to reflect the new deprecation policy.

**Event Handler Deduplication and Testing**
- Implements a deduplication mechanism in `button.tsx` to ensure `onClick`, `onFocus`, and `onBlur` handlers are only called once per native event, preventing double-firing issues caused by merging React Aria and user handlers. [[1]](diffhunk://#diff-dcab629ba156650ea7d30ad048bea91a1675395b451046695cac23ffb9cd203dR35-R110) [[2]](diffhunk://#diff-dcab629ba156650ea7d30ad048bea91a1675395b451046695cac23ffb9cd203dL58-R124)
- Adds a Storybook test (`EventHandlersFireOnce`) to verify that each event handler fires exactly once per user interaction, guarding against regressions.

**Deprecation of `onClick` in Favor of `onPress`**
- Introduces a `DeprecateOnClick` utility type that marks the `onClick` prop as deprecated in TypeScript, encouraging the use of `onPress` for more consistent cross-platform event handling.
- Applies the `DeprecateOnClick` type to the props of `Button`, `AccordionHeader`, `Link`, `MenuTrigger`, `NumberInputIncrementButton`, `NumberInputDecrementButton`, and `ToggleButton` to propagate the deprecation warning throughout the codebase. [[1]](diffhunk://#diff-33a06f755a2a7efb8b1616c5aea7aa87a5a3082f8569c706b01bcef7abdf232aL7-R7) [[2]](diffhunk://#diff-33a06f755a2a7efb8b1616c5aea7aa87a5a3082f8569c706b01bcef7abdf232aL45-R46) [[3]](diffhunk://#diff-33a06f755a2a7efb8b1616c5aea7aa87a5a3082f8569c706b01bcef7abdf232aL59-R61) [[4]](diffhunk://#diff-9b304cb5ad4cc160d400270b83c68b4fc319a9ebc29559ebd3c3cda0dca8a3f9L10-R13) [[5]](diffhunk://#diff-9b304cb5ad4cc160d400270b83c68b4fc319a9ebc29559ebd3c3cda0dca8a3f9L61-R71) [[6]](diffhunk://#diff-3812e145fd0433a013665d0d5ca9172ed8430cf2af811bd958a2ecda30d81693R7) [[7]](diffhunk://#diff-3812e145fd0433a013665d0d5ca9172ed8430cf2af811bd958a2ecda30d81693L45-R47) [[8]](diffhunk://#diff-3812e145fd0433a013665d0d5ca9172ed8430cf2af811bd958a2ecda30d81693L54-R57) [[9]](diffhunk://#diff-fdcacfa4c97d57cdb87f0aa360816f70f13bbf0f44ccb79c148a532a76fae8e0L12-R15) [[10]](diffhunk://#diff-fdcacfa4c97d57cdb87f0aa360816f70f13bbf0f44ccb79c148a532a76fae8e0L65-R78) [[11]](diffhunk://#diff-a67cbaa1dce84886ab4150c0ac1bccd60cd8cb92d34a42a0fd1c9305cc9c4f23L11-R14) [[12]](diffhunk://#diff-a67cbaa1dce84886ab4150c0ac1bccd60cd8cb92d34a42a0fd1c9305cc9c4f23L57-R66) [[13]](diffhunk://#diff-84d84b3917df77c7abc45543a31df807b54333e9530ae83cfdc4a57c01859d7bL3-R3) [[14]](diffhunk://#diff-84d84b3917df77c7abc45543a31df807b54333e9530ae83cfdc4a57c01859d7bL46-R54)

**Documentation and Changelog**
- Adds a changeset entry documenting the event handler deduplication and the deprecation of `onClick`.

**Summary of the most important changes:**

**Bug Fixes and Event Handling**
- Ensured that `onClick` and other event handlers in `Button` fire only once per interaction by deduplicating handler calls. [[1]](diffhunk://#diff-dcab629ba156650ea7d30ad048bea91a1675395b451046695cac23ffb9cd203dR35-R110) [[2]](diffhunk://#diff-dcab629ba156650ea7d30ad048bea91a1675395b451046695cac23ffb9cd203dL58-R124)
- Added a comprehensive Storybook test to verify correct event handler firing behavior.

**API Deprecations and Type Improvements**
- Introduced the `DeprecateOnClick` utility type to mark `onClick` as deprecated in favor of `onPress` for React Aria-based components.
- Updated prop types for `Button`, `AccordionHeader`, `Link`, `MenuTrigger`, `NumberInput` buttons, and `ToggleButton` to apply the deprecation and improve type safety. [[1]](diffhunk://#diff-33a06f755a2a7efb8b1616c5aea7aa87a5a3082f8569c706b01bcef7abdf232aL7-R7) [[2]](diffhunk://#diff-33a06f755a2a7efb8b1616c5aea7aa87a5a3082f8569c706b01bcef7abdf232aL45-R46) [[3]](diffhunk://#diff-33a06f755a2a7efb8b1616c5aea7aa87a5a3082f8569c706b01bcef7abdf232aL59-R61) [[4]](diffhunk://#diff-9b304cb5ad4cc160d400270b83c68b4fc319a9ebc29559ebd3c3cda0dca8a3f9L10-R13) [[5]](diffhunk://#diff-9b304cb5ad4cc160d400270b83c68b4fc319a9ebc29559ebd3c3cda0dca8a3f9L61-R71) [[6]](diffhunk://#diff-3812e145fd0433a013665d0d5ca9172ed8430cf2af811bd958a2ecda30d81693R7) [[7]](diffhunk://#diff-3812e145fd0433a013665d0d5ca9172ed8430cf2af811bd958a2ecda30d81693L45-R47) [[8]](diffhunk://#diff-3812e145fd0433a013665d0d5ca9172ed8430cf2af811bd958a2ecda30d81693L54-R57) [[9]](diffhunk://#diff-fdcacfa4c97d57cdb87f0aa360816f70f13bbf0f44ccb79c148a532a76fae8e0L12-R15) [[10]](diffhunk://#diff-fdcacfa4c97d57cdb87f0aa360816f70f13bbf0f44ccb79c148a532a76fae8e0L65-R78) [[11]](diffhunk://#diff-a67cbaa1dce84886ab4150c0ac1bccd60cd8cb92d34a42a0fd1c9305cc9c4f23L11-R14) [[12]](diffhunk://#diff-a67cbaa1dce84886ab4150c0ac1bccd60cd8cb92d34a42a0fd1c9305cc9c4f23L57-R66) [[13]](diffhunk://#diff-84d84b3917df77c7abc45543a31df807b54333e9530ae83cfdc4a57c01859d7bL3-R3) [[14]](diffhunk://#diff-84d84b3917df77c7abc45543a31df807b54333e9530ae83cfdc4a57c01859d7bL46-R54)

**Documentation**
- Added a changeset entry to communicate the event handler fix and the new deprecation policy for `onClick`.