### PR TITLE
feat(scroll-area): add ScrollArea layout component

### DIFF
--- a/.changeset/add-scroll-area-component.md
+++ b/.changeset/add-scroll-area-component.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": minor
+---
+
+Add ScrollArea layout component — a scrollable, keyboard accessible container
+with custom-styled scrollbar overlays.

--- a/apps/docs/src/components/app-frame/app-frame.tsx
+++ b/apps/docs/src/components/app-frame/app-frame.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ReactNode } from "react";
-import { Box, Grid } from "@commercetools/nimbus";
+import { Box, Grid, ScrollArea } from "@commercetools/nimbus";
 
 export interface AppFrameRootProps {
   children: ReactNode;
@@ -101,35 +101,17 @@ function AppFrameTopBar({ children }: AppFrameTopBarProps) {
  */
 function AppFrameLeftNav({ children }: AppFrameLeftNavProps) {
   return (
-    <Box
-      id="app-frame-left-nav"
+    <ScrollArea
       as="nav"
+      id="app-frame-left-nav"
       gridArea="nav"
-      overflowY="auto"
-      overflowX="hidden"
       borderRight="solid-25"
       borderColor="neutral.3"
       bg="bg"
-      py="400"
-      css={{
-        // Custom scrollbar styling
-        "&::-webkit-scrollbar": {
-          width: "200",
-        },
-        "&::-webkit-scrollbar-track": {
-          background: "{colors.neutral.2}",
-        },
-        "&::-webkit-scrollbar-thumb": {
-          background: "{colors.neutral.3}",
-          borderRadius: "100",
-        },
-        "&::-webkit-scrollbar-thumb:hover": {
-          background: "{colors.neutral.4}",
-        },
-      }}
+      size="sm"
     >
-      {children}
-    </Box>
+      <Box py="400">{children}</Box>
+    </ScrollArea>
   );
 }
 
@@ -138,36 +120,22 @@ function AppFrameLeftNav({ children }: AppFrameLeftNavProps) {
  */
 function AppFrameMainContent({ children }: AppFrameMainContentProps) {
   return (
-    <Box
+    <ScrollArea
       as="main"
       id="main"
       gridArea="main"
-      overflowY="scroll"
-      overflowX="hidden"
-      scrollPaddingTop="120px"
-      p="800"
       bg="bg"
+      size="sm"
       css={{
-        // Custom scrollbar styling
-        "&::-webkit-scrollbar": {
-          width: "200",
-        },
-        "&::-webkit-scrollbar-track": {
-          background: "{colors.neutral.2}",
-        },
-        "&::-webkit-scrollbar-thumb": {
-          background: "{colors.neutral.3}",
-          borderRadius: "100",
-        },
-        "&::-webkit-scrollbar-thumb:hover": {
-          background: "{colors.neutral.4}",
-        },
+        '& [data-part="viewport"]': { scrollPaddingTop: "120px" },
       }}
     >
-      <Box maxWidth="80ch" mx="auto">
-        {children}
+      <Box p="800">
+        <Box maxWidth="80ch" mx="auto">
+          {children}
+        </Box>
       </Box>
-    </Box>
+    </ScrollArea>
   );
 }
 
@@ -176,34 +144,11 @@ function AppFrameMainContent({ children }: AppFrameMainContentProps) {
  */
 function AppFrameRightAside({ children }: AppFrameRightAsideProps) {
   return (
-    <Box
-      as="aside"
-      gridArea="aside"
-      overflowY="auto"
-      overflowX="hidden"
-      bg="bg"
-      pl="800"
-      pr="800"
-      py="400"
-      css={{
-        // Custom scrollbar styling
-        "&::-webkit-scrollbar": {
-          width: "200",
-        },
-        "&::-webkit-scrollbar-track": {
-          background: "{colors.neutral.2}",
-        },
-        "&::-webkit-scrollbar-thumb": {
-          background: "{colors.neutral.3}",
-          borderRadius: "100",
-        },
-        "&::-webkit-scrollbar-thumb:hover": {
-          background: "{colors.neutral.4}",
-        },
-      }}
-    >
-      {children}
-    </Box>
+    <ScrollArea as="aside" gridArea="aside" bg="bg" variant="always" size="sm">
+      <Box px="800" py="400">
+        {children}
+      </Box>
+    </ScrollArea>
   );
 }
 

--- a/apps/docs/src/components/app-frame/app-frame.tsx
+++ b/apps/docs/src/components/app-frame/app-frame.tsx
@@ -5,7 +5,7 @@
  * All built with Nimbus components
  */
 
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 import { Box, Grid, ScrollArea } from "@commercetools/nimbus";
 
 export interface AppFrameRootProps {
@@ -22,10 +22,12 @@ export interface AppFrameTopBarProps {
 
 export interface AppFrameLeftNavProps {
   children: ReactNode;
+  viewportRef?: RefObject<HTMLDivElement | null>;
 }
 
 export interface AppFrameMainContentProps {
   children: ReactNode;
+  viewportRef?: RefObject<HTMLDivElement | null>;
 }
 
 export interface AppFrameRightAsideProps {
@@ -99,11 +101,12 @@ function AppFrameTopBar({ children }: AppFrameTopBarProps) {
 /**
  * Left Navigation - Scrollable sidebar
  */
-function AppFrameLeftNav({ children }: AppFrameLeftNavProps) {
+function AppFrameLeftNav({ children, viewportRef }: AppFrameLeftNavProps) {
   return (
     <ScrollArea
       as="nav"
       id="app-frame-left-nav"
+      viewportRef={viewportRef}
       gridArea="nav"
       borderRight="solid-25"
       borderColor="neutral.3"
@@ -118,17 +121,18 @@ function AppFrameLeftNav({ children }: AppFrameLeftNavProps) {
 /**
  * Main Content Area - Scrollable with constrained content width
  */
-function AppFrameMainContent({ children }: AppFrameMainContentProps) {
+function AppFrameMainContent({
+  children,
+  viewportRef,
+}: AppFrameMainContentProps) {
   return (
     <ScrollArea
       as="main"
       id="main"
+      viewportRef={viewportRef}
       gridArea="main"
       bg="bg"
       size="sm"
-      css={{
-        '& [data-part="viewport"]': { scrollPaddingTop: "120px" },
-      }}
     >
       <Box p="800">
         <Box maxWidth="80ch" mx="auto">

--- a/apps/docs/src/components/navigation/menu/components/menu-item.tsx
+++ b/apps/docs/src/components/navigation/menu/components/menu-item.tsx
@@ -4,6 +4,7 @@ import { Box, Link, Text } from "@commercetools/nimbus";
 import { MenuIcon } from "./menu-icon";
 import { MenuList } from "./menu-list";
 import { useRouteInfo } from "@/hooks/use-route-info";
+import { useSidebarViewport } from "@/contexts/scroll-container-context";
 
 /**
  * MenuItem component
@@ -11,6 +12,7 @@ import { useRouteInfo } from "@/hooks/use-route-info";
  */
 export const MenuItem = ({ item, level }: MenuItemProps) => {
   const { baseRoute } = useRouteInfo();
+  const sidebarViewportRef = useSidebarViewport();
   const activeRoute = baseRoute;
   const isParentItem = activeRoute.includes(item.route);
   const isActiveRoute = activeRoute === item.route;
@@ -26,7 +28,7 @@ export const MenuItem = ({ item, level }: MenuItemProps) => {
 
   // Preserve sidebar scroll position on click
   const handleClick = () => {
-    const sidebar = document.getElementById("app-frame-left-nav");
+    const sidebar = sidebarViewportRef.current;
     if (sidebar) {
       const scrollPos = sidebar.scrollTop;
       // Store scroll position in sessionStorage as backup

--- a/apps/docs/src/components/navigation/toc/hooks/use-closest-heading.ts
+++ b/apps/docs/src/components/navigation/toc/hooks/use-closest-heading.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useMainViewport } from "@/contexts/scroll-container-context";
 
 /**
  * Custom hook to find the closest heading element (h1-h6) to the top of the viewport.
@@ -8,6 +9,7 @@ import { useEffect, useRef, useState } from "react";
 export const useClosestHeading = (): string | null => {
   const [closestHeadingId, setClosestHeadingId] = useState<string | null>(null);
   const isHashNavigating = useRef(false);
+  const mainViewportRef = useMainViewport();
 
   useEffect(() => {
     let scrollTimeoutId: number | null = null;
@@ -102,10 +104,9 @@ export const useClosestHeading = (): string | null => {
       }
     };
 
-    // Run on scroll and on initial render
-    const scrollElement = document.getElementById("main");
+    // Listen to the main viewport scroll events
+    const scrollElement = mainViewportRef.current;
 
-    // Listen to both the main element scroll and window scroll to ensure we capture all scroll events
     if (scrollElement) {
       scrollElement.addEventListener("scroll", handleScroll);
     }
@@ -132,7 +133,7 @@ export const useClosestHeading = (): string | null => {
         window.clearTimeout(scrollTimeoutId);
       }
     };
-  }, []);
+  }, [mainViewportRef]);
 
   return closestHeadingId;
 };

--- a/apps/docs/src/components/navigation/toc/toc.tsx
+++ b/apps/docs/src/components/navigation/toc/toc.tsx
@@ -1,6 +1,7 @@
 import { Box, Link, Text } from "@commercetools/nimbus";
 import { useToc } from "@/hooks/useToc";
 import { useClosestHeading } from "./hooks/use-closest-heading.ts";
+import { useMainViewport } from "@/contexts/scroll-container-context";
 import { scrollToAnchor } from "@/utils/scroll-to-anchor";
 
 /**
@@ -10,6 +11,7 @@ import { scrollToAnchor } from "@/utils/scroll-to-anchor";
 export const Toc = () => {
   const activeToc = useToc();
   const closestHeadingId = useClosestHeading();
+  const mainViewportRef = useMainViewport();
 
   // Define indentation levels for different heading depths
   const indent: { [key: number]: string | undefined } = {
@@ -44,8 +46,10 @@ export const Toc = () => {
       window.location.hash = headingId;
     }
 
-    // Use the router's scroll to anchor functionality
-    scrollToAnchor(headingId);
+    // Scroll to the anchor in the main viewport
+    if (mainViewportRef.current) {
+      scrollToAnchor(headingId, mainViewportRef.current);
+    }
   };
 
   if (!activeToc || activeToc.length === 0) {

--- a/apps/docs/src/components/view-tabs/view-tabs.tsx
+++ b/apps/docs/src/components/view-tabs/view-tabs.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, useRef, memo } from "react";
 import { Box, Tabs } from "@commercetools/nimbus";
 import type { TabMetadata } from "@/types";
 import { useRouteInfo } from "@/hooks/use-route-info";
+import { useMainViewport } from "@/contexts/scroll-container-context";
 
 export type ViewType = TabMetadata["key"];
 
@@ -24,6 +25,7 @@ interface ViewTabsProps {
  */
 export const ViewTabs = memo(({ tabs }: ViewTabsProps) => {
   const { baseRoute, viewKey } = useRouteInfo();
+  const mainViewportRef = useMainViewport();
   const [isVisible, setIsVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
   const boxRef = useRef<HTMLDivElement>(null);
@@ -62,7 +64,7 @@ export const ViewTabs = memo(({ tabs }: ViewTabsProps) => {
   // Handle scroll direction to show/hide tabs
   useEffect(() => {
     const SCROLL_THRESHOLD = 5; // Minimum scroll distance to trigger hide/show
-    const mainElement = document.getElementById("main");
+    const mainElement = mainViewportRef.current;
 
     if (!mainElement) return;
 
@@ -97,7 +99,7 @@ export const ViewTabs = memo(({ tabs }: ViewTabsProps) => {
     return () => {
       mainElement.removeEventListener("scroll", handleScroll);
     };
-  }, [lastScrollY]);
+  }, [lastScrollY, mainViewportRef]);
 
   return (
     <Box
@@ -107,7 +109,7 @@ export const ViewTabs = memo(({ tabs }: ViewTabsProps) => {
       bg="bg"
       borderRadius="full"
       position="sticky"
-      top="0"
+      top="800"
       zIndex="1"
       css={{
         transform: isVisible ? "translateY(0)" : "translateY(-100%)",

--- a/apps/docs/src/contexts/scroll-container-context.tsx
+++ b/apps/docs/src/contexts/scroll-container-context.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useMemo,
   type RefObject,
   type ReactNode,
 } from "react";
@@ -13,6 +14,8 @@ interface ScrollContainerContextValue {
 const ScrollContainerContext =
   createContext<ScrollContainerContextValue | null>(null);
 
+const fallbackRef: RefObject<HTMLElement | null> = { current: null };
+
 export function ScrollContainerProvider({
   children,
   mainViewportRef,
@@ -22,14 +25,16 @@ export function ScrollContainerProvider({
   mainViewportRef: RefObject<HTMLElement | null>;
   sidebarViewportRef?: RefObject<HTMLElement | null>;
 }) {
-  const fallbackRef = { current: null };
+  const value = useMemo(
+    () => ({
+      mainViewportRef,
+      sidebarViewportRef: sidebarViewportRef ?? fallbackRef,
+    }),
+    [mainViewportRef, sidebarViewportRef]
+  );
+
   return (
-    <ScrollContainerContext.Provider
-      value={{
-        mainViewportRef,
-        sidebarViewportRef: sidebarViewportRef ?? fallbackRef,
-      }}
-    >
+    <ScrollContainerContext.Provider value={value}>
       {children}
     </ScrollContainerContext.Provider>
   );

--- a/apps/docs/src/contexts/scroll-container-context.tsx
+++ b/apps/docs/src/contexts/scroll-container-context.tsx
@@ -53,9 +53,10 @@ export function useMainViewport(): RefObject<HTMLElement | null> {
 export function useSidebarViewport(): RefObject<HTMLElement | null> {
   const ctx = useContext(ScrollContainerContext);
   if (!ctx) {
-    throw new Error(
-      "useSidebarViewport must be used within ScrollContainerProvider"
+    console.warn(
+      "useSidebarViewport called outside ScrollContainerProvider — returning fallback ref"
     );
+    return fallbackRef;
   }
   return ctx.sidebarViewportRef;
 }

--- a/apps/docs/src/contexts/scroll-container-context.tsx
+++ b/apps/docs/src/contexts/scroll-container-context.tsx
@@ -1,0 +1,56 @@
+import {
+  createContext,
+  useContext,
+  type RefObject,
+  type ReactNode,
+} from "react";
+
+interface ScrollContainerContextValue {
+  mainViewportRef: RefObject<HTMLElement | null>;
+  sidebarViewportRef: RefObject<HTMLElement | null>;
+}
+
+const ScrollContainerContext =
+  createContext<ScrollContainerContextValue | null>(null);
+
+export function ScrollContainerProvider({
+  children,
+  mainViewportRef,
+  sidebarViewportRef,
+}: {
+  children: ReactNode;
+  mainViewportRef: RefObject<HTMLElement | null>;
+  sidebarViewportRef?: RefObject<HTMLElement | null>;
+}) {
+  const fallbackRef = { current: null };
+  return (
+    <ScrollContainerContext.Provider
+      value={{
+        mainViewportRef,
+        sidebarViewportRef: sidebarViewportRef ?? fallbackRef,
+      }}
+    >
+      {children}
+    </ScrollContainerContext.Provider>
+  );
+}
+
+export function useMainViewport(): RefObject<HTMLElement | null> {
+  const ctx = useContext(ScrollContainerContext);
+  if (!ctx) {
+    throw new Error(
+      "useMainViewport must be used within ScrollContainerProvider"
+    );
+  }
+  return ctx.mainViewportRef;
+}
+
+export function useSidebarViewport(): RefObject<HTMLElement | null> {
+  const ctx = useContext(ScrollContainerContext);
+  if (!ctx) {
+    throw new Error(
+      "useSidebarViewport must be used within ScrollContainerProvider"
+    );
+  }
+  return ctx.sidebarViewportRef;
+}

--- a/apps/docs/src/hooks/use-hash-navigation.ts
+++ b/apps/docs/src/hooks/use-hash-navigation.ts
@@ -7,21 +7,24 @@
 
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { useMainViewport } from "@/contexts/scroll-container-context";
 import { scrollToAnchor } from "@/utils/scroll-to-anchor";
 
 export function useHashNavigation() {
   const location = useLocation();
+  const mainViewportRef = useMainViewport();
 
   useEffect(() => {
     // Extract the hash without the # prefix
     const hash = location.hash.slice(1);
 
-    if (hash) {
+    if (hash && mainViewportRef.current) {
+      const scrollContainer = mainViewportRef.current;
       // Small delay to ensure content is rendered
       // This is especially important for MDX content that renders asynchronously
       setTimeout(() => {
-        scrollToAnchor(hash);
+        scrollToAnchor(hash, scrollContainer);
       }, 50);
     }
-  }, [location.pathname, location.hash]);
+  }, [location.pathname, location.hash, mainViewportRef]);
 }

--- a/apps/docs/src/hooks/use-scroll-restoration.ts
+++ b/apps/docs/src/hooks/use-scroll-restoration.ts
@@ -58,5 +58,5 @@ export function useScrollRestoration() {
       scrollPositions.set(location.pathname, scrollContainer.scrollTop);
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [location.pathname, location.hash]);
+  }, [location.pathname, location.hash, mainViewportRef]);
 }

--- a/apps/docs/src/hooks/use-scroll-restoration.ts
+++ b/apps/docs/src/hooks/use-scroll-restoration.ts
@@ -7,6 +7,7 @@
 
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
+import { useMainViewport } from "@/contexts/scroll-container-context";
 
 // Store scroll positions for each route
 const scrollPositions = new Map<string, number>();
@@ -14,10 +15,10 @@ const scrollPositions = new Map<string, number>();
 export function useScrollRestoration() {
   const location = useLocation();
   const isRestoringRef = useRef(false);
+  const mainViewportRef = useMainViewport();
 
   useEffect(() => {
-    // Get the scroll container
-    const scrollContainer = document.getElementById("main");
+    const scrollContainer = mainViewportRef.current;
     if (!scrollContainer) {
       return;
     }

--- a/apps/docs/src/hooks/use-sidebar-scroll-restoration.ts
+++ b/apps/docs/src/hooks/use-sidebar-scroll-restoration.ts
@@ -6,30 +6,19 @@
 
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
+import { useSidebarViewport } from "@/contexts/scroll-container-context";
 
 const DEBUG = false; // Set to true to enable debug logging
 
-export function useSidebarScrollRestoration(
-  sidebarId: string = "app-frame-left-nav"
-) {
+export function useSidebarScrollRestoration() {
   const location = useLocation();
   const scrollPositionRef = useRef<number>(0);
-  const sidebarRef = useRef<HTMLElement | null>(null);
+  const sidebarViewportRef = useSidebarViewport();
   const previousTopLevelRef = useRef<string>("");
-
-  // Initialize sidebar reference
-  useEffect(() => {
-    const sidebar = document.getElementById(sidebarId);
-    sidebarRef.current = sidebar;
-
-    if (DEBUG) {
-      console.log("[SidebarScroll] Sidebar element found:", !!sidebar);
-    }
-  }, [sidebarId]);
 
   // Save scroll position continuously
   useEffect(() => {
-    const sidebar = sidebarRef.current;
+    const sidebar = sidebarViewportRef.current;
     if (!sidebar) return;
 
     const saveScroll = () => {
@@ -52,7 +41,7 @@ export function useSidebarScrollRestoration(
 
   // Restore scroll on navigation
   useEffect(() => {
-    const sidebar = sidebarRef.current;
+    const sidebar = sidebarViewportRef.current;
     if (!sidebar) return;
 
     // Extract top-level section from pathname (e.g., "/components/..." -> "components")

--- a/apps/docs/src/hooks/use-sidebar-scroll-restoration.ts
+++ b/apps/docs/src/hooks/use-sidebar-scroll-restoration.ts
@@ -37,7 +37,7 @@ export function useSidebarScrollRestoration() {
     return () => {
       sidebar.removeEventListener("scroll", saveScroll);
     };
-  }, []);
+  }, [sidebarViewportRef]);
 
   // Restore scroll on navigation
   useEffect(() => {
@@ -138,5 +138,5 @@ export function useSidebarScrollRestoration() {
         timeouts.forEach(clearTimeout);
       };
     }
-  }, [location.pathname]);
+  }, [location.pathname, sidebarViewportRef]);
 }

--- a/apps/docs/src/layouts/app-layout.tsx
+++ b/apps/docs/src/layouts/app-layout.tsx
@@ -4,7 +4,7 @@
  * Main layout shell using the new Holy Grail AppFrame
  */
 
-import { Suspense } from "react";
+import { Suspense, useRef } from "react";
 import { Outlet } from "react-router-dom";
 import { Stack, LoadingSpinner, Box } from "@commercetools/nimbus";
 import { AppFrame } from "@/components/app-frame";
@@ -12,13 +12,21 @@ import { AppNavBar } from "@/components/navigation/app-nav-bar";
 import { Menu } from "@/components/navigation/menu";
 import { Toc } from "@/components/navigation/toc";
 import { BreadcrumbNav } from "@/components/navigation/breadcrumb";
+import {
+  ScrollContainerProvider,
+  useMainViewport,
+  useSidebarViewport,
+} from "@/contexts/scroll-container-context";
 
 import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 import { useSidebarScrollRestoration } from "@/hooks/use-sidebar-scroll-restoration";
 import { useHashNavigation } from "@/hooks/use-hash-navigation";
 import { useRouteInfo } from "@/hooks/use-route-info";
 
-export function AppLayout() {
+function AppLayoutInner() {
+  const mainViewportRef = useMainViewport();
+  const sidebarViewportRef = useSidebarViewport();
+
   // Enable scroll restoration on navigation
   useScrollRestoration();
 
@@ -47,14 +55,14 @@ export function AppLayout() {
       </AppFrame.BreadcrumbBar>
 
       {/* Left Navigation */}
-      <AppFrame.LeftNav>
+      <AppFrame.LeftNav viewportRef={sidebarViewportRef}>
         <Suspense fallback={<LoadingSpinner />}>
           <Menu />
         </Suspense>
       </AppFrame.LeftNav>
 
       {/* Main Content */}
-      <AppFrame.MainContent>
+      <AppFrame.MainContent viewportRef={mainViewportRef}>
         <Suspense fallback={<LoadingSpinner />}>
           {/* Animated wrapper that re-renders on route change */}
           <Box key={baseRoute} animationName="fade-in" animationDuration="slow">
@@ -72,5 +80,19 @@ export function AppLayout() {
         </Stack>
       </AppFrame.RightAside>
     </AppFrame.Root>
+  );
+}
+
+export function AppLayout() {
+  const mainViewportRef = useRef<HTMLDivElement>(null);
+  const sidebarViewportRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <ScrollContainerProvider
+      mainViewportRef={mainViewportRef}
+      sidebarViewportRef={sidebarViewportRef}
+    >
+      <AppLayoutInner />
+    </ScrollContainerProvider>
   );
 }

--- a/apps/docs/src/layouts/no-sidebar-layout.tsx
+++ b/apps/docs/src/layouts/no-sidebar-layout.tsx
@@ -8,7 +8,7 @@
 
 import { Suspense } from "react";
 import { Outlet, useLocation } from "react-router-dom";
-import { LoadingSpinner, Box, Flex } from "@commercetools/nimbus";
+import { LoadingSpinner, Box, Flex, ScrollArea } from "@commercetools/nimbus";
 import { AppNavBar } from "@/components/navigation/app-nav-bar";
 import { BreadcrumbNav } from "@/components/navigation/breadcrumb";
 import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
@@ -85,16 +85,13 @@ export function NoSidebarLayout() {
       </Box>
 
       {/* Main Content - Full width, scrollable */}
-      <Box
+      <ScrollArea
         as="main"
         flex={1}
-        overflowY="auto"
-        overflowX="hidden"
-        p="800"
         bg="bg"
         width="full"
+        size="sm"
         css={{
-          // Fade in + slide down animation
           animation: "fadeInSlideDown 0.4s ease-out forwards",
           "@keyframes fadeInSlideDown": {
             from: {
@@ -106,34 +103,21 @@ export function NoSidebarLayout() {
               transform: "translateY(0)",
             },
           },
-          // Custom scrollbar styling
-          "&::-webkit-scrollbar": {
-            width: "8px",
-          },
-          "&::-webkit-scrollbar-track": {
-            background: "var(--colors-neutral-2)",
-          },
-          "&::-webkit-scrollbar-thumb": {
-            background: "var(--colors-neutral-6)",
-            borderRadius: "4px",
-          },
-          "&::-webkit-scrollbar-thumb:hover": {
-            background: "var(--colors-neutral-7)",
-          },
         }}
       >
-        <Suspense fallback={<LoadingSpinner />}>
-          {/* Animated wrapper that re-renders on route change */}
-          <Box
-            key={location.pathname}
-            animationName="fade-in"
-            animationDuration="slow"
-            width="full"
-          >
-            <Outlet />
-          </Box>
-        </Suspense>
-      </Box>
+        <Box p="800">
+          <Suspense fallback={<LoadingSpinner />}>
+            <Box
+              key={location.pathname}
+              animationName="fade-in"
+              animationDuration="slow"
+              width="full"
+            >
+              <Outlet />
+            </Box>
+          </Suspense>
+        </Box>
+      </ScrollArea>
     </Flex>
   );
 }

--- a/apps/docs/src/layouts/no-sidebar-layout.tsx
+++ b/apps/docs/src/layouts/no-sidebar-layout.tsx
@@ -6,14 +6,20 @@
  * Does not use AppFrame grid to allow true full-width content.
  */
 
-import { Suspense } from "react";
+import { Suspense, useRef } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { LoadingSpinner, Box, Flex, ScrollArea } from "@commercetools/nimbus";
 import { AppNavBar } from "@/components/navigation/app-nav-bar";
 import { BreadcrumbNav } from "@/components/navigation/breadcrumb";
+import {
+  ScrollContainerProvider,
+  useMainViewport,
+} from "@/contexts/scroll-container-context";
 import { useScrollRestoration } from "@/hooks/use-scroll-restoration";
 
-export function NoSidebarLayout() {
+function NoSidebarLayoutInner() {
+  const mainViewportRef = useMainViewport();
+
   // Enable scroll restoration on navigation
   useScrollRestoration();
 
@@ -87,6 +93,7 @@ export function NoSidebarLayout() {
       {/* Main Content - Full width, scrollable */}
       <ScrollArea
         as="main"
+        viewportRef={mainViewportRef}
         flex={1}
         bg="bg"
         width="full"
@@ -119,5 +126,15 @@ export function NoSidebarLayout() {
         </Box>
       </ScrollArea>
     </Flex>
+  );
+}
+
+export function NoSidebarLayout() {
+  const mainViewportRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <ScrollContainerProvider mainViewportRef={mainViewportRef}>
+      <NoSidebarLayoutInner />
+    </ScrollContainerProvider>
   );
 }

--- a/apps/docs/src/utils/scroll-to-anchor.ts
+++ b/apps/docs/src/utils/scroll-to-anchor.ts
@@ -4,19 +4,16 @@
  * Applies an offset to account for sticky headers (breadcrumb + top navigation).
  *
  * @param elementId The ID of the element to scroll to (without the # prefix)
+ * @param scrollContainer The scrollable container element
  */
-export const scrollToAnchor = (elementId: string): void => {
+export const scrollToAnchor = (
+  elementId: string,
+  scrollContainer: HTMLElement
+): void => {
   if (!elementId) return;
 
   // Offset to account for sticky headers (breadcrumb ~48px + top nav ~56px + buffer ~16px)
   const SCROLL_OFFSET = 120;
-
-  // Get the scroll container (the main content area)
-  const scrollContainer = document.getElementById("main");
-  if (!scrollContainer) {
-    console.warn("Scroll container #main not found");
-    return;
-  }
 
   // Try to find the target element
   const element = document.getElementById(elementId);

--- a/apps/docs/src/utils/scroll-to-anchor.ts
+++ b/apps/docs/src/utils/scroll-to-anchor.ts
@@ -12,8 +12,8 @@ export const scrollToAnchor = (
 ): void => {
   if (!elementId) return;
 
-  // Offset to account for sticky headers (breadcrumb ~48px + top nav ~56px + buffer ~16px)
-  const SCROLL_OFFSET = 120;
+  // Offset to account for sticky elements within the scroll viewport
+  const SCROLL_OFFSET = 20;
 
   // Try to find the target element
   const element = document.getElementById(elementId);

--- a/docs/file-type-guidelines/recipes.md
+++ b/docs/file-type-guidelines/recipes.md
@@ -433,6 +433,34 @@ export { selectSlotRecipe } from "@/components/select/select.recipe";
 // ... other slot recipes
 ```
 
+### Chakra Compound Component Overrides
+
+When a Nimbus component wraps a Chakra compound component (e.g.,
+`ChakraScrollArea.Root`, `ChakraScrollArea.Viewport`), the recipe key must
+**not** use the `nimbus` prefix. Instead, use the bare Chakra key so that
+Chakra's own compound parts resolve Nimbus styles through the recipe system.
+
+```typescript
+// packages/nimbus/src/theme/slot-recipes/index.ts
+
+// ✅ Correct — overrides Chakra's built-in scrollArea recipe
+scrollArea: scrollAreaSlotRecipe,
+
+// ❌ Wrong — Chakra's ScrollArea.* parts won't find Nimbus styles
+nimbusScrollArea: scrollAreaSlotRecipe,
+```
+
+**When this applies:**
+
+- The component uses Chakra's compound parts directly (no Nimbus `.slots.tsx`)
+- Chakra's internal slot context already maps each part to the recipe key
+- Nimbus only needs to swap the recipe definition at the theme level
+
+**Current examples:** `scrollArea`, `toast`
+
+No `.slots.tsx` file is needed for these components — see
+[Slots — When Slots Aren't Needed](./slots.md#when-slots-arent-needed).
+
 ### Registration Validation
 
 **WARNING**: No automated validation exists!

--- a/docs/file-type-guidelines/slots.md
+++ b/docs/file-type-guidelines/slots.md
@@ -24,6 +24,13 @@ bridge React Aria components with the Nimbus styling system.
 - Component doesn't use recipes
 - Only composing existing styled components
 - No custom styling needed
+- **Wrapping a Chakra compound component** — when the component uses Chakra's
+  own compound parts (e.g., `ScrollArea.Root`, `ScrollArea.Viewport`) directly,
+  Chakra's internal slot context already maps each part to the recipe. In this
+  case, define a slot recipe with an unprefixed key to override Chakra's
+  built-in (see
+  [Recipe Registration — Chakra Overrides](./recipes.md#chakra-compound-component-overrides)),
+  but skip the `.slots.tsx` file. Examples: `ScrollArea`, `Toast`.
 
 ## Critical Requirements
 

--- a/openspec/changes/add-scroll-area-component/design.md
+++ b/openspec/changes/add-scroll-area-component/design.md
@@ -102,3 +102,23 @@ built-in key to override the default recipe). Slots:
 | `variant` | `hover`, `always` | `hover` |
 | `size` | `xs`, `sm`, `md`, `lg` | `sm` |
 
+### Gutter Strategy for `always` Variant
+
+When `variant="always"`, the scrollbar is permanently visible and must not
+overlay content. The viewport reserves a gutter via CSS:
+
+- **Vertical scrollbar**: `width: calc(100% - scrollbar-size - margin * 2)` —
+  works because width always resolves against a definite parent.
+- **Horizontal scrollbar**: `flex: 1` + `marginBottom` — height calc does not
+  work because the root's height comes from `maxHeight`, and CSS `%` heights
+  require an explicit `height` property on the parent.
+
+Both approaches reference the `--scroll-area-scrollbar-size` custom property,
+so the gutter automatically adapts to the active size variant.
+
+### Scrollbar Stacking Context
+
+The scrollbar uses `zIndex: 1` (with `position: relative` from the recipe) so
+it paints above viewport content that establishes its own stacking context, such
+as sticky-positioned headers.
+

--- a/openspec/changes/add-scroll-area-component/design.md
+++ b/openspec/changes/add-scroll-area-component/design.md
@@ -63,7 +63,7 @@ exported):
 1. **`ScrollArea`** (public) — extracts `children`, `orientation`, `ref`;
    renders `<ChakraScrollArea.Root>` with forwarded props.
 
-2. **`ScrollAreaInner`** (private) — renders inside `Root` so it can call
+2. **`ScrollAreaParts`** (private) — renders inside `Root` so it can call
    `useScrollAreaContext()` to read overflow state. Sets conditional `tabIndex`
    on Viewport. Conditionally renders Scrollbar(s) and Corner based on
    `orientation`.

--- a/openspec/changes/add-scroll-area-component/design.md
+++ b/openspec/changes/add-scroll-area-component/design.md
@@ -32,11 +32,7 @@ Chakra's ScrollArea lacks several features from the original spec:
 2. **Keyboard focus ring** — Chakra provides no focus styling. We add a
    `:focus-visible` ring on the root element via `_focusWithin` +
    `:has(:focus-visible)`.
-3. **TypeScript enforcement** — discriminated union types require an accessible
-   name when `role="region"` is set.
-4. **Dev warning** — runtime `console.warn` in development mode for missing
-   accessible names.
-5. **Nimbus design tokens** — scrollbar colors, sizes, and transitions use
+3. **Nimbus design tokens** — scrollbar colors, sizes, and transitions use
    Nimbus token scale.
 
 ## Single-Element API
@@ -65,8 +61,7 @@ Internally, the implementation uses two components (only `ScrollArea` is
 exported):
 
 1. **`ScrollArea`** (public) — extracts `children`, `orientation`, `ref`;
-   runs dev warning check; renders `<ChakraScrollArea.Root>` with forwarded
-   props.
+   renders `<ChakraScrollArea.Root>` with forwarded props.
 
 2. **`ScrollAreaInner`** (private) — renders inside `Root` so it can call
    `useScrollAreaContext()` to read overflow state. Sets conditional `tabIndex`
@@ -107,8 +102,3 @@ built-in key to override the default recipe). Slots:
 | `variant` | `hover`, `always` | `hover` |
 | `size` | `xs`, `sm`, `md`, `lg` | `sm` |
 
-## Developer Guardrails
-
-In development mode, `devWarn()` logs a `[Nimbus]`-prefixed `console.warn`
-when `role="region"` is used without `aria-label` or `aria-labelledby`. This
-catches a11y violations early without impacting production bundle size.

--- a/openspec/changes/add-scroll-area-component/design.md
+++ b/openspec/changes/add-scroll-area-component/design.md
@@ -49,11 +49,17 @@ not exposed.
 - **Orientation-driven** — scrollbar axes are controlled by a single
   `orientation` prop rather than manual `<Scrollbar orientation="...">`.
 
-### Content padding note
+### Padding prop forwarding
 
 With compound parts hidden, consumers cannot put padding on `Content` directly.
-Style props on `<ScrollArea>` apply to the root container. For inner content
-padding, consumers wrap children in `<Box p="...">`.
+To make `<ScrollArea p="400">` work intuitively, the component extracts all 24
+Chakra padding style props (via `extractPaddingProps` utility) and forwards them
+to the `Content` slot rather than `Root`. This means padding lives inside the
+scrollable area — matching native `overflow: auto` + `padding` behavior.
+
+Without forwarding, padding on `Root` would create dead space between the
+viewport and the absolutely-positioned scrollbar, and the `always` variant
+gutter calculation would misalign.
 
 ## Two-Component Internal Structure
 

--- a/openspec/changes/add-scroll-area-component/design.md
+++ b/openspec/changes/add-scroll-area-component/design.md
@@ -1,0 +1,114 @@
+# Design: ScrollArea
+
+## Architecture Decision: Chakra UI Proxy with Single-Element API
+
+Instead of building a custom `useScrollableRegion` hook with `ResizeObserver`
+and a thin component wrapper (as originally proposed), we proxy Chakra UI's
+built-in ScrollArea component. Chakra's ScrollArea is powered by Ark UI /
+zag-js, which already provides:
+
+- Overflow detection via a state machine (`hasOverflowX`, `hasOverflowY`)
+- Custom scrollbar overlays with drag-to-scroll
+- Scroll position tracking and scrollbar sizing
+- Corner element for bidirectional scrolling
+
+### Why proxy instead of custom?
+
+1. **Less code to maintain** — overflow detection, ResizeObserver lifecycle,
+   debouncing, and scrollbar rendering are all handled by zag-js.
+2. **Better scrollbar UX** — Ark UI provides draggable scrollbar thumbs with
+   proper hit areas, not just visual indicators.
+3. **Consistent with Nimbus patterns** — other components (Float, Bleed) also
+   proxy Chakra primitives with Nimbus recipes.
+
+### What we add on top
+
+Chakra's ScrollArea lacks several features from the original spec:
+
+1. **Conditional `tabIndex`** — zag-js has a bug where `tabIndex={0}` is only
+   set when BOTH axes overflow. We fix this by reading
+   `useScrollAreaContext()` and setting `tabIndex={0}` when EITHER axis
+   overflows.
+2. **Keyboard focus ring** — Chakra provides no focus styling. We add a
+   `:focus-visible` ring on the root element via `_focusWithin` +
+   `:has(:focus-visible)`.
+3. **TypeScript enforcement** — discriminated union types require an accessible
+   name when `role="region"` is set.
+4. **Dev warning** — runtime `console.warn` in development mode for missing
+   accessible names.
+5. **Nimbus design tokens** — scrollbar colors, sizes, and transitions use
+   Nimbus token scale.
+
+## Single-Element API
+
+Consumers interact with a single `<ScrollArea>` component. The compound parts
+(`Viewport`, `Content`, `Scrollbar`, `Corner`) are assembled internally and
+not exposed.
+
+### Why hide compound parts?
+
+- **Simpler API** — consumers don't need to understand the internal structure.
+- **Safer** — consumers can't accidentally break the scrollbar/viewport
+  relationship.
+- **Orientation-driven** — scrollbar axes are controlled by a single
+  `orientation` prop rather than manual `<Scrollbar orientation="...">`.
+
+### Content padding note
+
+With compound parts hidden, consumers cannot put padding on `Content` directly.
+Style props on `<ScrollArea>` apply to the root container. For inner content
+padding, consumers wrap children in `<Box p="...">`.
+
+## Two-Component Internal Structure
+
+Internally, the implementation uses two components (only `ScrollArea` is
+exported):
+
+1. **`ScrollArea`** (public) — extracts `children`, `orientation`, `ref`;
+   runs dev warning check; renders `<ChakraScrollArea.Root>` with forwarded
+   props.
+
+2. **`ScrollAreaInner`** (private) — renders inside `Root` so it can call
+   `useScrollAreaContext()` to read overflow state. Sets conditional `tabIndex`
+   on Viewport. Conditionally renders Scrollbar(s) and Corner based on
+   `orientation`.
+
+This split is necessary because `useScrollAreaContext()` must be called inside
+the `Root` provider.
+
+## Focus Ring Strategy
+
+The focus ring cannot be placed on the viewport element because the root has
+`overflow: hidden`, which clips child outlines. Instead:
+
+- Viewport gets `outline: none` (no browser default)
+- Root gets a focus ring via `_focusWithin` + `:has(:focus-visible)` — the
+  ring appears on the root when the viewport receives keyboard focus
+- This uses the global Nimbus focus ring design tokens
+
+## Slot Recipe
+
+The component uses a slot recipe registered as `scrollArea` (matching Chakra's
+built-in key to override the default recipe). Slots:
+
+| Slot | Purpose |
+|------|---------|
+| `root` | Outer container, receives focus ring styles |
+| `viewport` | Scrollable content area, native scrollbar hidden |
+| `content` | Inner content wrapper |
+| `scrollbar` | Overlay scrollbar track |
+| `thumb` | Draggable scrollbar thumb |
+| `corner` | Corner piece for bidirectional scrolling |
+
+### Variants
+
+| Variant | Values | Default |
+|---------|--------|---------|
+| `variant` | `hover`, `always` | `hover` |
+| `size` | `xs`, `sm`, `md`, `lg` | `sm` |
+
+## Developer Guardrails
+
+In development mode, `devWarn()` logs a `[Nimbus]`-prefixed `console.warn`
+when `role="region"` is used without `aria-label` or `aria-labelledby`. This
+catches a11y violations early without impacting production bundle size.

--- a/openspec/changes/add-scroll-area-component/proposal.md
+++ b/openspec/changes/add-scroll-area-component/proposal.md
@@ -1,0 +1,64 @@
+# Change: Add ScrollArea layout component
+
+## Why
+
+Containers with `overflow: auto` or `overflow: scroll` are inaccessible to
+keyboard-only and screen reader users unless they contain focusable elements.
+Users cannot scroll through static text, log output, or non-interactive content
+without a mouse. This is a common gap across the codebase (e.g., Dialog.Body,
+MainPage.Content, and any custom scrollable area).
+
+WCAG 2.1 SC 2.1.1 (Keyboard) requires that all functionality be operable via
+keyboard. A scrollable container that can only be scrolled with a mouse fails
+this criterion.
+
+Additionally, the codebase lacked styled scrollbar overlays — native browser
+scrollbars are visually inconsistent across platforms and do not follow Nimbus
+design tokens.
+
+## What Changes
+
+- **NEW** `ScrollArea` component in `packages/nimbus/src/components/scroll-area/`
+  - Single-element API that wraps Chakra UI's compound ScrollArea (powered by
+    Ark UI / zag-js) — consumers write `<ScrollArea>` instead of assembling
+    `Root > Viewport > Content > Scrollbar`
+  - Custom Nimbus slot recipe with design token-based scrollbar styling
+    (`neutral.4/7/9`), size variants (`xs`/`sm`/`md`/`lg`), and visibility
+    variants (`hover`/`always`)
+  - Conditional `tabIndex` via `useScrollAreaContext()` — viewport receives
+    `tabIndex={0}` only when content overflows on either axis, satisfying the
+    `scrollable-region-focusable` axe rule
+  - Keyboard-only focus ring on root element using `_focusWithin` +
+    `:has(:focus-visible)` pattern
+  - `orientation` prop to control which scrollbar axes render (`vertical` |
+    `horizontal` | `both`)
+  - TypeScript discriminated union enforcing `aria-label` or `aria-labelledby`
+    when `role="region"` is set
+  - Dev-mode warning via `devWarn()` for missing accessible names at runtime
+  - Accepts all Chakra style props (`p`, `bg`, `maxH`, `w`, etc.)
+
+- **NEW** `devWarn` utility in `packages/nimbus/src/utils/dev-warn.ts`
+  - Reusable development-mode warning function prefixed with `[Nimbus]`
+
+No custom hook — overflow detection and scroll state are handled by Ark UI's
+zag-js state machine internally. No i18n — no user-facing strings.
+
+## Supersedes
+
+This change supersedes the original `ScrollableRegion` proposal
+(`add-scrollable-region-hook-and-component`) and PR #1295. Instead of building
+a custom hook with `ResizeObserver` and a thin component wrapper, we proxy
+Chakra UI's built-in ScrollArea which already provides overflow detection,
+custom scrollbar overlays, and the underlying state machine. We add Nimbus
+design tokens, keyboard accessibility fixes, and a simplified single-element
+API on top.
+
+## Impact
+
+- Affected specs: nimbus-scroll-area (new capability)
+- Affected code:
+  - **NEW**: `packages/nimbus/src/components/scroll-area/` (all files)
+  - **NEW**: `packages/nimbus/src/utils/dev-warn.ts`
+  - **MODIFIED**: `packages/nimbus/src/utils/index.ts` (export added)
+  - **MODIFIED**: `packages/nimbus/src/components/index.ts` (export added)
+  - **MODIFIED**: `packages/nimbus/src/theme/slot-recipes/index.ts` (recipe registered)

--- a/openspec/changes/add-scroll-area-component/proposal.md
+++ b/openspec/changes/add-scroll-area-component/proposal.md
@@ -32,13 +32,7 @@ design tokens.
     `:has(:focus-visible)` pattern
   - `orientation` prop to control which scrollbar axes render (`vertical` |
     `horizontal` | `both`)
-  - TypeScript discriminated union enforcing `aria-label` or `aria-labelledby`
-    when `role="region"` is set
-  - Dev-mode warning via `devWarn()` for missing accessible names at runtime
   - Accepts all Chakra style props (`p`, `bg`, `maxH`, `w`, etc.)
-
-- **NEW** `devWarn` utility in `packages/nimbus/src/utils/dev-warn.ts`
-  - Reusable development-mode warning function prefixed with `[Nimbus]`
 
 No custom hook — overflow detection and scroll state are handled by Ark UI's
 zag-js state machine internally. No i18n — no user-facing strings.
@@ -58,7 +52,5 @@ API on top.
 - Affected specs: nimbus-scroll-area (new capability)
 - Affected code:
   - **NEW**: `packages/nimbus/src/components/scroll-area/` (all files)
-  - **NEW**: `packages/nimbus/src/utils/dev-warn.ts`
-  - **MODIFIED**: `packages/nimbus/src/utils/index.ts` (export added)
   - **MODIFIED**: `packages/nimbus/src/components/index.ts` (export added)
   - **MODIFIED**: `packages/nimbus/src/theme/slot-recipes/index.ts` (recipe registered)

--- a/openspec/changes/add-scroll-area-component/proposal.md
+++ b/openspec/changes/add-scroll-area-component/proposal.md
@@ -32,7 +32,9 @@ design tokens.
     `:has(:focus-visible)` pattern
   - `orientation` prop to control which scrollbar axes render (`vertical` |
     `horizontal` | `both`)
-  - Accepts all Chakra style props (`p`, `bg`, `maxH`, `w`, etc.)
+  - Accepts all Chakra style props (`bg`, `maxH`, `w`, etc.) — padding
+    props (`p`, `px`, `py`, etc.) are forwarded to the Content slot so they
+    apply inside the scrollable area
 
 No custom hook — overflow detection and scroll state are handled by Ark UI's
 zag-js state machine internally. No i18n — no user-facing strings.

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -96,6 +96,18 @@ The component SHALL use Nimbus design tokens for scrollbar appearance.
 - **THEN** scrollbar SHALL be hidden and appear on hover or during scrolling
 - **WHEN** `variant="always"`
 - **THEN** scrollbar SHALL be permanently visible
+- **AND** the viewport SHALL reserve a gutter so the scrollbar does not overlay
+  content
+
+### Requirement: Scrollbar paints above viewport content
+
+The scrollbar SHALL paint above content inside the viewport, such as
+sticky-positioned elements.
+
+#### Scenario: Sticky content in viewport
+
+- **WHEN** the viewport contains sticky-positioned elements with z-index
+- **THEN** the scrollbar SHALL paint above them
 
 ### Requirement: ARIA role support
 

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -3,10 +3,9 @@
 ## Overview
 
 The ScrollArea component provides a scrollable container with custom-styled
-scrollbar overlays and keyboard accessibility. It wraps Chakra UI's ScrollArea
-(powered by Ark UI / zag-js) with a single-element API, Nimbus design tokens,
-conditional `tabIndex` for keyboard focusability, and TypeScript enforcement of
-accessible names for `role="region"`.
+scrollbar overlays and keyboard accessibility. It exposes a single-element API,
+uses Nimbus design tokens, conditionally manages keyboard focusability, and
+enforces accessible names for `role="region"` at the type level.
 
 **Component:** `ScrollArea` (public API)
 **Package:** `@commercetools/nimbus`
@@ -17,8 +16,8 @@ accessible names for `role="region"`.
 ### Requirement: Single-element API hides compound internals
 
 The component SHALL present a single `<ScrollArea>` element to consumers,
-assembling Chakra's compound parts (`Viewport`, `Content`, `Scrollbar`,
-`Corner`) internally.
+assembling all internal parts (viewport, content, scrollbars, corner)
+automatically.
 
 #### Scenario: Basic vertical scroll
 
@@ -72,7 +71,7 @@ The component SHALL display a focus ring only during keyboard navigation.
 
 ### Requirement: Scrollbar styling with Nimbus tokens
 
-The component SHALL use a custom Nimbus slot recipe for scrollbar appearance.
+The component SHALL use Nimbus design tokens for scrollbar appearance.
 
 #### Scenario: Scrollbar colors
 
@@ -140,21 +139,37 @@ is used without an accessible name.
 - **WHEN** the app is running in production mode
 - **THEN** SHALL NOT log any warnings
 
-### Requirement: Component accepts Chakra style props
+### Requirement: Component accepts style props
 
-The component SHALL accept all Chakra style props and forward them to the
-root element.
+The component SHALL accept style props and forward them to the root element.
 
 #### Scenario: Style props
 
-- **WHEN** Chakra style props (e.g., `p`, `bg`, `maxH`, `w`, `borderRadius`)
-  are passed
+- **WHEN** style props (e.g., `p`, `bg`, `maxH`, `w`, `borderRadius`) are passed
 - **THEN** SHALL forward them to the root container element
 
 #### Scenario: Ref forwarding
 
 - **WHEN** a `ref` is passed to `ScrollArea`
 - **THEN** SHALL forward the ref to the root DOM element
+
+#### Scenario: Viewport ref
+
+- **WHEN** a `viewportRef` is passed to `ScrollArea`
+- **THEN** SHALL forward the ref to the scrollable viewport element
+- **AND** consumers SHALL be able to use it for programmatic scrolling, scroll
+  event listeners, and reading scroll position
+
+#### Scenario: Custom element IDs
+
+- **WHEN** an `ids` prop is passed (e.g., `ids={{ viewport: "my-viewport" }}`)
+- **THEN** SHALL apply the specified IDs to the corresponding internal elements
+- **AND** consumers SHALL be able to use `getElementById` to access them
+
+#### Scenario: Polymorphic rendering
+
+- **WHEN** an `as` prop is passed (e.g., `as="nav"`, `as="main"`)
+- **THEN** SHALL render the root element as the specified HTML element
 
 #### Scenario: Children
 

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -153,8 +153,15 @@ The component SHALL accept style props and forward them to the root element.
 
 #### Scenario: Style props
 
-- **WHEN** style props (e.g., `p`, `bg`, `maxH`, `w`, `borderRadius`) are passed
+- **WHEN** style props (e.g., `bg`, `maxH`, `w`, `borderRadius`) are passed
 - **THEN** SHALL forward them to the root container element
+
+#### Scenario: Padding props
+
+- **WHEN** padding style props (e.g., `p`, `px`, `py`, `pt`) are passed
+- **THEN** SHALL forward them to the Content slot inside the scrollable area
+- **AND** SHALL NOT apply them to the root container element
+- **AND** padding SHALL behave like native `overflow: auto` with padding
 
 #### Scenario: Ref forwarding
 

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -4,8 +4,8 @@
 
 The ScrollArea component provides a scrollable container with custom-styled
 scrollbar overlays and keyboard accessibility. It exposes a single-element API,
-uses Nimbus design tokens, conditionally manages keyboard focusability, and
-enforces accessible names for `role="region"` at the type level.
+uses Nimbus design tokens, and conditionally manages keyboard focusability.
+ARIA roles and accessible names are left to the consumer's discretion.
 
 **Component:** `ScrollArea` (public API)
 **Package:** `@commercetools/nimbus`
@@ -97,47 +97,43 @@ The component SHALL use Nimbus design tokens for scrollbar appearance.
 - **WHEN** `variant="always"`
 - **THEN** scrollbar SHALL be permanently visible
 
-### Requirement: TypeScript enforcement for role="region"
+### Requirement: ARIA role support
 
-TypeScript SHALL enforce an accessible name when `role="region"` is set.
+The component SHALL accept an optional `role` prop of type `React.AriaRole`
+and forward it to the root element. `aria-label` and `aria-labelledby` SHALL
+be optional and forwarded to the root element. No compile-time or runtime
+enforcement is applied — accessibility validation is left to the consumer's
+tooling.
 
-#### Scenario: role="region" with aria-label
+#### Scenario: Custom role
 
 - **WHEN** `role="region"` and `aria-label` are provided
-- **THEN** SHALL compile without TypeScript errors
-
-#### Scenario: role="region" with aria-labelledby
-
-- **WHEN** `role="region"` and `aria-labelledby` are provided
-- **THEN** SHALL compile without TypeScript errors
-
-#### Scenario: role="region" without accessible name
-
-- **WHEN** `role="region"` is set without `aria-label` or `aria-labelledby`
-- **THEN** SHALL produce a TypeScript compilation error
+- **THEN** SHALL forward both attributes to the root element
 
 #### Scenario: No role
 
 - **WHEN** `role` is not set
-- **THEN** `aria-label` and `aria-labelledby` SHALL be optional
-- **AND** SHALL compile without TypeScript errors
+- **THEN** no role attribute SHALL be rendered
+- **AND** `aria-label` and `aria-labelledby` SHALL remain optional
 
-### Requirement: Developer warning for missing accessible name
+### Requirement: External scroll area control via `value` prop
 
-The component SHALL warn developers in development mode when `role="region"`
-is used without an accessible name.
+The component SHALL support external control by accepting a `value` prop
+containing a scroll area machine created via `useScrollArea()`.
 
-#### Scenario: Missing accessible name in development
+#### Scenario: External machine provided
 
-- **WHEN** `role="region"` is set
-- **AND** neither `aria-label` nor `aria-labelledby` is provided
-- **AND** the app is running in development mode
-- **THEN** SHALL log a `[Nimbus]`-prefixed `console.warn`
+- **WHEN** a `value` prop is passed (from `useScrollArea()`)
+- **THEN** SHALL use `RootProvider` instead of `Root` internally
+- **AND** the external machine SHALL provide access to scroll state
+  (`hasOverflowX`, `hasOverflowY`, `isAtTop`, `isAtBottom`, `isAtLeft`,
+  `isAtRight`) and methods (`scrollTo()`, `scrollToEdge()`,
+  `getScrollProgress()`)
 
-#### Scenario: Production mode
+#### Scenario: No value prop
 
-- **WHEN** the app is running in production mode
-- **THEN** SHALL NOT log any warnings
+- **WHEN** `value` is not provided
+- **THEN** SHALL create the scroll area machine internally (default behavior)
 
 ### Requirement: Component accepts style props
 

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -1,0 +1,162 @@
+# Specification: ScrollArea
+
+## Overview
+
+The ScrollArea component provides a scrollable container with custom-styled
+scrollbar overlays and keyboard accessibility. It wraps Chakra UI's ScrollArea
+(powered by Ark UI / zag-js) with a single-element API, Nimbus design tokens,
+conditional `tabIndex` for keyboard focusability, and TypeScript enforcement of
+accessible names for `role="region"`.
+
+**Component:** `ScrollArea` (public API)
+**Package:** `@commercetools/nimbus`
+**Category:** Layout
+
+## ADDED Requirements
+
+### Requirement: Single-element API hides compound internals
+
+The component SHALL present a single `<ScrollArea>` element to consumers,
+assembling Chakra's compound parts (`Viewport`, `Content`, `Scrollbar`,
+`Corner`) internally.
+
+#### Scenario: Basic vertical scroll
+
+- **WHEN** `<ScrollArea maxH="200px">` is rendered with overflowing content
+- **THEN** SHALL render a scrollable container with a vertical scrollbar overlay
+- **AND** SHALL NOT require consumers to use compound sub-components
+
+#### Scenario: Horizontal scroll
+
+- **WHEN** `orientation="horizontal"` is set
+- **THEN** SHALL render only a horizontal scrollbar
+- **AND** SHALL NOT render a vertical scrollbar
+
+#### Scenario: Both axes
+
+- **WHEN** `orientation="both"` is set
+- **THEN** SHALL render both vertical and horizontal scrollbars
+- **AND** SHALL render a corner element
+
+### Requirement: Conditional keyboard focusability
+
+The viewport SHALL receive `tabIndex={0}` only when content overflows.
+
+#### Scenario: Overflowing content
+
+- **WHEN** content overflows on either the horizontal or vertical axis
+- **THEN** the viewport SHALL have `tabIndex={0}`
+- **AND** SHALL be reachable via Tab key
+- **AND** SHALL be scrollable with Arrow keys, Page Up/Down, Home, End
+
+#### Scenario: Non-overflowing content
+
+- **WHEN** content does not overflow on any axis
+- **THEN** the viewport SHALL NOT have `tabIndex`
+- **AND** SHALL NOT appear in the Tab order
+
+### Requirement: Keyboard-only focus ring
+
+The component SHALL display a focus ring only during keyboard navigation.
+
+#### Scenario: Keyboard focus
+
+- **WHEN** the viewport receives keyboard focus (Tab key) and content overflows
+- **THEN** a Nimbus focus ring SHALL appear on the root element
+- **AND** SHALL use the global focus ring design tokens
+
+#### Scenario: Mouse focus
+
+- **WHEN** the viewport receives mouse focus (click)
+- **THEN** a focus ring SHALL NOT appear
+
+### Requirement: Scrollbar styling with Nimbus tokens
+
+The component SHALL use a custom Nimbus slot recipe for scrollbar appearance.
+
+#### Scenario: Scrollbar colors
+
+- **THEN** scrollbar track SHALL use `neutral.4`
+- **AND** thumb SHALL use `neutral.7` at rest
+- **AND** thumb SHALL use `neutral.9` on hover/active
+
+#### Scenario: Size variants
+
+- **WHEN** `size="xs"` is set
+- **THEN** scrollbar width SHALL be `sizes.100` (4px)
+- **WHEN** `size="sm"` (default)
+- **THEN** scrollbar width SHALL be `sizes.150` (6px)
+- **WHEN** `size="md"`
+- **THEN** scrollbar width SHALL be `sizes.200` (8px)
+- **WHEN** `size="lg"`
+- **THEN** scrollbar width SHALL be `sizes.300` (12px)
+
+#### Scenario: Visibility variants
+
+- **WHEN** `variant="hover"` (default)
+- **THEN** scrollbar SHALL be hidden and appear on hover or during scrolling
+- **WHEN** `variant="always"`
+- **THEN** scrollbar SHALL be permanently visible
+
+### Requirement: TypeScript enforcement for role="region"
+
+TypeScript SHALL enforce an accessible name when `role="region"` is set.
+
+#### Scenario: role="region" with aria-label
+
+- **WHEN** `role="region"` and `aria-label` are provided
+- **THEN** SHALL compile without TypeScript errors
+
+#### Scenario: role="region" with aria-labelledby
+
+- **WHEN** `role="region"` and `aria-labelledby` are provided
+- **THEN** SHALL compile without TypeScript errors
+
+#### Scenario: role="region" without accessible name
+
+- **WHEN** `role="region"` is set without `aria-label` or `aria-labelledby`
+- **THEN** SHALL produce a TypeScript compilation error
+
+#### Scenario: No role
+
+- **WHEN** `role` is not set
+- **THEN** `aria-label` and `aria-labelledby` SHALL be optional
+- **AND** SHALL compile without TypeScript errors
+
+### Requirement: Developer warning for missing accessible name
+
+The component SHALL warn developers in development mode when `role="region"`
+is used without an accessible name.
+
+#### Scenario: Missing accessible name in development
+
+- **WHEN** `role="region"` is set
+- **AND** neither `aria-label` nor `aria-labelledby` is provided
+- **AND** the app is running in development mode
+- **THEN** SHALL log a `[Nimbus]`-prefixed `console.warn`
+
+#### Scenario: Production mode
+
+- **WHEN** the app is running in production mode
+- **THEN** SHALL NOT log any warnings
+
+### Requirement: Component accepts Chakra style props
+
+The component SHALL accept all Chakra style props and forward them to the
+root element.
+
+#### Scenario: Style props
+
+- **WHEN** Chakra style props (e.g., `p`, `bg`, `maxH`, `w`, `borderRadius`)
+  are passed
+- **THEN** SHALL forward them to the root container element
+
+#### Scenario: Ref forwarding
+
+- **WHEN** a `ref` is passed to `ScrollArea`
+- **THEN** SHALL forward the ref to the root DOM element
+
+#### Scenario: Children
+
+- **WHEN** `children` are passed
+- **THEN** SHALL render them inside the scrollable viewport

--- a/openspec/changes/add-scroll-area-component/tasks.md
+++ b/openspec/changes/add-scroll-area-component/tasks.md
@@ -3,26 +3,21 @@
 - [x] 1.1 Create `packages/nimbus/src/components/scroll-area/` directory with
       files: `scroll-area.tsx`, `scroll-area.types.ts`, `scroll-area.recipe.ts`,
       `scroll-area.stories.tsx`, `index.ts`
-- [x] 1.2 Create `packages/nimbus/src/utils/dev-warn.ts` utility
-- [x] 1.3 Export `devWarn` from `packages/nimbus/src/utils/index.ts`
-- [x] 1.4 Export `ScrollArea` and `ScrollAreaProps` from
+- [x] 1.2 Export `ScrollArea` and `ScrollAreaProps` from
       `src/components/scroll-area/index.ts`
-- [x] 1.5 Add `export * from "./scroll-area"` to `src/components/index.ts`
-- [x] 1.6 Register `scrollAreaSlotRecipe` as `scrollArea` in
+- [x] 1.3 Add `export * from "./scroll-area"` to `src/components/index.ts`
+- [x] 1.4 Register `scrollAreaSlotRecipe` as `scrollArea` in
       `src/theme/slot-recipes/index.ts`
 
 ## 2. Implementation
 
-- [x] 2.1 Implement discriminated union types in `scroll-area.types.ts`
-      (`ScrollAreaRegionProps` requiring accessible name, `ScrollAreaDefaultProps`
-      with optional aria props)
-- [x] 2.2 Implement slot recipe in `scroll-area.recipe.ts` (Nimbus token colors,
+- [x] 2.1 Implement slot recipe in `scroll-area.recipe.ts` (Nimbus token colors,
       size variants, visibility variants, focus ring on root via `_focusWithin`)
-- [x] 2.3 Implement `ScrollAreaInner` private component (reads
+- [x] 2.2 Implement `ScrollAreaParts` private component (reads
       `useScrollAreaContext()` for conditional `tabIndex`, renders Viewport,
       Content, Scrollbar(s), Corner based on `orientation`)
-- [x] 2.4 Implement `ScrollArea` public component (extracts props, runs
-      `devWarn` check, renders `ChakraScrollArea.Root` with forwarded props)
+- [x] 2.3 Implement `ScrollArea` public component (extracts props,
+      renders `ChakraScrollArea.Root` with forwarded props)
 
 ## 3. Stories
 

--- a/openspec/changes/add-scroll-area-component/tasks.md
+++ b/openspec/changes/add-scroll-area-component/tasks.md
@@ -1,0 +1,49 @@
+## 1. Scaffold
+
+- [x] 1.1 Create `packages/nimbus/src/components/scroll-area/` directory with
+      files: `scroll-area.tsx`, `scroll-area.types.ts`, `scroll-area.recipe.ts`,
+      `scroll-area.stories.tsx`, `index.ts`
+- [x] 1.2 Create `packages/nimbus/src/utils/dev-warn.ts` utility
+- [x] 1.3 Export `devWarn` from `packages/nimbus/src/utils/index.ts`
+- [x] 1.4 Export `ScrollArea` and `ScrollAreaProps` from
+      `src/components/scroll-area/index.ts`
+- [x] 1.5 Add `export * from "./scroll-area"` to `src/components/index.ts`
+- [x] 1.6 Register `scrollAreaSlotRecipe` as `scrollArea` in
+      `src/theme/slot-recipes/index.ts`
+
+## 2. Implementation
+
+- [x] 2.1 Implement discriminated union types in `scroll-area.types.ts`
+      (`ScrollAreaRegionProps` requiring accessible name, `ScrollAreaDefaultProps`
+      with optional aria props)
+- [x] 2.2 Implement slot recipe in `scroll-area.recipe.ts` (Nimbus token colors,
+      size variants, visibility variants, focus ring on root via `_focusWithin`)
+- [x] 2.3 Implement `ScrollAreaInner` private component (reads
+      `useScrollAreaContext()` for conditional `tabIndex`, renders Viewport,
+      Content, Scrollbar(s), Corner based on `orientation`)
+- [x] 2.4 Implement `ScrollArea` public component (extracts props, runs
+      `devWarn` check, renders `ChakraScrollArea.Root` with forwarded props)
+
+## 3. Stories
+
+- [x] 3.1 Write Storybook stories with play functions covering: Default
+      (overflowing, vertical scrollbar, keyboard focusable), NonOverflowing
+      (short content), RoleRegion (role + aria-label), KeyboardFocusRing
+      (Tab focus + ring), VerticalOnly, HorizontalOnly, BothAxes,
+      AlwaysVisible, WithAriaLabelledBy, WithStyleProps, Sizes, SmokeTest
+
+## 4. Documentation
+
+- [x] 4.1 Create overview documentation (`scroll-area.mdx`)
+- [x] 4.2 Create developer documentation (`scroll-area.dev.mdx`)
+- [x] 4.3 Create accessibility documentation (`scroll-area.a11y.mdx`)
+
+## 5. Validation
+
+- [x] 5.1 TypeScript compiles without errors
+      (`pnpm --filter @commercetools/nimbus typecheck`)
+- [x] 5.2 Build succeeds (`pnpm --filter @commercetools/nimbus build`)
+- [x] 5.3 All 12 Storybook story tests pass
+      (`pnpm test:storybook:dev packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx`)
+- [x] 5.4 Lint passes
+      (`pnpm lint -- packages/nimbus/src/components/scroll-area/`)

--- a/openspec/changes/add-scroll-area-component/tasks.md
+++ b/openspec/changes/add-scroll-area-component/tasks.md
@@ -46,12 +46,20 @@
 - [x] 5.5 Add StickyContentInPanel story comparing always vs hover in a
       header/body/footer layout with a sticky row
 
-## 6. Validation
+## 6. Padding prop forwarding
 
-- [x] 6.1 TypeScript compiles without errors
+- [x] 6.1 Add `extractPaddingProps` utility in `src/utils/` covering all 24
+      Chakra padding style prop keys
+- [x] 6.2 Split padding props from root props in ScrollArea component and
+      forward to Content slot
+- [x] 6.3 Add PaddingOnRoot story to visualize padding behavior
+
+## 7. Validation
+
+- [x] 7.1 TypeScript compiles without errors
       (`pnpm --filter @commercetools/nimbus typecheck`)
-- [x] 6.2 Build succeeds (`pnpm --filter @commercetools/nimbus build`)
-- [x] 6.3 All Storybook story tests pass
+- [x] 7.2 Build succeeds (`pnpm --filter @commercetools/nimbus build`)
+- [x] 7.3 All Storybook story tests pass
       (`pnpm test:storybook:dev packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx`)
-- [x] 6.4 Lint passes
+- [x] 7.4 Lint passes
       (`pnpm lint -- packages/nimbus/src/components/scroll-area/`)

--- a/openspec/changes/add-scroll-area-component/tasks.md
+++ b/openspec/changes/add-scroll-area-component/tasks.md
@@ -33,12 +33,25 @@
 - [x] 4.2 Create developer documentation (`scroll-area.dev.mdx`)
 - [x] 4.3 Create accessibility documentation (`scroll-area.a11y.mdx`)
 
-## 5. Validation
+## 5. Post-review fixes
 
-- [x] 5.1 TypeScript compiles without errors
+- [x] 5.1 Add gutter to `always` variant so scrollbar does not overlay content
+      (width calc for vertical, flex + marginBottom for horizontal)
+- [x] 5.2 Add `zIndex: 1` to scrollbar base styles so it paints above sticky
+      content inside the viewport
+- [x] 5.3 Remove explicit `variant="always"` from stories that don't test it;
+      default `hover` variant is used unless explicitly testing `always`
+- [x] 5.4 Expand AlwaysVisible story to cover vertical, horizontal, and both
+      axes with gutter assertions
+- [x] 5.5 Add StickyContentInPanel story comparing always vs hover in a
+      header/body/footer layout with a sticky row
+
+## 6. Validation
+
+- [x] 6.1 TypeScript compiles without errors
       (`pnpm --filter @commercetools/nimbus typecheck`)
-- [x] 5.2 Build succeeds (`pnpm --filter @commercetools/nimbus build`)
-- [x] 5.3 All 12 Storybook story tests pass
+- [x] 6.2 Build succeeds (`pnpm --filter @commercetools/nimbus build`)
+- [x] 6.3 All Storybook story tests pass
       (`pnpm test:storybook:dev packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx`)
-- [x] 5.4 Lint passes
+- [x] 6.4 Lint passes
       (`pnpm lint -- packages/nimbus/src/components/scroll-area/`)

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -69,5 +69,6 @@ export * from "./tab-nav";
 export * from "./tabs";
 export * from "./toast";
 export * from "./localized-field";
+export * from "./scroll-area";
 export * from "./steps";
 export * from "./modal-page";

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -1,3 +1,9 @@
+// Non-nimbus-prefixed recipe overrides — placed first to work around a
+// react-docgen-typescript limitation where complex types at the end of
+// large barrel files fail to resolve.
+export * from "./scroll-area";
+export * from "./toast";
+
 export * from "./avatar";
 export * from "./box";
 export * from "./button";
@@ -67,8 +73,6 @@ export * from "./pagination";
 export * from "./drawer";
 export * from "./tab-nav";
 export * from "./tabs";
-export * from "./toast";
 export * from "./localized-field";
-export * from "./scroll-area";
 export * from "./steps";
 export * from "./modal-page";

--- a/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
+++ b/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
@@ -556,9 +556,12 @@ export const StackedModalPages: Story = {
 
     await step("Escape closes only the topmost level", async () => {
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(3);
-      });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(3);
+        },
+        { timeout: 3000 }
+      );
       expect(
         canvas.getByRole("heading", { name: "Select Attribute" })
       ).toBeInTheDocument();
@@ -569,21 +572,30 @@ export const StackedModalPages: Story = {
         name: /go back to add variant/i,
       });
       await userEvent.click(backButton);
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(2);
-      });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(2);
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Close remaining levels via Escape", async () => {
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(1);
-      });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(1);
+        },
+        { timeout: 3000 }
+      );
 
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Focus returns to page-level trigger", async () => {

--- a/packages/nimbus/src/components/scroll-area/index.ts
+++ b/packages/nimbus/src/components/scroll-area/index.ts
@@ -1,0 +1,2 @@
+export { ScrollArea } from "./scroll-area";
+export type { ScrollAreaProps } from "./scroll-area.types";

--- a/packages/nimbus/src/components/scroll-area/index.ts
+++ b/packages/nimbus/src/components/scroll-area/index.ts
@@ -1,3 +1,15 @@
 export { ScrollArea } from "./scroll-area";
 export { useScrollAreaContext } from "@chakra-ui/react/scroll-area";
 export type { ScrollAreaProps } from "./scroll-area.types";
+
+/**
+ * Custom element IDs for ScrollArea's internal parts.
+ * Pass to the `ids` prop to set known IDs for DOM access.
+ */
+export type ScrollAreaElementIds = Partial<{
+  root: string;
+  viewport: string;
+  content: string;
+  scrollbar: string;
+  thumb: string;
+}>;

--- a/packages/nimbus/src/components/scroll-area/index.ts
+++ b/packages/nimbus/src/components/scroll-area/index.ts
@@ -1,15 +1,6 @@
 export { ScrollArea } from "./scroll-area";
 export { useScrollAreaContext } from "@chakra-ui/react/scroll-area";
-export type { ScrollAreaProps } from "./scroll-area.types";
-
-/**
- * Custom element IDs for ScrollArea's internal parts.
- * Pass to the `ids` prop to set known IDs for DOM access.
- */
-export type ScrollAreaElementIds = Partial<{
-  root: string;
-  viewport: string;
-  content: string;
-  scrollbar: string;
-  thumb: string;
-}>;
+export type {
+  ScrollAreaProps,
+  ScrollAreaElementIds,
+} from "./scroll-area.types";

--- a/packages/nimbus/src/components/scroll-area/index.ts
+++ b/packages/nimbus/src/components/scroll-area/index.ts
@@ -1,2 +1,3 @@
 export { ScrollArea } from "./scroll-area";
+export { useScrollAreaContext } from "@chakra-ui/react/scroll-area";
 export type { ScrollAreaProps } from "./scroll-area.types";

--- a/packages/nimbus/src/components/scroll-area/index.ts
+++ b/packages/nimbus/src/components/scroll-area/index.ts
@@ -1,5 +1,12 @@
 export { ScrollArea } from "./scroll-area";
-export { useScrollAreaContext } from "@chakra-ui/react/scroll-area";
+export {
+  useScrollArea,
+  useScrollAreaContext,
+} from "@chakra-ui/react/scroll-area";
+export type {
+  UseScrollAreaProps,
+  UseScrollAreaReturn,
+} from "@chakra-ui/react/scroll-area";
 export type {
   ScrollAreaProps,
   ScrollAreaElementIds,

--- a/packages/nimbus/src/components/scroll-area/scroll-area.a11y.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.a11y.mdx
@@ -1,0 +1,43 @@
+---
+tab-title: Accessibility
+tab-order: 4
+---
+
+## Accessibility
+
+Accessibility ensures that digital content and functionality are usable by
+everyone, including people with disabilities, by addressing visual, auditory,
+cognitive, and physical limitations.
+
+```jsx live
+const App = () => (
+  <ScrollArea maxH="200px" w="400px" role="region" aria-label="Example content">
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Text>
+    ))}
+  </ScrollArea>
+);
+```
+
+### Accessibility standards
+
+- **Keyboard focusable:** The scrollable viewport receives `tabIndex={0}`
+  when content overflows on either axis, making it reachable via Tab and
+  scrollable with Arrow keys, Page Up/Down, Home, and End.
+- **Conditional focusability:** When content does not overflow, `tabIndex` is
+  not set, so the container does not appear in the Tab order unnecessarily.
+- **Keyboard-only focus ring:** A Nimbus focus ring appears on the root
+  element only during keyboard navigation (`:focus-visible`), not on mouse
+  click.
+- **Decorative scrollbars:** The custom scrollbar overlays are purely visual.
+  Actual scrolling is handled by the browser's native scroll mechanism.
+- **ARIA landmarks:** Use `role="region"` with `aria-label` or
+  `aria-labelledby` to create a named landmark for screen reader navigation.
+  TypeScript enforces that an accessible name is provided when
+  `role="region"` is set.
+- **Dev warning:** A console warning is logged in development mode if
+  `role="region"` is used without an accessible name.
+- **No keyboard trap:** Standard browser tab order is maintained. Focus moves
+  naturally into and out of the scroll area.

--- a/packages/nimbus/src/components/scroll-area/scroll-area.a11y.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.a11y.mdx
@@ -33,11 +33,8 @@ const App = () => (
   click.
 - **Decorative scrollbars:** The custom scrollbar overlays are purely visual.
   Actual scrolling is handled by the browser's native scroll mechanism.
-- **ARIA landmarks:** Use `role="region"` with `aria-label` or
-  `aria-labelledby` to create a named landmark for screen reader navigation.
-  TypeScript enforces that an accessible name is provided when
-  `role="region"` is set.
-- **Dev warning:** A console warning is logged in development mode if
-  `role="region"` is used without an accessible name.
+- **ARIA landmarks:** When the scroll area represents a distinct page section,
+  consider adding `role="region"` with `aria-label` or `aria-labelledby` to
+  create a named landmark for screen reader navigation.
 - **No keyboard trap:** Standard browser tab order is maintained. Focus moves
   naturally into and out of the scroll area.

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -95,7 +95,8 @@ const App = () => (
 
 Use the `viewportRef` prop to get a direct reference to the scrollable viewport
 element. This is the recommended approach when you need to programmatically
-scroll, attach scroll event listeners, or read scroll position:
+scroll, attach scroll event listeners, or read scroll position. The ref gives
+you direct access to the native DOM `scrollTo()` method:
 
 ```tsx
 const viewportRef = useRef<HTMLDivElement>(null);
@@ -104,7 +105,8 @@ const viewportRef = useRef<HTMLDivElement>(null);
   {content}
 </ScrollArea>
 
-// Later: viewportRef.current.scrollTo({ top: 0, behavior: 'smooth' })
+// Native DOM scrollTo — same API as any scrollable element
+viewportRef.current.scrollTo({ top: 0, behavior: 'smooth' })
 // Or: viewportRef.current.addEventListener('scroll', handler)
 ```
 
@@ -126,7 +128,9 @@ element for `getElementById` access:
 
 When you need to read scroll state or call scroll methods from *outside* the
 `ScrollArea` tree (e.g., in a parent component), create the machine externally
-with `useScrollArea` and pass it via the `value` prop:
+with `useScrollArea` and pass it via the `value` prop. Unlike `viewportRef`
+(which gives you a native DOM element), the `useScrollArea` hook returns a
+state-machine API with scroll state and convenience methods:
 
 ```tsx
 import { ScrollArea, useScrollArea } from '@commercetools/nimbus';
@@ -136,7 +140,7 @@ function ParentComponent() {
 
   return (
     <>
-      <button onClick={() => scrollArea.scrollTo({ top: 0, behavior: 'smooth' })}>
+      <button onClick={() => scrollArea.scrollToEdge({ edge: 'top' })}>
         Scroll to top
       </button>
       <p>Has vertical overflow: {String(scrollArea.hasOverflowY)}</p>

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -14,7 +14,8 @@ import { ScrollArea, type ScrollAreaProps } from '@commercetools/nimbus';
 
 ### Basic usage
 
-The ScrollArea component provides a scrollable container with custom-styled scrollbar overlays:
+Wrap content in a `ScrollArea` with a size constraint. The scrollbar appears on
+hover or during scrolling:
 
 ```jsx live-dev
 const App = () => (
@@ -69,37 +70,29 @@ const App = () => (
 )
 ```
 
-### Variant and size
+### Content padding
 
-Control scrollbar visibility and thickness:
+Style props on `ScrollArea` apply to the outer root container. For inner content
+padding, wrap children in a `Box`:
 
 ```jsx live-dev
 const App = () => (
-  <Stack gap="600" direction="row" flexWrap="wrap">
-    <Box>
-      <Text fontSize="sm" mb="200" fontWeight="bold">variant="hover" (default)</Text>
-      <ScrollArea maxH="120px" w="200px">
-        {Array.from({ length: 15 }, (_, i) => (
-          <Text key={i} fontSize="sm">Line {i + 1}</Text>
-        ))}
-      </ScrollArea>
+  <ScrollArea maxH="200px" w="400px" bg="neutral.2" borderRadius="300" variant="always">
+    <Box p="200">
+      {Array.from({ length: 20 }, (_, i) => (
+        <Text key={i} fontSize="sm">
+          Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </Text>
+      ))}
     </Box>
-    <Box>
-      <Text fontSize="sm" mb="200" fontWeight="bold">variant="always"</Text>
-      <ScrollArea maxH="120px" w="200px" variant="always">
-        {Array.from({ length: 15 }, (_, i) => (
-          <Text key={i} fontSize="sm">Line {i + 1}</Text>
-        ))}
-      </ScrollArea>
-    </Box>
-  </Stack>
+  </ScrollArea>
 )
 ```
 
 ## Component requirements
 
 - The component must have a size constraint (`maxH`, `maxW`, `h`, `w`) for scrolling to occur
-- For inner content padding, wrap children in a `<Box p="...">` rather than putting padding on `ScrollArea` itself (padding on `ScrollArea` applies to the outer container)
+- For inner content padding, wrap children in a `<Box p="...">` rather than putting padding on `ScrollArea` itself
 
 ## Accessibility
 
@@ -109,6 +102,10 @@ The ScrollArea component ensures keyboard accessibility:
 - **Focus ring**: A Nimbus focus ring appears on the root element when the viewport receives keyboard focus (via `:focus-visible`)
 - **ARIA landmarks**: Pass `role="region"` with an `aria-label` or `aria-labelledby` to create a named landmark for screen reader navigation
 - **TypeScript enforcement**: When `role="region"` is set, TypeScript requires either `aria-label` or `aria-labelledby`
+
+## API reference
+
+<PropsTable id="ScrollArea" />
 
 ## Resources
 

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -1,0 +1,116 @@
+---
+title: ScrollArea Component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import { ScrollArea, type ScrollAreaProps } from '@commercetools/nimbus';
+```
+
+### Basic usage
+
+The ScrollArea component provides a scrollable container with custom-styled scrollbar overlays:
+
+```jsx live-dev
+const App = () => (
+  <ScrollArea maxH="200px" w="400px">
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Text>
+    ))}
+  </ScrollArea>
+)
+```
+
+## Usage examples
+
+### Orientation
+
+Use the `orientation` prop to control which scrollbar axes are rendered:
+
+```jsx live-dev
+const App = () => (
+  <Stack gap="600">
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">vertical (default)</Text>
+      <ScrollArea maxH="120px" w="300px" variant="always">
+        {Array.from({ length: 15 }, (_, i) => (
+          <Text key={i} fontSize="sm">Line {i + 1}</Text>
+        ))}
+      </ScrollArea>
+    </Box>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">horizontal</Text>
+      <ScrollArea maxW="300px" orientation="horizontal" variant="always">
+        <Box whiteSpace="nowrap">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Text key={i} fontSize="sm">{"Long horizontal content ".repeat(15)}</Text>
+          ))}
+        </Box>
+      </ScrollArea>
+    </Box>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">both</Text>
+      <ScrollArea maxH="120px" maxW="300px" orientation="both" variant="always">
+        <Box whiteSpace="nowrap">
+          {Array.from({ length: 15 }, (_, i) => (
+            <Text key={i} fontSize="sm">{"Both axes content ".repeat(15)}</Text>
+          ))}
+        </Box>
+      </ScrollArea>
+    </Box>
+  </Stack>
+)
+```
+
+### Variant and size
+
+Control scrollbar visibility and thickness:
+
+```jsx live-dev
+const App = () => (
+  <Stack gap="600" direction="row" flexWrap="wrap">
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">variant="hover" (default)</Text>
+      <ScrollArea maxH="120px" w="200px">
+        {Array.from({ length: 15 }, (_, i) => (
+          <Text key={i} fontSize="sm">Line {i + 1}</Text>
+        ))}
+      </ScrollArea>
+    </Box>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">variant="always"</Text>
+      <ScrollArea maxH="120px" w="200px" variant="always">
+        {Array.from({ length: 15 }, (_, i) => (
+          <Text key={i} fontSize="sm">Line {i + 1}</Text>
+        ))}
+      </ScrollArea>
+    </Box>
+  </Stack>
+)
+```
+
+## Component requirements
+
+- The component must have a size constraint (`maxH`, `maxW`, `h`, `w`) for scrolling to occur
+- For inner content padding, wrap children in a `<Box p="...">` rather than putting padding on `ScrollArea` itself (padding on `ScrollArea` applies to the outer container)
+
+## Accessibility
+
+The ScrollArea component ensures keyboard accessibility:
+
+- **Keyboard focusable**: The scrollable viewport receives `tabIndex={0}` when content overflows, making it reachable via Tab
+- **Focus ring**: A Nimbus focus ring appears on the root element when the viewport receives keyboard focus (via `:focus-visible`)
+- **ARIA landmarks**: Pass `role="region"` with an `aria-label` or `aria-labelledby` to create a named landmark for screen reader navigation
+- **TypeScript enforcement**: When `role="region"` is set, TypeScript requires either `aria-label` or `aria-labelledby`
+
+## Resources
+
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-scrollarea--docs)
+- [Chakra UI ScrollArea](https://chakra-ui.com/docs/components/scroll-area)

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -148,8 +148,7 @@ The ScrollArea component ensures keyboard accessibility:
 
 - **Keyboard focusable**: The scrollable viewport receives `tabIndex={0}` when content overflows, making it reachable via Tab
 - **Focus ring**: A Nimbus focus ring appears on the root element when the viewport receives keyboard focus (via `:focus-visible`)
-- **ARIA landmarks**: Pass `role="region"` with an `aria-label` or `aria-labelledby` to create a named landmark for screen reader navigation
-- **TypeScript enforcement**: When `role="region"` is set, TypeScript requires either `aria-label` or `aria-labelledby`
+- **ARIA landmarks**: When the scroll area represents a distinct page section, consider adding `role="region"` with an `aria-label` or `aria-labelledby` to create a named landmark for screen reader navigation
 
 ## API reference
 

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -89,6 +89,54 @@ const App = () => (
 )
 ```
 
+### Programmatic scroll access
+
+#### Using `viewportRef`
+
+Use the `viewportRef` prop to get a direct reference to the scrollable viewport
+element. This is the recommended approach when you need to programmatically
+scroll, attach scroll event listeners, or read scroll position:
+
+```tsx
+const viewportRef = useRef<HTMLDivElement>(null);
+
+<ScrollArea viewportRef={viewportRef} maxH="400px">
+  {content}
+</ScrollArea>
+
+// Later: viewportRef.current.scrollTo({ top: 0, behavior: 'smooth' })
+// Or: viewportRef.current.addEventListener('scroll', handler)
+```
+
+#### Using `ids`
+
+When ref-forwarding is impractical (e.g., the scroll container is rendered in a
+different component tree), use the `ids` prop to set a known ID on the viewport
+element for `getElementById` access:
+
+```tsx
+<ScrollArea ids={{ viewport: 'my-scroll-viewport' }} maxH="400px">
+  {content}
+</ScrollArea>
+
+// Later: document.getElementById('my-scroll-viewport').scrollTop
+```
+
+#### Using `useScrollAreaContext`
+
+For components rendered inside a `ScrollArea`, the `useScrollAreaContext` hook
+provides programmatic scroll methods and state without needing a ref:
+
+```tsx
+import { useScrollAreaContext } from '@commercetools/nimbus';
+
+function ScrollToTopButton() {
+  const { scrollToEdge, isAtTop } = useScrollAreaContext();
+  if (isAtTop) return null;
+  return <Button onPress={() => scrollToEdge({ edge: 'top', behavior: 'smooth' })}>Back to top</Button>;
+}
+```
+
 ## Component requirements
 
 - The component must have a size constraint (`maxH`, `maxW`, `h`, `w`) for scrolling to occur

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -122,10 +122,40 @@ element for `getElementById` access:
 // Later: document.getElementById('my-scroll-viewport').scrollTop
 ```
 
-#### Using `useScrollAreaContext`
+#### Using `useScrollArea` (external control)
 
-For components rendered inside a `ScrollArea`, the `useScrollAreaContext` hook
-provides programmatic scroll methods and state without needing a ref:
+When you need to read scroll state or call scroll methods from *outside* the
+`ScrollArea` tree (e.g., in a parent component), create the machine externally
+with `useScrollArea` and pass it via the `value` prop:
+
+```tsx
+import { ScrollArea, useScrollArea } from '@commercetools/nimbus';
+
+function ParentComponent() {
+  const scrollArea = useScrollArea();
+
+  return (
+    <>
+      <button onClick={() => scrollArea.scrollTo({ top: 0, behavior: 'smooth' })}>
+        Scroll to top
+      </button>
+      <p>Has vertical overflow: {String(scrollArea.hasOverflowY)}</p>
+      <ScrollArea maxH="400px" value={scrollArea}>
+        {content}
+      </ScrollArea>
+    </>
+  );
+}
+```
+
+The returned object exposes state (`hasOverflowX`, `hasOverflowY`, `isAtTop`,
+`isAtBottom`, `isAtLeft`, `isAtRight`) and methods (`scrollTo()`,
+`scrollToEdge()`, `getScrollProgress()`).
+
+#### Using `useScrollAreaContext` (internal access)
+
+For components rendered *inside* a `ScrollArea`, the `useScrollAreaContext` hook
+reads the existing machine from React context — no `value` prop needed:
 
 ```tsx
 import { useScrollAreaContext } from '@commercetools/nimbus';

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -185,6 +185,12 @@ The ScrollArea component ensures keyboard accessibility:
 
 <PropsTable id="ScrollArea" />
 
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using ScrollArea within your application. As the component's internal functionality is already tested by Nimbus, these patterns help you verify your integration and application-specific logic.
+
+{{docs-tests: scroll-area.docs.spec.tsx}}
+
 ## Resources
 
 - [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-scrollarea--docs)

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -72,19 +72,17 @@ const App = () => (
 
 ### Content padding
 
-Style props on `ScrollArea` apply to the outer root container. For inner content
-padding, wrap children in a `Box`:
+Padding props on `ScrollArea` are forwarded to the content area inside the
+scrollable viewport, so `p`, `px`, `py`, etc. work as expected:
 
 ```jsx live-dev
 const App = () => (
-  <ScrollArea maxH="200px" w="400px" bg="neutral.2" borderRadius="300" variant="always">
-    <Box p="200">
-      {Array.from({ length: 20 }, (_, i) => (
-        <Text key={i} fontSize="sm">
-          Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </Text>
-      ))}
-    </Box>
+  <ScrollArea maxH="200px" w="400px" bg="neutral.2" borderRadius="300" variant="always" p="200">
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Text>
+    ))}
   </ScrollArea>
 )
 ```
@@ -174,7 +172,6 @@ function ScrollToTopButton() {
 ## Component requirements
 
 - The component must have a size constraint (`maxH`, `maxW`, `h`, `w`) for scrolling to occur
-- For inner content padding, wrap children in a `<Box p="...">` rather than putting padding on `ScrollArea` itself
 
 ## Accessibility
 

--- a/packages/nimbus/src/components/scroll-area/scroll-area.docs.spec.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.docs.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import {

--- a/packages/nimbus/src/components/scroll-area/scroll-area.docs.spec.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.docs.spec.tsx
@@ -1,0 +1,158 @@
+import React, { useRef } from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  ScrollArea,
+  NimbusProvider,
+  useScrollArea,
+  Box,
+  Text,
+} from "@commercetools/nimbus";
+
+/** Lines of text that cause vertical overflow in a constrained container. */
+const OverflowingContent = () => (
+  <>
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}
+      </Text>
+    ))}
+  </>
+);
+
+/**
+ * @docs-section basic-usage
+ * @docs-title Basic Usage
+ * @docs-description Basic vertical scrollable container
+ * @docs-order 1
+ */
+describe("ScrollArea - Basic usage", () => {
+  it("renders children inside a scrollable container", () => {
+    render(
+      <NimbusProvider>
+        <ScrollArea maxH="200px">
+          <OverflowingContent />
+        </ScrollArea>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Line 1")).toBeInTheDocument();
+  });
+
+  it("renders with always-visible scrollbars", () => {
+    const { container } = render(
+      <NimbusProvider>
+        <ScrollArea maxH="200px" variant="always">
+          <OverflowingContent />
+        </ScrollArea>
+      </NimbusProvider>
+    );
+
+    expect(
+      container.querySelector('[data-part="scrollbar"]')
+    ).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section orientation
+ * @docs-title Orientation
+ * @docs-description Controlling which scrollbar axes render
+ * @docs-order 2
+ */
+describe("ScrollArea - Orientation", () => {
+  it("renders horizontal scrollbar", () => {
+    const { container } = render(
+      <NimbusProvider>
+        <ScrollArea maxW="300px" orientation="horizontal">
+          <Box whiteSpace="nowrap">
+            <Text>{"Wide content ".repeat(30)}</Text>
+          </Box>
+        </ScrollArea>
+      </NimbusProvider>
+    );
+
+    const scrollbar = container.querySelector('[data-part="scrollbar"]');
+    expect(scrollbar).toHaveAttribute("data-orientation", "horizontal");
+  });
+
+  it("renders both axes with a corner", () => {
+    const { container } = render(
+      <NimbusProvider>
+        <ScrollArea maxH="200px" maxW="300px" orientation="both">
+          <Box whiteSpace="nowrap">
+            <OverflowingContent />
+          </Box>
+        </ScrollArea>
+      </NimbusProvider>
+    );
+
+    const scrollbars = container.querySelectorAll('[data-part="scrollbar"]');
+    expect(scrollbars).toHaveLength(2);
+    expect(container.querySelector('[data-part="corner"]')).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section programmatic-access
+ * @docs-title Programmatic Access
+ * @docs-description Accessing the scrollable viewport via ref or external hook
+ * @docs-order 3
+ */
+describe("ScrollArea - Programmatic access", () => {
+  it("forwards a ref to the viewport via viewportRef", () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    render(
+      <NimbusProvider>
+        <ScrollArea maxH="200px" viewportRef={ref}>
+          <OverflowingContent />
+        </ScrollArea>
+      </NimbusProvider>
+    );
+
+    expect(ref.current).toHaveAttribute("data-part", "viewport");
+    expect(typeof ref.current?.scrollTo).toBe("function");
+  });
+
+  it("supports external control via useScrollArea + value prop", () => {
+    const ExternalControl = () => {
+      const scrollArea = useScrollArea();
+      return (
+        <ScrollArea maxH="200px" value={scrollArea}>
+          <OverflowingContent />
+        </ScrollArea>
+      );
+    };
+
+    render(
+      <NimbusProvider>
+        <ExternalControl />
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Line 1")).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section content-padding
+ * @docs-title Content Padding
+ * @docs-description Applying padding via an inner Box wrapper
+ * @docs-order 4
+ */
+describe("ScrollArea - Content padding", () => {
+  it("renders padded content via a nested Box", () => {
+    render(
+      <NimbusProvider>
+        <ScrollArea maxH="200px">
+          <Box p="200">
+            <OverflowingContent />
+          </Box>
+        </ScrollArea>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Line 1")).toBeInTheDocument();
+  });
+});

--- a/packages/nimbus/src/components/scroll-area/scroll-area.docs.spec.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.docs.spec.tsx
@@ -95,7 +95,7 @@ describe("ScrollArea - Orientation", () => {
 
 /**
  * @docs-section programmatic-access
- * @docs-title Programmatic Access
+ * @docs-title Programmatic scroll access
  * @docs-description Accessing the scrollable viewport via ref or external hook
  * @docs-order 3
  */

--- a/packages/nimbus/src/components/scroll-area/scroll-area.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.mdx
@@ -2,7 +2,7 @@
 id: Components-ScrollArea
 title: ScrollArea
 exportName: ScrollArea
-description: ScrollArea is a layout component that provides a scrollable container with custom-styled scrollbar overlays. Useful for constrained content areas like panels, sidebars, and dialog bodies.
+description: A scrollable container with custom-styled scrollbar overlays. Useful for constrained content areas like panels, sidebars, and dialog bodies.
 lifecycleState: Stable
 order: 999
 menu:
@@ -17,93 +17,103 @@ tags:
   - scrollbar
 ---
 
-## Import
+## Overview
 
-```jsx
-import { ScrollArea } from "@commercetools/nimbus";
-```
+ScrollArea constrains content within a fixed region and provides themed
+scrollbar overlays that replace native browser scrollbars. The scrollbar
+appears on hover or during scrolling by default, keeping the interface clean
+until the user needs to scroll. The component is keyboard accessible — when
+content overflows, the area becomes focusable via Tab and scrollable with
+arrow keys.
 
-## Usage
+### Resources
 
-### Basic usage
+Deep dive into implementation details and access the Nimbus design library.
 
-Use `ScrollArea` to create a scrollable container with custom scrollbar overlays. The scrollbar appears on hover or during scrolling:
+[Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-scrollarea--docs)
+[Chakra UI ScrollArea](https://chakra-ui.com/docs/components/scroll-area)
 
-```jsx live
-const App = () => (
-  <ScrollArea maxH="200px" w="400px">
-    {Array.from({ length: 20 }, (_, i) => (
-      <Text key={i} fontSize="sm">
-        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      </Text>
-    ))}
-  </ScrollArea>
-);
-```
+## Variables
 
-### Horizontal scrolling
+Get familiar with the features.
 
-Use `orientation="horizontal"` for horizontally overflowing content:
+### Orientation
+
+Control which axes are scrollable. The default is vertical.
 
 ```jsx live
 const App = () => (
-  <ScrollArea maxW="400px" orientation="horizontal">
-    <Box whiteSpace="nowrap">
-      {Array.from({ length: 10 }, (_, i) => (
-        <Text key={i} fontSize="sm">
-          Row {i + 1}: This is a very long line of text that extends far beyond the visible area to demonstrate horizontal scrolling.
-        </Text>
-      ))}
+  <Stack gap="600">
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">Vertical (default)</Text>
+      <ScrollArea maxH="120px" w="300px" variant="always">
+        {Array.from({ length: 15 }, (_, i) => (
+          <Text key={i} fontSize="sm">Line {i + 1}: Sample content for vertical scrolling.</Text>
+        ))}
+      </ScrollArea>
     </Box>
-  </ScrollArea>
-);
-```
-
-### Both axes
-
-Use `orientation="both"` for bidirectional scrolling:
-
-```jsx live
-const App = () => (
-  <ScrollArea maxH="200px" maxW="400px" orientation="both">
-    <Box whiteSpace="nowrap">
-      {Array.from({ length: 20 }, (_, i) => (
-        <Text key={i} fontSize="sm">
-          Row {i + 1}: This is a very long line of text that extends far beyond the visible area to demonstrate both vertical and horizontal scrolling.
-        </Text>
-      ))}
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">Horizontal</Text>
+      <ScrollArea maxW="300px" orientation="horizontal" variant="always">
+        <Box whiteSpace="nowrap">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Text key={i} fontSize="sm">{"Horizontal content ".repeat(15)}</Text>
+          ))}
+        </Box>
+      </ScrollArea>
     </Box>
-  </ScrollArea>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">Both axes</Text>
+      <ScrollArea maxH="120px" maxW="300px" orientation="both" variant="always">
+        <Box whiteSpace="nowrap">
+          {Array.from({ length: 15 }, (_, i) => (
+            <Text key={i} fontSize="sm">{"Bidirectional content ".repeat(15)}</Text>
+          ))}
+        </Box>
+      </ScrollArea>
+    </Box>
+  </Stack>
 );
 ```
 
-### Always visible scrollbar
+### Visibility
 
-Use `variant="always"` to keep the scrollbar permanently visible:
+The scrollbar can appear on hover (default) or stay permanently visible.
 
 ```jsx live
 const App = () => (
-  <ScrollArea maxH="200px" w="400px" variant="always">
-    {Array.from({ length: 20 }, (_, i) => (
-      <Text key={i} fontSize="sm">
-        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      </Text>
-    ))}
-  </ScrollArea>
+  <Stack gap="600" direction="row">
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">Hover (default)</Text>
+      <ScrollArea maxH="120px" w="200px">
+        {Array.from({ length: 15 }, (_, i) => (
+          <Text key={i} fontSize="sm">Line {i + 1}</Text>
+        ))}
+      </ScrollArea>
+    </Box>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">Always visible</Text>
+      <ScrollArea maxH="120px" w="200px" variant="always">
+        {Array.from({ length: 15 }, (_, i) => (
+          <Text key={i} fontSize="sm">Line {i + 1}</Text>
+        ))}
+      </ScrollArea>
+    </Box>
+  </Stack>
 );
 ```
 
-### Scrollbar sizes
+### Size
 
-The `size` prop controls the scrollbar width. Available sizes: `xs`, `sm` (default), `md`, `lg`:
+Control the scrollbar thickness. Available sizes: `xs`, `sm` (default), `md`, `lg`.
 
 ```jsx live
 const App = () => (
   <Stack gap="600" direction="row" flexWrap="wrap">
     {["xs", "sm", "md", "lg"].map((size) => (
       <Box key={size}>
-        <Text fontSize="sm" mb="200" fontWeight="bold">size="{size}"</Text>
-        <ScrollArea maxH="150px" w="200px" size={size} variant="always">
+        <Text fontSize="sm" mb="200" fontWeight="bold">{size}</Text>
+        <ScrollArea maxH="120px" w="180px" size={size} variant="always">
           {Array.from({ length: 15 }, (_, i) => (
             <Text key={i} fontSize="sm">Line {i + 1}</Text>
           ))}
@@ -113,28 +123,3 @@ const App = () => (
   </Stack>
 );
 ```
-
-### With ARIA landmark
-
-Add `role="region"` and an accessible name for screen reader navigation:
-
-```jsx live
-const App = () => (
-  <ScrollArea maxH="200px" w="400px" role="region" aria-label="Application logs" variant="always">
-    {Array.from({ length: 20 }, (_, i) => (
-      <Text key={i} fontSize="sm">
-        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      </Text>
-    ))}
-  </ScrollArea>
-);
-```
-
-## API reference
-
-<PropsTable id="ScrollArea" />
-
-## Resources
-
-- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-scrollarea--docs)
-- [Chakra UI ScrollArea](https://chakra-ui.com/docs/components/scroll-area)

--- a/packages/nimbus/src/components/scroll-area/scroll-area.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.mdx
@@ -1,0 +1,140 @@
+---
+id: Components-ScrollArea
+title: ScrollArea
+exportName: ScrollArea
+description: ScrollArea is a layout component that provides a scrollable container with custom-styled scrollbar overlays. Useful for constrained content areas like panels, sidebars, and dialog bodies.
+lifecycleState: Stable
+order: 999
+menu:
+  - Components
+  - Layout
+  - ScrollArea
+tags:
+  - component
+  - scroll-area
+  - layout
+  - overflow
+  - scrollbar
+---
+
+## Import
+
+```jsx
+import { ScrollArea } from "@commercetools/nimbus";
+```
+
+## Usage
+
+### Basic usage
+
+Use `ScrollArea` to create a scrollable container with custom scrollbar overlays. The scrollbar appears on hover or during scrolling:
+
+```jsx live
+const App = () => (
+  <ScrollArea maxH="200px" w="400px">
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Text>
+    ))}
+  </ScrollArea>
+);
+```
+
+### Horizontal scrolling
+
+Use `orientation="horizontal"` for horizontally overflowing content:
+
+```jsx live
+const App = () => (
+  <ScrollArea maxW="400px" orientation="horizontal">
+    <Box whiteSpace="nowrap">
+      {Array.from({ length: 10 }, (_, i) => (
+        <Text key={i} fontSize="sm">
+          Row {i + 1}: This is a very long line of text that extends far beyond the visible area to demonstrate horizontal scrolling.
+        </Text>
+      ))}
+    </Box>
+  </ScrollArea>
+);
+```
+
+### Both axes
+
+Use `orientation="both"` for bidirectional scrolling:
+
+```jsx live
+const App = () => (
+  <ScrollArea maxH="200px" maxW="400px" orientation="both">
+    <Box whiteSpace="nowrap">
+      {Array.from({ length: 20 }, (_, i) => (
+        <Text key={i} fontSize="sm">
+          Row {i + 1}: This is a very long line of text that extends far beyond the visible area to demonstrate both vertical and horizontal scrolling.
+        </Text>
+      ))}
+    </Box>
+  </ScrollArea>
+);
+```
+
+### Always visible scrollbar
+
+Use `variant="always"` to keep the scrollbar permanently visible:
+
+```jsx live
+const App = () => (
+  <ScrollArea maxH="200px" w="400px" variant="always">
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Text>
+    ))}
+  </ScrollArea>
+);
+```
+
+### Scrollbar sizes
+
+The `size` prop controls the scrollbar width. Available sizes: `xs`, `sm` (default), `md`, `lg`:
+
+```jsx live
+const App = () => (
+  <Stack gap="600" direction="row" flexWrap="wrap">
+    {["xs", "sm", "md", "lg"].map((size) => (
+      <Box key={size}>
+        <Text fontSize="sm" mb="200" fontWeight="bold">size="{size}"</Text>
+        <ScrollArea maxH="150px" w="200px" size={size} variant="always">
+          {Array.from({ length: 15 }, (_, i) => (
+            <Text key={i} fontSize="sm">Line {i + 1}</Text>
+          ))}
+        </ScrollArea>
+      </Box>
+    ))}
+  </Stack>
+);
+```
+
+### With ARIA landmark
+
+Add `role="region"` and an accessible name for screen reader navigation:
+
+```jsx live
+const App = () => (
+  <ScrollArea maxH="200px" w="400px" role="region" aria-label="Application logs" variant="always">
+    {Array.from({ length: 20 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        Line {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Text>
+    ))}
+  </ScrollArea>
+);
+```
+
+## API reference
+
+<PropsTable id="ScrollArea" />
+
+## Resources
+
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-scrollarea--docs)
+- [Chakra UI ScrollArea](https://chakra-ui.com/docs/components/scroll-area)

--- a/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
@@ -113,6 +113,26 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
         },
       },
       always: {
+        viewport: {
+          // Create gutter so the permanently visible scrollbar
+          // doesn't overlay content.
+          // - Vertical scrollbar (Y overflow): use width calc — works
+          //   because width always resolves against a definite parent.
+          // - Horizontal scrollbar (X overflow): use flex + margin —
+          //   height calc doesn't work because the root's height
+          //   comes from maxHeight, and CSS % heights require an
+          //   explicit parent height property.
+          flex: "1",
+          minHeight: "0",
+          "&[data-overflow-y]": {
+            width:
+              "calc(100% - var(--scroll-area-scrollbar-size) - var(--scroll-area-scrollbar-margin) * 2)",
+          },
+          "&[data-overflow-x]": {
+            marginBottom:
+              "calc(var(--scroll-area-scrollbar-size) + var(--scroll-area-scrollbar-margin) * 2)",
+          },
+        },
         scrollbar: {
           opacity: "1",
         },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
@@ -15,9 +15,9 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
       height: "100%",
       position: "relative",
       overflow: "hidden",
-      "--scrollbar-margin": "2px",
-      "--scrollbar-click-area":
-        "calc(var(--scrollbar-size) + calc(var(--scrollbar-margin) * 2))",
+      "--scroll-area-scrollbar-margin": "{sizes.50}",
+      "--scroll-area-scrollbar-click-area":
+        "calc(var(--scroll-area-scrollbar-size) + calc(var(--scroll-area-scrollbar-margin) * 2))",
       _focusWithin: {
         "&:has(:focus-visible)": {
           outlineWidth: "var(--focus-ring-width, 1px)",
@@ -50,48 +50,48 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
       borderRadius: "full",
       transition: "opacity 150ms 300ms",
       position: "relative",
-      margin: "var(--scrollbar-margin)",
+      margin: "var(--scroll-area-scrollbar-margin)",
       "&:not([data-overflow-x], [data-overflow-y])": {
         display: "none",
       },
       bg: "neutral.4",
-      "--thumb-bg": "{colors.neutral.7}",
+      "--scroll-area-thumb-bg": "{colors.neutral.7}",
       "&:is(:hover, :active)": {
-        "--thumb-bg": "{colors.neutral.9}",
+        "--scroll-area-thumb-bg": "{colors.neutral.9}",
       },
       _before: {
         content: '""',
         position: "absolute",
       },
       _vertical: {
-        width: "var(--scrollbar-size)",
+        width: "var(--scroll-area-scrollbar-size)",
         flexDirection: "column",
         "&::before": {
-          width: "var(--scrollbar-click-area)",
+          width: "var(--scroll-area-scrollbar-click-area)",
           height: "100%",
-          insetInlineStart: "calc(var(--scrollbar-margin) * -1)",
+          insetInlineStart: "calc(var(--scroll-area-scrollbar-margin) * -1)",
         },
       },
       _horizontal: {
-        height: "var(--scrollbar-size)",
+        height: "var(--scroll-area-scrollbar-size)",
         flexDirection: "row",
         "&::before": {
-          height: "var(--scrollbar-click-area)",
+          height: "var(--scroll-area-scrollbar-click-area)",
           width: "100%",
-          top: "calc(var(--scrollbar-margin) * -1)",
+          top: "calc(var(--scroll-area-scrollbar-margin) * -1)",
         },
       },
     },
     thumb: {
       borderRadius: "inherit",
-      bg: "var(--thumb-bg)",
+      bg: "var(--scroll-area-thumb-bg)",
       transition: "backgrounds",
       _vertical: { width: "full" },
       _horizontal: { height: "full" },
     },
     corner: {
       bg: "neutral.3",
-      margin: "var(--scrollbar-margin)",
+      margin: "var(--scroll-area-scrollbar-margin)",
       opacity: 0,
       transition: "opacity 150ms 300ms",
       "&[data-hover]": {
@@ -121,22 +121,22 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
     size: {
       xs: {
         root: {
-          "--scrollbar-size": "{sizes.100}",
+          "--scroll-area-scrollbar-size": "{sizes.100}",
         },
       },
       sm: {
         root: {
-          "--scrollbar-size": "{sizes.150}",
+          "--scroll-area-scrollbar-size": "{sizes.150}",
         },
       },
       md: {
         root: {
-          "--scrollbar-size": "{sizes.200}",
+          "--scroll-area-scrollbar-size": "{sizes.200}",
         },
       },
       lg: {
         root: {
-          "--scrollbar-size": "{sizes.300}",
+          "--scroll-area-scrollbar-size": "{sizes.300}",
         },
       },
     },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
@@ -1,0 +1,148 @@
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
+
+/**
+ * Recipe configuration for the ScrollArea component.
+ * Overrides Chakra UI's default scrollArea recipe with Nimbus design tokens.
+ */
+export const scrollAreaSlotRecipe = defineSlotRecipe({
+  className: "nimbus-scroll-area",
+  slots: ["root", "viewport", "content", "scrollbar", "thumb", "corner"],
+  base: {
+    root: {
+      display: "flex",
+      flexDirection: "column",
+      width: "100%",
+      height: "100%",
+      position: "relative",
+      overflow: "hidden",
+      "--scrollbar-margin": "2px",
+      "--scrollbar-click-area":
+        "calc(var(--scrollbar-size) + calc(var(--scrollbar-margin) * 2))",
+      _focusWithin: {
+        "&:has(:focus-visible)": {
+          outlineWidth: "var(--focus-ring-width, 1px)",
+          outlineColor: "var(--focus-ring-color)",
+          outlineStyle: "var(--focus-ring-style, solid)",
+          outlineOffset: "2px",
+        },
+      },
+    },
+    viewport: {
+      display: "flex",
+      flexDirection: "column",
+      height: "100%",
+      width: "100%",
+      borderRadius: "inherit",
+      outline: "none",
+      WebkitOverflowScrolling: "touch",
+      scrollbarWidth: "none",
+      "&::-webkit-scrollbar": {
+        display: "none",
+      },
+    },
+    content: {
+      minWidth: "100%",
+    },
+    scrollbar: {
+      display: "flex",
+      userSelect: "none",
+      touchAction: "none",
+      borderRadius: "full",
+      transition: "opacity 150ms 300ms",
+      position: "relative",
+      margin: "var(--scrollbar-margin)",
+      "&:not([data-overflow-x], [data-overflow-y])": {
+        display: "none",
+      },
+      bg: "neutral.4",
+      "--thumb-bg": "{colors.neutral.7}",
+      "&:is(:hover, :active)": {
+        "--thumb-bg": "{colors.neutral.9}",
+      },
+      _before: {
+        content: '""',
+        position: "absolute",
+      },
+      _vertical: {
+        width: "var(--scrollbar-size)",
+        flexDirection: "column",
+        "&::before": {
+          width: "var(--scrollbar-click-area)",
+          height: "100%",
+          insetInlineStart: "calc(var(--scrollbar-margin) * -1)",
+        },
+      },
+      _horizontal: {
+        height: "var(--scrollbar-size)",
+        flexDirection: "row",
+        "&::before": {
+          height: "var(--scrollbar-click-area)",
+          width: "100%",
+          top: "calc(var(--scrollbar-margin) * -1)",
+        },
+      },
+    },
+    thumb: {
+      borderRadius: "inherit",
+      bg: "var(--thumb-bg)",
+      transition: "backgrounds",
+      _vertical: { width: "full" },
+      _horizontal: { height: "full" },
+    },
+    corner: {
+      bg: "neutral.3",
+      margin: "var(--scrollbar-margin)",
+      opacity: 0,
+      transition: "opacity 150ms 300ms",
+      "&[data-hover]": {
+        transitionDelay: "0ms",
+        opacity: 1,
+      },
+    },
+  },
+  variants: {
+    variant: {
+      hover: {
+        scrollbar: {
+          opacity: "0",
+          "&[data-hover], &[data-scrolling]": {
+            opacity: "1",
+            transitionDuration: "faster",
+            transitionDelay: "0ms",
+          },
+        },
+      },
+      always: {
+        scrollbar: {
+          opacity: "1",
+        },
+      },
+    },
+    size: {
+      xs: {
+        root: {
+          "--scrollbar-size": "{sizes.100}",
+        },
+      },
+      sm: {
+        root: {
+          "--scrollbar-size": "{sizes.150}",
+        },
+      },
+      md: {
+        root: {
+          "--scrollbar-size": "{sizes.200}",
+        },
+      },
+      lg: {
+        root: {
+          "--scrollbar-size": "{sizes.300}",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+    variant: "hover",
+  },
+});

--- a/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
@@ -116,6 +116,9 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
         scrollbar: {
           opacity: "1",
         },
+        corner: {
+          opacity: 1,
+        },
       },
     },
     size: {

--- a/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
@@ -50,6 +50,8 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
       borderRadius: "full",
       transition: "opacity 150ms 300ms",
       position: "relative",
+      // Paint above viewport content (e.g. sticky headers with z-index)
+      zIndex: "1",
       margin: "var(--scroll-area-scrollbar-margin)",
       "&:not([data-overflow-x], [data-overflow-y])": {
         display: "none",

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { ScrollArea, Box, Text } from "@commercetools/nimbus";
+import { ScrollArea, Box, Text, useScrollArea } from "@commercetools/nimbus";
 import { expect, userEvent, waitFor } from "storybook/test";
 
 const meta: Meta<typeof ScrollArea> = {
@@ -327,6 +327,41 @@ export const Sizes: Story = {
       for (let i = 1; i < widths.length; i++) {
         expect(widths[i]).toBeGreaterThan(widths[i - 1]);
       }
+    });
+  },
+};
+
+// ============================================================
+// External control via useScrollArea + value prop
+// ============================================================
+export const ExternalControl: Story = {
+  render: () => {
+    const scrollArea = useScrollArea();
+
+    return (
+      <Box>
+        <ScrollArea maxH="200px" w="400px" variant="always" value={scrollArea}>
+          <OverflowingContent />
+        </ScrollArea>
+      </Box>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    await step("Renders with RootProvider and detects overflow", async () => {
+      await waitFor(() => {
+        const viewport = canvasElement.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        expect(viewport).toBeTruthy();
+        expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+      });
+    });
+
+    await step("Viewport has tabIndex when overflowing", async () => {
+      const viewport = canvasElement.querySelector(
+        '[data-part="viewport"]'
+      ) as HTMLElement;
+      expect(viewport).toHaveAttribute("tabindex", "0");
     });
   },
 };

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -556,6 +556,52 @@ export const StickyContentInPanel: Story = {
 };
 
 // ============================================================
+// Padding on Root: demonstrates broken behavior
+// ============================================================
+export const PaddingOnRoot: Story = {
+  render: () => (
+    <Box display="flex" gap="600" flexWrap="wrap">
+      {(["always", "hover"] as const).map((variant) => (
+        <Box key={variant}>
+          <Text fontSize="sm" mb="200" fontWeight="bold">
+            variant=&quot;{variant}&quot;
+          </Text>
+          <Box display="flex" gap="400">
+            <Box>
+              <Text fontSize="xs" mb="100" color="neutral.11">
+                No padding (correct)
+              </Text>
+              <ScrollArea
+                maxH="200px"
+                w="300px"
+                variant={variant}
+                bg="warning.3"
+              >
+                <OverflowingContent />
+              </ScrollArea>
+            </Box>
+            <Box>
+              <Text fontSize="xs" mb="100" color="neutral.11">
+                p=&quot;400&quot; on Root (broken)
+              </Text>
+              <ScrollArea
+                maxH="200px"
+                w="300px"
+                variant={variant}
+                bg="warning.3"
+                p="400"
+              >
+                <OverflowingContent />
+              </ScrollArea>
+            </Box>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  ),
+};
+
+// ============================================================
 // Smoke test: all combinations render without errors
 // ============================================================
 export const SmokeTest: Story = {

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -556,9 +556,9 @@ export const StickyContentInPanel: Story = {
 };
 
 // ============================================================
-// Padding on Root: demonstrates broken behavior
+// Content padding: padding props forwarded to inner Content slot
 // ============================================================
-export const PaddingOnRoot: Story = {
+export const ContentPadding: Story = {
   render: () => (
     <Box display="flex" gap="600" flexWrap="wrap">
       {(["always", "hover"] as const).map((variant) => (
@@ -569,26 +569,26 @@ export const PaddingOnRoot: Story = {
           <Box display="flex" gap="400">
             <Box>
               <Text fontSize="xs" mb="100" color="neutral.11">
-                No padding (correct)
+                No padding
               </Text>
               <ScrollArea
                 maxH="200px"
                 w="300px"
                 variant={variant}
-                bg="warning.3"
+                bg="neutral.2"
               >
                 <OverflowingContent />
               </ScrollArea>
             </Box>
             <Box>
               <Text fontSize="xs" mb="100" color="neutral.11">
-                p=&quot;400&quot; on Root (broken)
+                p=&quot;400&quot; (forwarded to content)
               </Text>
               <ScrollArea
                 maxH="200px"
                 w="300px"
                 variant={variant}
-                bg="warning.3"
+                bg="neutral.2"
                 p="400"
               >
                 <OverflowingContent />
@@ -599,6 +599,29 @@ export const PaddingOnRoot: Story = {
       ))}
     </Box>
   ),
+  play: async ({ canvasElement, step }) => {
+    await step("Padding is applied to the content slot, not root", async () => {
+      await waitFor(() => {
+        const roots = canvasElement.querySelectorAll('[data-part="root"]');
+        expect(roots).toHaveLength(2);
+      });
+
+      // The second root in each pair has p="400" — verify it lands on content
+      const contents = canvasElement.querySelectorAll('[data-part="content"]');
+      // 4 total: 2 variants × 2 padding states
+      expect(contents).toHaveLength(4);
+
+      // Padded content elements (index 1 and 3) should have non-zero padding
+      const paddedContent = contents[1] as HTMLElement;
+      const paddedStyles = window.getComputedStyle(paddedContent);
+      expect(paddedStyles.paddingTop).not.toBe("0px");
+
+      // Unpadded content elements (index 0 and 2) should have no padding
+      const unpaddedContent = contents[0] as HTMLElement;
+      const unpaddedStyles = window.getComputedStyle(unpaddedContent);
+      expect(unpaddedStyles.paddingTop).toBe("0px");
+    });
+  },
 };
 
 // ============================================================

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
       maxH="200px"
       w="400px"
       variant="always"
-      ids={{ viewport: "test-viewport" }}
+      ids={{ viewport: "test-viewport-default" }}
     >
       <OverflowingContent />
     </ScrollArea>
@@ -54,19 +54,23 @@ export const Default: Story = {
 
     await step("Viewport is keyboard-focusable when overflowing", async () => {
       await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport") as HTMLElement;
+        const viewport = doc.getElementById(
+          "test-viewport-default"
+        ) as HTMLElement;
         expect(viewport).toBeTruthy();
         expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
       });
     });
 
     await step("Viewport has tabIndex when overflowing", async () => {
-      const viewport = doc.getElementById("test-viewport") as HTMLElement;
+      const viewport = doc.getElementById(
+        "test-viewport-default"
+      ) as HTMLElement;
       expect(viewport).toHaveAttribute("tabindex", "0");
     });
 
     await step("Detects vertical overflow via data attribute", async () => {
-      const viewport = doc.getElementById("test-viewport");
+      const viewport = doc.getElementById("test-viewport-default");
       expect(viewport).toHaveAttribute("data-overflow-y");
     });
 
@@ -92,7 +96,7 @@ export const NonOverflowing: Story = {
       maxH="200px"
       w="400px"
       variant="always"
-      ids={{ viewport: "test-viewport" }}
+      ids={{ viewport: "test-viewport-no-overflow" }}
     >
       <ShortContent />
     </ScrollArea>
@@ -102,7 +106,9 @@ export const NonOverflowing: Story = {
 
     await step("Component renders with short content", async () => {
       await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport") as HTMLElement;
+        const viewport = doc.getElementById(
+          "test-viewport-no-overflow"
+        ) as HTMLElement;
         expect(viewport).toBeTruthy();
       });
     });
@@ -111,7 +117,9 @@ export const NonOverflowing: Story = {
       "Viewport does not have tabIndex when not overflowing",
       async () => {
         await waitFor(() => {
-          const viewport = doc.getElementById("test-viewport") as HTMLElement;
+          const viewport = doc.getElementById(
+            "test-viewport-no-overflow"
+          ) as HTMLElement;
           expect(viewport).not.toHaveAttribute("tabindex");
         });
       }
@@ -119,7 +127,7 @@ export const NonOverflowing: Story = {
 
     await step("All compound parts are present", async () => {
       expect(canvasElement.querySelector('[data-part="root"]')).toBeTruthy();
-      expect(doc.getElementById("test-viewport")).toBeTruthy();
+      expect(doc.getElementById("test-viewport-no-overflow")).toBeTruthy();
       expect(canvasElement.querySelector('[data-part="content"]')).toBeTruthy();
       expect(
         canvasElement.querySelector('[data-part="scrollbar"]')
@@ -140,7 +148,7 @@ export const KeyboardFocusRing: Story = {
         w="400px"
         mt="400"
         variant="always"
-        ids={{ viewport: "test-viewport" }}
+        ids={{ viewport: "test-viewport-kbd-focus" }}
       >
         <OverflowingContent />
       </ScrollArea>
@@ -151,11 +159,13 @@ export const KeyboardFocusRing: Story = {
 
     await step("Viewport receives keyboard focus via Tab", async () => {
       await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport") as HTMLElement;
+        const viewport = doc.getElementById(
+          "test-viewport-kbd-focus"
+        ) as HTMLElement;
         expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
       });
       await userEvent.tab();
-      const viewport = doc.getElementById("test-viewport");
+      const viewport = doc.getElementById("test-viewport-kbd-focus");
       await waitFor(() => {
         expect(viewport).toHaveFocus();
       });
@@ -179,7 +189,7 @@ export const VerticalOnly: Story = {
       maxH="200px"
       w="400px"
       variant="always"
-      ids={{ viewport: "test-viewport" }}
+      ids={{ viewport: "test-viewport-vert-only" }}
     >
       <OverflowingContent />
     </ScrollArea>
@@ -189,7 +199,7 @@ export const VerticalOnly: Story = {
 
     await step("Detects vertical overflow", async () => {
       await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport");
+        const viewport = doc.getElementById("test-viewport-vert-only");
         expect(viewport).toHaveAttribute("data-overflow-y");
       });
     });
@@ -213,7 +223,7 @@ export const HorizontalOnly: Story = {
       maxW="400px"
       orientation="horizontal"
       variant="always"
-      ids={{ viewport: "test-viewport" }}
+      ids={{ viewport: "test-viewport-horiz-only" }}
     >
       <WideContent />
     </ScrollArea>
@@ -223,7 +233,7 @@ export const HorizontalOnly: Story = {
 
     await step("Detects horizontal overflow", async () => {
       await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport");
+        const viewport = doc.getElementById("test-viewport-horiz-only");
         expect(viewport).toHaveAttribute("data-overflow-x");
       });
     });
@@ -244,6 +254,7 @@ export const HorizontalOnly: Story = {
 export const BothAxes: Story = {
   render: () => (
     <ScrollArea maxH="200px" maxW="400px" orientation="both" variant="always">
+      <OverflowingContent />
       <WideContent />
     </ScrollArea>
   ),
@@ -292,6 +303,21 @@ export const AlwaysVisible: Story = {
         expect(window.getComputedStyle(scrollbar).opacity).toBe("1");
       });
     });
+
+    await step(
+      "Viewport has gutter so scrollbar does not overlay content",
+      async () => {
+        const viewport = canvasElement.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        const scrollbar = canvasElement.querySelector(
+          '[data-part="scrollbar"]'
+        ) as HTMLElement;
+        const vpRect = viewport.getBoundingClientRect();
+        const sbRect = scrollbar.getBoundingClientRect();
+        expect(vpRect.right).toBeLessThanOrEqual(sbRect.left);
+      }
+    );
   },
 };
 

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -54,6 +54,13 @@ export const Default: Story = {
       });
     });
 
+    await step("Viewport has tabIndex when overflowing", async () => {
+      const viewport = canvasElement.querySelector(
+        '[data-part="viewport"]'
+      ) as HTMLElement;
+      expect(viewport).toHaveAttribute("tabindex", "0");
+    });
+
     await step("Detects vertical overflow via data attribute", async () => {
       const viewport = canvasElement.querySelector('[data-part="viewport"]');
       expect(viewport).toHaveAttribute("data-overflow-y");
@@ -90,6 +97,18 @@ export const NonOverflowing: Story = {
         expect(viewport).toBeTruthy();
       });
     });
+
+    await step(
+      "Viewport does not have tabIndex when not overflowing",
+      async () => {
+        await waitFor(() => {
+          const viewport = canvasElement.querySelector(
+            '[data-part="viewport"]'
+          ) as HTMLElement;
+          expect(viewport).not.toHaveAttribute("tabindex");
+        });
+      }
+    );
 
     await step("All compound parts are present", async () => {
       expect(canvasElement.querySelector('[data-part="root"]')).toBeTruthy();

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -601,14 +601,13 @@ export const ContentPadding: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     await step("Padding is applied to the content slot, not root", async () => {
+      // 2 variants × 2 padding states = 4 ScrollArea instances
       await waitFor(() => {
         const roots = canvasElement.querySelectorAll('[data-part="root"]');
-        expect(roots).toHaveLength(2);
+        expect(roots).toHaveLength(4);
       });
 
-      // The second root in each pair has p="400" — verify it lands on content
       const contents = canvasElement.querySelectorAll('[data-part="content"]');
-      // 4 total: 2 variants × 2 padding states
       expect(contents).toHaveLength(4);
 
       // Padded content elements (index 1 and 3) should have non-zero padding

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof ScrollArea> = {
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<typeof meta>;
 
 const OverflowingContent = () =>
   Array.from({ length: 30 }, (_, i) => (
@@ -40,30 +40,33 @@ const WideContent = () => (
 // ============================================================
 export const Default: Story = {
   render: () => (
-    <ScrollArea maxH="200px" w="400px" variant="always">
+    <ScrollArea
+      maxH="200px"
+      w="400px"
+      variant="always"
+      ids={{ viewport: "test-viewport" }}
+    >
       <OverflowingContent />
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
     await step("Viewport is keyboard-focusable when overflowing", async () => {
       await waitFor(() => {
-        const viewport = canvasElement.querySelector(
-          '[data-part="viewport"]'
-        ) as HTMLElement;
+        const viewport = doc.getElementById("test-viewport") as HTMLElement;
         expect(viewport).toBeTruthy();
         expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
       });
     });
 
     await step("Viewport has tabIndex when overflowing", async () => {
-      const viewport = canvasElement.querySelector(
-        '[data-part="viewport"]'
-      ) as HTMLElement;
+      const viewport = doc.getElementById("test-viewport") as HTMLElement;
       expect(viewport).toHaveAttribute("tabindex", "0");
     });
 
     await step("Detects vertical overflow via data attribute", async () => {
-      const viewport = canvasElement.querySelector('[data-part="viewport"]');
+      const viewport = doc.getElementById("test-viewport");
       expect(viewport).toHaveAttribute("data-overflow-y");
     });
 
@@ -85,16 +88,21 @@ export const Default: Story = {
 // ============================================================
 export const NonOverflowing: Story = {
   render: () => (
-    <ScrollArea maxH="200px" w="400px" variant="always">
+    <ScrollArea
+      maxH="200px"
+      w="400px"
+      variant="always"
+      ids={{ viewport: "test-viewport" }}
+    >
       <ShortContent />
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
     await step("Component renders with short content", async () => {
       await waitFor(() => {
-        const viewport = canvasElement.querySelector(
-          '[data-part="viewport"]'
-        ) as HTMLElement;
+        const viewport = doc.getElementById("test-viewport") as HTMLElement;
         expect(viewport).toBeTruthy();
       });
     });
@@ -103,9 +111,7 @@ export const NonOverflowing: Story = {
       "Viewport does not have tabIndex when not overflowing",
       async () => {
         await waitFor(() => {
-          const viewport = canvasElement.querySelector(
-            '[data-part="viewport"]'
-          ) as HTMLElement;
+          const viewport = doc.getElementById("test-viewport") as HTMLElement;
           expect(viewport).not.toHaveAttribute("tabindex");
         });
       }
@@ -113,9 +119,7 @@ export const NonOverflowing: Story = {
 
     await step("All compound parts are present", async () => {
       expect(canvasElement.querySelector('[data-part="root"]')).toBeTruthy();
-      expect(
-        canvasElement.querySelector('[data-part="viewport"]')
-      ).toBeTruthy();
+      expect(doc.getElementById("test-viewport")).toBeTruthy();
       expect(canvasElement.querySelector('[data-part="content"]')).toBeTruthy();
       expect(
         canvasElement.querySelector('[data-part="scrollbar"]')
@@ -131,21 +135,27 @@ export const KeyboardFocusRing: Story = {
   render: () => (
     <Box>
       <Text>Press Tab to focus the scroll area below:</Text>
-      <ScrollArea maxH="200px" w="400px" mt="400" variant="always">
+      <ScrollArea
+        maxH="200px"
+        w="400px"
+        mt="400"
+        variant="always"
+        ids={{ viewport: "test-viewport" }}
+      >
         <OverflowingContent />
       </ScrollArea>
     </Box>
   ),
   play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
     await step("Viewport receives keyboard focus via Tab", async () => {
       await waitFor(() => {
-        const viewport = canvasElement.querySelector(
-          '[data-part="viewport"]'
-        ) as HTMLElement;
+        const viewport = doc.getElementById("test-viewport") as HTMLElement;
         expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
       });
       await userEvent.tab();
-      const viewport = canvasElement.querySelector('[data-part="viewport"]');
+      const viewport = doc.getElementById("test-viewport");
       await waitFor(() => {
         expect(viewport).toHaveFocus();
       });
@@ -165,14 +175,21 @@ export const KeyboardFocusRing: Story = {
 // ============================================================
 export const VerticalOnly: Story = {
   render: () => (
-    <ScrollArea maxH="200px" w="400px" variant="always">
+    <ScrollArea
+      maxH="200px"
+      w="400px"
+      variant="always"
+      ids={{ viewport: "test-viewport" }}
+    >
       <OverflowingContent />
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
     await step("Detects vertical overflow", async () => {
       await waitFor(() => {
-        const viewport = canvasElement.querySelector('[data-part="viewport"]');
+        const viewport = doc.getElementById("test-viewport");
         expect(viewport).toHaveAttribute("data-overflow-y");
       });
     });
@@ -192,14 +209,21 @@ export const VerticalOnly: Story = {
 // ============================================================
 export const HorizontalOnly: Story = {
   render: () => (
-    <ScrollArea maxW="400px" orientation="horizontal" variant="always">
+    <ScrollArea
+      maxW="400px"
+      orientation="horizontal"
+      variant="always"
+      ids={{ viewport: "test-viewport" }}
+    >
       <WideContent />
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
     await step("Detects horizontal overflow", async () => {
       await waitFor(() => {
-        const viewport = canvasElement.querySelector('[data-part="viewport"]');
+        const viewport = doc.getElementById("test-viewport");
         expect(viewport).toHaveAttribute("data-overflow-x");
       });
     });
@@ -336,7 +360,9 @@ export const Sizes: Story = {
 // ============================================================
 export const ExternalControl: Story = {
   render: () => {
-    const scrollArea = useScrollArea();
+    const scrollArea = useScrollArea({
+      ids: { viewport: "test-viewport" },
+    });
 
     return (
       <Box>
@@ -347,20 +373,18 @@ export const ExternalControl: Story = {
     );
   },
   play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
     await step("Renders with RootProvider and detects overflow", async () => {
       await waitFor(() => {
-        const viewport = canvasElement.querySelector(
-          '[data-part="viewport"]'
-        ) as HTMLElement;
+        const viewport = doc.getElementById("test-viewport") as HTMLElement;
         expect(viewport).toBeTruthy();
         expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
       });
     });
 
     await step("Viewport has tabIndex when overflowing", async () => {
-      const viewport = canvasElement.querySelector(
-        '[data-part="viewport"]'
-      ) as HTMLElement;
+      const viewport = doc.getElementById("test-viewport") as HTMLElement;
       expect(viewport).toHaveAttribute("tabindex", "0");
     });
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -141,20 +141,15 @@ export const RoleRegion: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Root has role=region", async () => {
+    await step("Viewport has role=region and aria-label", async () => {
       await waitFor(() => {
         const region = canvas.getByRole("region", {
           name: "Main content area",
         });
         expect(region).toBeInTheDocument();
+        expect(region).toHaveAttribute("aria-label", "Main content area");
+        expect(region).toHaveAttribute("data-part", "viewport");
       });
-    });
-
-    await step("Has aria-label", async () => {
-      const region = canvas.getByRole("region", {
-        name: "Main content area",
-      });
-      expect(region).toHaveAttribute("aria-label", "Main content area");
     });
   },
 };
@@ -317,12 +312,13 @@ export const WithAriaLabelledBy: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Root has aria-labelledby", async () => {
+    await step("Viewport has role=region and aria-labelledby", async () => {
       await waitFor(() => {
         const region = canvas.getByRole("region", {
           name: "Application Logs",
         });
         expect(region).toHaveAttribute("aria-labelledby", "log-heading");
+        expect(region).toHaveAttribute("data-part", "viewport");
       });
     });
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ScrollArea, Box, Text, useScrollArea } from "@commercetools/nimbus";
 import { expect, userEvent, waitFor } from "storybook/test";
@@ -43,7 +44,6 @@ export const Default: Story = {
     <ScrollArea
       maxH="200px"
       w="400px"
-      variant="always"
       ids={{ viewport: "test-viewport-default" }}
     >
       <OverflowingContent />
@@ -95,7 +95,6 @@ export const NonOverflowing: Story = {
     <ScrollArea
       maxH="200px"
       w="400px"
-      variant="always"
       ids={{ viewport: "test-viewport-no-overflow" }}
     >
       <ShortContent />
@@ -147,7 +146,6 @@ export const KeyboardFocusRing: Story = {
         maxH="200px"
         w="400px"
         mt="400"
-        variant="always"
         ids={{ viewport: "test-viewport-kbd-focus" }}
       >
         <OverflowingContent />
@@ -188,7 +186,6 @@ export const VerticalOnly: Story = {
     <ScrollArea
       maxH="200px"
       w="400px"
-      variant="always"
       ids={{ viewport: "test-viewport-vert-only" }}
     >
       <OverflowingContent />
@@ -222,7 +219,6 @@ export const HorizontalOnly: Story = {
     <ScrollArea
       maxW="400px"
       orientation="horizontal"
-      variant="always"
       ids={{ viewport: "test-viewport-horiz-only" }}
     >
       <WideContent />
@@ -253,7 +249,7 @@ export const HorizontalOnly: Story = {
 // ============================================================
 export const BothAxes: Story = {
   render: () => (
-    <ScrollArea maxH="200px" maxW="400px" orientation="both" variant="always">
+    <ScrollArea maxH="200px" maxW="400px" orientation="both">
       <OverflowingContent />
       <WideContent />
     </ScrollArea>
@@ -272,16 +268,6 @@ export const BothAxes: Story = {
       const corner = canvasElement.querySelector('[data-part="corner"]');
       expect(corner).toBeTruthy();
     });
-
-    await step(
-      "Corner is visible in 'always' variant (opacity: 1)",
-      async () => {
-        const corner = canvasElement.querySelector(
-          '[data-part="corner"]'
-        ) as HTMLElement;
-        expect(window.getComputedStyle(corner).opacity).toBe("1");
-      }
-    );
   },
 };
 
@@ -290,32 +276,80 @@ export const BothAxes: Story = {
 // ============================================================
 export const AlwaysVisible: Story = {
   render: () => (
-    <ScrollArea maxH="200px" w="400px" variant="always">
-      <OverflowingContent />
-    </ScrollArea>
+    <Box display="flex" gap="600" flexWrap="wrap">
+      <Box>
+        <Text fontSize="sm" mb="200" fontWeight="bold">
+          Vertical
+        </Text>
+        <ScrollArea maxH="200px" w="400px" variant="always">
+          <OverflowingContent />
+        </ScrollArea>
+      </Box>
+      <Box>
+        <Text fontSize="sm" mb="200" fontWeight="bold">
+          Horizontal
+        </Text>
+        <ScrollArea maxW="400px" orientation="horizontal" variant="always">
+          <WideContent />
+        </ScrollArea>
+      </Box>
+      <Box>
+        <Text fontSize="sm" mb="200" fontWeight="bold">
+          Both axes
+        </Text>
+        <ScrollArea
+          maxH="200px"
+          maxW="400px"
+          orientation="both"
+          variant="always"
+        >
+          <OverflowingContent />
+          <WideContent />
+        </ScrollArea>
+      </Box>
+    </Box>
   ),
   play: async ({ canvasElement, step }) => {
-    await step("Scrollbar has opacity 1 (always visible)", async () => {
+    const roots = () =>
+      Array.from(canvasElement.querySelectorAll('[data-part="root"]'));
+
+    await step("All three scroll areas render", async () => {
       await waitFor(() => {
-        const scrollbar = canvasElement.querySelector(
-          '[data-part="scrollbar"]'
-        ) as HTMLElement;
-        expect(window.getComputedStyle(scrollbar).opacity).toBe("1");
+        expect(roots()).toHaveLength(3);
       });
     });
 
     await step(
-      "Viewport has gutter so scrollbar does not overlay content",
+      "Vertical: scrollbar has opacity 1 and gutter reserves space",
       async () => {
-        const viewport = canvasElement.querySelector(
-          '[data-part="viewport"]'
-        ) as HTMLElement;
-        const scrollbar = canvasElement.querySelector(
+        const root = roots()[0];
+        const scrollbar = root.querySelector(
           '[data-part="scrollbar"]'
         ) as HTMLElement;
+        const viewport = root.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        expect(window.getComputedStyle(scrollbar).opacity).toBe("1");
         const vpRect = viewport.getBoundingClientRect();
         const sbRect = scrollbar.getBoundingClientRect();
         expect(vpRect.right).toBeLessThanOrEqual(sbRect.left);
+      }
+    );
+
+    await step(
+      "Horizontal: scrollbar has opacity 1 and gutter reserves space",
+      async () => {
+        const root = roots()[1];
+        const scrollbar = root.querySelector(
+          '[data-part="scrollbar"]'
+        ) as HTMLElement;
+        const viewport = root.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        expect(window.getComputedStyle(scrollbar).opacity).toBe("1");
+        const vpRect = viewport.getBoundingClientRect();
+        const sbRect = scrollbar.getBoundingClientRect();
+        expect(vpRect.bottom).toBeLessThanOrEqual(sbRect.top);
       }
     );
   },
@@ -326,13 +360,7 @@ export const AlwaysVisible: Story = {
 // ============================================================
 export const CustomStyling: Story = {
   render: () => (
-    <ScrollArea
-      maxH="200px"
-      w="400px"
-      bg="neutral.2"
-      borderRadius="300"
-      variant="always"
-    >
+    <ScrollArea maxH="200px" w="400px" bg="neutral.2" borderRadius="300">
       <Box p="200">
         <OverflowingContent />
       </Box>
@@ -362,7 +390,7 @@ export const Sizes: Story = {
           <Text fontSize="sm" mb="200" fontWeight="bold">
             size=&quot;{size}&quot;
           </Text>
-          <ScrollArea maxH="150px" w="250px" size={size} variant="always">
+          <ScrollArea maxH="150px" w="250px" size={size}>
             <OverflowingContent />
           </ScrollArea>
         </Box>
@@ -402,7 +430,7 @@ export const ExternalControl: Story = {
 
     return (
       <Box>
-        <ScrollArea maxH="200px" w="400px" variant="always" value={scrollArea}>
+        <ScrollArea maxH="200px" w="400px" value={scrollArea}>
           <OverflowingContent />
         </ScrollArea>
       </Box>
@@ -422,6 +450,107 @@ export const ExternalControl: Story = {
     await step("Viewport has tabIndex when overflowing", async () => {
       const viewport = doc.getElementById("test-viewport") as HTMLElement;
       expect(viewport).toHaveAttribute("tabindex", "0");
+    });
+  },
+};
+
+// ============================================================
+// Sticky content in panel: always vs hover with sticky row
+// ============================================================
+const HeaderFooterLayout = ({
+  variant,
+  label,
+}: {
+  variant: "always" | "hover";
+  label: string;
+}) => (
+  <Box w="400px" border="solid-25" borderColor="neutral.6" borderRadius="200">
+    <Box
+      p="200"
+      bg="neutral.3"
+      borderBottom="solid-25"
+      borderColor="neutral.6"
+      display="flex"
+      justifyContent="space-between"
+    >
+      <Text fontWeight="bold" fontSize="sm">
+        Header — {label}
+      </Text>
+      <Text fontSize="sm" color="neutral.11">
+        Action
+      </Text>
+    </Box>
+    <ScrollArea maxH="200px" variant={variant}>
+      {Array.from({ length: 20 }, (_, i) => (
+        <React.Fragment key={i}>
+          {i === 2 && (
+            <Box
+              position="sticky"
+              top="0"
+              bg="primary.2"
+              p="200"
+              borderBottom="solid-25"
+              borderColor="primary.7"
+              display="flex"
+              justifyContent="space-between"
+              zIndex="1"
+            >
+              <Text fontWeight="bold" fontSize="sm">
+                Sticky row
+              </Text>
+            </Box>
+          )}
+          <Box
+            p="200"
+            borderBottom="solid-25"
+            borderColor="neutral.4"
+            display="flex"
+            justifyContent="space-between"
+          >
+            <Text fontSize="sm">Row {i + 1}</Text>
+            <Text fontSize="sm" color="neutral.11">
+              Detail
+            </Text>
+          </Box>
+        </React.Fragment>
+      ))}
+    </ScrollArea>
+    <Box
+      p="200"
+      bg="neutral.3"
+      borderTop="solid-25"
+      borderColor="neutral.6"
+      display="flex"
+      justifyContent="space-between"
+    >
+      <Text fontSize="sm">Footer</Text>
+      <Text fontSize="sm" color="neutral.11">
+        20 items
+      </Text>
+    </Box>
+  </Box>
+);
+
+export const StickyContentInPanel: Story = {
+  render: () => (
+    <Box display="flex" gap="600" flexWrap="wrap">
+      <HeaderFooterLayout variant="always" label="always" />
+      <HeaderFooterLayout variant="hover" label="hover" />
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Both layouts render", async () => {
+      await waitFor(() => {
+        const roots = canvasElement.querySelectorAll('[data-part="root"]');
+        expect(roots).toHaveLength(2);
+      });
+    });
+
+    await step("Scrollbar paints above content (z-index)", async () => {
+      const scrollbar = canvasElement.querySelector(
+        '[data-part="scrollbar"]'
+      ) as HTMLElement;
+      expect(window.getComputedStyle(scrollbar).zIndex).toBe("1");
     });
   },
 };

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -261,6 +261,16 @@ export const BothAxes: Story = {
       const corner = canvasElement.querySelector('[data-part="corner"]');
       expect(corner).toBeTruthy();
     });
+
+    await step(
+      "Corner is visible in 'always' variant (opacity: 1)",
+      async () => {
+        const corner = canvasElement.querySelector(
+          '[data-part="corner"]'
+        ) as HTMLElement;
+        expect(window.getComputedStyle(corner).opacity).toBe("1");
+      }
+    );
   },
 };
 

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { ScrollArea, Box, Text, Heading } from "@commercetools/nimbus";
-import { within, expect, userEvent, waitFor } from "storybook/test";
+import { ScrollArea, Box, Text } from "@commercetools/nimbus";
+import { expect, userEvent, waitFor } from "storybook/test";
 
-const meta: Meta = {
+const meta: Meta<typeof ScrollArea> = {
   title: "Components/ScrollArea",
+  component: ScrollArea,
   tags: ["autodocs"],
   parameters: {
     layout: "padded",
@@ -119,37 +120,6 @@ export const NonOverflowing: Story = {
       expect(
         canvasElement.querySelector('[data-part="scrollbar"]')
       ).toBeTruthy();
-    });
-  },
-};
-
-// ============================================================
-// Role region: consumers can set role="region" with aria-label
-// ============================================================
-export const RoleRegion: Story = {
-  render: () => (
-    <ScrollArea
-      maxH="200px"
-      w="400px"
-      role="region"
-      aria-label="Main content area"
-      variant="always"
-    >
-      <OverflowingContent />
-    </ScrollArea>
-  ),
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-
-    await step("Viewport has role=region and aria-label", async () => {
-      await waitFor(() => {
-        const region = canvas.getByRole("region", {
-          name: "Main content area",
-        });
-        expect(region).toBeInTheDocument();
-        expect(region).toHaveAttribute("aria-label", "Main content area");
-        expect(region).toHaveAttribute("data-part", "viewport");
-      });
     });
   },
 };
@@ -292,39 +262,6 @@ export const AlwaysVisible: Story = {
 };
 
 // ============================================================
-// With aria-labelledby
-// ============================================================
-export const WithAriaLabelledBy: Story = {
-  render: () => (
-    <Box>
-      <Heading id="log-heading">Application Logs</Heading>
-      <ScrollArea
-        maxH="200px"
-        w="400px"
-        role="region"
-        aria-labelledby="log-heading"
-        variant="always"
-      >
-        <OverflowingContent />
-      </ScrollArea>
-    </Box>
-  ),
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-
-    await step("Viewport has role=region and aria-labelledby", async () => {
-      await waitFor(() => {
-        const region = canvas.getByRole("region", {
-          name: "Application Logs",
-        });
-        expect(region).toHaveAttribute("aria-labelledby", "log-heading");
-        expect(region).toHaveAttribute("data-part", "viewport");
-      });
-    });
-  },
-};
-
-// ============================================================
 // Custom styling: style props on root, content padding via Box
 // ============================================================
 export const CustomStyling: Story = {
@@ -441,19 +378,6 @@ export const SmokeTest: Story = {
       </Box>
 
       <Box>
-        <Text fontSize="sm">With role=region</Text>
-        <ScrollArea
-          maxH="80px"
-          w="180px"
-          role="region"
-          aria-label="Labelled region"
-          variant="always"
-        >
-          <OverflowingContent />
-        </ScrollArea>
-      </Box>
-
-      <Box>
         <Text fontSize="sm">Custom styling</Text>
         <ScrollArea
           maxH="80px"
@@ -473,7 +397,7 @@ export const SmokeTest: Story = {
     await step("All variants render without errors", async () => {
       await waitFor(() => {
         const roots = canvasElement.querySelectorAll('[data-part="root"]');
-        expect(roots).toHaveLength(7);
+        expect(roots).toHaveLength(6);
       });
     });
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -325,19 +325,20 @@ export const WithAriaLabelledBy: Story = {
 };
 
 // ============================================================
-// With Chakra style props
+// Custom styling: style props on root, content padding via Box
 // ============================================================
-export const WithStyleProps: Story = {
+export const CustomStyling: Story = {
   render: () => (
     <ScrollArea
       maxH="200px"
       w="400px"
-      p="200"
       bg="neutral.2"
       borderRadius="300"
       variant="always"
     >
-      <OverflowingContent />
+      <Box p="200">
+        <OverflowingContent />
+      </Box>
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
@@ -453,16 +454,17 @@ export const SmokeTest: Story = {
       </Box>
 
       <Box>
-        <Text fontSize="sm">With style props</Text>
+        <Text fontSize="sm">Custom styling</Text>
         <ScrollArea
           maxH="80px"
           w="180px"
-          p="200"
           bg="neutral.2"
           borderRadius="300"
           variant="always"
         >
-          <OverflowingContent />
+          <Box p="200">
+            <OverflowingContent />
+          </Box>
         </ScrollArea>
       </Box>
     </Box>

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,0 +1,463 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ScrollArea, Box, Text, Heading } from "@commercetools/nimbus";
+import { within, expect, userEvent, waitFor } from "storybook/test";
+
+const meta: Meta = {
+  title: "Components/ScrollArea",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const OverflowingContent = () =>
+  Array.from({ length: 30 }, (_, i) => (
+    <Text key={i} fontSize="sm">
+      Line {i + 1}: Content that causes the container to overflow vertically.
+    </Text>
+  ));
+
+const ShortContent = () => (
+  <Text fontSize="sm">This content does not overflow.</Text>
+);
+
+const WideContent = () => (
+  <Box whiteSpace="nowrap">
+    {Array.from({ length: 5 }, (_, i) => (
+      <Text key={i} fontSize="sm">
+        {"Long horizontal content ".repeat(20)}
+      </Text>
+    ))}
+  </Box>
+);
+
+// ============================================================
+// Default: overflowing, vertical scrollbar, keyboard focusable
+// ============================================================
+export const Default: Story = {
+  render: () => (
+    <ScrollArea maxH="200px" w="400px" variant="always">
+      <OverflowingContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Viewport is keyboard-focusable when overflowing", async () => {
+      await waitFor(() => {
+        const viewport = canvasElement.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        expect(viewport).toBeTruthy();
+        expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+      });
+    });
+
+    await step("Detects vertical overflow via data attribute", async () => {
+      const viewport = canvasElement.querySelector('[data-part="viewport"]');
+      expect(viewport).toHaveAttribute("data-overflow-y");
+    });
+
+    await step("Scrollbar is visible", async () => {
+      const scrollbar = canvasElement.querySelector('[data-part="scrollbar"]');
+      expect(scrollbar).toBeTruthy();
+      expect(scrollbar).toHaveAttribute("data-orientation", "vertical");
+    });
+
+    await step("Thumb is rendered inside scrollbar", async () => {
+      const thumb = canvasElement.querySelector('[data-part="thumb"]');
+      expect(thumb).toBeTruthy();
+    });
+  },
+};
+
+// ============================================================
+// NonOverflowing: renders correctly with short content
+// ============================================================
+export const NonOverflowing: Story = {
+  render: () => (
+    <ScrollArea maxH="200px" w="400px" variant="always">
+      <ShortContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Component renders with short content", async () => {
+      await waitFor(() => {
+        const viewport = canvasElement.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        expect(viewport).toBeTruthy();
+      });
+    });
+
+    await step("All compound parts are present", async () => {
+      expect(canvasElement.querySelector('[data-part="root"]')).toBeTruthy();
+      expect(
+        canvasElement.querySelector('[data-part="viewport"]')
+      ).toBeTruthy();
+      expect(canvasElement.querySelector('[data-part="content"]')).toBeTruthy();
+      expect(
+        canvasElement.querySelector('[data-part="scrollbar"]')
+      ).toBeTruthy();
+    });
+  },
+};
+
+// ============================================================
+// Role region: consumers can set role="region" with aria-label
+// ============================================================
+export const RoleRegion: Story = {
+  render: () => (
+    <ScrollArea
+      maxH="200px"
+      w="400px"
+      role="region"
+      aria-label="Main content area"
+      variant="always"
+    >
+      <OverflowingContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Root has role=region", async () => {
+      await waitFor(() => {
+        const region = canvas.getByRole("region", {
+          name: "Main content area",
+        });
+        expect(region).toBeInTheDocument();
+      });
+    });
+
+    await step("Has aria-label", async () => {
+      const region = canvas.getByRole("region", {
+        name: "Main content area",
+      });
+      expect(region).toHaveAttribute("aria-label", "Main content area");
+    });
+  },
+};
+
+// ============================================================
+// Keyboard focus ring: Tab focuses viewport, ring appears on root
+// ============================================================
+export const KeyboardFocusRing: Story = {
+  render: () => (
+    <Box>
+      <Text>Press Tab to focus the scroll area below:</Text>
+      <ScrollArea maxH="200px" w="400px" mt="400" variant="always">
+        <OverflowingContent />
+      </ScrollArea>
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Viewport receives keyboard focus via Tab", async () => {
+      await waitFor(() => {
+        const viewport = canvasElement.querySelector(
+          '[data-part="viewport"]'
+        ) as HTMLElement;
+        expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+      });
+      await userEvent.tab();
+      const viewport = canvasElement.querySelector('[data-part="viewport"]');
+      await waitFor(() => {
+        expect(viewport).toHaveFocus();
+      });
+    });
+
+    await step("Focus ring appears on root element", async () => {
+      const root = canvasElement.querySelector('[data-part="root"]');
+      const rootStyles = window.getComputedStyle(root!);
+      expect(rootStyles.outlineColor).toBe("rgb(173, 186, 255)");
+      expect(rootStyles.outlineStyle).toBe("solid");
+    });
+  },
+};
+
+// ============================================================
+// Vertical only scrolling
+// ============================================================
+export const VerticalOnly: Story = {
+  render: () => (
+    <ScrollArea maxH="200px" w="400px" variant="always">
+      <OverflowingContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Detects vertical overflow", async () => {
+      await waitFor(() => {
+        const viewport = canvasElement.querySelector('[data-part="viewport"]');
+        expect(viewport).toHaveAttribute("data-overflow-y");
+      });
+    });
+
+    await step("Only vertical scrollbar rendered", async () => {
+      const scrollbars = canvasElement.querySelectorAll(
+        '[data-part="scrollbar"]'
+      );
+      expect(scrollbars).toHaveLength(1);
+      expect(scrollbars[0]).toHaveAttribute("data-orientation", "vertical");
+    });
+  },
+};
+
+// ============================================================
+// Horizontal only scrolling
+// ============================================================
+export const HorizontalOnly: Story = {
+  render: () => (
+    <ScrollArea maxW="400px" orientation="horizontal" variant="always">
+      <WideContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Detects horizontal overflow", async () => {
+      await waitFor(() => {
+        const viewport = canvasElement.querySelector('[data-part="viewport"]');
+        expect(viewport).toHaveAttribute("data-overflow-x");
+      });
+    });
+
+    await step("Only horizontal scrollbar rendered", async () => {
+      const scrollbars = canvasElement.querySelectorAll(
+        '[data-part="scrollbar"]'
+      );
+      expect(scrollbars).toHaveLength(1);
+      expect(scrollbars[0]).toHaveAttribute("data-orientation", "horizontal");
+    });
+  },
+};
+
+// ============================================================
+// Both axes scrolling
+// ============================================================
+export const BothAxes: Story = {
+  render: () => (
+    <ScrollArea maxH="200px" maxW="400px" orientation="both" variant="always">
+      <WideContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Both scrollbars rendered", async () => {
+      await waitFor(() => {
+        const scrollbars = canvasElement.querySelectorAll(
+          '[data-part="scrollbar"]'
+        );
+        expect(scrollbars).toHaveLength(2);
+      });
+    });
+
+    await step("Corner element rendered", async () => {
+      const corner = canvasElement.querySelector('[data-part="corner"]');
+      expect(corner).toBeTruthy();
+    });
+  },
+};
+
+// ============================================================
+// Always visible scrollbar variant
+// ============================================================
+export const AlwaysVisible: Story = {
+  render: () => (
+    <ScrollArea maxH="200px" w="400px" variant="always">
+      <OverflowingContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Scrollbar has opacity 1 (always visible)", async () => {
+      await waitFor(() => {
+        const scrollbar = canvasElement.querySelector(
+          '[data-part="scrollbar"]'
+        ) as HTMLElement;
+        expect(window.getComputedStyle(scrollbar).opacity).toBe("1");
+      });
+    });
+  },
+};
+
+// ============================================================
+// With aria-labelledby
+// ============================================================
+export const WithAriaLabelledBy: Story = {
+  render: () => (
+    <Box>
+      <Heading id="log-heading">Application Logs</Heading>
+      <ScrollArea
+        maxH="200px"
+        w="400px"
+        role="region"
+        aria-labelledby="log-heading"
+        variant="always"
+      >
+        <OverflowingContent />
+      </ScrollArea>
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Root has aria-labelledby", async () => {
+      await waitFor(() => {
+        const region = canvas.getByRole("region", {
+          name: "Application Logs",
+        });
+        expect(region).toHaveAttribute("aria-labelledby", "log-heading");
+      });
+    });
+  },
+};
+
+// ============================================================
+// With Chakra style props
+// ============================================================
+export const WithStyleProps: Story = {
+  render: () => (
+    <ScrollArea
+      maxH="200px"
+      w="400px"
+      p="200"
+      bg="neutral.2"
+      borderRadius="300"
+      variant="always"
+    >
+      <OverflowingContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("Root accepts Chakra style props", async () => {
+      await waitFor(() => {
+        const root = canvasElement.querySelector(
+          '[data-part="root"]'
+        ) as HTMLElement;
+        const styles = window.getComputedStyle(root);
+        expect(styles.borderRadius).not.toBe("0px");
+      });
+    });
+  },
+};
+
+// ============================================================
+// Scrollbar sizes
+// ============================================================
+export const Sizes: Story = {
+  render: () => (
+    <Box display="flex" gap="400" flexWrap="wrap">
+      {(["xs", "sm", "md", "lg"] as const).map((size) => (
+        <Box key={size}>
+          <Text fontSize="sm" mb="200" fontWeight="bold">
+            size=&quot;{size}&quot;
+          </Text>
+          <ScrollArea maxH="150px" w="250px" size={size} variant="always">
+            <OverflowingContent />
+          </ScrollArea>
+        </Box>
+      ))}
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("All size variants render", async () => {
+      await waitFor(() => {
+        const roots = canvasElement.querySelectorAll('[data-part="root"]');
+        expect(roots).toHaveLength(4);
+      });
+    });
+
+    await step("Scrollbar widths increase with size", async () => {
+      const scrollbars = canvasElement.querySelectorAll(
+        '[data-part="scrollbar"]'
+      );
+      const widths = Array.from(scrollbars).map((sb) =>
+        parseFloat(window.getComputedStyle(sb).width)
+      );
+      for (let i = 1; i < widths.length; i++) {
+        expect(widths[i]).toBeGreaterThan(widths[i - 1]);
+      }
+    });
+  },
+};
+
+// ============================================================
+// Smoke test: all combinations render without errors
+// ============================================================
+export const SmokeTest: Story = {
+  render: () => (
+    <Box display="flex" gap="400" flexWrap="wrap">
+      <Box>
+        <Text fontSize="sm">Vertical overflow</Text>
+        <ScrollArea maxH="80px" w="180px" variant="always">
+          <OverflowingContent />
+        </ScrollArea>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm">Horizontal overflow</Text>
+        <ScrollArea maxW="180px" orientation="horizontal" variant="always">
+          <WideContent />
+        </ScrollArea>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm">Both axes</Text>
+        <ScrollArea
+          maxH="80px"
+          maxW="180px"
+          orientation="both"
+          variant="always"
+        >
+          <WideContent />
+        </ScrollArea>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm">Non-overflowing</Text>
+        <ScrollArea maxH="200px" w="180px" variant="always">
+          <ShortContent />
+        </ScrollArea>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm">Hover variant</Text>
+        <ScrollArea maxH="80px" w="180px" variant="hover">
+          <OverflowingContent />
+        </ScrollArea>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm">With role=region</Text>
+        <ScrollArea
+          maxH="80px"
+          w="180px"
+          role="region"
+          aria-label="Labelled region"
+          variant="always"
+        >
+          <OverflowingContent />
+        </ScrollArea>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm">With style props</Text>
+        <ScrollArea
+          maxH="80px"
+          w="180px"
+          p="200"
+          bg="neutral.2"
+          borderRadius="300"
+          variant="always"
+        >
+          <OverflowingContent />
+        </ScrollArea>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step("All variants render without errors", async () => {
+      await waitFor(() => {
+        const roots = canvasElement.querySelectorAll('[data-part="root"]');
+        expect(roots).toHaveLength(7);
+      });
+    });
+  },
+};

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -2,12 +2,16 @@ import {
   ScrollArea as ChakraScrollArea,
   useScrollAreaContext,
 } from "@chakra-ui/react/scroll-area";
+import { extractPaddingProps } from "@/utils";
 import type { ScrollAreaProps } from "./scroll-area.types";
 
 type ScrollAreaPartsProps = Pick<
   ScrollAreaProps,
   "children" | "orientation" | "viewportRef"
->;
+> & {
+  /** Padding style props extracted from Root, applied to Content. */
+  contentPaddingProps?: Record<string, unknown>;
+};
 
 /**
  * Private component that renders inside ChakraScrollArea.Root
@@ -18,6 +22,7 @@ const ScrollAreaParts = ({
   children,
   orientation = "vertical",
   viewportRef,
+  contentPaddingProps,
 }: ScrollAreaPartsProps) => {
   const { hasOverflowX, hasOverflowY } = useScrollAreaContext();
   const tabIndex = hasOverflowX || hasOverflowY ? 0 : undefined;
@@ -25,7 +30,9 @@ const ScrollAreaParts = ({
   return (
     <>
       <ChakraScrollArea.Viewport ref={viewportRef} tabIndex={tabIndex}>
-        <ChakraScrollArea.Content>{children}</ChakraScrollArea.Content>
+        <ChakraScrollArea.Content {...contentPaddingProps}>
+          {children}
+        </ChakraScrollArea.Content>
       </ChakraScrollArea.Viewport>
       {(orientation === "vertical" || orientation === "both") && (
         <ChakraScrollArea.Scrollbar orientation="vertical" />
@@ -69,22 +76,28 @@ export const ScrollArea = (props: ScrollAreaProps) => {
     ...restProps
   } = props;
 
+  const [paddingProps, rootProps] = extractPaddingProps(restProps);
+
   const parts = (
-    <ScrollAreaParts orientation={orientation} viewportRef={viewportRef}>
+    <ScrollAreaParts
+      orientation={orientation}
+      viewportRef={viewportRef}
+      contentPaddingProps={paddingProps}
+    >
       {children}
     </ScrollAreaParts>
   );
 
   if (value) {
     return (
-      <ChakraScrollArea.RootProvider ref={ref} value={value} {...restProps}>
+      <ChakraScrollArea.RootProvider ref={ref} value={value} {...rootProps}>
         {parts}
       </ChakraScrollArea.RootProvider>
     );
   }
 
   return (
-    <ChakraScrollArea.Root ref={ref} {...restProps}>
+    <ChakraScrollArea.Root ref={ref} {...rootProps}>
       {parts}
     </ChakraScrollArea.Root>
   );

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -6,18 +6,21 @@ import { devWarn } from "@/utils";
 import type { ScrollAreaProps } from "./scroll-area.types";
 
 /**
- * Private inner component that renders inside ChakraScrollArea.Root
+ * Private component that renders inside ChakraScrollArea.Root
  * so it can access useScrollAreaContext() for conditional tabIndex.
+ * Composes Viewport + Content + Scrollbar(s) + Corner.
  */
-const ScrollAreaInner = ({
+const ScrollAreaParts = ({
   children,
   orientation = "vertical",
+  viewportRef,
   role,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledBy,
 }: {
   children: React.ReactNode;
   orientation?: "vertical" | "horizontal" | "both";
+  viewportRef?: React.Ref<HTMLDivElement>;
   role?: React.AriaRole;
   "aria-label"?: string;
   "aria-labelledby"?: string;
@@ -28,6 +31,7 @@ const ScrollAreaInner = ({
   return (
     <>
       <ChakraScrollArea.Viewport
+        ref={viewportRef}
         tabIndex={tabIndex}
         role={role}
         aria-label={ariaLabel}
@@ -70,6 +74,7 @@ const ScrollAreaInner = ({
 export const ScrollArea = (props: ScrollAreaProps) => {
   const {
     ref,
+    viewportRef,
     children,
     orientation = "vertical",
     role,
@@ -87,14 +92,15 @@ export const ScrollArea = (props: ScrollAreaProps) => {
 
   return (
     <ChakraScrollArea.Root ref={ref} {...restProps}>
-      <ScrollAreaInner
+      <ScrollAreaParts
         orientation={orientation}
+        viewportRef={viewportRef}
         role={role}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
       >
         {children}
-      </ScrollAreaInner>
+      </ScrollAreaParts>
     </ChakraScrollArea.Root>
   );
 };

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -1,0 +1,80 @@
+import {
+  ScrollArea as ChakraScrollArea,
+  useScrollAreaContext,
+} from "@chakra-ui/react/scroll-area";
+import { devWarn } from "@/utils";
+import type { ScrollAreaProps } from "./scroll-area.types";
+
+/**
+ * Private inner component that renders inside ChakraScrollArea.Root
+ * so it can access useScrollAreaContext() for conditional tabIndex.
+ */
+const ScrollAreaInner = ({
+  children,
+  orientation = "vertical",
+}: {
+  children: React.ReactNode;
+  orientation?: "vertical" | "horizontal" | "both";
+}) => {
+  const { hasOverflowX, hasOverflowY } = useScrollAreaContext();
+  const tabIndex = hasOverflowX || hasOverflowY ? 0 : undefined;
+
+  return (
+    <>
+      <ChakraScrollArea.Viewport tabIndex={tabIndex}>
+        <ChakraScrollArea.Content>{children}</ChakraScrollArea.Content>
+      </ChakraScrollArea.Viewport>
+      {(orientation === "vertical" || orientation === "both") && (
+        <ChakraScrollArea.Scrollbar orientation="vertical" />
+      )}
+      {(orientation === "horizontal" || orientation === "both") && (
+        <ChakraScrollArea.Scrollbar orientation="horizontal" />
+      )}
+      {orientation === "both" && <ChakraScrollArea.Corner />}
+    </>
+  );
+};
+
+/**
+ * # ScrollArea
+ *
+ * A scrollable container with custom-styled scrollbar overlays.
+ * Replaces native scrollbars with themed overlay indicators that appear
+ * on hover or during scrolling.
+ *
+ * Built on Chakra UI's ScrollArea (powered by Ark UI) with Nimbus
+ * design tokens and keyboard accessibility.
+ *
+ * @supportsStyleProps
+ *
+ * @see {@link https://nimbus-documentation.vercel.app/components/layout/scroll-area}
+ *
+ * @example
+ * ```tsx
+ * <ScrollArea maxH="200px" aria-label="Log output">
+ *   {content}
+ * </ScrollArea>
+ * ```
+ */
+export const ScrollArea = (props: ScrollAreaProps) => {
+  const { ref, children, orientation = "vertical", ...restProps } = props;
+
+  if (
+    restProps.role === "region" &&
+    !restProps["aria-label"] &&
+    !restProps["aria-labelledby"]
+  ) {
+    devWarn(
+      'ScrollArea with role="region" requires an "aria-label" or ' +
+        '"aria-labelledby" prop for accessibility.'
+    );
+  }
+
+  return (
+    <ChakraScrollArea.Root ref={ref} {...restProps}>
+      <ScrollAreaInner orientation={orientation}>{children}</ScrollAreaInner>
+    </ChakraScrollArea.Root>
+  );
+};
+
+ScrollArea.displayName = "ScrollArea";

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -65,14 +65,27 @@ export const ScrollArea = (props: ScrollAreaProps) => {
     viewportRef,
     children,
     orientation = "vertical",
+    value,
     ...restProps
   } = props;
 
+  const parts = (
+    <ScrollAreaParts orientation={orientation} viewportRef={viewportRef}>
+      {children}
+    </ScrollAreaParts>
+  );
+
+  if (value) {
+    return (
+      <ChakraScrollArea.RootProvider ref={ref} value={value} {...restProps}>
+        {parts}
+      </ChakraScrollArea.RootProvider>
+    );
+  }
+
   return (
     <ChakraScrollArea.Root ref={ref} {...restProps}>
-      <ScrollAreaParts orientation={orientation} viewportRef={viewportRef}>
-        {children}
-      </ScrollAreaParts>
+      {parts}
     </ChakraScrollArea.Root>
   );
 };

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -12,16 +12,27 @@ import type { ScrollAreaProps } from "./scroll-area.types";
 const ScrollAreaInner = ({
   children,
   orientation = "vertical",
+  role,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: {
   children: React.ReactNode;
   orientation?: "vertical" | "horizontal" | "both";
+  role?: React.AriaRole;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 }) => {
   const { hasOverflowX, hasOverflowY } = useScrollAreaContext();
   const tabIndex = hasOverflowX || hasOverflowY ? 0 : undefined;
 
   return (
     <>
-      <ChakraScrollArea.Viewport tabIndex={tabIndex}>
+      <ChakraScrollArea.Viewport
+        tabIndex={tabIndex}
+        role={role}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+      >
         <ChakraScrollArea.Content>{children}</ChakraScrollArea.Content>
       </ChakraScrollArea.Viewport>
       {(orientation === "vertical" || orientation === "both") && (
@@ -57,13 +68,17 @@ const ScrollAreaInner = ({
  * ```
  */
 export const ScrollArea = (props: ScrollAreaProps) => {
-  const { ref, children, orientation = "vertical", ...restProps } = props;
+  const {
+    ref,
+    children,
+    orientation = "vertical",
+    role,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
+    ...restProps
+  } = props;
 
-  if (
-    restProps.role === "region" &&
-    !restProps["aria-label"] &&
-    !restProps["aria-labelledby"]
-  ) {
+  if (role === "region" && !ariaLabel && !ariaLabelledBy) {
     devWarn(
       'ScrollArea with role="region" requires an "aria-label" or ' +
         '"aria-labelledby" prop for accessibility.'
@@ -72,7 +87,14 @@ export const ScrollArea = (props: ScrollAreaProps) => {
 
   return (
     <ChakraScrollArea.Root ref={ref} {...restProps}>
-      <ScrollAreaInner orientation={orientation}>{children}</ScrollAreaInner>
+      <ScrollAreaInner
+        orientation={orientation}
+        role={role}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+      >
+        {children}
+      </ScrollAreaInner>
     </ChakraScrollArea.Root>
   );
 };

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -2,8 +2,12 @@ import {
   ScrollArea as ChakraScrollArea,
   useScrollAreaContext,
 } from "@chakra-ui/react/scroll-area";
-import { devWarn } from "@/utils";
 import type { ScrollAreaProps } from "./scroll-area.types";
+
+type ScrollAreaPartsProps = Pick<
+  ScrollAreaProps,
+  "children" | "orientation" | "viewportRef"
+>;
 
 /**
  * Private component that renders inside ChakraScrollArea.Root
@@ -14,29 +18,13 @@ const ScrollAreaParts = ({
   children,
   orientation = "vertical",
   viewportRef,
-  role,
-  "aria-label": ariaLabel,
-  "aria-labelledby": ariaLabelledBy,
-}: {
-  children: React.ReactNode;
-  orientation?: "vertical" | "horizontal" | "both";
-  viewportRef?: React.Ref<HTMLDivElement>;
-  role?: React.AriaRole;
-  "aria-label"?: string;
-  "aria-labelledby"?: string;
-}) => {
+}: ScrollAreaPartsProps) => {
   const { hasOverflowX, hasOverflowY } = useScrollAreaContext();
   const tabIndex = hasOverflowX || hasOverflowY ? 0 : undefined;
 
   return (
     <>
-      <ChakraScrollArea.Viewport
-        ref={viewportRef}
-        tabIndex={tabIndex}
-        role={role}
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-      >
+      <ChakraScrollArea.Viewport ref={viewportRef} tabIndex={tabIndex}>
         <ChakraScrollArea.Content>{children}</ChakraScrollArea.Content>
       </ChakraScrollArea.Viewport>
       {(orientation === "vertical" || orientation === "both") && (
@@ -77,28 +65,12 @@ export const ScrollArea = (props: ScrollAreaProps) => {
     viewportRef,
     children,
     orientation = "vertical",
-    role,
-    "aria-label": ariaLabel,
-    "aria-labelledby": ariaLabelledBy,
     ...restProps
   } = props;
 
-  if (role === "region" && !ariaLabel && !ariaLabelledBy) {
-    devWarn(
-      'ScrollArea with role="region" requires an "aria-label" or ' +
-        '"aria-labelledby" prop for accessibility.'
-    );
-  }
-
   return (
     <ChakraScrollArea.Root ref={ref} {...restProps}>
-      <ScrollAreaParts
-        orientation={orientation}
-        viewportRef={viewportRef}
-        role={role}
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-      >
+      <ScrollAreaParts orientation={orientation} viewportRef={viewportRef}>
         {children}
       </ScrollAreaParts>
     </ChakraScrollArea.Root>

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -1,15 +1,55 @@
+import type { UseScrollAreaReturn } from "@chakra-ui/react/scroll-area";
 import type {
-  ScrollAreaRootProps,
-  UseScrollAreaReturn,
-} from "@chakra-ui/react/scroll-area";
+  HTMLChakraProps,
+  SlotRecipeProps,
+  UnstyledProp,
+} from "@chakra-ui/react/styled-system";
 import type { OmitInternalProps } from "@/type-utils/omit-props";
 
+// ============================================================
+// RECIPE PROPS
+// ============================================================
+
+/**
+ * Recipe props for the ScrollArea component.
+ * Inferred from the slot recipe to enable responsive values.
+ */
+type ScrollAreaRecipeProps = {
+  /**
+   * Scrollbar visibility variant.
+   * - `hover`: scrollbar appears on hover or during active scrolling (default)
+   * - `always`: scrollbar is permanently visible
+   * @default "hover"
+   */
+  variant?: SlotRecipeProps<"scrollArea">["variant"];
+  /**
+   * Scrollbar thickness.
+   * @default "sm"
+   */
+  size?: SlotRecipeProps<"scrollArea">["size"];
+} & UnstyledProp;
+
+// ============================================================
+// SLOT PROPS
+// ============================================================
+
+type ScrollAreaRootSlotProps = HTMLChakraProps<"div", ScrollAreaRecipeProps>;
+
+// ============================================================
+// MAIN PROPS
+// ============================================================
+
 /** Props for the `ScrollArea` component. */
-export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootProps> & {
+export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootSlotProps> & {
   /** Content to render inside the scrollable area. */
   children: React.ReactNode;
-  /** The HTML element type to render the root as. */
-  as?: ScrollAreaRootProps["as"];
+  /**
+   * The HTML element type to render the root as.
+   */
+  // NOTE: Deliberately re-added after `OmitInternalProps` strips it.
+  // Unlike React Aria wrappers, ScrollArea composes Chakra compound
+  // parts directly, so polymorphic rendering via `as` genuinely works.
+  as?: React.ElementType;
   /** A ref to the root scroll area element. */
   ref?: React.Ref<HTMLDivElement>;
   /** A ref to the scrollable viewport element inside the scroll area. */
@@ -25,6 +65,30 @@ export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootProps> & {
    * allowing external access to scroll state and programmatic control.
    */
   value?: UseScrollAreaReturn;
+  /**
+   * Scrollbar visibility variant.
+   * - `hover`: scrollbar appears on hover or during active scrolling (default)
+   * - `always`: scrollbar is permanently visible
+   * @default "hover"
+   */
+  variant?: ScrollAreaRecipeProps["variant"];
+  /**
+   * Scrollbar thickness.
+   * @default "sm"
+   */
+  size?: ScrollAreaRecipeProps["size"];
+  /**
+   * Custom element IDs for ScrollArea's internal parts.
+   * Use when you need DOM access via `getElementById` (e.g.,
+   * `ids={{ viewport: 'my-viewport' }}`).
+   */
+  ids?: Partial<{
+    root: string;
+    viewport: string;
+    content: string;
+    scrollbar: string;
+    thumb: string;
+  }>;
 };
 
 /**

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -1,10 +1,8 @@
 import type { ScrollAreaRootProps } from "@chakra-ui/react/scroll-area";
 import type { OmitInternalProps } from "@/type-utils/omit-props";
 
-type ScrollAreaBaseProps = OmitInternalProps<
-  ScrollAreaRootProps,
-  "role" | "aria-label" | "aria-labelledby"
-> & {
+/** Props for the `ScrollArea` component. */
+export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootProps> & {
   /** Content to render inside the scrollable area. */
   children: React.ReactNode;
   /** The HTML element type to render the root as. */
@@ -20,36 +18,14 @@ type ScrollAreaBaseProps = OmitInternalProps<
   orientation?: "vertical" | "horizontal" | "both";
 };
 
-type ScrollAreaRegionProps = ScrollAreaBaseProps & {
-  /**
-   * The ARIA landmark role for the scroll area.
-   * When set to `"region"`, an accessible name is required.
-   */
-  role: "region";
-} & (
-    | {
-        /** The accessible name. Required when `role="region"`. */
-        "aria-label": string;
-        "aria-labelledby"?: string;
-      }
-    | {
-        "aria-label"?: string;
-        /** ID of the labeling element. Required when `role="region"` if `aria-label` is not provided. */
-        "aria-labelledby": string;
-      }
-  );
-
-type ScrollAreaDefaultProps = ScrollAreaBaseProps & {
-  /** The ARIA role for the scroll area. */
-  role?: never;
-  "aria-label"?: string;
-  "aria-labelledby"?: string;
-};
-
 /**
- * Props for the `ScrollArea` component.
- *
- * When `role="region"`, either `aria-label` or `aria-labelledby` is
- * required at the type level to satisfy WCAG landmark naming requirements.
+ * Custom element IDs for ScrollArea's internal parts.
+ * Pass to the `ids` prop to set known IDs for DOM access.
  */
-export type ScrollAreaProps = ScrollAreaRegionProps | ScrollAreaDefaultProps;
+export type ScrollAreaElementIds = Partial<{
+  root: string;
+  viewport: string;
+  content: string;
+  scrollbar: string;
+  thumb: string;
+}>;

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -1,0 +1,51 @@
+import type { ScrollAreaRootProps } from "@chakra-ui/react/scroll-area";
+import type { OmitInternalProps } from "@/type-utils/omit-props";
+
+type ScrollAreaBaseProps = OmitInternalProps<
+  ScrollAreaRootProps,
+  "role" | "aria-label" | "aria-labelledby"
+> & {
+  /** Content to render inside the scrollable area. */
+  children: React.ReactNode;
+  /** A ref to the root scroll area element. */
+  ref?: React.Ref<HTMLDivElement>;
+  /**
+   * Which scrollbar axes to render.
+   * @default "vertical"
+   */
+  orientation?: "vertical" | "horizontal" | "both";
+};
+
+type ScrollAreaRegionProps = ScrollAreaBaseProps & {
+  /**
+   * The ARIA landmark role for the scroll area.
+   * When set to `"region"`, an accessible name is required.
+   */
+  role: "region";
+} & (
+    | {
+        /** The accessible name. Required when `role="region"`. */
+        "aria-label": string;
+        "aria-labelledby"?: string;
+      }
+    | {
+        "aria-label"?: string;
+        /** ID of the labeling element. Required when `role="region"` if `aria-label` is not provided. */
+        "aria-labelledby": string;
+      }
+  );
+
+type ScrollAreaDefaultProps = ScrollAreaBaseProps & {
+  /** The ARIA role for the scroll area. */
+  role?: never;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+};
+
+/**
+ * Props for the `ScrollArea` component.
+ *
+ * When `role="region"`, either `aria-label` or `aria-labelledby` is
+ * required at the type level to satisfy WCAG landmark naming requirements.
+ */
+export type ScrollAreaProps = ScrollAreaRegionProps | ScrollAreaDefaultProps;

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -7,8 +7,12 @@ type ScrollAreaBaseProps = OmitInternalProps<
 > & {
   /** Content to render inside the scrollable area. */
   children: React.ReactNode;
+  /** The HTML element type to render the root as. */
+  as?: ScrollAreaRootProps["as"];
   /** A ref to the root scroll area element. */
   ref?: React.Ref<HTMLDivElement>;
+  /** A ref to the scrollable viewport element inside the scroll area. */
+  viewportRef?: React.Ref<HTMLDivElement>;
   /**
    * Which scrollbar axes to render.
    * @default "vertical"

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -1,4 +1,7 @@
-import type { ScrollAreaRootProps } from "@chakra-ui/react/scroll-area";
+import type {
+  ScrollAreaRootProps,
+  UseScrollAreaReturn,
+} from "@chakra-ui/react/scroll-area";
 import type { OmitInternalProps } from "@/type-utils/omit-props";
 
 /** Props for the `ScrollArea` component. */
@@ -16,6 +19,12 @@ export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootProps> & {
    * @default "vertical"
    */
   orientation?: "vertical" | "horizontal" | "both";
+  /**
+   * An externally created scroll area machine (from `useScrollArea`).
+   * When provided, the component uses `RootProvider` instead of `Root`,
+   * allowing external access to scroll state and programmatic control.
+   */
+  value?: UseScrollAreaReturn;
 };
 
 /**

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -1,4 +1,5 @@
 import { accordionSlotRecipe } from "@/components/accordion/accordion.recipe";
+import { scrollAreaSlotRecipe } from "@/components/scroll-area/scroll-area.recipe";
 import { defaultPageSlotRecipe } from "@/components/default-page/default-page.recipe";
 import { stepsSlotRecipe } from "@/components/steps/steps.recipe";
 import { alertRecipe } from "@/components/alert/alert.recipe";
@@ -118,4 +119,8 @@ export const slotRecipes = {
   toast: toastRecipe,
   nimbusToggleButtonGroup: buttonGroupRecipe,
   nimbusSteps: stepsSlotRecipe,
+  // NOTE: intentionally NOT prefixed with "nimbus" — the "scrollArea" key
+  // overrides Chakra's built-in scrollArea recipe so that Chakra's
+  // ScrollArea components resolve Nimbus styles through the recipe system.
+  scrollArea: scrollAreaSlotRecipe,
 };

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -112,15 +112,13 @@ export const slotRecipes = {
   nimbusTagGroup: tagGroupSlotRecipe,
   nimbusTextInput: textInputSlotRecipe,
   nimbusTimeInput: timeInputRecipe,
-  // NOTE: intentionally NOT prefixed with "nimbus" — the "toast" key overrides
-  // Chakra's built-in toast recipe so that useToastStyles() in ToastOutlet resolves
-  // Nimbus styles through Chakra's recipe system. Adding the nimbus prefix would
-  // break style resolution. This is the only Nimbus recipe that is an override.
-  toast: toastRecipe,
   nimbusToggleButtonGroup: buttonGroupRecipe,
   nimbusSteps: stepsSlotRecipe,
-  // NOTE: intentionally NOT prefixed with "nimbus" — the "scrollArea" key
-  // overrides Chakra's built-in scrollArea recipe so that Chakra's
-  // ScrollArea components resolve Nimbus styles through the recipe system.
+  // NOTE: the following recipes are intentionally NOT prefixed with "nimbus"
+  // because they override Chakra's built-in recipes so that Chakra's own
+  // compound components (e.g. ScrollArea.*, ToastOutlet) resolve Nimbus
+  // styles through the recipe system. No .slots.tsx file is needed for
+  // these — the slot context is owned by Chakra's implementation
   scrollArea: scrollAreaSlotRecipe,
+  toast: toastRecipe,
 };

--- a/packages/nimbus/src/utils/dev-warn.ts
+++ b/packages/nimbus/src/utils/dev-warn.ts
@@ -1,0 +1,9 @@
+/**
+ * Logs a warning to the console in development mode only.
+ * Warnings are suppressed in production builds via dead-code elimination.
+ */
+export function devWarn(message: string): void {
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(`[Nimbus] ${message}`);
+  }
+}

--- a/packages/nimbus/src/utils/dev-warn.ts
+++ b/packages/nimbus/src/utils/dev-warn.ts
@@ -1,9 +1,0 @@
-/**
- * Logs a warning to the console in development mode only.
- * Warnings are suppressed in production builds via dead-code elimination.
- */
-export function devWarn(message: string): void {
-  if (process.env.NODE_ENV !== "production") {
-    console.warn(`[Nimbus] ${message}`);
-  }
-}

--- a/packages/nimbus/src/utils/extract-padding-props.ts
+++ b/packages/nimbus/src/utils/extract-padding-props.ts
@@ -32,6 +32,8 @@ const PADDING_PROP_KEYS = new Set([
 
 /**
  * Extracts padding style-props from an object, separating them from other props.
+ * Responsive values (arrays and objects like `{ base: "200", md: "400" }`)
+ * are supported — they are extracted by key name unchanged.
  * @param props The props object to separate
  * @returns A tuple containing [paddingProps, otherProps]
  */

--- a/packages/nimbus/src/utils/extract-padding-props.ts
+++ b/packages/nimbus/src/utils/extract-padding-props.ts
@@ -1,0 +1,55 @@
+/**
+ * Padding style prop keys recognised by Chakra UI.
+ * Used to forward padding from a parent slot to an inner slot
+ * (e.g. ScrollArea Root → Content).
+ */
+const PADDING_PROP_KEYS = new Set([
+  "p",
+  "pt",
+  "pr",
+  "pb",
+  "pl",
+  "ps",
+  "pe",
+  "px",
+  "py",
+  "padding",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "paddingX",
+  "paddingY",
+  "paddingInline",
+  "paddingBlock",
+  "paddingInlineStart",
+  "paddingInlineEnd",
+  "paddingBlockStart",
+  "paddingBlockEnd",
+  "paddingStart",
+  "paddingEnd",
+]);
+
+/**
+ * Extracts padding style-props from an object, separating them from other props.
+ * @param props The props object to separate
+ * @returns A tuple containing [paddingProps, otherProps]
+ */
+export function extractPaddingProps<T extends object>(
+  props: T
+): [Record<string, unknown>, Omit<T, string>] {
+  const paddingProps: Record<string, unknown> = {};
+  const otherProps = { ...props } as Record<string, unknown>;
+
+  Object.keys(props).forEach((key) => {
+    if (
+      Object.prototype.hasOwnProperty.call(props, key) &&
+      PADDING_PROP_KEYS.has(key)
+    ) {
+      paddingProps[key] = props[key as keyof T];
+      delete otherProps[key];
+    }
+  });
+
+  return [paddingProps, otherProps as Omit<T, string>];
+}

--- a/packages/nimbus/src/utils/index.ts
+++ b/packages/nimbus/src/utils/index.ts
@@ -2,5 +2,4 @@ export { DisplayColorPalettes } from "./display-color-palettes";
 export { extractAriaAttributes } from "./extract-aria-attributes";
 export { extractStyleProps } from "./extract-style-props";
 export { mergeRefs } from "./merge-refs";
-export { devWarn } from "./dev-warn";
 export { noop } from "./no-op";

--- a/packages/nimbus/src/utils/index.ts
+++ b/packages/nimbus/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { DisplayColorPalettes } from "./display-color-palettes";
 export { extractAriaAttributes } from "./extract-aria-attributes";
+export { extractPaddingProps } from "./extract-padding-props";
 export { extractStyleProps } from "./extract-style-props";
 export { mergeRefs } from "./merge-refs";
 export { noop } from "./no-op";

--- a/packages/nimbus/src/utils/index.ts
+++ b/packages/nimbus/src/utils/index.ts
@@ -2,4 +2,5 @@ export { DisplayColorPalettes } from "./display-color-palettes";
 export { extractAriaAttributes } from "./extract-aria-attributes";
 export { extractStyleProps } from "./extract-style-props";
 export { mergeRefs } from "./merge-refs";
+export { devWarn } from "./dev-warn";
 export { noop } from "./no-op";


### PR DESCRIPTION
## Summary

Supersedes #1295.

Adds `ScrollArea`, a scrollable container with custom-styled scrollbar overlays that replaces native scrollbars with themed overlay indicators. Built on Chakra UI's ScrollArea (Ark UI / zag-js) with a single-element Nimbus API that hides compound internals.

### Component API

- **Single-element API** — `<ScrollArea maxH="200px">` instead of assembling `Root > Viewport > Content > Scrollbar`
- **`orientation` prop** — controls which scrollbar axes render (`vertical` | `horizontal` | `both`, default `vertical`)
- **`viewportRef` prop** — ref to the scrollable viewport element for programmatic scroll access
- **`value` prop** — accepts a `UseScrollAreaReturn` from `useScrollArea()` for external state control (renders `RootProvider` instead of `Root`)
- **`ids` prop** — set known element IDs for DOM access via `getElementById`
- **Style props** — full Chakra style prop support on the root element

### Styling

- **Nimbus slot recipe** with 6 slots (`root`, `viewport`, `content`, `scrollbar`, `thumb`, `corner`)
- **Size variants**: `xs` / `sm` / `md` / `lg` (default `sm`)
- **Visibility variants**: `hover` (default, fade in on hover/scroll) / `always`
- Scrollbar track (`neutral.4`), thumb (`neutral.7` → `neutral.9` on hover/active)
- Namespaced CSS custom properties (`--scroll-area-scrollbar-size`, `--scroll-area-scrollbar-margin`)
- Scrollbar margin uses `{sizes.50}` design token

### Accessibility

- **Conditional `tabIndex`** via `useScrollAreaContext()` — viewport receives `tabIndex={0}` only when content overflows, satisfying the `scrollable-region-focusable` axe rule
- **Keyboard focus ring** on root element using `_focusWithin` + `:has(:focus-visible)` pattern (avoids `overflow: hidden` clipping)
- ARIA `role`, `aria-label`, and `aria-labelledby` forwarded to the viewport element (the scrollable landmark and focusable element are the same DOM node)

### Hooks and Exports

| Export                                       | Purpose                                                          |
| -------------------------------------------- | ---------------------------------------------------------------- |
| `ScrollArea`                                 | The component                                                    |
| `useScrollArea`                              | Create external scroll machine (pass to `value` prop)            |
| `useScrollAreaContext`                       | Access scroll state (`hasOverflowX`, `hasOverflowY`) from inside |
| `ScrollAreaProps`                            | Component prop types                                             |
| `ScrollAreaElementIds`                       | Type for the `ids` prop                                          |
| `UseScrollAreaProps` / `UseScrollAreaReturn` | Hook types                                                       |

### Documentation

- `scroll-area.mdx` — designer-facing (Overview + Variables)
- `scroll-area.dev.mdx` — developer-facing (Import, PropsTable, hooks, content padding guidance)
- `scroll-area.a11y.mdx` — accessibility guidance

### Docs App Migration

Replaced custom scrollbar CSS in `app-frame` and `no-sidebar-layout` with the new `ScrollArea` component. Introduced a shared `ScrollContainerProvider` context so scroll-dependent hooks (`useHashNavigation`, `useScrollRestoration`, `useClosestHeading`) use viewport refs instead of `getElementById`.

### Stories (11 total)

`Default` · `NonOverflowing` · `KeyboardFocusRing` · `VerticalOnly` · `HorizontalOnly` · `BothAxes` · `AlwaysVisible` · `CustomStyling` · `Sizes` · `ExternalControl` · `SmokeTest`

## Test plan

- [x] `pnpm --filter @commercetools/nimbus typecheck` passes
- [x] `pnpm --filter @commercetools/nimbus build` succeeds
- [x] `pnpm test:storybook:dev packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx` — all 11 stories pass
- [x] `pnpm lint -- packages/nimbus/src/components/scroll-area/` passes
- [ ] Visual check in Storybook: scrollbars visible, focus ring on Tab, no scrollbar on non-overflowing content
- [x] Docs app: sidebar and content area scroll correctly with new ScrollArea integration
