### PR TITLE
chore(docs): remove unused meta tags

### DIFF
--- a/.claude/commands/mdx-from-wireframe.md
+++ b/.claude/commands/mdx-from-wireframe.md
@@ -76,7 +76,6 @@ Before writing examples, check the actual component implementation:
 id: Components-ComponentName
 title: Component Name
 description: Brief one-line description
-documentState: InitialDraft
 order: 999
 menu:
   - Components

--- a/.claude/skills/writing-designer-documentation/SKILL.md
+++ b/.claude/skills/writing-designer-documentation/SKILL.md
@@ -67,7 +67,6 @@ packages/nimbus/src/components/{component}/{component}.mdx
 id: Components-ComponentName
 title: Component Name
 description: Brief one-line description
-documentState: InitialDraft # InitialDraft|ReviewedInternal|Published
 lifecycleState: Stable # Experimental|Alpha|Beta|Stable|Deprecated
 order: 999
 menu:

--- a/docs/file-type-guidelines/documentation.md
+++ b/docs/file-type-guidelines/documentation.md
@@ -81,14 +81,10 @@ These fields appear in some components but are not required:
 ---
 # Lifecycle indicators (when applicable)
 lifecycleState: Experimental|Alpha|Beta|Stable|Deprecated|EOL
-documentState: InitialDraft|ReviewedInternal|Published
 
 # Design resources (when available)
 figmaLink: >-
   https://www.figma.com/design/...
-
-# Legacy fields (avoid in new components)
-documentAudiences: []
 ---
 ```
 
@@ -405,7 +401,6 @@ title: Badge
 description:
   Briefly highlights or categorizes associated UI elements with concise visual
   cues for status or metadata.
-documentState: InitialDraft
 order: 999
 menu:
   - Components
@@ -448,7 +443,6 @@ figmaLink: >-
 id: Components-TextInput
 title: TextInput
 description: An input component that takes in a text as input
-documentState: InitialDraft
 order: 999
 menu:
   - Components

--- a/openspec/specs/nimbus-loading-spinner/spec.md
+++ b/openspec/specs/nimbus-loading-spinner/spec.md
@@ -481,7 +481,7 @@ The component SHALL provide comprehensive documentation per nimbus-core standard
 #### Scenario: MDX documentation file
 - **WHEN** loading-spinner.mdx exists
 - **THEN** SHALL include frontmatter with id, title, description
-- **AND** SHALL include documentState, order, menu, tags
+- **AND** SHALL include order, menu, tags
 - **AND** SHALL include figmaLink to design library
 - **AND** SHALL provide usage guidelines and best practices
 

--- a/packages/nimbus-icons/README.mdx
+++ b/packages/nimbus-icons/README.mdx
@@ -2,7 +2,6 @@
 id: Icons
 title: Icons
 description: display Icons
-documentState: InitialDraft
 layout: no-sidebar
 order: 5
 menu:

--- a/packages/nimbus/src/components/accordion/accordion.mdx
+++ b/packages/nimbus/src/components/accordion/accordion.mdx
@@ -3,8 +3,6 @@ id: Components-Accordion
 title: Accordion
 exportName: Accordion
 description: A collapsable component lets users show and hide sections of related content on a page.
-documentState: ReviewedInternal
-documentAudiences: []
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/alert/alert.mdx
+++ b/packages/nimbus/src/components/alert/alert.mdx
@@ -3,7 +3,6 @@ id: Components-Alert
 title: Alert
 exportName: Alert
 description: For urgent, high-impact messages, such as system alerts, alert banners are used to ensure visibility and encourage immediate user response.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/avatar/avatar.mdx
+++ b/packages/nimbus/src/components/avatar/avatar.mdx
@@ -3,7 +3,6 @@ id: Components-Avatar
 title: Avatar
 exportName: Avatar
 description: A small image or icon that identifies and personalizes the user within the interface.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/badge/badge.mdx
+++ b/packages/nimbus/src/components/badge/badge.mdx
@@ -2,7 +2,6 @@
 id: Components-Badge
 title: Badge
 description: Briefly highlights or categorizes associated UI elements with concise visual cues for status or metadata.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/box/box.mdx
+++ b/packages/nimbus/src/components/box/box.mdx
@@ -3,7 +3,6 @@ id: Components-Box
 title: Box
 exportName: Box
 description: Box is a basic layout component that serves as a wrapper or container. It's based on the Chakra UI Box component and supports all style props for rapid UI development.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/button/button.mdx
+++ b/packages/nimbus/src/components/button/button.mdx
@@ -3,8 +3,6 @@ id: Components-Button
 title: Button
 exportName: Button
 description: A button serves as a standardized, reusable component for triggering actions and navigating.
-documentState: ReviewedInternal
-documentAudiences: []
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/calendar/calendar.mdx
+++ b/packages/nimbus/src/components/calendar/calendar.mdx
@@ -3,7 +3,6 @@ id: Components-Calendar
 title: Calendar
 exportName: Calendar
 description: Calendars display a grid of days in one or more months and allow users to select a single date.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/card/card.mdx
+++ b/packages/nimbus/src/components/card/card.mdx
@@ -3,7 +3,6 @@ id: Components-Card
 title: Card
 exportName: Card
 description: A versatile container component presents self-contained information, often combining text, images, and actions, making it ideal for displaying summaries or content previews.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/checkbox/checkbox.mdx
+++ b/packages/nimbus/src/components/checkbox/checkbox.mdx
@@ -3,8 +3,6 @@ id: Components-Checkbox
 title: Checkbox
 exportName: Checkbox
 description: Checkbox allows for toggling of features, allowing users to select more than one option where needed. Checkboxes support selected, unselected, indeterminate, and disabled states.
-documentState: ReviewedInternal
-documentAudiences: []
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/code/code.mdx
+++ b/packages/nimbus/src/components/code/code.mdx
@@ -3,7 +3,6 @@ id: Components-Code
 title: Code
 exportName: Code
 description: renders code blocks
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/combobox/combobox.mdx
+++ b/packages/nimbus/src/components/combobox/combobox.mdx
@@ -3,7 +3,6 @@ id: Components-ComboBox
 title: Combo box
 exportName: ComboBox
 description: A combobox is an input that combines a text field with a pop-up list of options. It allows users to select a value from a predefined list or enter their own custom value.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/data-table/data-table.mdx
+++ b/packages/nimbus/src/components/data-table/data-table.mdx
@@ -3,7 +3,6 @@ id: Components-DataTable
 title: Data table
 exportName: DataTable
 description: Data tables display sets of data across rows and columns. Use them to organize information, enable comparisons, and allow users to inspect and interact with large datasets.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/field-errors/field-errors.mdx
+++ b/packages/nimbus/src/components/field-errors/field-errors.mdx
@@ -3,7 +3,6 @@ id: Components-FieldErrors
 title: Field errors
 exportName: FieldErrors
 description: Context specific, localized error messages for individual form fields.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/flex/flex.mdx
+++ b/packages/nimbus/src/components/flex/flex.mdx
@@ -3,7 +3,6 @@ id: Components-Flex
 title: Flex
 exportName: Flex
 description: Flex is a layout component that provides a convenient way to create flexible layouts based on CSS Flexbox. It's based on the Chakra UI Flex component and supports all style props for rapid UI development.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/form-field/form-field.mdx
+++ b/packages/nimbus/src/components/form-field/form-field.mdx
@@ -3,7 +3,6 @@ id: Components-FormField
 title: Form field
 exportName: FormField
 description: Form fields are the building blocks of user interaction, collecting essential data, facilitating actions, and enabling customization within digital interfaces.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/grid/grid.mdx
+++ b/packages/nimbus/src/components/grid/grid.mdx
@@ -3,7 +3,6 @@ id: Components-Grid
 title: Grid
 exportName: Grid
 description: The Grid Layout Component provides a flexible and responsive way to structure content using a two-dimensional grid system. It allows elements to be arranged in rows and columns, enabling dynamic and efficient layouts for different screen sizes. The component accepts all the chakra supported properties and Grid.Item as children elements.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/group/group.mdx
+++ b/packages/nimbus/src/components/group/group.mdx
@@ -3,8 +3,6 @@ id: Components-Group
 title: Group
 exportName: Group
 description: Groups related elements together for better organization and layout.
-documentState: InitialDraft
-documentAudiences: []
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/heading/heading.mdx
+++ b/packages/nimbus/src/components/heading/heading.mdx
@@ -3,7 +3,6 @@ id: Components-Heading
 title: Heading
 exportName: Heading
 description: The heading component establishes typographic hierarchy throughout the product experience. It is crucial for organizing content, defining page structure, and improving content scan ability.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 2
 menu:

--- a/packages/nimbus/src/components/icon-button/icon-button.mdx
+++ b/packages/nimbus/src/components/icon-button/icon-button.mdx
@@ -3,7 +3,6 @@ id: Components-IconButton
 title: Icon button
 exportName: IconButton
 description: Provides a compact and visually efficient way to represent actions, especially when space is limited or the action is universally understood.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/icon-toggle-button/icon-toggle-button.mdx
+++ b/packages/nimbus/src/components/icon-toggle-button/icon-toggle-button.mdx
@@ -3,7 +3,6 @@ id: Components-IconToggleButton
 title: Icon toggle button
 exportName: IconToggleButton
 description: An interactive icon button that toggles between two binary states such as active and inactive.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/icon/icon.mdx
+++ b/packages/nimbus/src/components/icon/icon.mdx
@@ -3,7 +3,6 @@ id: Components-Icon
 title: Icon
 exportName: Icon
 description: An icon is a small graphical symbol used to represent an object, action, or idea within a user interface.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/image/image.mdx
+++ b/packages/nimbus/src/components/image/image.mdx
@@ -3,7 +3,6 @@ id: Components-Image
 title: Image
 exportName: Image
 description: An image component is used to display visual content like photographs, illustrations, or graphics within the UI to support, illustrate, or enhance textual information.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/kbd/kbd.mdx
+++ b/packages/nimbus/src/components/kbd/kbd.mdx
@@ -3,7 +3,6 @@ id: Components-Kbd
 title: Kbd
 exportName: Kbd
 description: The KBD component visually renders a keystroke or key combination to highlight it within textual instructions.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/link/link.mdx
+++ b/packages/nimbus/src/components/link/link.mdx
@@ -3,7 +3,6 @@ id: Components-link
 title: Link
 exportName: Link
 description: A link is a clickable element that navigates users to another page, section of the page, or resource, and is visually distinguished by styling.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/list/list.mdx
+++ b/packages/nimbus/src/components/list/list.mdx
@@ -3,7 +3,6 @@ id: Components-List
 title: List
 exportName: List
 description: The list component organizes related items or data into a vertical, scannable format.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.mdx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.mdx
@@ -3,7 +3,6 @@ id: Components-LoadingSpinner
 title: Loading spinner
 exportName: LoadingSpinner
 description: A circular visual indicator that displays the loading status of an ongoing process. It can represent either determinate or indeterminate progress.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/localized-field/localized-field.mdx
+++ b/packages/nimbus/src/components/localized-field/localized-field.mdx
@@ -3,7 +3,6 @@ id: Components-LocalizedField
 title: Localized field
 exportName: LocalizedField
 description: A localized field is a single component that enables users to input and manage content for multiple language versions of a piece of data within one unified form area.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/money-input/money-input.mdx
+++ b/packages/nimbus/src/components/money-input/money-input.mdx
@@ -3,7 +3,6 @@ id: Components-MoneyInput
 title: Money input
 exportName: MoneyInput
 description: A controlled input for money values that combines currency selection with amount input, supporting both standard and high-precision monetary values.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.mdx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.mdx
@@ -3,7 +3,6 @@ id: Components-MultilineTextInput
 title: Multiline text input
 exportName: MultilineTextInput
 description: A multi-line text input allows users to enter longer blocks of text across multiple lines. It is suitable for paragraphs, descriptions, or any input requiring more than a single line.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/number-input/number-input.mdx
+++ b/packages/nimbus/src/components/number-input/number-input.mdx
@@ -3,7 +3,6 @@ id: Components-NumberInput
 title: Number input
 exportName: NumberInput
 description: A number input allows users to enter numerical values and adjust them incrementally.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/page-content/page-content.mdx
+++ b/packages/nimbus/src/components/page-content/page-content.mdx
@@ -3,7 +3,6 @@ id: Components-PageContent
 title: PageContent
 exportName: PageContent
 description: A layout component that constrains page content width and arranges content in single or multi-column layouts. It consolidates multiple width-based containers into a single compound component with explicit column control.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/pagination/pagination.mdx
+++ b/packages/nimbus/src/components/pagination/pagination.mdx
@@ -3,8 +3,6 @@ id: Components-Pagination
 title: Pagination
 exportName: Pagination
 description: Pagination is a component that divides a large set of content or data into sequential pages, providing navigation controls to move between them.
-documentState: InitialDraft
-documentAudiences: []
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/password-input/password-input.mdx
+++ b/packages/nimbus/src/components/password-input/password-input.mdx
@@ -3,7 +3,6 @@ id: Components-PasswordInput
 title: Password input
 exportName: PasswordInput
 description: A password input is a text field that hides entered characters for secure password entry.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/progress-bar/progress-bar.mdx
+++ b/packages/nimbus/src/components/progress-bar/progress-bar.mdx
@@ -3,7 +3,6 @@ id: Components-ProgressBar
 title: Progress bar
 exportName: ProgressBar
 description: A linear visual indicator that displays the loading or completion state of an ongoing process. It can represent either determinate or indeterminate progress.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/radio-input/radio-input.mdx
+++ b/packages/nimbus/src/components/radio-input/radio-input.mdx
@@ -3,7 +3,6 @@ id: Components-RadioInput
 title: Radio input
 exportName: RadioInput
 description: A set of closely related, mutually exclusive or complementary actions that are important enough to be displayed directly in the interface for quick access.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/scoped-search-input/scoped-search-input.mdx
+++ b/packages/nimbus/src/components/scoped-search-input/scoped-search-input.mdx
@@ -3,7 +3,6 @@ id: Components-ScopedSearchInput
 title: Scoped search input
 exportName: ScopedSearchInput
 description: Enables users to define where their search query is applied using a closely paired scope selector.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/select/select.mdx
+++ b/packages/nimbus/src/components/select/select.mdx
@@ -3,7 +3,6 @@ id: Components-Select
 title: Select
 exportName: Select
 description: A select input is a form field that presents users with a dropdown menu of options to choose from.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/separator/separator.mdx
+++ b/packages/nimbus/src/components/separator/separator.mdx
@@ -3,8 +3,6 @@ id: Components-Separator
 title: Separator
 exportName: Separator
 description: A separator is a visual or semantic line that groups and divides content, establishing rhythm and hierarchy within a layout.
-documentState: InitialDraft
-documentAudiences: []
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/simple-grid/simple-grid.mdx
+++ b/packages/nimbus/src/components/simple-grid/simple-grid.mdx
@@ -3,7 +3,6 @@ id: Components-SimpleGrid
 title: Simple grid
 exportName: SimpleGrid
 description: SimpleGrid offers an intuitive way to easily create responsive grid layouts.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/split-button/split-button.mdx
+++ b/packages/nimbus/src/components/split-button/split-button.mdx
@@ -3,7 +3,6 @@ id: Components-SplitButton
 title: Split button
 exportName: SplitButton
 description: A split button merges a main action with a dropdown for related, less common actions.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/stack/stack.mdx
+++ b/packages/nimbus/src/components/stack/stack.mdx
@@ -3,7 +3,6 @@ id: Components-Stack
 title: Stack
 exportName: Stack
 description: An easily customizable Stack component, re-exported from Chakra UI stack component, that provides a consistent and responsive layout structure across different products. Stacks allow you to effortlessly build flexible layouts with automatic distribution. You can arrange elements horizontally or vertically, adding spacing and/or separators between each item.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/steps/steps.mdx
+++ b/packages/nimbus/src/components/steps/steps.mdx
@@ -2,7 +2,6 @@
 id: Components-Steps
 title: Steps
 description: A progress indicator with built-in navigation that visually communicates the user's position within a multi-step process such as forms, wizards, and onboarding flows.
-documentState: InitialDraft
 lifecycleState: Beta
 order: 999
 menu:

--- a/packages/nimbus/src/components/switch/switch.mdx
+++ b/packages/nimbus/src/components/switch/switch.mdx
@@ -3,7 +3,6 @@ id: Components-Switch
 title: Switch
 exportName: Switch
 description: A clear, visual toggle, allowing users to activate or deactivate a setting quickly.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/table/table.mdx
+++ b/packages/nimbus/src/components/table/table.mdx
@@ -3,7 +3,6 @@ id: Components-Table
 title: Table
 exportName: Table
 description: The Table component provides a straightforward way to display static, read-only data in a tabular format. It uses semantic HTML table elements and is designed for simple data presentation without interactive features like sorting, filtering, or selection.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/tabs/tabs.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.mdx
@@ -3,7 +3,6 @@ id: Components-Tabs
 title: Tabs
 exportName: Tabs
 description: Organizes content into distinct sections, enabling users to switch views within a single container.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/tag-group/tag-group.mdx
+++ b/packages/nimbus/src/components/tag-group/tag-group.mdx
@@ -3,7 +3,6 @@ id: Components-TagGroup
 title: Tag group
 exportName: TagGroup
 description: A tag group is a compact, interactive element. It categorizes, labels, or adds attributes to objects for quick recognition and filtering.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/text-input/text-input.mdx
+++ b/packages/nimbus/src/components/text-input/text-input.mdx
@@ -3,7 +3,6 @@ id: Components-TextInput
 title: Text input
 exportName: TextInput
 description: Allows users to enter information like names, addresses, emails, passwords, search queries, or any other text-based data.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/text/text.mdx
+++ b/packages/nimbus/src/components/text/text.mdx
@@ -3,7 +3,6 @@ id: Components-Text
 title: Text
 exportName: Text
 description: Text styles are predefined collections of typography rules (including font-size, font-weight, line-height, and letter-spacing) that create reusable, consistent styles.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/time-input/time-input.mdx
+++ b/packages/nimbus/src/components/time-input/time-input.mdx
@@ -3,7 +3,6 @@ id: Components-TimeInput
 title: Time input
 exportName: TimeInput
 description: A time input allows users to enter and select a specific time. It supports flexible input methods while ensuring accuracy and ease of use.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/toast/toast.mdx
+++ b/packages/nimbus/src/components/toast/toast.mdx
@@ -2,7 +2,6 @@
 id: Components-Toast
 title: Toast
 description: Displays brief, temporary notifications that confirm actions or provide status updates without interrupting the user's workflow.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
+++ b/packages/nimbus/src/components/toggle-button-group/toggle-button-group.mdx
@@ -3,7 +3,6 @@ id: Components-ToggleButtonGroup
 title: Toggle button group
 exportName: ToggleButtonGroup
 description: A set of closely related, mutually exclusive or complementary actions that are important enough to be displayed directly in the interface for quick access.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/toggle-button/toggle-button.mdx
+++ b/packages/nimbus/src/components/toggle-button/toggle-button.mdx
@@ -3,7 +3,6 @@ id: Components-ToggleButton
 title: Toggle button
 exportName: ToggleButton
 description: An interactive button that toggles between two binary states such as active and inactive.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/toolbar/toolbar.mdx
+++ b/packages/nimbus/src/components/toolbar/toolbar.mdx
@@ -3,7 +3,6 @@ id: Components-Toolbar
 title: Toolbar
 exportName: Toolbar
 description: Toolbars organize related actions and controls in a compact bar for easy access. They provide consistent placement for common or contextual tasks within an application.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/tooltip/tooltip.mdx
+++ b/packages/nimbus/src/components/tooltip/tooltip.mdx
@@ -3,7 +3,6 @@ id: Components-tooltip
 title: Tooltip
 exportName: Tooltip
 description: A contextual popup that displays a description for an element. 
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/components/visually-hidden/visually-hidden.mdx
+++ b/packages/nimbus/src/components/visually-hidden/visually-hidden.mdx
@@ -3,7 +3,6 @@ id: Components-VisuallyHidden
 title: Visually hidden
 exportName: VisuallyHidden
 description: Makes content accessible to screen readers but hides it visually.
-documentState: InitialDraft
 lifecycleState: Stable
 order: 999
 menu:

--- a/packages/nimbus/src/docs/accessibility.mdx
+++ b/packages/nimbus/src/docs/accessibility.mdx
@@ -2,7 +2,6 @@
 id: Components-Accessibility
 title: Accessibility
 description: Components designed to enhance accessibility and ARIA compliance.
-documentState: InitialDraft
 order: 12
 menu:
   - Components

--- a/packages/nimbus/src/docs/architecture-decisions/adr-0000-architecture-decision-records.mdx
+++ b/packages/nimbus/src/docs/architecture-decisions/adr-0000-architecture-decision-records.mdx
@@ -3,7 +3,6 @@ id: Architecture-Decision-Records
 title: "ADR: Using Architecture Decision Records"
 description:
   "An explanation of what Architecture Decision Records are and how we use them"
-documentState: "InitialDraft"
 order: 0
 menu:
   - Home

--- a/packages/nimbus/src/docs/architecture-decisions/adr-0001-consumer-component-apis.mdx
+++ b/packages/nimbus/src/docs/architecture-decisions/adr-0001-consumer-component-apis.mdx
@@ -4,7 +4,6 @@ title: "ADR: On Consumer Component API's"
 description:
   "Architecture decision record on how to structure component APIs for
   flexibility and maintainability"
-documentState: "InitialDraft"
 order: 1
 menu:
   - Home

--- a/packages/nimbus/src/docs/architecture-decisions/adr-0002-compound-component-extraction.mdx
+++ b/packages/nimbus/src/docs/architecture-decisions/adr-0002-compound-component-extraction.mdx
@@ -4,7 +4,6 @@ title:
   "ADR: Standardizing Compound Component Extraction to a `components` Directory"
 description:
   "Architecture decision record on organizing compound component implementations"
-documentState: "InitialDraft"
 order: 2
 menu:
   - Home

--- a/packages/nimbus/src/docs/architecture-decisions/adr-0003-component-lifecycle-states.mdx
+++ b/packages/nimbus/src/docs/architecture-decisions/adr-0003-component-lifecycle-states.mdx
@@ -4,7 +4,6 @@ title: "ADR: Nimbus Software Lifecycle States"
 description:
   "Architecture decision record defining the lifecycle states for Nimbus
   components, hooks, utilities, classes, etc."
-documentState: "InitialDraft"
 order: 3
 menu:
   - Home

--- a/packages/nimbus/src/docs/background.mdx
+++ b/packages/nimbus/src/docs/background.mdx
@@ -3,7 +3,6 @@ id: Style Props-Background
 title: Background
 description:
   JSX style props for styling background colors, gradients, and images.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/border.mdx
+++ b/packages/nimbus/src/docs/border.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Border
 title: Border
 description: JSX style props for styling border and border radius.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/buttons.mdx
+++ b/packages/nimbus/src/docs/buttons.mdx
@@ -2,7 +2,6 @@
 id: Components-Buttons
 title: Buttons
 description: Components for triggering actions, submitting forms, and navigation.
-documentState: InitialDraft
 order: 3
 menu:
   - Components

--- a/packages/nimbus/src/docs/components-layout.mdx
+++ b/packages/nimbus/src/docs/components-layout.mdx
@@ -2,7 +2,6 @@
 id: Layout
 title: Layout
 description: Components that structure the content on the page.
-documentState: InitialDraft
 order: 1
 menu:
   - Components

--- a/packages/nimbus/src/docs/components.mdx
+++ b/packages/nimbus/src/docs/components.mdx
@@ -3,7 +3,6 @@ id: Components
 title: Components
 description:
   React components for building robust and visually appealing applications.
-documentState: InitialDraft
 order: 3
 menu:
   - Components

--- a/packages/nimbus/src/docs/contribute-setup.mdx
+++ b/packages/nimbus/src/docs/contribute-setup.mdx
@@ -2,7 +2,6 @@
 id: Home-Contribute-Setup
 title: Local Development Setup
 description: Set up nimbus for local development
-documentState: InitialDraft
 order: 1
 menu:
   - Home

--- a/packages/nimbus/src/docs/data-display.mdx
+++ b/packages/nimbus/src/docs/data-display.mdx
@@ -2,7 +2,6 @@
 id: Components-Data Display
 title: Data Display
 description: Components for presenting data or visual content.
-documentState: InitialDraft
 order: 8
 menu:
   - Components

--- a/packages/nimbus/src/docs/display.mdx
+++ b/packages/nimbus/src/docs/display.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Display
 title: Display
 description: Style props for styling display of an element.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/effects.mdx
+++ b/packages/nimbus/src/docs/effects.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Effects
 title: Effects
 description: JSX style props for styling box shadows, opacity, and more
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/feedback.mdx
+++ b/packages/nimbus/src/docs/feedback.mdx
@@ -2,7 +2,6 @@
 id: Components-Feedback
 title: Feedback
 description: Components for providing user feedback.
-documentState: InitialDraft
 order: 6
 menu:
   - Components

--- a/packages/nimbus/src/docs/fields.mdx
+++ b/packages/nimbus/src/docs/fields.mdx
@@ -2,7 +2,6 @@
 id: Patterns-Fields
 title: Fields
 description: Field pattern components that integrate inputs within FormField for consistent form layouts
-documentState: InitialDraft
 order: 1
 menu:
   - Patterns

--- a/packages/nimbus/src/docs/filters.mdx
+++ b/packages/nimbus/src/docs/filters.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Filters
 title: Filters
 description: JSX style props for applying various filters to elements.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/flex-and-grid.mdx
+++ b/packages/nimbus/src/docs/flex-and-grid.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Flex and Grid
 title: Flex and Grid
 description: JSX style props to control flex and grid layouts
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/forms.mdx
+++ b/packages/nimbus/src/docs/forms.mdx
@@ -2,7 +2,6 @@
 id: Components-Forms
 title: Forms
 description: Components for form validation, localization, and error handling.
-documentState: InitialDraft
 order: 11
 menu:
   - Components

--- a/packages/nimbus/src/docs/home-contribute.mdx
+++ b/packages/nimbus/src/docs/home-contribute.mdx
@@ -2,7 +2,6 @@
 id: Home-Contribute-1746704391512
 title: Contributing
 description: Contribute to the nimbus development
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/home-core-concepts.mdx
+++ b/packages/nimbus/src/docs/home-core-concepts.mdx
@@ -2,7 +2,6 @@
 id: Home-Core Concepts
 title: Core Concepts
 description: Quick start guide to set up and use the package.
-documentState: InitialDraft
 order: 2
 menu:
   - Home

--- a/packages/nimbus/src/docs/home-installation.mdx
+++ b/packages/nimbus/src/docs/home-installation.mdx
@@ -2,7 +2,6 @@
 id: Home-Installation-1746704940030
 title: Installation
 description: How to add Nimbus to your react frontend
-documentState: InitialDraft
 order: 1
 menu:
   - Home

--- a/packages/nimbus/src/docs/home-testing-setup.mdx
+++ b/packages/nimbus/src/docs/home-testing-setup.mdx
@@ -2,7 +2,6 @@
 id: Home-Testing-Setup
 title: Testing Setup
 description: Configure Jest or Vitest to test Nimbus components
-documentState: InitialDraft
 order: 1.6
 menu:
   - Home

--- a/packages/nimbus/src/docs/home.mdx
+++ b/packages/nimbus/src/docs/home.mdx
@@ -2,7 +2,6 @@
 id: Home
 title: Home
 description: Start here if you're new.
-documentState: InitialDraft
 order: 1
 menu:
   - Home

--- a/packages/nimbus/src/docs/hooks.mdx
+++ b/packages/nimbus/src/docs/hooks.mdx
@@ -2,7 +2,6 @@
 id: Hooke
 title: Hooke
 description: react hooks
-documentState: InitialDraft
 order: 999
 menu:
   - Hooks

--- a/packages/nimbus/src/docs/inputs.mdx
+++ b/packages/nimbus/src/docs/inputs.mdx
@@ -2,7 +2,6 @@
 id: Components-Inputs
 title: Inputs
 description: Form controls for data entry and selection
-documentState: InitialDraft
 order: 5
 menu:
   - Components

--- a/packages/nimbus/src/docs/interactivity.mdx
+++ b/packages/nimbus/src/docs/interactivity.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Interactivity
 title: Interactivity
 description: JSX style props to enhance interactivity on an element
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/layout.mdx
+++ b/packages/nimbus/src/docs/layout.mdx
@@ -3,7 +3,6 @@ id: Style Props-Layout
 title: Layout
 description:
   JSX style props to control the width, height, and spacing of elements
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/list.mdx
+++ b/packages/nimbus/src/docs/list.mdx
@@ -2,7 +2,6 @@
 id: Style Props-List
 title: List
 description: JSX style props for customizing list styles.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/markdown.mdx
+++ b/packages/nimbus/src/docs/markdown.mdx
@@ -2,7 +2,6 @@
 id: Markdown
 title: Markdown
 description: a page with many mdx & markdown features
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/media.mdx
+++ b/packages/nimbus/src/docs/media.mdx
@@ -2,7 +2,6 @@
 id: Media
 title: Media
 description: Components for displaying media content.
-documentState: InitialDraft
 order: 4
 menu:
   - Components

--- a/packages/nimbus/src/docs/naivgation.mdx
+++ b/packages/nimbus/src/docs/naivgation.mdx
@@ -2,7 +2,6 @@
 id: Components-Naivgation
 title: Navigation
 description: Components for moving through an application.
-documentState: InitialDraft
 order: 2
 menu:
   - Components

--- a/packages/nimbus/src/docs/nimbus-exports.mdx
+++ b/packages/nimbus/src/docs/nimbus-exports.mdx
@@ -2,7 +2,6 @@
 id: NimbusExportStats
 title: Nimbus Export Stats
 description: List of exports from the @commercetools/nimbus package
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/patterns.mdx
+++ b/packages/nimbus/src/docs/patterns.mdx
@@ -2,7 +2,6 @@
 id: Patterns
 title: Patterns
 description: Reusable component patterns and compositions for common use cases
-documentState: InitialDraft
 order: 4
 menu:
   - Patterns

--- a/packages/nimbus/src/docs/playground.mdx
+++ b/packages/nimbus/src/docs/playground.mdx
@@ -2,7 +2,6 @@
 id: Home-Playground
 title: Playground
 description: collection of pages with an explorative character
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/release.mdx
+++ b/packages/nimbus/src/docs/release.mdx
@@ -2,7 +2,6 @@
 id: Home-Release-Process
 title: Release Process
 description: How Nimbus releases work and how to stay informed
-documentState: InitialDraft
 order: 4
 menu:
   - Home

--- a/packages/nimbus/src/docs/sizing.mdx
+++ b/packages/nimbus/src/docs/sizing.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Sizing
 title: Sizing
 description: JSX style props for sizing an element
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/spacing.mdx
+++ b/packages/nimbus/src/docs/spacing.mdx
@@ -3,7 +3,6 @@ id: Style Props-Spacing
 title: Spacing
 description:
   JSX style props for controlling the padding and margin of an element.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/style-props-typography.mdx
+++ b/packages/nimbus/src/docs/style-props-typography.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Typography
 title: Typography
 description: JSX style props for styling text
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/style-props.mdx
+++ b/packages/nimbus/src/docs/style-props.mdx
@@ -2,7 +2,6 @@
 id: Home-Style Props
 title: Style Props
 description: JSX style props for applying CSS rules
-documentState: InitialDraft
 order: 5
 menu:
   - Home

--- a/packages/nimbus/src/docs/svg.mdx
+++ b/packages/nimbus/src/docs/svg.mdx
@@ -2,7 +2,6 @@
 id: Style Props-SVG
 title: SVG
 description: JSX style props for SVG elements.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tables.mdx
+++ b/packages/nimbus/src/docs/tables.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Tables
 title: Tables
 description: JSX style props for styling table elements.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/toc.mdx
+++ b/packages/nimbus/src/docs/toc.mdx
@@ -2,7 +2,6 @@
 id: Toc
 title: Toc
 description: Let's get the table of contents automatically generated
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens-other.mdx
+++ b/packages/nimbus/src/docs/tokens-other.mdx
@@ -2,7 +2,6 @@
 id: Tokens-Other
 title: Other
 description: Less frequently used design-tokens
-documentState: InitialDraft
 order: 9999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens.mdx
+++ b/packages/nimbus/src/docs/tokens.mdx
@@ -3,7 +3,6 @@ id: DesignTokens
 title: Design Tokens
 description:
   Style definitions (colors, fonts, spacing, etc.) for consistent UI components.
-documentState: InitialDraft
 order: 2
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/animations.mdx
+++ b/packages/nimbus/src/docs/tokens/animations.mdx
@@ -2,7 +2,6 @@
 id: TokensAnimations
 title: Animations
 description: The list of available animation tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/aspect-ratios.mdx
+++ b/packages/nimbus/src/docs/tokens/aspect-ratios.mdx
@@ -2,8 +2,6 @@
 id: TokensAspectRatios
 title: Aspect Ratios
 description: The list of available aspect ratio tokens
-documentState: InitialDraft
-documentAudiences: []
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/blurs.mdx
+++ b/packages/nimbus/src/docs/tokens/blurs.mdx
@@ -2,7 +2,6 @@
 id: TokensBlurs
 title: Blurs
 description: The list of available blur tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/borders.mdx
+++ b/packages/nimbus/src/docs/tokens/borders.mdx
@@ -2,7 +2,6 @@
 id: TokensBorders
 title: Borders
 description: The list of available border tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/breakpoints.mdx
+++ b/packages/nimbus/src/docs/tokens/breakpoints.mdx
@@ -2,7 +2,6 @@
 id: Breakpoints
 title: Breakpoints
 description: The list of available breakpoints
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/colors.mdx
+++ b/packages/nimbus/src/docs/tokens/colors.mdx
@@ -2,7 +2,6 @@
 id: Colors
 title: Colors
 description: available colors
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/cursors.mdx
+++ b/packages/nimbus/src/docs/tokens/cursors.mdx
@@ -2,7 +2,6 @@
 id: TokensCursors
 title: Cursors
 description: The list of available cursor tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/radii.mdx
+++ b/packages/nimbus/src/docs/tokens/radii.mdx
@@ -2,7 +2,6 @@
 id: TokensRadii
 title: Radii
 description: The list of available radius tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/shadows.mdx
+++ b/packages/nimbus/src/docs/tokens/shadows.mdx
@@ -2,7 +2,6 @@
 id: TokensShadows
 title: Shadows
 description: The list of available shadow tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/sizes.mdx
+++ b/packages/nimbus/src/docs/tokens/sizes.mdx
@@ -2,7 +2,6 @@
 id: TokensSizes
 title: Sizes
 description: The list of available size tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/spacing.mdx
+++ b/packages/nimbus/src/docs/tokens/spacing.mdx
@@ -2,7 +2,6 @@
 id: Spacing
 title: Spacing
 description: Spacing tokens are used to define the space between elements.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/typography.mdx
+++ b/packages/nimbus/src/docs/tokens/typography.mdx
@@ -2,7 +2,6 @@
 id: TokensTypography
 title: Typography
 description: everything typography related
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/tokens/z-indices.mdx
+++ b/packages/nimbus/src/docs/tokens/z-indices.mdx
@@ -2,7 +2,6 @@
 id: ZIndex
 title: Z-Indices
 description: The list of available z-index tokens
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/transforms.mdx
+++ b/packages/nimbus/src/docs/transforms.mdx
@@ -2,7 +2,6 @@
 id: Style Props-Transforms
 title: Transforms
 description: JSX style props for transforming elements.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/transitions.mdx
+++ b/packages/nimbus/src/docs/transitions.mdx
@@ -3,7 +3,6 @@ id: Style Props-Transitions
 title: Transitions
 description:
   JSX style props for controlling an element's transition and animation.
-documentState: InitialDraft
 order: 999
 menu:
   - Home

--- a/packages/nimbus/src/docs/typography.mdx
+++ b/packages/nimbus/src/docs/typography.mdx
@@ -2,7 +2,6 @@
 id: Components-Typography
 title: Typography
 description: Components for text styling and formatting.
-documentState: InitialDraft
 order: 7
 menu:
   - Components

--- a/packages/nimbus/src/docs/utilities.mdx
+++ b/packages/nimbus/src/docs/utilities.mdx
@@ -2,7 +2,6 @@
 id: Components-Utilities
 title: Utilities
 description: Low-level or functional components for utility purposes.
-documentState: InitialDraft
 order: 9
 menu:
   - Components

--- a/packages/nimbus/src/hooks/use-copy-to-clipboard/use-copy-to-clipboard.mdx
+++ b/packages/nimbus/src/hooks/use-copy-to-clipboard/use-copy-to-clipboard.mdx
@@ -2,7 +2,6 @@
 id: useCopyToClipboard
 title: useCopyToClipboard
 description: copy text to the clipboard
-documentState: InitialDraft
 order: 999
 menu:
   - Hooks

--- a/packages/nimbus/src/hooks/use-hotkeys/use-hotkeys.mdx
+++ b/packages/nimbus/src/hooks/use-hotkeys/use-hotkeys.mdx
@@ -2,7 +2,6 @@
 id: useHotkeys
 title: useHotkeys
 description: use keyboard shortcuts to do stuff
-documentState: InitialDraft
 order: 999
 menu:
   - Hooks

--- a/packages/nimbus/src/patterns/fields/date-range-picker-field/date-range-picker-field.mdx
+++ b/packages/nimbus/src/patterns/fields/date-range-picker-field/date-range-picker-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-DateRangePickerField
 title: Date range picker field
 exportName: DateRangePickerField
 description: This pattern component integrates the DateRangePicker within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns

--- a/packages/nimbus/src/patterns/fields/money-input-field/money-input-field.mdx
+++ b/packages/nimbus/src/patterns/fields/money-input-field/money-input-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-MoneyInputField
 title: Money input field
 exportName: MoneyInputField
 description: This pattern component integrates the MoneyInput within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns

--- a/packages/nimbus/src/patterns/fields/multiline-text-input-field/multiline-text-input-field.mdx
+++ b/packages/nimbus/src/patterns/fields/multiline-text-input-field/multiline-text-input-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-MultilineTextInputField
 title: Multiline text input field
 exportName: MultilineTextInputField
 description: This pattern component integrates the MultilineTextInput within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns

--- a/packages/nimbus/src/patterns/fields/number-input-field/number-input-field.mdx
+++ b/packages/nimbus/src/patterns/fields/number-input-field/number-input-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-NumberInputField
 title: Number input field
 exportName: NumberInputField
 description: This pattern component integrates the NumberInput within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns

--- a/packages/nimbus/src/patterns/fields/password-input-field/password-input-field.mdx
+++ b/packages/nimbus/src/patterns/fields/password-input-field/password-input-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-PasswordInputField
 title: Password input field
 exportName: PasswordInputField
 description: This pattern component integrates the PasswordInput within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns

--- a/packages/nimbus/src/patterns/fields/search-input-field/search-input-field.mdx
+++ b/packages/nimbus/src/patterns/fields/search-input-field/search-input-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-SearchInputField
 title: Search input field
 exportName: SearchInputField
 description: This pattern component integrates the SearchInput within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns

--- a/packages/nimbus/src/patterns/fields/text-input-field/text-input-field.mdx
+++ b/packages/nimbus/src/patterns/fields/text-input-field/text-input-field.mdx
@@ -3,7 +3,6 @@ id: Patterns-TextInputField
 title: Text input field
 exportName: TextInputField
 description: This pattern component integrates the TextInput within a FormField using a simple, consistent, and opinionated API.
-documentState: InitialDraft
 order: 999
 menu:
   - Patterns


### PR DESCRIPTION
## Summary
- Removes `documentState` and `documentAudiences` frontmatter fields from all 127 MDX files (components, docs, patterns, hooks)
- Removes references from generation scripts/commands/skills (`documentation.md`, `SKILL.md`, `mdx-from-wireframe.md`, `spec.md`)

## Test plan
- [x] `pnpm typecheck` passes
- [ ] CI passes

[CRAFT-2070](https://commercetools.atlassian.net/browse/CRAFT-2070)

[CRAFT-2070]: https://commercetools.atlassian.net/browse/CRAFT-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ