### PR TITLE
fix(docs): replace npx tsx with pnpm tsx in build:docs script

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm run build:docs && pnpm run build:app && pnpm run copy-index",
-    "build:docs": "npx tsx ./scripts/build.ts",
+    "build:docs": "pnpm tsx ./scripts/build.ts",
     "build:app": "vite build",
     "copy-index": "cp dist/index.html dist/404.html",
     "dev": "pnpm tsx ./scripts/dev.ts",


### PR DESCRIPTION
## 🐛 Problem

Running `npx tsx ./scripts/build.ts` (the `build:docs` script) produces a stream of npm warnings:

```
npm warn Unknown env config "recursive". This will stop working in the next major version of npm.
npm warn Unknown env config "catalog-mode". This will stop working in the next major version of npm.
npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
npm warn Unknown env config "catalog". This will stop working in the next major version of npm.
npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
npm warn Unknown env config "catalogs". This will stop working in the next major version of npm.
npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
```

**🔍 Root cause:** `npx` delegates execution to npm, which reads `.npmrc` and emits warnings for every pnpm-specific key it doesn't recognise. These warnings will become **💥 hard errors** in the next npm major version.

## ✅ Fix

Replace `npx tsx` with `pnpm tsx` in the `build:docs` script.

- 📦 `tsx` is already declared as a workspace dependency (`catalog:tooling`) — no new dependency needed.
- 🤝 The sibling `dev` script in the same file already uses `pnpm tsx`, so this makes both scripts consistent.
- 🧠 Routing execution through `pnpm` means `.npmrc` is interpreted by pnpm, which understands all project config keys.

## 🔧 Change

```diff
- "build:docs": "npx tsx ./scripts/build.ts",
+ "build:docs": "pnpm tsx ./scripts/build.ts",
```

## 🧪 Test plan

- [ ] Run `pnpm --filter docs build:docs` — no npm warnings should appear 🔇
- [ ] Verify docs site builds successfully as before 🏗️