### PR TITLE
feat(utils): add `stringToColorPalette` utility

### DIFF
--- a/apps/docs/src/components/doc-metadata/doc-metadata.tsx
+++ b/apps/docs/src/components/doc-metadata/doc-metadata.tsx
@@ -1,4 +1,10 @@
-import { Badge, Heading, Stack, Text } from "@commercetools/nimbus";
+import {
+  Badge,
+  Heading,
+  Stack,
+  Text,
+  stringToColorPalette,
+} from "@commercetools/nimbus";
 import { lifecycleStateDescriptions } from "@/schemas/lifecycle-states";
 import type { DocMetadataProps } from "./doc-metadata.types";
 
@@ -49,7 +55,11 @@ export const DocMetadata = ({
         <Stack direction="row" gap="200" alignItems="center" flexWrap="wrap">
           {/* Tags */}
           {tags?.map((tag) => (
-            <Badge key={tag} size="2xs" colorPalette="neutral">
+            <Badge
+              key={tag}
+              size="2xs"
+              colorPalette={stringToColorPalette(tag)}
+            >
               {tag}
             </Badge>
           ))}

--- a/packages/nimbus/src/index.ts
+++ b/packages/nimbus/src/index.ts
@@ -3,3 +3,4 @@ export * from "./hooks";
 export * from "./patterns";
 export * from "./theme";
 export * from "./type-utils";
+export { stringToColorPalette } from "./utils/string-to-color-palette";

--- a/packages/nimbus/src/type-utils/shared-types.ts
+++ b/packages/nimbus/src/type-utils/shared-types.ts
@@ -1,6 +1,7 @@
 import {
   SEMANTIC_COLOR_PALETTES,
   ALL_COLOR_PALETTES,
+  SYSTEM_COLOR_PALETTES,
 } from "@/constants/color-palettes";
 /**
  * Shared type re-exports from external dependencies.
@@ -32,6 +33,13 @@ export type NimbusColorPalette = (typeof ALL_COLOR_PALETTES)[number];
  * Derived from SEMANTIC_PALETTES constant to ensure type safety when referencing palettes.
  */
 type SemanticColorPalette = (typeof SEMANTIC_COLOR_PALETTES)[number];
+
+/**
+ * Union type of the 25 system color palette names.
+ * Derived from SYSTEM_COLOR_PALETTES constant. Useful for components that accept
+ * a system palette (e.g. avatars, tags, data visualization).
+ */
+export type SystemColorPalette = (typeof SYSTEM_COLOR_PALETTES)[number];
 
 /**
  * Utility Type that narrows the colorPalette prop in chakra-ui recipes to only accept semantic color palettes

--- a/packages/nimbus/src/utils/index.ts
+++ b/packages/nimbus/src/utils/index.ts
@@ -3,3 +3,4 @@ export { extractAriaAttributes } from "./extract-aria-attributes";
 export { extractStyleProps } from "./extract-style-props";
 export { mergeRefs } from "./merge-refs";
 export { noop } from "./no-op";
+export { stringToColorPalette } from "./string-to-color-palette";

--- a/packages/nimbus/src/utils/string-to-color-palette.spec.ts
+++ b/packages/nimbus/src/utils/string-to-color-palette.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { SYSTEM_COLOR_PALETTES } from "@/constants/color-palettes";
+import { stringToColorPalette } from "./string-to-color-palette";
+
+describe("stringToColorPalette", () => {
+  it("returns a valid system color palette for a regular string", () => {
+    const result = stringToColorPalette("hello");
+    expect(SYSTEM_COLOR_PALETTES).toContain(result);
+  });
+
+  it("is deterministic — same input always produces the same output", () => {
+    const input = "John Doe";
+    const first = stringToColorPalette(input);
+    const second = stringToColorPalette(input);
+    expect(first).toBe(second);
+  });
+
+  it("produces varied outputs across different inputs", () => {
+    const inputs = [
+      "Alice",
+      "Bob",
+      "Charlie",
+      "Delta",
+      "Echo",
+      "Foxtrot",
+      "Golf",
+      "Hotel",
+      "India",
+      "Juliet",
+    ];
+    const palettes = new Set(inputs.map(stringToColorPalette));
+    expect(palettes.size).toBeGreaterThan(1);
+  });
+
+  it("handles an empty string without throwing", () => {
+    expect(() => stringToColorPalette("")).not.toThrow();
+    expect(SYSTEM_COLOR_PALETTES).toContain(stringToColorPalette(""));
+  });
+
+  it("handles a single character", () => {
+    const result = stringToColorPalette("a");
+    expect(SYSTEM_COLOR_PALETTES).toContain(result);
+  });
+
+  it("handles a very long string", () => {
+    const longString = "a".repeat(10_000);
+    expect(() => stringToColorPalette(longString)).not.toThrow();
+    expect(SYSTEM_COLOR_PALETTES).toContain(stringToColorPalette(longString));
+  });
+
+  it("returns different palettes for strings that differ only in case", () => {
+    const lower = stringToColorPalette("nimbus");
+    const upper = stringToColorPalette("NIMBUS");
+    // They may or may not be equal; just ensure both are valid palettes.
+    expect(SYSTEM_COLOR_PALETTES).toContain(lower);
+    expect(SYSTEM_COLOR_PALETTES).toContain(upper);
+  });
+
+  it("maps every result to a value in SYSTEM_COLOR_PALETTES", () => {
+    const samples = [
+      "commerce",
+      "tools",
+      "design",
+      "system",
+      "nimbus",
+      "12345",
+      "!@#$%",
+      " ",
+    ];
+    for (const sample of samples) {
+      expect(SYSTEM_COLOR_PALETTES).toContain(stringToColorPalette(sample));
+    }
+  });
+});

--- a/packages/nimbus/src/utils/string-to-color-palette.ts
+++ b/packages/nimbus/src/utils/string-to-color-palette.ts
@@ -1,0 +1,32 @@
+import { SYSTEM_COLOR_PALETTES } from "@/constants/color-palettes";
+
+type SystemColorPalette = (typeof SYSTEM_COLOR_PALETTES)[number];
+
+/**
+ * Deterministically maps an input string to one of the 25 system color palettes.
+ *
+ * Uses the djb2 hashing algorithm to produce a stable, evenly-distributed
+ * mapping. The same input always returns the same palette, making it suitable
+ * for assigning consistent colors to entities such as user avatars, category
+ * tags, or data visualization labels.
+ *
+ * @param input - The string to hash into a color palette.
+ * @returns A system color palette name from the 25 available options.
+ *
+ * @example
+ * ```tsx
+ * const palette = stringToColorPalette("John Doe");
+ * // palette is always the same value for "John Doe", e.g. "violet"
+ *
+ * <Avatar colorPalette={stringToColorPalette(user.name)}>JD</Avatar>
+ * ```
+ */
+export const stringToColorPalette = (input: string): SystemColorPalette => {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0; // Convert to 32-bit integer
+  }
+  const index = Math.abs(hash) % SYSTEM_COLOR_PALETTES.length;
+  return SYSTEM_COLOR_PALETTES[index];
+};


### PR DESCRIPTION
> [!NOTE]
> I want colored badges, but I am also too lazy to create a mapping. This utility deterministically picks a colorPalette from the available ones, based on an input-string. The same string will always return the same colorPalette name. It can be used in cases where we know we need variance but not to which extend.

<img width="770" height="276" alt="image" src="https://github.com/user-attachments/assets/1e478988-ca63-458d-a16e-6eae482660bc" />


## Summary
- Adds `stringToColorPalette()` — a pure function that deterministically maps any input string to one of the 25 system color palettes using djb2 hashing
- Exports `SystemColorPalette` type from shared-types for reuse across the codebase
- Includes 8 unit tests covering determinism, distribution, and edge cases

## Test plan
- [x] Unit tests pass (`pnpm test:dev packages/nimbus/src/utils/string-to-color-palette.spec.ts`)
- [x] TypeScript typecheck passes (`pnpm --filter @commercetools/nimbus typecheck`)