### PR TITLE
FEC-414: prepare MCP for npm packaging

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,7 +15,7 @@
       "@commercetools/nimbus-design-token-ts-plugin"
     ]
   ],
-  "ignore": ["@commercetools/nimbus-i18n", "@commercetools/nimbus-mcp", "color-tokens", "blank-app", "docs"],
+  "ignore": ["@commercetools/nimbus-i18n", "color-tokens", "blank-app", "docs"],
   "access": "restricted",
   "baseBranch": "main",
   "bumpVersionsWithWorkspaceProtocolOnly": false,

--- a/.changeset/rich-flies-stand.md
+++ b/.changeset/rich-flies-stand.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/nimbus-mcp": minor
+---
+
+Prepare Nimbus MCP for publishing on NPM

--- a/packages/nimbus-mcp/package.json
+++ b/packages/nimbus-mcp/package.json
@@ -3,10 +3,18 @@
   "version": "0.1.0",
   "description": "MCP server for the Nimbus design system",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "files": [
     "dist",
     "data"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/nimbus.git"
+  },
   "bin": {
     "nimbus-mcp": "./dist/index.js"
   },

--- a/packages/nimbus-mcp/package.json
+++ b/packages/nimbus-mcp/package.json
@@ -2,8 +2,11 @@
   "name": "@commercetools/nimbus-mcp",
   "version": "0.1.0",
   "description": "MCP server for the Nimbus design system",
-  "private": true,
   "type": "module",
+  "files": [
+    "dist",
+    "data"
+  ],
   "bin": {
     "nimbus-mcp": "./dist/index.js"
   },


### PR DESCRIPTION
  ## Summary

  - Remove `"private": true` from `packages/nimbus-mcp/package.json` to enable npm publishing
  - Add `"files": ["dist", "data"]` to ensure the gitignored `data/` directory (generated at build time) is included
  in the tarball
  - Remove `@commercetools/nimbus-mcp` from the changeset `ignore` array to enable version management

  ## Verification

  | Check | Result |
  |---|---|
  | `npm pack` produces valid tarball | 452 files — includes `dist/`, `data/`, and `bin` entry |
  | Package size | 1.2 MB compressed / 10.2 MB unpacked |
  | Bundled server starts | Confirmed (`node dist/index.js`) |
  | Tests | 59/59 passing |

  ## What's not included

  `npx` end-to-end verification and tool-level validation are deferred until the remaining tools land (currently in
  review). This PR unblocks publishing configuration so we can verify the full flow once all 6 tools are merged.

  Closes FEC-414

  ## Test plan

  - [ ] `pnpm --filter @commercetools/nimbus-mcp build` succeeds
  - [ ] `npm pack` in `packages/nimbus-mcp/` produces tarball with `dist/index.js`, `data/icons.json`,
  `data/tokens.json`, and `data/docs/`
  - [ ] `pnpm test packages/nimbus-mcp/src/` passes all tests
  - [ ] Unpacked size is ~10 MB

  🤖 Generated with [Claude Code](https://claude.com/claude-code)