### PR TITLE
fix(bundle): use dedicated action for baseline commit

### DIFF
--- a/.github/workflows/update-bundle-baseline.yml
+++ b/.github/workflows/update-bundle-baseline.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Update bundle size baseline
         run: node scripts/check-bundle-size.mjs --update-baseline
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: step-security/git-auto-commit-action@v7
         with:
           commit_message: "chore: update bundle size baseline [skip ci]"
           file_pattern: "packages/nimbus/bundle-size-baseline.json"


### PR DESCRIPTION
This pull request simplifies the workflow for updating the bundle size baseline in the GitHub Actions configuration. 

* Replaced manual git commands for committing and pushing updates to `packages/nimbus/bundle-size-baseline.json` with the `step-security/git-auto-commit-action`, making the process more reliable and maintainable.