### PR TITLE
fix(security): resolve dependabot alerts via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
       "hono": ">=4.12.7",
       "@hono/node-server": ">=1.19.10",
       "ajv@>=8.0.0 <8.18.0": ">=8.18.0",
-      "minimatch@>=10.0.0 <10.2.3": ">=10.2.3"
+      "minimatch@>=10.0.0 <10.2.3": ">=10.2.3",
+      "flatted": ">=3.4.0",
+      "undici": ">=7.24.0"
     },
     "onlyBuiltDependencies": [
       "@bundled-es-modules/glob",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,8 @@ overrides:
   '@hono/node-server': '>=1.19.10'
   ajv@>=8.0.0 <8.18.0: '>=8.18.0'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
+  flatted: '>=3.4.0'
+  undici: '>=7.24.0'
 
 importers:
 
@@ -5073,8 +5075,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -7260,8 +7262,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.4:
+    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -13266,10 +13268,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.1: {}
 
   for-each@0.3.5:
     dependencies:
@@ -13830,7 +13832,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.4
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -15920,7 +15922,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.22.0: {}
+  undici@7.24.4: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Summary

This PR resolves 7 Dependabot security alerts by adding pnpm overrides to force patched versions of two transitive dependencies.

Both packages are transitive (not direct) dependencies, so pnpm overrides are used — consistent with existing patterns in this repo (e.g., `minimatch`, `ajv`).

## 🔒 Vulnerabilities Fixed

| Package | Severity | GHSA | Version Change | Via |
|---------|----------|------|----------------|-----|
| undici | HIGH | GHSA-v9p9-hfj2-hcw8 | 7.22.0 → 7.24.4 | vitest → jsdom |
| undici | HIGH | GHSA-vrm6-8vpv-qv8q | 7.22.0 → 7.24.4 | vitest → jsdom |
| undici | HIGH | GHSA-f269-vfmq-vjvj | 7.22.0 → 7.24.4 | vitest → jsdom |
| undici | MEDIUM | GHSA-2mjp-6q6p-2qxm | 7.22.0 → 7.24.4 | vitest → jsdom |
| undici | MEDIUM | GHSA-phc3-fgpg-7m6h | 7.22.0 → 7.24.4 | vitest → jsdom |
| undici | MEDIUM | GHSA-4992-7rv2-5pvq | 7.22.0 → 7.24.4 | vitest → jsdom |
| flatted | HIGH | GHSA-25h7-pfq9-p65f | 3.3.3 → 3.4.1 | eslint → flat-cache |

## 🔧 Changes

Added two entries to `pnpm.overrides` in `package.json`:
```json
"flatted": ">=3.4.0",
"undici": ">=7.24.0"
```

## ✅ Validation

All checks passed before commit:
- ✅ `pnpm lint` - No linting errors
- ✅ `pnpm typecheck` - No type errors
- ✅ `pnpm test` - 2031 tests passing (155 test files)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)