### PR TITLE
fix(security): resolve CVE-2026-33228 flatted prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "@hono/node-server": ">=1.19.10",
       "ajv@>=8.0.0 <8.18.0": ">=8.18.0",
       "minimatch@>=10.0.0 <10.2.3": ">=10.2.3",
-      "flatted": ">=3.4.0",
+      "flatted": ">=3.4.2",
       "undici": ">=7.24.0"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ overrides:
   '@hono/node-server': '>=1.19.10'
   ajv@>=8.0.0 <8.18.0: '>=8.18.0'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  flatted: '>=3.4.0'
+  flatted: '>=3.4.2'
   undici: '>=7.24.0'
 
 importers:
@@ -5142,8 +5142,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -13396,10 +13396,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Update `pnpm.overrides` for `flatted` from `>=3.4.0` to `>=3.4.2` to resolve prototype pollution vulnerability via `parse()` in flatted <= 3.4.1

## Vulnerabilities Fixed

| Package | Severity | CVE | Version Change |
|---------|----------|-----|----------------|
| flatted | HIGH | CVE-2026-33228 | 3.4.1 → 3.4.2 |

## Validation

All checks passed before PR creation:
- `pnpm lint` - No linting errors
- `pnpm typecheck` - No type errors
- `pnpm test:unit` - All 1115 tests passing

## Review Checklist

- [ ] Verify no breaking changes in dependency updates
- [ ] Confirm CVE-2026-33228 is addressed

---

Generated with [Claude Code](https://claude.ai/claude-code)