### PR TITLE
chore(deps): update globals to 17.4.0 and @react-types/shared to 3.33.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ catalogs:
       specifier: ^2.8.12
       version: 2.8.12
     '@react-types/shared':
-      specifier: ^3.33.0
-      version: 3.33.0
+      specifier: ^3.33.1
+      version: 3.33.1
     '@storybook/addon-a11y':
       specifier: ^10.2.13
       version: 10.2.13
@@ -134,8 +134,8 @@ catalogs:
       specifier: ^13.0.6
       version: 13.0.6
     globals:
-      specifier: ^17.3.0
-      version: 17.3.0
+      specifier: ^17.4.0
+      version: 17.4.0
     jsdom:
       specifier: ^28.1.0
       version: 28.1.0
@@ -257,7 +257,7 @@ importers:
         version: 10.2.13(eslint@10.0.2)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       globals:
         specifier: catalog:tooling
-        version: 17.3.0
+        version: 17.4.0
       playwright:
         specifier: catalog:tooling
         version: 1.58.2
@@ -315,7 +315,7 @@ importers:
         version: 0.5.2(eslint@10.0.2)
       globals:
         specifier: catalog:tooling
-        version: 17.3.0
+        version: 17.4.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -487,7 +487,7 @@ importers:
         version: 0.5.2(eslint@10.0.2)
       globals:
         specifier: catalog:tooling
-        version: 17.3.0
+        version: 17.4.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -612,7 +612,7 @@ importers:
         version: 1.1.5
       '@react-types/shared':
         specifier: catalog:tooling
-        version: 3.33.0(react@19.2.0)
+        version: 3.33.1(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: catalog:tooling
         version: 10.2.13(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -3064,6 +3064,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-types/shared@3.33.1':
+    resolution: {integrity: sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@react-types/slider@3.8.3':
     resolution: {integrity: sha512-HCDegYiUA27CcJKvFwgpR8ktFKf2nAirXqQEgVPV4uxk6JIeiRx41yqM/xPJGfmaqa7BARYARLT41yN2V8Kadg==}
     peerDependencies:
@@ -5406,8 +5411,8 @@ packages:
     engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globals@17.3.0:
-    resolution: {integrity: sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==}
+  globals@17.4.0:
+    resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -10233,7 +10238,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.0)
       '@react-aria/utils': 3.33.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-stately/flags': 3.1.2
-      '@react-types/shared': 3.33.0(react@19.2.0)
+      '@react-types/shared': 3.33.1(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -10990,6 +10995,10 @@ snapshots:
       react: 19.2.0
 
   '@react-types/shared@3.33.0(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-types/shared@3.33.1(react@19.2.0)':
     dependencies:
       react: 19.2.0
 
@@ -13863,7 +13872,7 @@ snapshots:
       minimatch: 10.2.4
       once: 1.4.0
 
-  globals@17.3.0: {}
+  globals@17.4.0: {}
 
   globby@11.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ catalogs:
   tooling:
     "@fission-ai/openspec": ^1.2.0
     eslint-plugin-react-hooks: ^7.0.1
-    globals: ^17.3.0
+    globals: ^17.4.0
     glob: ^13.0.6
     typescript: ~5.9.3
     typescript-eslint: ^8.56.1
@@ -19,7 +19,7 @@ catalogs:
     "@babel/runtime": ^7.28.6
     "@babel/preset-typescript": ^7.28.5
     "@eslint/js": ^10.0.1
-    "@react-types/shared": ^3.33.0
+    "@react-types/shared": ^3.33.1
     eslint: ^10.0.2
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.5


### PR DESCRIPTION
## Summary

- Bump `globals` from `^17.3.0` to `^17.4.0` (patch)
- Bump `@react-types/shared` from `^3.33.0` to `^3.33.1` (patch)

## Test plan

- [x] `pnpm install --lockfile-only` succeeds
- [x] `pnpm build:packages` passes
- [x] `pnpm test` passes (pre-existing flaky combobox test unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)