### PR TITLE
chore(dependabot): group dependency updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,69 @@ updates:
       timezone: "Europe/Berlin" # Optional: Specify timezone for the schedule time
     labels:
       - "dependencies"
+    groups:
+      # React ecosystem: react, react-dom, emotion, chakra-ui, next-themes
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@emotion/*"
+          - "@chakra-ui/*"
+          - "next-themes"
+      # React Aria / React Stately / Internationalized packages
+      react-aria:
+        patterns:
+          - "react-aria"
+          - "react-aria-components"
+          - "react-stately"
+          - "@react-aria/*"
+          - "@react-types/*"
+          - "@react-stately/*"
+          - "@internationalized/*"
+      # Storybook and its addons
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+          - "@vueless/storybook-dark-mode"
+          - "eslint-plugin-storybook"
+      # Vitest, Playwright and testing libraries
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "playwright"
+          - "@playwright/*"
+          - "jsdom"
+          - "@testing-library/*"
+      # Vite, Rollup and build tooling
+      build-tooling:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vite-*"
+          - "rollup"
+          - "rollup-*"
+          - "@preconstruct/*"
+          - "vite-bundle-analyzer"
+      # TypeScript, ESLint, Prettier and code quality tools
+      linting-and-types:
+        patterns:
+          - "typescript"
+          - "typescript-eslint"
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-*"
+          - "prettier"
+          - "globals"
+          - "glob"
+          - "tsx"
+      # Babel transpilation packages
+      babel:
+        patterns:
+          - "@babel/*"
     ignore:
       # @types/node version must match Node.js runtime version (v24 LTS)
       # Upgrading to @types/node@25+ would add types for APIs not available in our runtime


### PR DESCRIPTION
## Summary

Dependabot was opening individual PRs per package (or small batches), which quickly consumed the 5 open PR limit and created a lot of noise. This change adds \`groups\` to the Dependabot config so that related packages are always batched into a single PR.

**7 groups defined, each mapping to a logical ecosystem:**

| Group | Covers |
|---|---|
| \`react\` | react, react-dom, @types/react\*, @emotion/\*, @chakra-ui/\*, next-themes |
| \`react-aria\` | react-aria\*, react-stately\*, @react-aria/\*, @react-types/\*, @internationalized/\* |
| \`storybook\` | storybook, @storybook/\*, eslint-plugin-storybook, dark-mode addon |
| \`testing\` | vitest, @vitest/\*, playwright, jsdom, @testing-library/\* |
| \`build-tooling\` | vite, @vitejs/\*, rollup\*, @preconstruct/\*, vite-\* plugins |
| \`linting-and-types\` | typescript\*, eslint\*, prettier, globals, glob, tsx |
| \`babel\` | @babel/\* |

Groups were derived directly from the catalogs defined in \`pnpm-workspace.yaml\`, so they reflect the logical groupings already established in the project.

Each group counts as 1 PR against the open PR limit, regardless of how many packages are inside. In the best case this means ≤7 grouped PRs + a handful of ungrouped ones (e.g. \`dequal\`, \`dompurify\`, \`lodash\`) — well within the 5-per-interval limit per group.

This also fixes a concrete problem we had: Storybook packages like \`storybook\`, \`@storybook/addon-docs\`, \`@storybook/addon-vitest\`, etc. are always released together at the same version, but Dependabot was updating them in separate PRs. With the 5-PR cap, some would get merged while others were deferred, leaving the Storybook packages out of sync until the next cycle caught up. Grouping ensures all Storybook packages (and similarly co-versioned ecosystems like Vitest) are always updated atomically in a single PR.

## Test plan

- No code changes — config only
- Verify next Dependabot run produces grouped PRs instead of individual ones