### PR TITLE
CRAFT 2108 | ensure parent DataTableBase component is generic to allow for inference of user's column/row types

### DIFF
--- a/.changeset/chilly-plants-type.md
+++ b/.changeset/chilly-plants-type.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Updated parent DataTableBase component to be a generic function that accepts the
+user's row data type, enabling type inference on data table rows.

--- a/packages/nimbus/src/components/data-table/data-table.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.tsx
@@ -16,11 +16,13 @@ import { useLocalizedStringFormatter } from "@/hooks";
 import { dataTableMessagesStrings } from "./data-table.messages";
 
 // Default DataTable component that provides the standard structure
-const DataTableBase = function DataTable({
+const DataTableBase = function DataTable<
+  T extends object = Record<string, unknown>,
+>({
   ref: forwardedRef,
   footer,
   ...props
-}: DataTableProps & {
+}: DataTableProps<T> & {
   footer?: React.ReactNode;
   ref?: React.Ref<HTMLDivElement>;
 }) {


### PR DESCRIPTION
This pull request introduces a generic type parameter to the `DataTable` component to improve type safety and flexibility. The change allows the `DataTable` to accept a generic type argument, making it easier to work with strongly-typed data.

Fix in response to [this slack thread](https://commercetools.slack.com/archives/C0ACFBKAHTM/p1770999806723639).

Type Safety Enhancements:

* Added a generic type parameter `T` to the `DataTable` component definition, defaulting to `Record<string, unknown>`, and updated the `DataTableProps` type usage to `DataTableProps<T>`. This allows consumers to specify the shape of the data used in the table for better type checking.