### PR TITLE
fix(nimbus): use absolute paths for vitest project references

### DIFF
--- a/packages/nimbus/vitest.config.ts
+++ b/packages/nimbus/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "path";
 
 /**
  * Root Vitest configuration that orchestrates multiple test projects.
@@ -11,9 +12,9 @@ export default defineConfig({
   test: {
     projects: [
       // Storybook tests (browser-based)
-      "./vitest.storybook.config.ts",
+      resolve(__dirname, "./vitest.storybook.config.ts"),
       // Unit tests (JSDOM-based)
-      "./vitest.unit.config.ts",
+      resolve(__dirname, "./vitest.unit.config.ts"),
     ],
   },
 });


### PR DESCRIPTION
> [!NOTE]
> When debugging flaky tests of the rich-text-input, I noticed that it's not possible to run the storybook tests from within storybook anymore, this PR addresses the issue

## Summary

- Fixes a startup error when running tests from within the Storybook dev server via `@storybook/addon-vitest`
- The addon was resolving relative project paths against the config file path itself (treating it as a directory), producing invalid paths like `vitest.config.ts/vitest.storybook.config.ts`
- Switching to `resolve(__dirname, ...)` makes the paths absolute so Vitest resolves them correctly regardless of how the addon invokes the config

## Root Cause

`@storybook/addon-vitest` starts Vitest internally and passes the `vitest.config.ts` path as the entry point. Vitest then tried to resolve the relative `projects` entries (`"./vitest.storybook.config.ts"`) relative to that path — treating the config filename as a directory — producing the broken path.

## Error before fix

```
Projects definition references a non-existing file or a directory:
/Volumes/Code/nimbus/packages/nimbus/vitest.config.ts/vitest.storybook.config.ts
```

## Test plan

- [ ] Start Storybook dev server (`pnpm storybook`) and open the test panel — Vitest should start without the path resolution error
- [ ] Run unit tests via `pnpm test:unit` to confirm the unit config still resolves correctly
- [ ] Run storybook tests via `pnpm test:storybook` to confirm the storybook config still resolves correctly