### PR TITLE
docs(skills): add type reuse and test/doc guidance to jira-implement-task

### DIFF
--- a/.claude/skills/jira-implement-task/SKILL.md
+++ b/.claude/skills/jira-implement-task/SKILL.md
@@ -74,6 +74,12 @@ Read the ticket description carefully and implement all requested changes:
 - If the ticket references specific files, modify those files
 - If the ticket is a documentation change, focus on content accuracy
 - If the ticket is a code change, follow the project's component guidelines
+- If the ticket requires new types, search for adjacent or colocated type files
+  first (e.g., `types.ts`, `*.types.ts`) to reuse existing patterns, shared
+  types, and naming conventions before creating new ones
+- If implementation changes affect behavior, check whether colocated tests
+  (`.spec.tsx`, `.stories.tsx`, `.docs.spec.tsx`) or documentation (`.dev.mdx`)
+  need corresponding updates
 - If the ticket is ambiguous, ask the user for clarification before proceeding
 - If the ticket implements a new component, implement an OpenSpec proposal using
   the `/propose-component` command.


### PR DESCRIPTION
## Summary
- Add guidance to search for adjacent/colocated type files before creating new types, encouraging pattern reuse
- Add reminder to check whether colocated tests and documentation need updating when behavior changes

## Test plan
- [ ] Review the updated SKILL.md for clarity and correctness
- [ ] Verify guidelines integrate naturally with existing implementation steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)