### PR TITLE
fix(bundle): addresses error in update-bundle workflow

### DIFF
--- a/.github/workflows/update-bundle-baseline.yml
+++ b/.github/workflows/update-bundle-baseline.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Commit updated baseline
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/nimbus/bundle-size-baseline.json


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by configuring Git to recognize the workspace as a safe directory before committing changes.

  * Added `git config --global --add safe.directory "$GITHUB_WORKSPACE"` to the `.github/workflows/update-bundle-baseline.yml` workflow to prevent potential permission issues during automated commits.