### PR TITLE
fix(docs): forward SIGINT/SIGTERM to child processes in dev server

### DIFF
--- a/apps/docs/scripts/dev.ts
+++ b/apps/docs/scripts/dev.ts
@@ -17,6 +17,14 @@ const mdxWatcher = spawn("pnpm", ["tsx", "./scripts/watcher.ts"], {
   stdio: "inherit",
 });
 
+function killChildren() {
+  viteProcess.kill();
+  mdxWatcher.kill();
+}
+
+process.on("SIGINT", killChildren);
+process.on("SIGTERM", killChildren);
+
 function waitForExit() {
   return new Promise((resolve) => {
     viteProcess.on("exit", resolve);


### PR DESCRIPTION
## Summary

- `apps/docs/scripts/dev.ts` spawned `vite` and the MDX watcher as child processes but never forwarded termination signals to them
- Killing the terminal left both processes orphaned, keeping `http://localhost:5173` alive after the developer intended to stop the server
- Adds `SIGINT` and `SIGTERM` handlers that call `.kill()` on both children

## Test plan

- [x] Run `pnpm start:docs`
- [x] Confirm the docs site is reachable at `http://localhost:5173`
- [x] Kill the process (Ctrl+C or close terminal)
- [x] Confirm `http://localhost:5173` is no longer reachable

Fixes [CRAFT-2154](https://commercetools.atlassian.net/browse/CRAFT-2154)

[CRAFT-2154]: https://commercetools.atlassian.net/browse/CRAFT-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ