### PR TITLE
CRAFT-2111: fix(number-input): prevent overflow when width is constrained

### DIFF
--- a/packages/nimbus/src/components/number-input/number-input.recipe.ts
+++ b/packages/nimbus/src/components/number-input/number-input.recipe.ts
@@ -41,13 +41,11 @@ export const numberInputRecipe = defineSlotRecipe({
       },
     },
     leadingElement: {
-      overflow: "hidden",
       display: "flex",
       alignItems: "center",
       color: "neutral.11",
     },
     trailingElement: {
-      overflow: "hidden",
       display: "flex",
       alignItems: "center",
       color: "neutral.11",


### PR DESCRIPTION
## Summary

When a `NumberInput` is given a fixed width (e.g. `width="9ch"` as used by `Pagination`), typing a long value like "123456789" causes the input to overflow its container and trigger horizontal scroll.

### Root cause

This is a well-known CSS flexbox gotcha. The `<input>` element inside the `inline-flex` root has `flexShrink: 1`, but flex items default to `min-width: auto` — meaning they cannot shrink below their intrinsic content width. Once the typed value exceeds the container's width, the shrink has no effect and the content overflows.

### Fix

Two defensive CSS properties added to `number-input.recipe.ts`:

- **`minWidth: 0` on the `input` slot** — the standard fix that allows a flex item to shrink below its content width
- **`overflow: hidden` on the `root` slot** — a safety net to clip any visual overflow at the component boundary

Additionally, `overflow: hidden` was **removed** from the `leadingElement` and `trailingElement` slots. These slots have no fixed dimensions (they size to content as flex children), so overflow: hidden could never clip content — it only clipped things that paint outside the box, like focus outlines on interactive children (e.g. icon buttons). The root's overflow: hidden now serves as the single boundary guard instead.

## Test plan

- [x] `pnpm --filter @commercetools/nimbus build` passes
- [x] NumberInput story tests pass (10/10)
- [x] Pagination story tests pass (9/9)
- [x] Visual check in Storybook: type a long number into a width-constrained NumberInput — content clips instead of overflowing
- [x] Verify focus ring remains visible on the root
- [x] Verify focus outline on leading/trailing interactive elements is no longer clipped