### PR TITLE
FEC-746: improve loweredrelevancefields data

### DIFF
--- a/packages/nimbus-mcp/scripts/build-search-index.ts
+++ b/packages/nimbus-mcp/scripts/build-search-index.ts
@@ -26,6 +26,7 @@ export async function buildSearchIndex(outDir?: string) {
   }>;
 
   for (const entry of index) {
+    if (entry._lower) continue;
     const title = entry.title.toLowerCase();
     const description = entry.description.toLowerCase();
     const tags = entry.tags.join(" ").toLowerCase();
@@ -36,6 +37,12 @@ export async function buildSearchIndex(outDir?: string) {
       tags,
       content,
       combined: title + " " + description + " " + tags + " " + content,
+      titleNoSpaces: title.replace(/\s+/g, ""),
+      descriptionNoSpaces: description.replace(/\s+/g, ""),
+      tagsNoSpaces: tags.replace(/\s+/g, ""),
+      titleWords: title.split(/\s+/).filter(Boolean),
+      descriptionWords: description.split(/\s+/).filter(Boolean),
+      tagsWords: tags.split(/\s+/).filter(Boolean),
     };
   }
 

--- a/packages/nimbus-mcp/src/data-loader.ts
+++ b/packages/nimbus-mcp/src/data-loader.ts
@@ -79,7 +79,14 @@ export const getRouteManifest = lazyJson<RouteManifest>(
 // Per-component route data
 // ---------------------------------------------------------------------------
 
-/** Cache for per-component route data, keyed by slug. */
+/**
+ * Cache for per-component route data, keyed by slug.
+ *
+ * Lifecycle: grows without eviction. This is safe because the MCP server runs
+ * as a short-lived stdio process — one per editor session — so memory is
+ * reclaimed when the process exits. If the server is ever adapted for SSE or
+ * other long-lived transports, an LRU eviction policy should be added here.
+ */
 const routeDataCache = new Map<string, RouteData>();
 
 /**

--- a/packages/nimbus-mcp/src/tools/search-docs.ts
+++ b/packages/nimbus-mcp/src/tools/search-docs.ts
@@ -72,6 +72,12 @@ function getLoweredFields(
         tags,
         content,
         combined: title + " " + description + " " + tags + " " + content,
+        titleNoSpaces: title.replace(/\s+/g, ""),
+        descriptionNoSpaces: description.replace(/\s+/g, ""),
+        tagsNoSpaces: tags.replace(/\s+/g, ""),
+        titleWords: title.split(/\s+/).filter(Boolean),
+        descriptionWords: description.split(/\s+/).filter(Boolean),
+        tagsWords: tags.split(/\s+/).filter(Boolean),
       });
     }
   }
@@ -206,6 +212,14 @@ function findCandidates(
   return { matched, expanded };
 }
 
+/**
+ * Cache for per-route searchable views, keyed by slug.
+ *
+ * Lifecycle: grows without eviction. This is safe because the MCP server runs
+ * as a short-lived stdio process — one per editor session — so memory is
+ * reclaimed when the process exits. If the server is ever adapted for SSE or
+ * other long-lived transports, an LRU eviction policy should be added here.
+ */
 const routeViewsCache = new Map<string, CachedRouteViews>();
 
 /**
@@ -247,9 +261,7 @@ async function getRouteViews(route: string): Promise<CachedRouteViews> {
       }
     }
   } else if (routeData.mdx) {
-    const { stripped, lower } = getCachedViewContent(
-      routeData as unknown as { mdx: string }
-    );
+    const { stripped, lower } = getCachedViewContent({ mdx: routeData.mdx });
     rawViews.push({
       key: "overview",
       content: stripped,

--- a/packages/nimbus-mcp/src/types.ts
+++ b/packages/nimbus-mcp/src/types.ts
@@ -363,6 +363,18 @@ export interface LoweredRelevanceFields {
   content: string;
   /** All fields concatenated for fast single-string search. */
   combined: string;
+  /** Title with whitespace removed (for compound-word fuzzy matching). */
+  titleNoSpaces?: string;
+  /** Description with whitespace removed (for compound-word fuzzy matching). */
+  descriptionNoSpaces?: string;
+  /** Tags with whitespace removed (for compound-word fuzzy matching). */
+  tagsNoSpaces?: string;
+  /** Pre-split title words (for word-level fuzzy matching). */
+  titleWords?: string[];
+  /** Pre-split description words (for word-level fuzzy matching). */
+  descriptionWords?: string[];
+  /** Pre-split tags words (for word-level fuzzy matching). */
+  tagsWords?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/nimbus-mcp/src/utils/relevance.ts
+++ b/packages/nimbus-mcp/src/utils/relevance.ts
@@ -245,32 +245,61 @@ export function fuzzyScorePreLowered(
     content: WEIGHTS.content / 2,
   } as const;
 
+  // Pre-compute noSpaces and words arrays once, falling back to runtime
+  // computation if the pre-split fields aren't available.
+  const fieldData = [
+    {
+      text: fields.title,
+      noSpaces: fields.titleNoSpaces ?? fields.title.replace(/\s+/g, ""),
+      words: fields.titleWords ?? fields.title.split(/\s+/).filter(Boolean),
+      weight: FUZZY_WEIGHTS.title,
+    },
+    {
+      text: fields.description,
+      noSpaces:
+        fields.descriptionNoSpaces ?? fields.description.replace(/\s+/g, ""),
+      words:
+        fields.descriptionWords ??
+        fields.description.split(/\s+/).filter(Boolean),
+      weight: FUZZY_WEIGHTS.description,
+    },
+    {
+      text: fields.tags,
+      noSpaces: fields.tagsNoSpaces ?? fields.tags.replace(/\s+/g, ""),
+      words: fields.tagsWords ?? fields.tags.split(/\s+/).filter(Boolean),
+      weight: FUZZY_WEIGHTS.tags,
+    },
+  ];
+
   for (const token of tokens) {
     if (token.length < 3) continue;
     const maxDist = token.length <= 4 ? 1 : token.length <= 7 ? 2 : 3;
 
-    // Helper: check if token fuzzy-matches any word in text, OR if token is
-    // a substring of the concatenated text (catches "datepicker" in "date picker"
-    // and "btn" in "button").
-    const fuzzyMatchField = (text: string): boolean => {
+    for (const { text, noSpaces, words, weight } of fieldData) {
       // Substring match (fast) — handles compound words like "datepicker" in "date picker"
-      if (text.includes(token)) return true;
-      // Also try with spaces removed for compound matching
-      if (text.replace(/\s+/g, "").includes(token)) return true;
-      // Then word-level checks: Levenshtein + prefix matching
-      for (const word of text.split(/\s+/)) {
-        if (word.length === 0) continue;
-        // Levenshtein for typo tolerance
-        if (boundedLevenshtein(token, word, maxDist) >= 0) return true;
-        // Prefix match: "checkmark" matches "check*" words and vice versa
-        if (token.startsWith(word) || word.startsWith(token)) return true;
+      if (text.includes(token)) {
+        score += weight;
+        continue;
       }
-      return false;
-    };
-
-    if (fuzzyMatchField(fields.title)) score += FUZZY_WEIGHTS.title;
-    if (fuzzyMatchField(fields.description)) score += FUZZY_WEIGHTS.description;
-    if (fuzzyMatchField(fields.tags)) score += FUZZY_WEIGHTS.tags;
+      // Also try with spaces removed for compound matching
+      if (noSpaces.includes(token)) {
+        score += weight;
+        continue;
+      }
+      // Word-level checks: Levenshtein + prefix matching
+      let matched = false;
+      for (const word of words) {
+        if (boundedLevenshtein(token, word, maxDist) >= 0) {
+          matched = true;
+          break;
+        }
+        if (token.startsWith(word) || word.startsWith(token)) {
+          matched = true;
+          break;
+        }
+      }
+      if (matched) score += weight;
+    }
     // Skip content for fuzzy — too many words, too slow, too many false positives
   }
   return score;


### PR DESCRIPTION
## Summary                                                                                                
  - Pre-compute `*NoSpaces` and `*Words` fields on `LoweredRelevanceFields` at index build time and in      
  `getLoweredFields()`, eliminating redundant `replace`/`split` calls per token per field during fuzzy      
  search                                                                                                    
  - Add lifecycle comments to `routeDataCache` and `routeViewsCache` documenting the stdio process          
  assumption and when eviction would be needed                                                              
  - Remove unsafe `as unknown as { mdx: string }` double cast in `getRouteViews`
  - Add idempotency guard (`if (entry._lower) continue`) in `buildSearchIndex` to prevent                   
  double-augmentation on re-runs                                                                            
                                               
  ## Test plan                                                                                              
  - [ ] `pnpm test:unit` passes                            
  - [ ] `pnpm typecheck` passes                
  - [ ] Manual MCP search queries return expected results