### PR TITLE
fix(docs): properly terminate dev-server processes on SIGINT/SIGTERM

### DIFF
--- a/apps/docs/scripts/dev.ts
+++ b/apps/docs/scripts/dev.ts
@@ -17,13 +17,14 @@ const mdxWatcher = spawn("pnpm", ["tsx", "./scripts/watcher.ts"], {
   stdio: "inherit",
 });
 
-function killChildren() {
+function cleanup() {
   viteProcess.kill();
   mdxWatcher.kill();
+  process.exit();
 }
 
-process.on("SIGINT", killChildren);
-process.on("SIGTERM", killChildren);
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);
 
 function waitForExit() {
   return new Promise((resolve) => {

--- a/apps/docs/scripts/watcher.ts
+++ b/apps/docs/scripts/watcher.ts
@@ -240,6 +240,16 @@ watcher
     console.error("Error watching files:", error)
   );
 
+// Graceful shutdown — close chokidar and cancel pending debounced work
+function shutdown() {
+  writeManifestAndSearch.cancel();
+  handleTypeChange.cancel();
+  watcher.close().then(() => process.exit());
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
 // Log watcher status
 const clr = "\x1b[33m%s\x1b[0m";
 console.log(clr, "\n----------------------------------------------------");


### PR DESCRIPTION
## Summary

Fixes zombie dev-server processes that survive Ctrl+C, consuming CPU and producing stale output.

## Why the previous fix (#1115) didn't work

PR #1115 added SIGINT/SIGTERM handlers to `dev.ts` that called `.kill()` on child processes. However, registering a custom `SIGINT` handler in Node.js **overrides the default behavior** — which is to exit the process. The handler killed the children but never called `process.exit()`, so `dev.ts` itself (and its parent `tsx`/`pnpm` chain) stayed alive indefinitely after Ctrl+C.

Additionally, `watcher.ts` had no signal handling at all. Chokidar's `usePolling: true` kept its event loop alive, and in-flight debounced callbacks (manifest generation, type parsing) could still fire after the signal — producing "[TSX] Updated component types" and "[MDX]" output after the dev-server appeared stopped.

## What this PR does

- **`dev.ts`**: Calls `process.exit()` after killing children, so the entire parent process tree terminates
- **`watcher.ts`**: Adds SIGINT/SIGTERM handlers that cancel pending lodash debounced work and close chokidar before exiting

## Test plan

- [x] Run `pnpm start:docs`, press Ctrl+C, then run `pgrep -la "vite|watcher|tsx"` — no leftover processes
- [x] Open a file in the IDE after stopping the dev-server — no "[MDX]" or "[TSX]" output appears
- [x] Start and stop the dev-server multiple times — no duplicate output from stacked zombie watchers