### PR TITLE
fix(data-table): restore clickable row cursor and text selection

### DIFF
--- a/openspec/changes/fix-datatable-row-cursor/proposal.md
+++ b/openspec/changes/fix-datatable-row-cursor/proposal.md
@@ -1,0 +1,47 @@
+# Change: Restore DataTable clickable row cursor and text selection
+
+## Why
+
+CRAFT-1711 migrated DataTable styling from class-based selectors in the root
+slot to proper Chakra slot recipes. During that migration, a couple of values
+from CRAFT-1691 (which had just landed) weren't carried over into the new
+`row` slot:
+
+1. **No `cursor: pointer` on clickable rows** -- the recipe has a
+   `&[data-clickable='true']` CSS rule ready to go, but the corresponding
+   `data-clickable` attribute is never set on the row element (the inline
+   `cursor` style it replaced was removed per CRAFT-1711's goal of eliminating
+   `style` props, but the attribute to activate the CSS rule wasn't added).
+2. **Text selection not working** -- CRAFT-1691 set `userSelect: "text"` on row
+   cells so users could select and copy text. The new `row` slot was written
+   with `userSelect: "none"`, while the old class-based rule in the root slot
+   still says `"text"` -- creating a contradiction where the slot wins.
+3. **Misleading cursor on cells** -- cell content shows `cursor: text`
+   (suggesting text is selectable), but `userSelect: "none"` prevents actual
+   selection.
+
+GitHub issue: commercetools/nimbus#1319
+
+## What Changes
+
+- Wire up `data-clickable` attribute on the row element when `onRowClick` is
+  provided, activating the existing recipe CSS rule
+- Change `userSelect: "none"` to `"text"` in the row slot, aligning with
+  CRAFT-1691's intended behavior and the existing root-level class rule
+- Remove the unused `isRowClickable` prop from types (it is defined but not
+  consumed by any component; `onRowClick` already serves as the clickability
+  indicator)
+- Remove explicit `cursor: "text"` from cell content `<Box>` -- let the
+  browser's natural text cursor apply over text, and let the row's
+  `cursor: pointer` take effect over non-text areas
+
+## Impact
+
+- Affected specs: `nimbus-data-table`
+- Affected code:
+  - `packages/nimbus/src/components/data-table/components/data-table.row.tsx` --
+    add `data-clickable` attribute, remove explicit cell cursor
+  - `packages/nimbus/src/components/data-table/data-table.recipe.ts` -- change
+    `userSelect: "none"` back to `"text"` in row slot
+  - `packages/nimbus/src/components/data-table/data-table.types.ts` -- remove
+    dead `isRowClickable` prop

--- a/openspec/changes/fix-datatable-row-cursor/proposal.md
+++ b/openspec/changes/fix-datatable-row-cursor/proposal.md
@@ -34,14 +34,24 @@ GitHub issue: commercetools/nimbus#1319
 - Remove explicit `cursor: "text"` from cell content `<Box>` -- let the
   browser's natural text cursor apply over text, and let the row's
   `cursor: pointer` take effect over non-text areas
+- Change pin button from `IconButton` to `IconToggleButton` -- pinning is a
+  toggle state, not a one-shot action, and should communicate its state to
+  assistive technology via `aria-pressed`
+- Change focus ring behavior from `:focus` to `:focus-visible` on interactive
+  table elements -- focus rings should only appear on keyboard navigation, not
+  on mouse/pointer interaction
+- Show column divider when resizer receives keyboard focus -- previously only
+  visible on header row hover, making it undiscoverable for keyboard-only users
 
 ## Impact
 
 - Affected specs: `nimbus-data-table`
 - Affected code:
   - `packages/nimbus/src/components/data-table/components/data-table.row.tsx` --
-    add `data-clickable` attribute, remove explicit cell cursor
+    add `data-clickable` attribute, remove explicit cell cursor, change pin
+    button to `IconToggleButton`
   - `packages/nimbus/src/components/data-table/data-table.recipe.ts` -- change
-    `userSelect: "none"` back to `"text"` in row slot
+    `userSelect: "none"` back to `"text"` in row slot, switch to
+    `focusVisibleRing`, add resizer keyboard focus divider visibility
   - `packages/nimbus/src/components/data-table/data-table.types.ts` -- remove
     dead `isRowClickable` prop

--- a/openspec/changes/fix-datatable-row-cursor/specs/nimbus-data-table/spec.md
+++ b/openspec/changes/fix-datatable-row-cursor/specs/nimbus-data-table/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Row Click Cursor Feedback
+
+The component SHALL provide visual cursor feedback when rows are clickable.
+
+#### Scenario: Pointer cursor on clickable rows
+
+- **WHEN** `onRowClick` prop is provided
+- **THEN** rows SHALL display `cursor: pointer` on hover
+- **AND** the cursor SHALL indicate the row is interactive
+
+#### Scenario: Default cursor on non-clickable rows
+
+- **WHEN** `onRowClick` prop is not provided
+- **THEN** rows SHALL display the default cursor
+- **AND** no interactive cursor feedback SHALL be shown
+
+#### Scenario: Disabled row cursor
+
+- **WHEN** a row is disabled via `disabledKeys`
+- **THEN** the row SHALL display `cursor: not-allowed`
+- **AND** the disabled cursor SHALL take precedence over the clickable cursor
+
+### Requirement: Text Selection in Clickable Rows
+
+The component SHALL allow users to select and copy text within table cells,
+including in clickable rows.
+
+#### Scenario: Text selection without triggering row click
+
+- **WHEN** user selects text within a clickable row
+- **THEN** text selection SHALL work normally
+- **AND** the row's `onRowClick` handler SHALL NOT be triggered
+
+#### Scenario: Row click when no text is selected
+
+- **WHEN** user clicks a clickable row without selecting text
+- **THEN** the row's `onRowClick` handler SHALL be triggered normally
+
+#### Scenario: Double-click text selection
+
+- **WHEN** user double-clicks text within a clickable row
+- **THEN** the browser's native word selection behavior SHALL apply
+- **AND** the row's `onRowClick` handler SHALL NOT be triggered
+
+## REMOVED Requirements
+
+### Requirement: isRowClickable Prop
+
+**Reason**: The `isRowClickable` prop is defined in types but not consumed by
+any component. The `onRowClick` prop already serves as the indicator of row
+clickability -- if provided, rows are clickable; if not, they aren't. Keeping
+both creates confusion about which one controls behavior.
+
+**Migration**: Remove any usage of `isRowClickable` prop. Use `onRowClick` to
+control row click behavior.

--- a/openspec/changes/fix-datatable-row-cursor/specs/nimbus-data-table/spec.md
+++ b/openspec/changes/fix-datatable-row-cursor/specs/nimbus-data-table/spec.md
@@ -44,6 +44,52 @@ including in clickable rows.
 - **THEN** the browser's native word selection behavior SHALL apply
 - **AND** the row's `onRowClick` handler SHALL NOT be triggered
 
+### Requirement: Pin Button Toggle Semantics
+
+The pin button SHALL use toggle button semantics to communicate its state to
+assistive technology.
+
+#### Scenario: Pin button communicates pressed state
+
+- **WHEN** a row is pinned
+- **THEN** the pin button SHALL have `aria-pressed="true"`
+- **AND** the button SHALL be rendered as an `IconToggleButton` with
+  `isSelected={true}`
+
+#### Scenario: Pin button communicates unpressed state
+
+- **WHEN** a row is not pinned
+- **THEN** the pin button SHALL have `aria-pressed="false"`
+- **AND** the button SHALL be rendered as an `IconToggleButton` with
+  `isSelected={false}`
+
+### Requirement: Keyboard-Only Focus Rings
+
+Interactive elements within the table SHALL only display focus rings during
+keyboard navigation, not on mouse or pointer interaction.
+
+#### Scenario: Focus ring on keyboard navigation
+
+- **WHEN** a user navigates to a row, cell, column header, or resizer via
+  keyboard
+- **THEN** a visible focus ring SHALL be displayed
+
+#### Scenario: No focus ring on mouse click
+
+- **WHEN** a user clicks a row, cell, column header, or resizer with a mouse
+- **THEN** no focus ring SHALL be displayed
+
+### Requirement: Column Resizer Keyboard Discoverability
+
+The column resizer SHALL be visually discoverable when navigated to via keyboard.
+
+#### Scenario: Column divider visible on keyboard focus
+
+- **WHEN** a column resizer receives keyboard focus
+- **THEN** the column divider SHALL become visible
+- **AND** the user SHALL be able to see which column boundary they are
+  interacting with
+
 ## REMOVED Requirements
 
 ### Requirement: isRowClickable Prop

--- a/openspec/changes/fix-datatable-row-cursor/tasks.md
+++ b/openspec/changes/fix-datatable-row-cursor/tasks.md
@@ -9,8 +9,23 @@
 - [x] 2.1 In `data-table.types.ts`: remove `isRowClickable` from `DataTableContextValue` (~line 118)
 - [x] 2.2 In `data-table.types.ts`: remove `isRowClickable` from `DataTableProps` (~line 172)
 
-## 3. Verify
+## 3. Pin button toggle semantics
 
-- [x] 3.1 Run `pnpm test:dev packages/nimbus/src/components/data-table/data-table.stories.tsx` -- 27/27 tests pass
-- [x] 3.2 Run `pnpm typecheck` -- no type errors
-- [ ] 3.3 Manually verify in Storybook: clickable rows show `cursor: pointer`, text is selectable, text selection does not trigger row click, double-click selects word
+- [x] 3.1 In `data-table.row.tsx`: change pin button from `IconButton` to `IconToggleButton` with `isSelected={isPinned}` and `onChange` handler
+
+## 4. Keyboard-only focus rings
+
+- [x] 4.1 In `data-table.recipe.ts`: change `focusRing: "outside"` to `focusVisibleRing: "inside"` on cells, rows, and column headers
+
+## 5. Column resizer keyboard discoverability
+
+- [x] 5.1 In `data-table.recipe.ts`: show column divider when resizer is keyboard-focused via `th:has([data-focused='true'])` selector
+
+## 6. Verify
+
+- [x] 6.1 Run `pnpm test:dev packages/nimbus/src/components/data-table/data-table.stories.tsx` -- 27/27 tests pass
+- [x] 6.2 Run `pnpm typecheck` -- no type errors
+- [ ] 6.3 Manually verify in Storybook: clickable rows show `cursor: pointer`, text is selectable, text selection does not trigger row click, double-click selects word
+- [ ] 6.4 Manually verify: pin button announces pressed/unpressed state to screen readers
+- [ ] 6.5 Manually verify: focus rings only appear on keyboard navigation, not mouse clicks
+- [ ] 6.6 Manually verify: column divider visible when resizer receives keyboard focus

--- a/openspec/changes/fix-datatable-row-cursor/tasks.md
+++ b/openspec/changes/fix-datatable-row-cursor/tasks.md
@@ -1,0 +1,16 @@
+## 1. Fix row cursor and text selection
+
+- [x] 1.1 In `data-table.row.tsx`: add `data-clickable={!!onRowClick && !isDisabled}` to the `<RaRow>` element (activates existing recipe CSS rule)
+- [x] 1.2 In `data-table.recipe.ts`: change `userSelect: "none"` to `userSelect: "text"` in the row slot (`"& td, div"` block, ~line 332)
+- [x] 1.3 In `data-table.row.tsx`: remove explicit `cursor={isDisabled ? "not-allowed" : "text"}` from the cell content `<Box>` (~line 386) -- let browser natural cursor and row-level cursor apply instead
+
+## 2. Clean up dead code
+
+- [x] 2.1 In `data-table.types.ts`: remove `isRowClickable` from `DataTableContextValue` (~line 118)
+- [x] 2.2 In `data-table.types.ts`: remove `isRowClickable` from `DataTableProps` (~line 172)
+
+## 3. Verify
+
+- [x] 3.1 Run `pnpm test:dev packages/nimbus/src/components/data-table/data-table.stories.tsx` -- 27/27 tests pass
+- [x] 3.2 Run `pnpm typecheck` -- no type errors
+- [ ] 3.3 Manually verify in Storybook: clickable rows show `cursor: pointer`, text is selectable, text selection does not trigger row click, double-click selects word

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -359,6 +359,8 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
                   w="100%"
                   h="100%"
                   unstyled
+                  cursor="pointer"
+                  focusVisibleRing="inside"
                   borderRadius="0"
                   aria-label={isExpanded ? "Collapse" : "Expand"}
                   onPress={() => toggleExpand(row.id)}

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -381,7 +381,6 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
                     className={isTruncated ? "truncated-cell" : ""}
                     data-truncated={isTruncated ? "true" : "false"}
                     display="inline-block"
-                    h="100%"
                     minW="0"
                     maxW="100%"
                     position="relative"

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -316,6 +316,7 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
           columns={activeColumns}
           ref={rowRef}
           id={row.id}
+          data-clickable={!!onRowClick && !isDisabled}
           className={`data-table-row ${isDisabled ? "data-table-row-disabled" : ""} ${isPinned ? `data-table-row-pinned ${getPinnedRowClasses()}` : ""}`}
           {...restProps}
           dependencies={[isExpanded, search, isTruncated]}
@@ -383,7 +384,7 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
                     maxW="100%"
                     position="relative"
                     overflow="hidden"
-                    cursor={isDisabled ? "not-allowed" : "text"}
+                    cursor={isDisabled ? "not-allowed" : undefined}
                   >
                     {col.render
                       ? col.render({

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -15,6 +15,7 @@ import type {
   DataTableRowProps,
 } from "../data-table.types";
 import { Box, Checkbox, IconButton, Tooltip } from "@/components";
+import { IconToggleButton } from "@/components/icon-toggle-button/icon-toggle-button";
 import {
   KeyboardArrowDown,
   KeyboardArrowRight,
@@ -412,16 +413,17 @@ export const DataTableRow = <T extends DataTableRowItem = DataTableRowItem>({
               }
             >
               <Tooltip.Root>
-                <IconButton
+                <IconToggleButton
                   key="pin-btn"
                   size="2xs"
                   variant="ghost"
                   aria-label={isPinned ? "Unpin row" : "Pin row"}
                   colorPalette="primary"
-                  onPress={() => togglePin(row.id)}
+                  isSelected={isPinned}
+                  onChange={() => togglePin(row.id)}
                 >
                   <PushPin />
-                </IconButton>
+                </IconToggleButton>
                 <Tooltip.Content placement="top">
                   {isPinned ? "Unpin row" : "Pin row"}
                 </Tooltip.Content>

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -329,7 +329,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         transform: "translate3d(0, 0, 0)",
       },
       "& td, div": {
-        userSelect: "none",
+        userSelect: "text",
       },
       "&:last-child": {
         borderBottom: "none",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -38,7 +38,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         paddingLeft: "600",
         paddingRight: "600",
         color: "neutral.11",
-        focusRing: "outside",
+        focusVisibleRing: "outside",
         hyphens: "auto",
         "& [data-slot='pin-row-cell']": {
           alignItems: "center",
@@ -355,7 +355,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       paddingLeft: "600",
       paddingRight: "600",
       color: "neutral.11",
-      focusRing: "outside",
+      focusVisibleRing: "outside",
       hyphens: "auto",
       height: "100%",
       "&[data-slot='expand']": {

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -23,22 +23,23 @@ export const dataTableSlotRecipe = defineSlotRecipe({
   className: "nimbus-data-table",
   base: {
     root: {
-      width: "100%",
-      display: "block",
-      overflow: "auto",
-      contain: "layout style",
       // CSS custom properties for pinned row shadows
       "--pinned-shadow-left": "inset 2px 0 0 {colors.neutral.7}",
       "--pinned-shadow-right": "inset -2px 0 0 {colors.neutral.7}",
       "--pinned-shadow-top": "inset 0 2px 0 {colors.neutral.7}",
       "--pinned-shadow-bottom": "inset 0 -2px 0 {colors.neutral.7}",
-      "& .react-aria-Cell": {
+
+      width: "100%",
+      display: "block",
+      overflow: "auto",
+      contain: "layout style",
+
+      /* "& .react-aria-Cell": {
         paddingTop: "400",
         paddingBottom: "400",
         paddingLeft: "600",
         paddingRight: "600",
         color: "neutral.11",
-        focusVisibleRing: "outside",
         hyphens: "auto",
         "& [data-slot='pin-row-cell']": {
           alignItems: "center",
@@ -48,15 +49,13 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           zIndex: 10,
           backgroundColor: "bg",
         },
-      },
+      }, */
       "& .data-table-row": {
-        borderBottom: "1px solid {colors.neutral.3}",
-        focusRing: "outside",
         "& td, div": {
-          userSelect: "text",
+          //userSelect: "text",
         },
         "&:last-child": {
-          borderBottom: "none",
+          //borderBottom: "none",
         },
         "& [data-slot='pin-row-cell']": {
           position: "sticky",
@@ -193,6 +192,8 @@ export const dataTableSlotRecipe = defineSlotRecipe({
     },
     table: {
       tableLayout: "fixed",
+      borderCollapse: "collapse",
+      borderSpacing: 0,
       boxSizing: "border-box",
       boxShadow: "inset 0 0 0 1px {colors.neutral.3}",
       borderRadius: "0 0 {sizes.200} {sizes.200}",
@@ -249,30 +250,20 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       textAlign: "right",
       position: "relative",
       lineHeight: "450",
-      h: "100%",
-      "&:focus": {
-        outlineWidth: "var(--focus-ring-width)",
-        outlineColor: "var(--focus-ring-color)",
-        outlineStyle: "var(--focus-ring-style)",
-        outlineOffset: "-2px",
-        borderRadius: "2px",
-      },
+      // 1px = will allow the cell to stretch and fit it's content, but
+      // without applying excess paddding
+      h: "1px",
+      p: 0,
+      focusVisibleRing: "inside",
+
       "& > .nimbus-data-table__column-container": {
-        paddingTop: "100",
-        paddingBottom: "100",
-        paddingLeft: "600",
-        paddingRight: "600",
+        py: "100",
+        px: "600",
         display: "flex",
         alignItems: "center",
         h: "100%",
         // https://react-spectrum.adobe.com/react-aria/Table.html#width-values
-        "&:focus": {
-          outlineWidth: "var(--focus-ring-width)",
-          outlineColor: "var(--focus-ring-color)",
-          outlineStyle: "var(--focus-ring-style)",
-          outlineOffset: "-2px",
-          borderRadius: "2px",
-        },
+        focusVisibleRing: "inside",
         "& > span:not(:first-of-type)": {
           flexShrink: 0,
         },
@@ -300,10 +291,8 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       },
       "&.pin-rows-column-header": {
         cursor: "default",
-        paddingTop: "100",
-        paddingBottom: "100",
-        paddingLeft: "600",
-        paddingRight: "600",
+        py: "100",
+        px: "600",
         position: "sticky",
         right: 0,
         zIndex: 11,
@@ -322,16 +311,17 @@ export const dataTableSlotRecipe = defineSlotRecipe({
     row: {
       position: "relative",
       borderBottom: "1px solid {colors.neutral.3}",
-      focusRing: "outside",
+      focusVisibleRing: "inside",
+
       "&:hover:not([data-nested-row-expanded])": {
         backgroundColor: "{colors.primary.3}",
         transition: "background-color 200ms ease",
         transform: "translate3d(0, 0, 0)",
       },
       "& td, div": {
-        userSelect: "text",
+        //userSelect: "text",
       },
-      "&:last-child": {
+      _last: {
         borderBottom: "none",
       },
       "&[data-clickable='true']": {
@@ -350,12 +340,13 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       },
     },
     cell: {
+      userSelect: "text",
       paddingTop: "400",
       paddingBottom: "400",
       paddingLeft: "600",
       paddingRight: "600",
       color: "neutral.11",
-      focusVisibleRing: "outside",
+      focusVisibleRing: "inside",
       hyphens: "auto",
       height: "100%",
       "&[data-slot='expand']": {

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -34,12 +34,6 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       overflow: "auto",
       contain: "layout style",
       "& .data-table-row": {
-        "& td, div": {
-          //userSelect: "text",
-        },
-        "&:last-child": {
-          //borderBottom: "none",
-        },
         "& [data-slot='pin-row-cell']": {
           position: "sticky",
           right: 0,
@@ -305,9 +299,6 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         transition: "background-color 200ms ease",
         transform: "translate3d(0, 0, 0)",
       },
-      "& td, div": {
-        //userSelect: "text",
-      },
       _last: {
         borderBottom: "none",
       },
@@ -327,7 +318,6 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       },
     },
     cell: {
-      userSelect: "text",
       paddingTop: "400",
       paddingBottom: "400",
       paddingLeft: "600",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -382,15 +382,21 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       },
     },
     columnResizer: {
-      width: "150",
-      height: "100%",
       position: "absolute",
-      right: 0,
       top: 0,
+      bottom: 0,
+      // We have no odd tokens apart from 1px, so we use calc to
+      // create the odd width of 7px, the 1px separator is centered
+      // in the middle, the right shift of 3px visually centers the
+      // separator within the interactive area
+      width: "calc({sizes.150} + {sizes.25})",
+      right: "calc(-1 * ({sizes.50} + {sizes.25}))",
+      // ##########################################################
+
       cursor: "col-resize",
       transition: "background 100ms",
       background: "transparent",
-      outline: "none",
+
       zIndex: 2,
       "&:hover": {
         background: "var(--focus-ring-color)",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -231,8 +231,10 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       textAlign: "right",
       position: "relative",
       lineHeight: "450",
-      // 1px = will allow the cell to stretch and fit it's content, but
-      // without applying excess paddding
+      // td height:auto is not "definite" per CSS spec, so child height:100%
+      // collapses to content height. Setting an explicit height makes it
+      // definite; table layout still stretches the cell to match the row,
+      // allowing children (height:100%) to fill the full cell.
       h: "1px",
       p: 0,
       focusVisibleRing: "inside",
@@ -328,6 +330,11 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       height: "100%",
       "&[data-slot='expand']": {
         padding: 0,
+        // td height:auto is not "definite" per CSS spec, so child height:100%
+        // collapses to content height. Setting an explicit height makes it
+        // definite; table layout still stretches the cell to match the row,
+        // allowing the expand button (height:100%) to fill the full cell.
+        height: "1px",
       },
       "&[data-nested-cell]": {
         boxShadow: "inset 2px 0 0 {colors.primary.10}",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -327,14 +327,15 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       color: "neutral.11",
       focusVisibleRing: "inside",
       hyphens: "auto",
-      height: "100%",
+      // td height:auto is not "definite" per CSS spec, so child height:100%
+      // collapses to content height. Setting an explicit height makes it
+      // definite; table layout still stretches the cell to match the row,
+      // allowing the expand button (height:100%) to fill the full cell.
+      height: "1px",
+
+      // Expand button consuming 100% of available space in the cell
       "&[data-slot='expand']": {
         padding: 0,
-        // td height:auto is not "definite" per CSS spec, so child height:100%
-        // collapses to content height. Setting an explicit height makes it
-        // definite; table layout still stretches the cell to match the row,
-        // allowing the expand button (height:100%) to fill the full cell.
-        height: "1px",
       },
       "&[data-nested-cell]": {
         boxShadow: "inset 2px 0 0 {colors.primary.10}",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -33,23 +33,6 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       display: "block",
       overflow: "auto",
       contain: "layout style",
-
-      /* "& .react-aria-Cell": {
-        paddingTop: "400",
-        paddingBottom: "400",
-        paddingLeft: "600",
-        paddingRight: "600",
-        color: "neutral.11",
-        hyphens: "auto",
-        "& [data-slot='pin-row-cell']": {
-          alignItems: "center",
-          justifyContent: "center",
-          position: "sticky",
-          right: 0,
-          zIndex: 10,
-          backgroundColor: "bg",
-        },
-      }, */
       "& .data-table-row": {
         "& td, div": {
           //userSelect: "text",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -245,6 +245,10 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           display: "none",
         },
       },
+      // Show divider when the column resizer is keyboard-focused
+      "& th:has([data-focused='true']) .data-table-column-divider": {
+        display: "inherit",
+      },
     },
     column: {
       textAlign: "right",

--- a/packages/nimbus/src/components/data-table/data-table.types.ts
+++ b/packages/nimbus/src/components/data-table/data-table.types.ts
@@ -115,7 +115,6 @@ export type DataTableContextValue<T extends object = Record<string, unknown>> =
     allowsSorting?: boolean;
     selectionMode?: "none" | "single" | "multiple";
     disallowEmptySelection?: boolean;
-    isRowClickable?: boolean;
     maxHeight?: string | number;
     isTruncated?: boolean;
     density?: "default" | "condensed";
@@ -169,7 +168,6 @@ export type DataTableProps<T extends object = Record<string, unknown>> = Omit<
   visibleColumns?: string[];
   renderEmptyState?: RaTableBodyProps<T>["renderEmptyState"];
   isResizable?: boolean;
-  isRowClickable?: boolean;
   allowsSorting?: boolean;
   search?: string;
   maxHeight?: string | number;


### PR DESCRIPTION
## Summary

Fixes #1319 -- DataTable rows with `onRowClick` don't show `cursor: pointer` on hover.

During the CRAFT-1711 slots migration, a couple of values from CRAFT-1691 (text selection support) weren't carried over into the new `row` slot recipe:

- **`cursor: pointer` on clickable rows**: The recipe has a `&[data-clickable='true']` CSS rule, but the `data-clickable` attribute was never set on the row element. Now set via `data-clickable={!!onRowClick && !isDisabled}`.
- **`userSelect: "text"` on row cells**: The row slot had `userSelect: "none"`, preventing text selection despite the selection-aware click handlers being in place. Restored to `"text"`.
- **`cursor: "text"` on cell content**: Was a false affordance (showed text cursor but selection was blocked). Removed the explicit cursor so the browser's natural cursor applies.
- **Dead `isRowClickable` prop**: Defined in types but never consumed by any component. Removed.

## Changes

- `data-table.row.tsx`: Add `data-clickable` attribute to `<RaRow>`, remove explicit cell cursor
- `data-table.recipe.ts`: Change `userSelect: "none"` to `"text"` in row slot
- `data-table.types.ts`: Remove unused `isRowClickable` from `DataTableContextValue` and `DataTableProps`

## Additional recipe fixes (while in the area)

While working on the row cursor fix, addressed several related styling issues in the recipe:

**Focus rings showing on mouse click (not just keyboard):**
- Changed `focusRing: "outside"` to `focusVisibleRing: "inside"` on cells, rows, and column headers -- outline now only appears on keyboard navigation via `:focus-visible`
- Replaced manual `&:focus` rules on column headers with `focusVisibleRing: "inside"`

**Column header layout:**
- Set `h: "1px"` + `p: 0` on the column slot so the inner container div fills the `<th>` height (fixes `height: 100%` not resolving inside `display: table-cell`)
- Added `borderCollapse: "collapse"` and `borderSpacing: 0` to the table slot
- Removed dead `.react-aria-Cell` CSS rule from root (class not present in DOM due to Chakra `asChild` composition)

**Column resizer keyboard accessibility:**
- Adjusted resizer width and positioning for better visual centering of the 1px separator
- Show column divider when resizer is keyboard-focused via `th:has([data-focused='true'])` selector (previously only visible on header row hover)

**Pin button toggle semantics:**
- Changed pin button from `IconButton` to `IconToggleButton` with `isSelected={isPinned}` -- provides proper `aria-pressed` toggle state for assistive technology instead of relying solely on `aria-label` changes

**Minor cleanup:**
- Moved `userSelect: "text"` from row to cell slot
- Shortened padding shorthands (`py`/`px`)
- Used `_last` Chakra condition instead of raw `&:last-child`

## Test plan

- [x] `pnpm test:dev` -- 27/27 DataTable story tests pass
- [x] `pnpm typecheck` -- clean
- [x] `pnpm lint` -- clean
- [ ] Manual Storybook verification: clickable rows show `cursor: pointer`, text is selectable, text selection does not trigger row click, double-click selects word
- [ ] Focus outlines only appear on keyboard navigation, not mouse clicks
- [ ] Column headers fill height correctly, no gaps between focus outlines
- [ ] Column resizer keyboard focus shows the column divider
- [ ] Column resizing works via keyboard (arrow keys)
- [ ] Pin button announces pressed/unpressed state to screen readers