### PR TITLE
feat(nimbus): add semantic tags to component MDX frontmatter

### DIFF
--- a/packages/nimbus/src/components/accordion/accordion.mdx
+++ b/packages/nimbus/src/components/accordion/accordion.mdx
@@ -13,6 +13,10 @@ menu:
   - Accordion
 tags:
   - component
+  - accordion
+  - expandable
+  - disclosure
+  - panels
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=2702-5711&t=kxCRBAio5yKpfcU0-4
 ---

--- a/packages/nimbus/src/components/alert/alert.mdx
+++ b/packages/nimbus/src/components/alert/alert.mdx
@@ -13,6 +13,10 @@ menu:
   - Alert
 tags:
   - component
+  - alert
+  - notification
+  - status
+  - banner
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=2702-5723
 ---

--- a/packages/nimbus/src/components/avatar/avatar.mdx
+++ b/packages/nimbus/src/components/avatar/avatar.mdx
@@ -12,6 +12,10 @@ menu:
   - Avatar
 tags:
   - component
+  - avatar
+  - user
+  - profile
+  - image
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=346-2611&t=WljaKGkdJ1dZn3oM-4
 ---

--- a/packages/nimbus/src/components/badge/badge.mdx
+++ b/packages/nimbus/src/components/badge/badge.mdx
@@ -13,6 +13,10 @@ menu:
   - Badge
 tags:
   - component
+  - badge
+  - label
+  - status
+  - indicator
 ---
 
 # Badge

--- a/packages/nimbus/src/components/box/box.mdx
+++ b/packages/nimbus/src/components/box/box.mdx
@@ -12,6 +12,10 @@ menu:
   - Box
 tags:
   - component
+  - box
+  - container
+  - wrapper
+  - layout
 ---
 
 # Box

--- a/packages/nimbus/src/components/calendar/calendar.mdx
+++ b/packages/nimbus/src/components/calendar/calendar.mdx
@@ -14,6 +14,10 @@ menu:
   - Calendar
 tags:
   - component
+  - calendar
+  - date
+  - picker
+  - month
 ---
 
 # Calendar

--- a/packages/nimbus/src/components/card/card.mdx
+++ b/packages/nimbus/src/components/card/card.mdx
@@ -12,6 +12,10 @@ menu:
   - Card
 tags:
   - component
+  - card
+  - container
+  - surface
+  - content
 figmaLink: >-
   https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=1793-8790&m=dev
 ---

--- a/packages/nimbus/src/components/checkbox/checkbox.mdx
+++ b/packages/nimbus/src/components/checkbox/checkbox.mdx
@@ -13,6 +13,10 @@ menu:
   - Checkbox
 tags:
   - component
+  - checkbox
+  - input
+  - toggle
+  - boolean
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=346-2571&t=WljaKGkdJ1dZn3oM-4
 ---

--- a/packages/nimbus/src/components/code/code.mdx
+++ b/packages/nimbus/src/components/code/code.mdx
@@ -11,7 +11,10 @@ menu:
   - Typography
   - Code
 tags:
+  - component
   - code
+  - syntax
+  - monospace
 
 ---
 

--- a/packages/nimbus/src/components/combobox/combobox.mdx
+++ b/packages/nimbus/src/components/combobox/combobox.mdx
@@ -12,6 +12,10 @@ menu:
   - Combo box
 tags:
   - component
+  - combobox
+  - autocomplete
+  - dropdown
+  - typeahead
 ---
 
 # Combo box input

--- a/packages/nimbus/src/components/form-field/form-field.mdx
+++ b/packages/nimbus/src/components/form-field/form-field.mdx
@@ -12,6 +12,10 @@ menu:
   - Form field
 tags:
   - component
+  - form
+  - field
+  - label
+  - input wrapper
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=349-2635&m=dev
 ---

--- a/packages/nimbus/src/components/grid/grid.mdx
+++ b/packages/nimbus/src/components/grid/grid.mdx
@@ -14,6 +14,10 @@ menu:
   - Grid
 tags:
   - component
+  - grid
+  - layout
+  - columns
+  - rows
 ---
 
 # Grid

--- a/packages/nimbus/src/components/group/group.mdx
+++ b/packages/nimbus/src/components/group/group.mdx
@@ -13,6 +13,10 @@ menu:
   - Group
 tags:
   - component
+  - group
+  - fieldset
+  - form
+  - cluster
 ---
 
 # Group

--- a/packages/nimbus/src/components/icon/icon.mdx
+++ b/packages/nimbus/src/components/icon/icon.mdx
@@ -12,6 +12,10 @@ menu:
   - Icon
 tags:
   - component
+  - icon
+  - svg
+  - graphic
+  - symbol
 ---
 
 # Icon

--- a/packages/nimbus/src/components/link/link.mdx
+++ b/packages/nimbus/src/components/link/link.mdx
@@ -12,6 +12,10 @@ menu:
   - Link
 tags:
   - component
+  - link
+  - anchor
+  - navigation
+  - href
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=384-5726
 ---

--- a/packages/nimbus/src/components/list/list.mdx
+++ b/packages/nimbus/src/components/list/list.mdx
@@ -11,8 +11,11 @@ menu:
   - Typography
   - List
 tags:
+  - component
   - list
   - collections
+  - ordered
+  - unordered
 ---
 
 # List

--- a/packages/nimbus/src/components/menu/menu.mdx
+++ b/packages/nimbus/src/components/menu/menu.mdx
@@ -12,6 +12,10 @@ menu:
   - Menu
 tags:
   - component
+  - menu
+  - dropdown
+  - actions
+  - context menu
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=346-2569
 ---

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.mdx
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.mdx
@@ -10,9 +10,11 @@ menu:
   - Utilities
   - Nimbus provider
 tags:
+  - component
   - system
-  - required
+  - provider
   - setup
+  - theme
 
 ---
 

--- a/packages/nimbus/src/components/number-input/number-input.mdx
+++ b/packages/nimbus/src/components/number-input/number-input.mdx
@@ -12,6 +12,10 @@ menu:
   - Number input
 tags:
   - component
+  - number
+  - input
+  - numeric
+  - stepper
 ---
 
 # Number input

--- a/packages/nimbus/src/components/pagination/pagination.mdx
+++ b/packages/nimbus/src/components/pagination/pagination.mdx
@@ -13,6 +13,10 @@ menu:
   - Pagination
 tags:
   - component
+  - pagination
+  - paging
+  - navigation
+  - pages
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system
   

--- a/packages/nimbus/src/components/password-input/password-input.mdx
+++ b/packages/nimbus/src/components/password-input/password-input.mdx
@@ -13,9 +13,11 @@ menu:
   - Inputs
   - Password input
 tags:
+  - component
   - forms
   - password
   - input
+  - secure
 ---
 
 # Password input

--- a/packages/nimbus/src/components/radio-input/radio-input.mdx
+++ b/packages/nimbus/src/components/radio-input/radio-input.mdx
@@ -12,6 +12,10 @@ menu:
   - Radio input
 tags:
   - component
+  - radio
+  - input
+  - selection
+  - option
 ---
 
 # Radio input

--- a/packages/nimbus/src/components/select/select.mdx
+++ b/packages/nimbus/src/components/select/select.mdx
@@ -14,6 +14,10 @@ menu:
   - Select input
 tags:
   - component
+  - select
+  - dropdown
+  - picker
+  - options
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=2304-22847&m=dev
 ---

--- a/packages/nimbus/src/components/separator/separator.mdx
+++ b/packages/nimbus/src/components/separator/separator.mdx
@@ -12,7 +12,11 @@ menu:
   - Layout
   - Separator
 tags:
-  - document
+  - component
+  - divider
+  - separator
+  - line
+  - section
 ---
 
 # Separator

--- a/packages/nimbus/src/components/simple-grid/simple-grid.mdx
+++ b/packages/nimbus/src/components/simple-grid/simple-grid.mdx
@@ -11,8 +11,11 @@ menu:
   - Layout
   - Simple grid
 tags:
+  - component
   - grid
   - simple
+  - layout
+  - columns
 ---
 
 # Simple grid

--- a/packages/nimbus/src/components/stack/stack.mdx
+++ b/packages/nimbus/src/components/stack/stack.mdx
@@ -14,6 +14,10 @@ menu:
   - Stack
 tags:
   - component
+  - stack
+  - layout
+  - vertical
+  - horizontal
 ---
 
 # Stack

--- a/packages/nimbus/src/components/table/table.mdx
+++ b/packages/nimbus/src/components/table/table.mdx
@@ -11,9 +11,10 @@ menu:
   - Data Display
   - Table
 tags:
+  - component
   - table
   - tabular data
-  - static table
+  - static
   - read-only
 ---
 

--- a/packages/nimbus/src/components/tag-group/tag-group.mdx
+++ b/packages/nimbus/src/components/tag-group/tag-group.mdx
@@ -12,6 +12,10 @@ menu:
   - Tag group
 tags:
   - component
+  - tag
+  - chip
+  - label
+  - removable
 figmaLink: >-
   https://www.figma.com/design/AvtPX6g7OGGCRvNlatGOIY/NIMBUS-design-system?node-id=4292-25466
 ---

--- a/packages/nimbus/src/components/text-input/text-input.mdx
+++ b/packages/nimbus/src/components/text-input/text-input.mdx
@@ -12,6 +12,10 @@ menu:
   - Text input
 tags:
   - component
+  - text
+  - input
+  - field
+  - string
 ---
 
 # Text input

--- a/packages/nimbus/src/components/tooltip/tooltip.mdx
+++ b/packages/nimbus/src/components/tooltip/tooltip.mdx
@@ -12,7 +12,10 @@ menu:
   - Tooltip
 tags:
   - component
-  - media
+  - tooltip
+  - popover
+  - hint
+  - hover
 figmaLink: >-
   https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?node-id=1695-45519&m
 ---

--- a/packages/nimbus/src/components/visually-hidden/visually-hidden.mdx
+++ b/packages/nimbus/src/components/visually-hidden/visually-hidden.mdx
@@ -12,6 +12,10 @@ menu:
   - Visually hidden
 tags:
   - component
+  - accessibility
+  - screen reader
+  - hidden
+  - a11y
 ---
 
 # Visually hidden


### PR DESCRIPTION
## Summary

- Adds 3-5 semantic tags to 31 component MDX frontmatter files to improve `list_components` MCP tool fuzzy search
- Fixes 5 components missing the `component` base tag (Code, List, Password input, Separator, Simple grid)
- Fixes 3 components with misleading tags (Tooltip had `media`, Table had `static table`, Nimbus provider missing `component`)
- Upgrades 23 components from bare `["component"]` to meaningful semantic tags (synonyms, purpose, domain)

**[CRAFT-2194](https://commercetools.atlassian.net/browse/CRAFT-2194)**

## Test plan

- [x] nimbus-mcp tests pass (3/3)
- [ ] `list_components(query: "dropdown")` returns Select, ComboBox, Menu
- [ ] `list_components(query: "avatar")` matches Avatar via tags
- [ ] No component has only `["component"]` — all have 3+ semantic tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRAFT-2194]: https://commercetools.atlassian.net/browse/CRAFT-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ