### PR TITLE
fix: remove @fission-ai/openspec from onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     },
     "onlyBuiltDependencies": [
       "@bundled-es-modules/glob",
-      "@fission-ai/openspec",
       "@swc/core",
       "es5-ext",
       "esbuild",


### PR DESCRIPTION
## Summary

- Removes `@fission-ai/openspec` from `pnpm.onlyBuiltDependencies` in the root `package.json`

## Background

This entry was accidentally introduced via #1125. It was previously proposed in #1138 and explicitly rejected after a security review: the package's postinstall script modifies `~/.zshrc` or `~/.bashrc` to install shell tab completions, which reaches into the user's home directory. While the current version is not actively harmful, it creates a supply chain risk if the package were ever compromised. The decision in #1138 was to accept the pnpm warning rather than allow the postinstall to run.

Closes the regression introduced by #1125.