### PR TITLE
fix(bundle-workflow): mark workspace as safe and allow manual triggering

### DIFF
--- a/.github/workflows/update-bundle-baseline.yml
+++ b/.github/workflows/update-bundle-baseline.yml
@@ -1,6 +1,7 @@
 name: Update Bundle Size Baseline
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -19,6 +20,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: ./.github/actions/ci
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for maintaining the bundle size baseline. The changes improve manual triggering options and ensure the workspace is properly configured for git operations.

Workflow enhancements:

* Added `workflow_dispatch` to the `.github/workflows/update-bundle-baseline.yml` file, allowing the workflow to be triggered manually in addition to on pushes to `main`.

Git configuration improvements:

* Added a step to mark the workspace as safe for git by running `git config --global --add safe.directory "$GITHUB_WORKSPACE"`, preventing potential git safety errors during workflow execution.