### PR TITLE
fix(bundle): replace action

### DIFF
--- a/.github/workflows/update-bundle-baseline.yml
+++ b/.github/workflows/update-bundle-baseline.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Update bundle size baseline
         run: node scripts/check-bundle-size.mjs --update-baseline
 
-      - uses: step-security/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: update bundle size baseline [skip ci]"
           file_pattern: "packages/nimbus/bundle-size-baseline.json"


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change switches the action used for automatically committing updates to the bundle size baseline.

- Workflow update:
  * In `.github/workflows/update-bundle-baseline.yml`, replaced the `step-security/git-auto-commit-action` with `stefanzweifel/git-auto-commit-action` for committing updates to the bundle size baseline.