### PR TITLE
CRAFT 2115 | refetch github token before canary release in release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,15 @@ jobs:
           SKIP_POSTINSTALL_DEV_SETUP: true
 
       # Publish canary releases only if the packages weren't published already
+      - name: Regenerate GitHub token for canary
+        if: steps.changesets.outputs.published != 'true' && github.ref ==
+          'refs/heads/main'
+        id: generate_github_token_canary
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+
       - name: Publishing canary releases to npm registry
         if: steps.changesets.outputs.published != 'true' && github.ref ==
           'refs/heads/main'
@@ -86,4 +95,4 @@ jobs:
           pnpm changeset version --snapshot canary
           pnpm changeset publish --tag canary
         env:
-          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token_canary.outputs.token }}


### PR DESCRIPTION
This pull request updates the release workflow to improve the publishing process for canary releases. The changes focus on generating and using a dedicated GitHub token specifically for canary releases.
[
See this gh action for example failure](https://github.com/commercetools/nimbus/actions/runs/22107967172/job/63896030214#step:11:1)

**Release workflow improvements:**

* Added a new step to regenerate a GitHub token specifically for canary releases using the `tibdex/github-app-token` action, with credentials provided via repository secrets.
* Updated the canary publishing step to use the newly generated canary GitHub token instead of the general token, ensuring proper authentication and separation of concerns.