### PR TITLE
fix: use full scoped package name in changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,7 +20,7 @@
     "color-tokens",
     "blank-app",
     "docs",
-    "nimbus-mcp"
+    "@commercetools/nimbus-mcp"
   ],
   "access": "restricted",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary

- Fixes `nimbus-mcp` → `@commercetools/nimbus-mcp` in `.changeset/config.json`
- Changesets requires the full scoped package name to match against the workspace, otherwise it throws a `ValidationError`

## Test plan

- [ ] Release workflow no longer fails with changeset validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)