### PR TITLE
fix(release error): update changesets/action version to 1.7.0 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Creating release pull request or publishing release to npm registry
         id: changesets
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@v1.7.0
         with:
           publish: pnpm changeset publish
           version: pnpm changeset:version-and-format


### PR DESCRIPTION
This pull request updates the version of the `changesets/action` GitHub Action used in the release workflow. The update moves from version 1.5.3 to 1.7.0, which may include bug fixes, new features, or improvements.

- Workflow dependency update:
  * Upgraded `changesets/action` in `.github/workflows/release.yml` from `v1.5.3` to `v1.7.0` to ensure the release workflow uses the latest features and fixes.