### PR TITLE
feat(drawer): add shouldDelayOnClose prop

### DIFF
--- a/.changeset/drawer-fullscreen-delay-close.md
+++ b/.changeset/drawer-fullscreen-delay-close.md
@@ -1,7 +1,7 @@
 ---
-"@commercetools/nimbus": minor
+"@commercetools/nimbus": patch
 ---
 
-Add `shouldDelayOnClose` to Drawer component. When `true`, backdrop dismissal is
-disabled while Escape and close buttons still fire `onOpenChange(false)`,
-allowing close attempts to be intercepted for unsaved changes confirmation.
+Add documentation and story for intercepting Drawer close attempts using
+`isDismissable` with controlled mode, demonstrating the unsaved changes
+confirmation pattern.

--- a/packages/nimbus/src/components/drawer/components/drawer.content.tsx
+++ b/packages/nimbus/src/components/drawer/components/drawer.content.tsx
@@ -26,29 +26,23 @@ export const DrawerContent = (props: DrawerContentProps) => {
     isDismissable = true, // Default to true so clicking outside closes the drawer
     isKeyboardDismissDisabled,
     shouldCloseOnInteractOutside,
-    shouldDelayOnClose = false,
     isOpen,
     onOpenChange,
     defaultOpen,
   } = useDrawerRootContext();
-
-  // When shouldDelayOnClose is true, disable backdrop dismissal to prevent
-  // accidental close. Escape key and close buttons still fire onOpenChange(false),
-  // allowing the consumer to show confirmation before closing.
-  const effectiveIsDismissable = shouldDelayOnClose ? false : isDismissable;
 
   // When there's a Drawer.Trigger, DialogTrigger manages state via React Context
   // When there's NO Drawer.Trigger, ModalOverlay must manage its own state
   const modalProps = hasDrawerTrigger
     ? {
         // With trigger: Only pass dismissal props, state is managed by DialogTrigger
-        isDismissable: effectiveIsDismissable,
+        isDismissable,
         isKeyboardDismissDisabled,
         shouldCloseOnInteractOutside,
       }
     : {
         // Without trigger: Pass state management props to ModalOverlay
-        isDismissable: effectiveIsDismissable,
+        isDismissable,
         isKeyboardDismissDisabled,
         shouldCloseOnInteractOutside,
         isOpen,

--- a/packages/nimbus/src/components/drawer/drawer.dev.mdx
+++ b/packages/nimbus/src/components/drawer/drawer.dev.mdx
@@ -253,9 +253,9 @@ const App = () => (
 - `isKeyboardDismissDisabled={false}`: Allow closing with Escape key (default: false)
 - Both can be combined for fine-grained control
 
-### Preventing accidental close with shouldDelayOnClose
+### Intercepting close for unsaved changes
 
-Use `shouldDelayOnClose` to prevent accidental closing when forms have unsaved changes. When enabled, backdrop click is disabled. Escape key and close buttons still fire `onOpenChange(false)`, allowing close attempts to be intercepted:
+Use `isDismissable={false}` with controlled mode to prevent accidental closing when forms have unsaved changes. Backdrop click is disabled, while Escape key and close buttons still fire `onOpenChange(false)`, allowing close attempts to be intercepted:
 
 ```jsx live-dev
 const App = () => {
@@ -282,7 +282,7 @@ const App = () => {
       <Drawer.Root
         isOpen={isOpen}
         onOpenChange={handleOpenChange}
-        shouldDelayOnClose={hasUnsavedChanges}
+        isDismissable={!hasUnsavedChanges}
         placement="right"
       >
         <Drawer.Content>
@@ -328,9 +328,9 @@ const App = () => {
 ```
 
 **Key behavior:**
-- `shouldDelayOnClose={true}`: Backdrop click is disabled. Escape and close buttons fire `onOpenChange(false)` which can be intercepted to show a confirmation dialog.
-- Requires controlled mode (`isOpen` + `onOpenChange`)
-- The drawer stays open as long as `isOpen` is not set to `false`
+- `isDismissable={false}`: Backdrop click is disabled. Escape and close buttons still fire `onOpenChange(false)` which can be intercepted to show a confirmation dialog.
+- Combine with controlled mode (`isOpen` + `onOpenChange`) to intercept close attempts
+- Toggle `isDismissable` dynamically based on form state (e.g. `isDismissable={!hasUnsavedChanges}`)
 
 ### Uncontrolled mode
 

--- a/packages/nimbus/src/components/drawer/drawer.guidelines.mdx
+++ b/packages/nimbus/src/components/drawer/drawer.guidelines.mdx
@@ -16,8 +16,9 @@ experience.
 - **Keep content focused**: Drawers should have a single, clear purpose
 - **Provide clear actions**: Always include obvious ways to proceed or dismiss
 - **Make dismissal easy**: Support Escape key, close buttons, and click-outside
-  behavior. For forms with unsaved changes, use `shouldDelayOnClose` to intercept
-  close attempts and show a confirmation before discarding data
+  behavior. For forms with unsaved changes, use `isDismissable={false}` with
+  controlled mode to intercept close attempts and show a confirmation before
+  discarding data
 - **Maintain focus flow**: Focus should move logically through interactive
   elements
 - **Size appropriately**: Choose sizes that fit your content without

--- a/packages/nimbus/src/components/drawer/drawer.stories.tsx
+++ b/packages/nimbus/src/components/drawer/drawer.stories.tsx
@@ -983,11 +983,12 @@ export const NestedDrawers: Story = {
 };
 
 /**
- * Drawer with shouldDelayOnClose prevents accidental closing when forms have
- * unsaved changes. Backdrop click is disabled. Escape key and close buttons
- * still fire onOpenChange(false), allowing the close attempt to be intercepted.
+ * Demonstrates intercepting close attempts for unsaved changes confirmation.
+ * Uses `isDismissable={false}` to disable backdrop click while Escape key
+ * and close buttons still fire `onOpenChange(false)`, which is intercepted
+ * to show a confirmation dialog before closing.
  */
-export const ShouldDelayOnClose: Story = {
+export const UnsavedChangesConfirmation: Story = {
   args: {},
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
@@ -1023,7 +1024,7 @@ export const ShouldDelayOnClose: Story = {
         <Drawer.Root
           isOpen={isOpen}
           onOpenChange={handleOpenChange}
-          shouldDelayOnClose={hasUnsavedChanges}
+          isDismissable={!hasUnsavedChanges}
           placement="right"
         >
           <Drawer.Content>
@@ -1071,7 +1072,7 @@ export const ShouldDelayOnClose: Story = {
                 )}
 
                 <Text>
-                  When <Code>shouldDelayOnClose</Code> is <Code>true</Code>,
+                  When <Code>isDismissable</Code> is <Code>false</Code>,
                   backdrop click is disabled. Escape key and close buttons still
                   fire <Code>onOpenChange(false)</Code>, which is intercepted to
                   show a confirmation dialog.

--- a/packages/nimbus/src/components/drawer/drawer.types.ts
+++ b/packages/nimbus/src/components/drawer/drawer.types.ts
@@ -100,17 +100,6 @@ export type DrawerRootProps = OmitInternalProps<DrawerRootSlotProps> & {
    */
   showBackdrop?: boolean;
 
-  /**
-   * When true, disables backdrop click dismissal. Escape key and close buttons
-   * still fire `onOpenChange(false)`, allowing close attempts to be intercepted
-   * (e.g., to show an "unsaved changes" confirmation before closing).
-   *
-   * Requires controlled mode (`isOpen` + `onOpenChange`).
-   *
-   * @default false
-   */
-  shouldDelayOnClose?: boolean;
-
   /** A Title for the drawer, optional, as long as the Drawer.Title component is used
    * or there is a Heading component used inside the Drawer with
    * a `slot`-property set to `title`.


### PR DESCRIPTION
## Summary

- Removes `shouldDelayOnClose` prop — it was functionally identical to `isDismissable={false}`
- Adds documentation and story demonstrating the unsaved changes confirmation pattern using existing `isDismissable` + controlled mode
- No new API surface; the pattern uses props already exposed by `Drawer.Root`

## Design Decision

The `shouldDelayOnClose` prop was removed because it added API surface without adding behavior. The existing `isDismissable` prop (passed through to React Aria's `ModalOverlay`) already controls backdrop dismissal, and controlled mode (`isOpen` + `onOpenChange`) already allows intercepting close attempts. Documentation now teaches this pattern directly.

The `variant="fullscreen"` originally included in this PR has been **removed**. The fullscreen layout is specific to the upcoming `ModalPage` component (CRAFT-2188) and has no standalone use case on `Drawer`.

## Test plan

- [x] Open the `UnsavedChangesConfirmation` story — clicking the backdrop should not close the drawer
- [x] Escape key and close button still call `onOpenChange(false)` so the consumer can intercept
- [x] Toggling "Has unsaved changes" off restores normal backdrop-dismiss behavior (`isDismissable={true}`)
- [x] Existing drawer sizes, placements, and dismissal behavior are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)