### PR TITLE
fix(ci): add extract-intl step to build pipeline

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -25,8 +25,16 @@ runs:
       run: pnpm install
       shell: bash
 
-    - name: Building packages
-      # Skip docs build - saves disk space and build time
-      # Vercel handles docs deployment and builds them separately
-      run: pnpm build:tokens && pnpm build:packages
+    - name: Build design tokens
+      run: pnpm build:tokens
+      shell: bash
+
+    - name: Extract and compile i18n messages
+      # Generates *.messages.ts and intl/*.ts files (gitignored) required at build time
+      run: pnpm extract-intl
+      shell: bash
+
+    - name: Build packages
+      # Skip docs build - Vercel handles docs deployment separately
+      run: pnpm build:packages
       shell: bash


### PR DESCRIPTION
## Summary
- Adds the missing `pnpm extract-intl` step to the CI action, which generates gitignored `*.messages.ts` and `intl/*.ts` files required at build time
- Splits the single chained build command into separate named steps for better visibility in the GitHub Actions UI

## Root cause

PR #987 (`53b01dcda`, Jan 30) migrated i18n from `react-intl` to compile-time message parsing. As part of that change, all generated `*.messages.ts` and `intl/*.ts` files were removed from git and added to `.gitignore` — but the CI action was not updated to run `pnpm extract-intl` before building.

This went unnoticed because no PR since #987 had introduced a new i18n import. All existing components already had their `*.messages.ts` files present at the time of the merge, and no new ones were added — until the toast component.

The toast PR (#1072) initially had a `// TODO` placeholder for i18n. Once the actual `toast.messages` import was wired up (`1aa61fd62`), CI failed with:

```
Could not resolve "./toast.messages" from "src/components/toast/toast.outlet.tsx"
```

This would also break for any future PR that adds i18n to a new or existing component.

## Test plan
- [ ] CI build passes on this PR
- [ ] Verify the three build steps appear separately in GitHub Actions UI