### PR TITLE
CRAFT-2100: audit and fix broken, incorrect, inconsistent component docs links

### DIFF
--- a/packages/nimbus/src/components/accordion/accordion.dev.mdx
+++ b/packages/nimbus/src/components/accordion/accordion.dev.mdx
@@ -482,5 +482,5 @@ application-specific logic.
 ## Resources
 
 - [Accordion Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-accordion--docs)
-- [React Aria DisclosureGroup Documentation](https://react-aria.adobe.com/DisclosureGroup)
+- [React Aria DisclosureGroup Documentation](https://react-spectrum.adobe.com/react-aria/DisclosureGroup.html)
 - [WAI-ARIA Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)

--- a/packages/nimbus/src/components/button/button.dev.mdx
+++ b/packages/nimbus/src/components/button/button.dev.mdx
@@ -216,5 +216,5 @@ These examples demonstrate how to test your implementation when using Button in 
 ## Resources
 
 - [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-buttons-button--docs)
-- [React Aria Button](https://react-spectrum.adobe.com/react-aria/useButton.html)
+- [React Aria Button](https://react-spectrum.adobe.com/react-aria/Button.html)
 

--- a/packages/nimbus/src/components/date-picker/date-picker.dev.mdx
+++ b/packages/nimbus/src/components/date-picker/date-picker.dev.mdx
@@ -24,7 +24,7 @@ const App = () => (
 
 ## Working with date values
 
-The DatePicker component relies on [`@internationalized/date`](https://react-spectrum.adobe.com/internationalized/date/index.html)'s date types for type-safe date handling. This library provides calendar-system-aware date representations that work correctly across different locales and time zones.
+The DatePicker component relies on [`@internationalized/date`](https://react-spectrum.adobe.com/internationalized/date/)'s date types for type-safe date handling. This library provides calendar-system-aware date representations that work correctly across different locales and time zones.
 
 ### Date types
 

--- a/packages/nimbus/src/components/date-range-picker/date-range-picker.dev.mdx
+++ b/packages/nimbus/src/components/date-range-picker/date-range-picker.dev.mdx
@@ -97,9 +97,6 @@ type DateRange = {
 // start and end to avoid semantic issues.
 ```
 
-> [!TIP]\
-> See [Adobe's @internationalized/date documentation](https://react-spectrum.adobe.com/internationalized/date/index.html) for complete API reference and advanced usage.
-
 ## Usage examples
 
 ### Size options

--- a/packages/nimbus/src/components/icon-toggle-button/icon-toggle-button.dev.mdx
+++ b/packages/nimbus/src/components/icon-toggle-button/icon-toggle-button.dev.mdx
@@ -361,4 +361,4 @@ These examples demonstrate how to test your implementation when using IconToggle
 ## Resources
 
 - [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-buttons-icontogglebutton--docs)
-- [React Aria ToggleButton](https://react-aria.adobe.com/ToggleButton)
+- [React Aria ToggleButton](https://react-spectrum.adobe.com/react-aria/ToggleButton.html)

--- a/packages/nimbus/src/components/icon/icon.dev.mdx
+++ b/packages/nimbus/src/components/icon/icon.dev.mdx
@@ -434,6 +434,6 @@ These examples demonstrate how to test your implementation when using Icon withi
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-icon--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-icon--docs)
 - [Material Design Icons](https://fonts.google.com/icons)
 - [ARIA Authoring Practices - Icon Usage](https://www.w3.org/WAI/ARIA/apg/)

--- a/packages/nimbus/src/components/link/link.dev.mdx
+++ b/packages/nimbus/src/components/link/link.dev.mdx
@@ -272,5 +272,5 @@ These examples demonstrate how to test your implementation when using Link withi
 ## Resources
 
 - [Link Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-link--docs)
-- [React Aria Link](https://react-aria.adobe.com/Link)
+- [React Aria Link](https://react-spectrum.adobe.com/react-aria/Link.html)
 - [WCAG Link Guidelines](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.dev.mdx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.dev.mdx
@@ -96,5 +96,5 @@ These examples demonstrate how to test your implementation when using LoadingSpi
 ## Resources
 
 - [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-loadingspinner--docs)
-- [React Aria ProgressBar](https://react-spectrum.adobe.com/react-aria/useProgressBar.html)
+- [React Aria ProgressBar](https://react-spectrum.adobe.com/react-aria/ProgressBar.html)
 

--- a/packages/nimbus/src/components/spacer/spacer.dev.mdx
+++ b/packages/nimbus/src/components/spacer/spacer.dev.mdx
@@ -375,7 +375,7 @@ These examples demonstrate how to test your implementation when using Spacer wit
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-spacer--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-spacer--docs)
 - [Chakra UI Box](https://chakra-ui.com/docs/components/box)
 - [CSS Flexbox Guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 - [Stack Component](/components/layout/stack)

--- a/packages/nimbus/src/components/split-button/split-button.dev.mdx
+++ b/packages/nimbus/src/components/split-button/split-button.dev.mdx
@@ -531,7 +531,7 @@ These examples demonstrate how to test your implementation when using SplitButto
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-buttons-splitbutton--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-buttons-splitbutton--docs)
 - [React Aria Menu](https://react-spectrum.adobe.com/react-aria/Menu.html)
 - [ARIA Menu Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/)
 - [Menu Component](/components/navigation/menu)

--- a/packages/nimbus/src/components/stack/stack.dev.mdx
+++ b/packages/nimbus/src/components/stack/stack.dev.mdx
@@ -436,7 +436,7 @@ These examples demonstrate how to test your implementation when using Stack with
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-stack--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-stack--docs)
 - [Chakra UI Stack Documentation](https://www.chakra-ui.com/docs/components/stack)
 - [Box Component](/components/layout/box)
 - [Flex Component](/components/layout/flex)

--- a/packages/nimbus/src/components/switch/switch.dev.mdx
+++ b/packages/nimbus/src/components/switch/switch.dev.mdx
@@ -359,7 +359,7 @@ These examples demonstrate how to test your implementation when using Switch wit
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-switch--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-switch--docs)
 - [React Aria Switch](https://react-spectrum.adobe.com/react-aria/useSwitch.html)
 - [WAI-ARIA Switch Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/switch/)
 - [ARIA: switch role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role)

--- a/packages/nimbus/src/components/time-input/time-input.dev.mdx
+++ b/packages/nimbus/src/components/time-input/time-input.dev.mdx
@@ -70,7 +70,7 @@ time.second;   // 0
 ```
 
 > [!TIP]\
-> See [@internationalized/date documentation](https://react-spectrum.adobe.com/internationalized/date/index.html) for complete API reference and advanced usage.
+> See [@internationalized/date documentation](https://react-spectrum.adobe.com/internationalized/date/) for complete API reference and advanced usage.
 
 ## Usage examples
 
@@ -670,6 +670,6 @@ These examples demonstrate how to test your implementation when using TimeInput 
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-timeinput--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-timeinput--docs)
 - [React Aria TimeField](https://react-spectrum.adobe.com/react-aria/TimeField.html)
-- [@internationalized/date documentation](https://react-spectrum.adobe.com/internationalized/date/index.html)
+- [@internationalized/date documentation](https://react-spectrum.adobe.com/internationalized/date/)

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.dev.mdx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.dev.mdx
@@ -459,5 +459,5 @@ These examples demonstrate how to test your implementation when using ToggleButt
 ## Resources
 
 - [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-buttons-togglebuttongroup--docs)
-- [React Aria ToggleButton](https://react-aria.adobe.com/ToggleButton)
+- [React Aria ToggleButton](https://react-spectrum.adobe.com/react-aria/ToggleButton.html)
 - [ARIA: radio role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role)

--- a/packages/nimbus/src/components/toggle-button/toggle-button.dev.mdx
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.dev.mdx
@@ -459,7 +459,7 @@ These examples demonstrate how to test your implementation when using ToggleButt
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook-commercetools.vercel.app/?path=/docs/components-buttons-togglebutton--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-buttons-togglebutton--docs)
 - [React Aria ToggleButton](https://react-spectrum.adobe.com/react-aria/ToggleButton.html)
 - [ARIA Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
 - [Button Component](/components/buttons/button)


### PR DESCRIPTION
This PR performs an audit and consolidation of component docs links:

## Summary                                                                                                                                                                      
                                                                                                                                                                             
  - Fix 4 broken react-aria.adobe.com links → react-spectrum.adobe.com/react-aria/                                                                                             
  - Fix 7 Storybook links using wrong domain (nimbus-storybook-commercetools → nimbus-storybook)                                                                               
  - Fix 2 outdated hook-based React Aria URLs (useButton.html → Button.html, useProgressBar.html → ProgressBar.html)                                                           
  - Remove duplicate @internationalized/date callout in date-range-picker docs                          
  - Normalize @internationalized/date URLs to consistent format (remove index.html) across 3 files

## Test plan

  - Grep confirms zero remaining matches for react-aria.adobe.com, nimbus-storybook-commercetools, useButton.html, useProgressBar.html, and internationalized/date/index.html
  - Spot-checked corrected React Aria URLs via Playwright — pages resolve correctly
  - pnpm build:docs passes without regressions

Addresses [CRAFT-2100](https://commercetools.atlassian.net/jira/software/c/projects/CRAFT/boards/362?selectedIssue=CRAFT-2100) 

[CRAFT-2100]: https://commercetools.atlassian.net/browse/CRAFT-2100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ