### PR TITLE
feat(mcp build): use tsup to build the mcp into a single entry point

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -9,11 +9,18 @@
     "directory": "packages/i18n"
   },
   "homepage": "https://nimbus-documentation.vercel.app/home",
-  "keywords": ["typescript", "design-system", "react", "nimbus"],
+  "keywords": [
+    "typescript",
+    "design-system",
+    "react",
+    "nimbus"
+  ],
   "license": "MIT",
   "private": true,
   "sideEffects": false,
-  "files": ["data"],
+  "files": [
+    "data"
+  ],
   "scripts": {
     "build": "pnpm build:compile",
     "build:compile": "pnpm build:split && pnpm build:compile-strings && pnpm build:dictionaries",
@@ -23,6 +30,6 @@
     "clean:intl": "find ../nimbus/src/components -type d -name 'intl' -exec rm -rf {} +"
   },
   "devDependencies": {
-    "@internationalized/string-compiler": "catalog:"
+    "@internationalized/string-compiler": "catalog:react"
   }
 }

--- a/packages/nimbus-mcp/package.json
+++ b/packages/nimbus-mcp/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsup",
     "dev": "tsx src/index.ts",
     "mcp-inspector": "mcp-inspector tsx src/index.ts",
     "mcp-inspector:cli": "mcp-inspector --cli tsx src/index.ts"
@@ -26,7 +26,8 @@
   "devDependencies": {
     "@modelcontextprotocol/inspector": "catalog:tooling",
     "@types/node": "catalog:utils",
-    "typescript": "catalog:tooling",
-    "tsx": "catalog:tooling"
+    "tsup": "catalog:tooling",
+    "tsx": "catalog:tooling",
+    "typescript": "catalog:tooling"
   }
 }

--- a/packages/nimbus-mcp/tsup.config.ts
+++ b/packages/nimbus-mcp/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: "esm",
+  target: "node20",
+  bundle: true,
+  clean: true,
+});

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@chakra-ui/cli": "catalog:react",
     "@emotion/is-prop-valid": "catalog:react",
-    "@github-ui/storybook-addon-performance-panel": "catalog:",
+    "@github-ui/storybook-addon-performance-panel": "catalog:tooling",
     "@internationalized/string": "catalog:react",
     "@react-aria/interactions": "catalog:react",
     "dequal": "catalog:utils",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
-  default:
-    '@github-ui/storybook-addon-performance-panel':
-      specifier: ^1.1.4
-      version: 1.1.4
-    '@internationalized/string-compiler':
-      specifier: ^3.3.0
-      version: 3.3.0
   react:
     '@chakra-ui/cli':
       specifier: ^3.33.0
@@ -31,6 +24,9 @@ catalogs:
     '@internationalized/string':
       specifier: ^3.2.7
       version: 3.2.7
+    '@internationalized/string-compiler':
+      specifier: ^3.3.0
+      version: 3.3.0
     '@react-aria/optimize-locales-plugin':
       specifier: 1.1.5
       version: 1.1.5
@@ -62,6 +58,9 @@ catalogs:
     '@fission-ai/openspec':
       specifier: ^1.2.0
       version: 1.2.0
+    '@github-ui/storybook-addon-performance-panel':
+      specifier: ^1.1.4
+      version: 1.1.4
     '@modelcontextprotocol/inspector':
       specifier: ^0.21.1
       version: 0.21.1
@@ -149,6 +148,9 @@ catalogs:
     storybook:
       specifier: ^10.2.13
       version: 10.2.13
+    tsup:
+      specifier: ^8.5.1
+      version: 8.5.1
     tsx:
       specifier: ^4.21.0
       version: 4.21.0
@@ -533,7 +535,7 @@ importers:
   packages/i18n:
     devDependencies:
       '@internationalized/string-compiler':
-        specifier: 'catalog:'
+        specifier: catalog:react
         version: 3.3.0
 
   packages/nimbus:
@@ -545,7 +547,7 @@ importers:
         specifier: catalog:react
         version: 1.4.0
       '@github-ui/storybook-addon-performance-panel':
-        specifier: 'catalog:'
+        specifier: catalog:tooling
         version: 1.1.4(@storybook/icons@2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.2.13(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@internationalized/string':
         specifier: catalog:react
@@ -788,6 +790,9 @@ importers:
       '@types/node':
         specifier: catalog:utils
         version: 24.10.13
+      tsup:
+        specifier: catalog:tooling
+        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.10.13))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: catalog:tooling
         version: 4.21.0
@@ -4440,6 +4445,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
@@ -4447,6 +4458,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -4511,6 +4526,10 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -4636,6 +4655,10 @@ packages:
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -5243,6 +5266,9 @@ packages:
   find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -5786,6 +5812,10 @@ packages:
       react:
         optional: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
@@ -5866,11 +5896,19 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   linkify-it@3.0.3:
     resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
@@ -6559,6 +6597,24 @@ packages:
     resolution: {integrity: sha512-CebpbHc96zgFjGgdQ6BqBy6XIUgRx1xXWCAAk6oke02RZ5nxwo9KQejTg8y7uYEeI9kv8jKQPYjoe6REsY23vw==}
     engines: {node: '>=6.5'}
 
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   postcss-value-parser@3.3.1:
     resolution: {integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==}
 
@@ -6799,6 +6855,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -7323,6 +7383,9 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -7445,6 +7508,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: ~5.9.3
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -12815,9 +12897,16 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.0):
+    dependencies:
+      esbuild: 0.27.0
+      load-tsconfig: 0.2.5
+
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -12874,6 +12963,10 @@ snapshots:
   chardet@2.1.1: {}
 
   check-error@2.1.1: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   chokidar@5.0.0:
     dependencies:
@@ -12975,6 +13068,8 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  consola@3.4.2: {}
 
   content-disposition@0.5.2: {}
 
@@ -13292,7 +13387,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
@@ -13681,6 +13776,12 @@ snapshots:
   find-yarn-workspace-root@2.0.0:
     dependencies:
       micromatch: 4.0.8
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.59.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -14233,6 +14334,8 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.0
 
+  joycon@3.1.1: {}
+
   js-cookie@2.2.1: {}
 
   js-tokens@4.0.0: {}
@@ -14324,11 +14427,15 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   linkify-it@3.0.3:
     dependencies:
       uc.micro: 1.0.6
+
+  load-tsconfig@0.2.5: {}
 
   local-pkg@1.1.2:
     dependencies:
@@ -14929,7 +15036,7 @@ snapshots:
 
   mlly@1.8.0:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
@@ -15260,6 +15367,14 @@ snapshots:
   postcss-calc-ast-parser@0.1.4:
     dependencies:
       postcss-value-parser: 3.3.1
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      tsx: 4.21.0
+      yaml: 2.8.2
 
   postcss-value-parser@3.3.1: {}
 
@@ -15598,6 +15713,8 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 
@@ -16196,7 +16313,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
-      glob: 13.0.5
+      glob: 13.0.6
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
@@ -16262,6 +16379,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinycolor2@1.6.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
 
@@ -16359,6 +16478,36 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.10.13))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.0)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.0
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.59.0
+      source-map: 0.7.6
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.10.13)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,6 @@ packages:
   - packages/*
   - apps/*
 
-catalog:
-  '@internationalized/string-compiler': ^3.3.0
-  '@github-ui/storybook-addon-performance-panel': ^1.1.4
-
 catalogMode: strict
 
 catalogs:
@@ -15,6 +11,7 @@ catalogs:
     glob: ^13.0.6
     typescript: ~5.9.3
     typescript-eslint: ^8.56.1
+    tsup: ^8.5.1
     tsx: ^4.21.0
     "@modelcontextprotocol/inspector": ^0.21.1
     "@babel/core": ^7.29.0
@@ -28,22 +25,22 @@ catalogs:
     eslint-plugin-react-refresh: ^0.5.2
     express-rate-limit: ^8.2.1
     prettier: ^3.8.1
-    '@preconstruct/cli': ^2.8.12
-    '@vitejs/plugin-react': ^5.1.4
-    '@vitejs/plugin-react-swc': ^4.2.3
+    "@preconstruct/cli": ^2.8.12
+    "@vitejs/plugin-react": ^5.1.4
+    "@vitejs/plugin-react-swc": ^4.2.3
     vite: ^7.3.1
     vite-bundle-analyzer: ^1.3.6
     vite-plugin-dts: ^4.5.4
     vite-tsconfig-paths: ^6.1.1
     rollup: ^4.59.0
     rollup-plugin-tree-shakeable: ^2.0.0
-    '@vitest/browser': ^4.0.18
-    '@vitest/browser-playwright': ^4.0.18
-    '@vitest/coverage-v8': ^4.0.18
-    '@testing-library/dom': 10.4.1
-    '@testing-library/jest-dom': ^6.9.1
-    '@testing-library/user-event': ^14.6.1
-    '@testing-library/react': ^16.3.2
+    "@vitest/browser": ^4.0.18
+    "@vitest/browser-playwright": ^4.0.18
+    "@vitest/coverage-v8": ^4.0.18
+    "@testing-library/dom": 10.4.1
+    "@testing-library/jest-dom": ^6.9.1
+    "@testing-library/user-event": ^14.6.1
+    "@testing-library/react": ^16.3.2
     playwright: ^1.58.2
     vitest: ^4.0.18
     storybook: ^10.2.13
@@ -53,24 +50,26 @@ catalogs:
     "@storybook/addon-vitest": ^10.2.13
     "@storybook/react-vite": ^10.2.13
     "@vueless/storybook-dark-mode": ^10.0.7
+    "@github-ui/storybook-addon-performance-panel": ^1.1.4
     jsdom: ^28.1.0
   react:
-    '@types/react': ^19.2.14
-    '@types/react-dom': ^19.2.3
+    "@types/react": ^19.2.14
+    "@types/react-dom": ^19.2.3
     react: ^19.0.0
     react-dom: ^19.0.0
-    '@emotion/react': ^11.14.0
-    '@emotion/is-prop-valid': ^1.4.0
-    '@chakra-ui/cli': ^3.33.0
-    '@chakra-ui/react': ^3.33.0
+    "@emotion/react": ^11.14.0
+    "@emotion/is-prop-valid": ^1.4.0
+    "@chakra-ui/cli": ^3.33.0
+    "@chakra-ui/react": ^3.33.0
     next-themes: ^0.4.6
     react-aria: 3.46.0
     react-aria-components: 1.15.1
     react-stately: 3.44.0
-    '@react-aria/interactions': 3.27.0
-    '@react-aria/optimize-locales-plugin': 1.1.5
-    '@internationalized/date': ^3.11.0
-    '@internationalized/string': ^3.2.7
+    "@react-aria/interactions": 3.27.0
+    "@react-aria/optimize-locales-plugin": 1.1.5
+    "@internationalized/date": ^3.11.0
+    "@internationalized/string": ^3.2.7
+    "@internationalized/string-compiler": ^3.3.0
   utils:
     dequal: ^2.0.3
     dompurify: ^3.3.1


### PR DESCRIPTION
This pull request updates the build tooling and dependency management for the `nimbus-mcp` and `nimbus` packages, focusing on switching the build system to `tsup`, improving dependency catalog usage, and cleaning up related configuration files. The changes also add and update several package dependencies in the lockfile to support the new build process.

**Build System Updates:**

* Switched the build tool for `nimbus-mcp` from `tsc` to `tsup` for bundling, and added a new `tsup.config.ts` configuration file specifying entry point, output format, and target environment. (`packages/nimbus-mcp/package.json`, `packages/nimbus-mcp/tsup.config.ts`, `pnpm-lock.yaml`) [[1]](diffhunk://#diff-741f24e14eb160de9c938f95f4b4b80fa9c60e017cdc3ef5ba5eaf4cf24e92afL16-R16) [[2]](diffhunk://#diff-741f24e14eb160de9c938f95f4b4b80fa9c60e017cdc3ef5ba5eaf4cf24e92afL29-R31) [[3]](diffhunk://#diff-14751710ca4b8a5bb8555e0432999ec49de548fdd228544a3f040877b6992dbbR1-R9) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR793-R795) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7512-R7530)

**Dependency Catalog and Package Management:**

* Updated dependency catalog references for `@github-ui/storybook-addon-performance-panel` and `@internationalized/string-compiler` to use the correct catalogs (`tooling` and `react` respectively) in both `package.json` and `pnpm-lock.yaml`. (`packages/nimbus/package.json`, `packages/i18n/package.json`, `pnpm-lock.yaml`) [[1]](diffhunk://#diff-452400c2828904b2936c7cfb9d1c24fcb0eb366c846b3947267f926cca6399ecL54-R54) [[2]](diffhunk://#diff-b521a60001d6c012f4a294bdba3be54c1e1a6aa8a059fb2d3b0fd4e41ec5c5a4L26-R33) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL536-R538) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL548-R550)
* Reformatted arrays in `packages/i18n/package.json` for consistency.

**Lockfile and Dependency Additions:**

* Added and updated a number of dependencies in `pnpm-lock.yaml` to support the new build process, including `tsup`, `bundle-require`, `cac`, `chokidar`, `consola`, `fix-dts-default-cjs-exports`, `joycon`, `lilconfig`, `load-tsconfig`, `postcss-load-config`, `readdirp`, and `tinyexec`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4448-R4453) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4462-R4465) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4530-R4533) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4659-R4662) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5269-R5271) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5815-R5818) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5899-R5912) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6600-R6617) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6859-R6862) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7386-R7388) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7512-R7530) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12900-R12910) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12967-R12970) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR13072-R13073) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13295-R13390) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR13780-R13785) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14337-R14338) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14430-R14439) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14932-R15039) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15371-R15378) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15717-R15718)

These updates modernize the build process, ensure correct dependency resolution, and maintain consistency across the monorepo.