### PR TITLE
ci: use github-api commit mode for signed changeset commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -73,6 +74,7 @@ jobs:
           commit: "ci(changesets): version packages"
           title: "ci(changesets): version packages"
           createGithubReleases: true
+          commitMode: "github-api"
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           SKIP_POSTINSTALL_DEV_SETUP: true


### PR DESCRIPTION
## Summary
- Adds `commitMode: "github-api"` to `changesets/action` so commits and tags are created via the GitHub API and automatically GPG-signed by GitHub
- This satisfies the org-level "Require signed commits" ruleset (ID 14540095) that was blocking the version PR from being merged
- Adds `workflow_dispatch` trigger for manual testing

## Context
The [org-level ruleset](https://commercetools.atlassian.net/wiki/spaces/S/blog/2026/03/06/1990262896/Enforcing+signed+commits+across+the+GitHub+Enterprise), which was enforced starting on April 10th, requires signed commits on all branches. The `changesets/action` defaults to `commitMode: "git-cli"` which creates unsigned commits via `git commit` + `git push`. The `"github-api"` mode (available since v1.5.0, we're on v1.5.3) creates commits through the GitHub API instead, which GitHub automatically signs.

## Test plan
- [ ] Merge to main and wait for next push with pending changesets
- [ ] Verify the commit on `changeset-release/main` shows as **Verified**
- [ ] Verify the version PR can be merged without signature violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)