### PR TITLE
fix(scroll-area): prevent silent horizontal overflow and fix child sizing

### DIFF
--- a/.changeset/fix-scroll-area-orientation-overflow.md
+++ b/.changeset/fix-scroll-area-orientation-overflow.md
@@ -8,4 +8,7 @@ grow to fit its widest child, so siblings sized at `100%` inherited that
 overgrown width. The wrapper is now sized to the viewport by default, and the
 default `orientation` is `"both"` so descendant overflow surfaces a scrollbar
 indicator instead of being silently scrollable. Setting `orientation` to
-`"vertical"` or `"horizontal"` now actively clips the opposite axis.
+`"vertical"` or `"horizontal"` now actively clips the opposite axis. The content
+wrapper now also fills the viewport vertically, so consumers can vertically
+center a shorter child with flex/grid + `height: 100%` — previously the wrapper
+was intrinsic-height and centering resolved against the child's own height.

--- a/.changeset/fix-scroll-area-orientation-overflow.md
+++ b/.changeset/fix-scroll-area-orientation-overflow.md
@@ -1,0 +1,11 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Fix `ScrollArea` silently overflowing and stretching `width: 100%` children.
+Zag's default `min-width: fit-content` on the content slot caused the wrapper to
+grow to fit its widest child, so siblings sized at `100%` inherited that
+overgrown width. The wrapper is now sized to the viewport by default, and the
+default `orientation` is `"both"` so descendant overflow surfaces a scrollbar
+indicator instead of being silently scrollable. Setting `orientation` to
+`"vertical"` or `"horizontal"` now actively clips the opposite axis.

--- a/openspec/changes/add-scroll-area-component/design.md
+++ b/openspec/changes/add-scroll-area-component/design.md
@@ -34,6 +34,35 @@ Chakra's ScrollArea lacks several features from the original spec:
    `:has(:focus-visible)`.
 3. **Nimbus design tokens** — scrollbar colors, sizes, and transitions use
    Nimbus token scale.
+4. **Content-wrapper sizing override** — zag-js always writes `min-width:
+   fit-content` inline on the content slot so horizontal scroll works. That
+   stretches the wrapper to the widest child, which silently stretches every
+   `width: 100%` sibling to that overgrown width. For default and `vertical`
+   orientations we override the content slot with `min-width: 100%; width:
+   100%; height: 100%` so siblings size to the viewport and consumers can
+   vertically center shorter children with flex/grid + `height: 100%`.
+   Descendant overflow on either axis still surfaces as viewport scroll via
+   `scrollHeight` / `scrollWidth`, so the default `orientation="both"` still
+   produces a visible horizontal indicator — just without the silent
+   stretching side effect.
+5. **Active axis clipping for strict orientations** — for
+   `orientation="vertical"` / `"horizontal"` we also write `overflowX` /
+   `overflowY: hidden` inline on the viewport so a descendant with an
+   explicit fixed size cannot escape. Inline style is required because
+   zag-js writes `overflow: auto` inline, and recipe classes cannot
+   outspecify inline styles.
+6. **Per-axis scrollbar visibility** — the recipe hides each scrollbar
+   based on its own axis data attribute (`[data-orientation=vertical]:not([data-overflow-y])`
+   and the horizontal counterpart), so a vertical scrollbar never paints
+   when only the horizontal axis overflows.
+7. **`overflow*` removed from props** — `overflow`, `overflowX`, and
+   `overflowY` are omitted from `ScrollAreaProps` because the component
+   owns overflow internally. Consumer values would silently break scroll
+   behavior (the root has `overflow: hidden`, the viewport owns `overflow:
+   auto`, and strict orientations own axis clipping).
+8. **`ids` limited to honored parts** — the `ids` prop accepts only `root`,
+   `viewport`, and `content`. Scrollbar and thumb elements are located by
+   data attributes in the state machine and cannot be renamed.
 
 ## Single-Element API
 

--- a/openspec/changes/add-scroll-area-component/proposal.md
+++ b/openspec/changes/add-scroll-area-component/proposal.md
@@ -31,10 +31,23 @@ design tokens.
   - Keyboard-only focus ring on root element using `_focusWithin` +
     `:has(:focus-visible)` pattern
   - `orientation` prop to control which scrollbar axes render (`vertical` |
-    `horizontal` | `both`)
+    `horizontal` | `both`), defaulting to `"both"` so descendant overflow on
+    either axis always surfaces a visible scrollbar indicator. Setting
+    `orientation` to `"vertical"` or `"horizontal"` actively clips the
+    opposite axis on the viewport.
+  - Content wrapper is sized to the viewport by default (width and height)
+    to preserve `width: 100%` sibling sizing and enable vertical centering of
+    shorter children with flex/grid + `height: 100%`. For strict
+    `orientation="horizontal"`, the wrapper keeps Zag's `min-width:
+    fit-content` so rows of items scroll as usual.
   - Accepts all Chakra style props (`bg`, `maxH`, `w`, etc.) — padding
     props (`p`, `px`, `py`, etc.) are forwarded to the Content slot so they
-    apply inside the scrollable area
+    apply inside the scrollable area. `overflow`, `overflowX`, `overflowY`
+    are removed from the prop surface because the component owns overflow
+    internally and consumer values would break scroll behavior silently.
+  - `ids` prop is limited to `root`, `viewport`, and `content` — the only
+    parts the underlying state machine honors. Scrollbar and thumb elements
+    are located by data attributes and cannot be renamed via `ids`.
 
 No custom hook — overflow detection and scroll state are handled by Ark UI's
 zag-js state machine internally. No i18n — no user-facing strings.

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -143,10 +143,10 @@ and vice versa.
 
 ### Requirement: Content wrapper sizes to viewport by default
 
-For the default and `vertical` orientations, the internal content wrapper
-SHALL be sized to the viewport (both width and height) so siblings with
-`width: 100%` size against the viewport, and so consumers can vertically
-center a shorter child with flex/grid + `height: 100%`.
+For default and `vertical` orientations, the content wrapper SHALL be sized
+to the viewport (both width and height) so siblings with `width: 100%` size
+against the viewport, and so consumers can vertically center a shorter child
+with flex/grid + `height: 100%`.
 
 Descendant overflow on either axis SHALL still be surfaced as viewport
 scroll via `scrollHeight` / `scrollWidth`, so scrolling is unaffected.

--- a/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
+++ b/openspec/changes/add-scroll-area-component/specs/nimbus-scroll-area/spec.md
@@ -19,10 +19,12 @@ The component SHALL present a single `<ScrollArea>` element to consumers,
 assembling all internal parts (viewport, content, scrollbars, corner)
 automatically.
 
-#### Scenario: Basic vertical scroll
+#### Scenario: Default orientation surfaces both scrollbars
 
-- **WHEN** `<ScrollArea maxH="200px">` is rendered with overflowing content
-- **THEN** SHALL render a scrollable container with a vertical scrollbar overlay
+- **WHEN** `<ScrollArea maxH="200px">` is rendered without an explicit
+  `orientation` prop
+- **THEN** SHALL default to `orientation="both"` and render both vertical and
+  horizontal scrollbars whenever their axis overflows
 - **AND** SHALL NOT require consumers to use compound sub-components
 
 #### Scenario: Horizontal scroll
@@ -36,6 +38,27 @@ automatically.
 - **WHEN** `orientation="both"` is set
 - **THEN** SHALL render both vertical and horizontal scrollbars
 - **AND** SHALL render a corner element
+
+### Requirement: Strict orientations clip the opposite axis
+
+When `orientation` is `"vertical"` or `"horizontal"`, the viewport SHALL
+actively clip overflow on the opposite axis so descendant overflow cannot
+scroll silently.
+
+#### Scenario: Vertical-only suppresses horizontal overflow
+
+- **WHEN** `orientation="vertical"` is set and descendant content is wider
+  than the viewport
+- **THEN** the viewport SHALL apply `overflow-x: hidden`
+- **AND** the content wrapper SHALL be constrained to viewport width so
+  sibling elements with `width: 100%` size against the viewport, not the
+  widest descendant
+
+#### Scenario: Horizontal-only suppresses vertical overflow
+
+- **WHEN** `orientation="horizontal"` is set and descendant content is
+  taller than the viewport
+- **THEN** the viewport SHALL apply `overflow-y: hidden`
 
 ### Requirement: Conditional keyboard focusability
 
@@ -99,6 +122,61 @@ The component SHALL use Nimbus design tokens for scrollbar appearance.
 - **AND** the viewport SHALL reserve a gutter so the scrollbar does not overlay
   content
 
+### Requirement: Per-axis scrollbar visibility
+
+Each scrollbar SHALL be rendered only when its own axis overflows. A
+vertical scrollbar SHALL NOT appear when only the horizontal axis overflows,
+and vice versa.
+
+#### Scenario: Only vertical axis overflows
+
+- **WHEN** content overflows on the vertical axis but fits horizontally
+- **THEN** the vertical scrollbar SHALL be visible
+- **AND** the horizontal scrollbar SHALL NOT paint, regardless of the
+  `orientation` prop rendering it into the DOM
+
+#### Scenario: Only horizontal axis overflows
+
+- **WHEN** content overflows on the horizontal axis but fits vertically
+- **THEN** the horizontal scrollbar SHALL be visible
+- **AND** the vertical scrollbar SHALL NOT paint
+
+### Requirement: Content wrapper sizes to viewport by default
+
+For the default and `vertical` orientations, the internal content wrapper
+SHALL be sized to the viewport (both width and height) so siblings with
+`width: 100%` size against the viewport, and so consumers can vertically
+center a shorter child with flex/grid + `height: 100%`.
+
+Descendant overflow on either axis SHALL still be surfaced as viewport
+scroll via `scrollHeight` / `scrollWidth`, so scrolling is unaffected.
+
+For `orientation="horizontal"`, the wrapper SHALL instead preserve Zag's
+`min-width: fit-content` so a row of items can scroll horizontally.
+
+#### Scenario: `width: 100%` sibling of a wide child
+
+- **WHEN** a `ScrollArea` with default or vertical orientation contains a
+  sibling with `width: 100%` alongside an intrinsically wider element
+- **THEN** the `width: 100%` sibling SHALL size against the viewport width,
+  not the wider element's width
+
+#### Scenario: Vertical centering of a short child
+
+- **WHEN** a consumer renders a single child with flex/grid centering and
+  `height: 100%` inside a `ScrollArea` whose children are shorter than the
+  viewport
+- **THEN** the child SHALL be vertically centered within the viewport
+- **AND** the content wrapper SHALL fill the viewport vertically so the
+  child's `height: 100%` resolves against a definite height
+
+#### Scenario: Horizontal orientation preserves fit-content
+
+- **WHEN** `orientation="horizontal"` is set with a row of items whose
+  total width exceeds the viewport
+- **THEN** the content wrapper SHALL grow to fit its widest descendants
+- **AND** the horizontal scrollbar SHALL reflect that overflow
+
 ### Requirement: Scrollbar paints above viewport content
 
 The scrollbar SHALL paint above content inside the viewport, such as
@@ -150,11 +228,20 @@ containing a scroll area machine created via `useScrollArea()`.
 ### Requirement: Component accepts style props
 
 The component SHALL accept style props and forward them to the root element.
+Style props that would collide with the component's internal overflow
+contract (`overflow`, `overflowX`, `overflowY`) SHALL be removed from the
+prop surface at the type level.
 
 #### Scenario: Style props
 
 - **WHEN** style props (e.g., `bg`, `maxH`, `w`, `borderRadius`) are passed
 - **THEN** SHALL forward them to the root container element
+
+#### Scenario: Overflow props rejected
+
+- **WHEN** a consumer attempts to pass `overflow`, `overflowX`, or
+  `overflowY`
+- **THEN** the prop SHALL NOT be accepted by the `ScrollArea` type
 
 #### Scenario: Padding props
 
@@ -178,8 +265,11 @@ The component SHALL accept style props and forward them to the root element.
 #### Scenario: Custom element IDs
 
 - **WHEN** an `ids` prop is passed (e.g., `ids={{ viewport: "my-viewport" }}`)
-- **THEN** SHALL apply the specified IDs to the corresponding internal elements
+- **THEN** SHALL apply the specified IDs to the corresponding internal
+  elements
 - **AND** consumers SHALL be able to use `getElementById` to access them
+- **AND** the accepted keys SHALL be limited to `root`, `viewport`, and
+  `content` — the only parts the underlying state machine honors
 
 #### Scenario: Polymorphic rendering
 

--- a/openspec/changes/add-scroll-area-component/tasks.md
+++ b/openspec/changes/add-scroll-area-component/tasks.md
@@ -22,10 +22,13 @@
 ## 3. Stories
 
 - [x] 3.1 Write Storybook stories with play functions covering: Default
-      (overflowing, vertical scrollbar, keyboard focusable), NonOverflowing
-      (short content), RoleRegion (role + aria-label), KeyboardFocusRing
-      (Tab focus + ring), VerticalOnly, HorizontalOnly, BothAxes,
-      AlwaysVisible, WithAriaLabelledBy, WithStyleProps, Sizes, SmokeTest
+      (overflowing, vertical scrollbar, keyboard focusable),
+      DefaultSurfacesBothScrollbars, DefaultChildSizing (sibling sizing
+      invariants), NonOverflowing, ContentFillsViewport (vertical centering
+      of a shorter child), KeyboardFocusRing, StrictOrientations (axis
+      clipping + opposite-axis suppression), AlwaysVisible, CustomStyling,
+      Sizes, ExternalControl, DynamicContent, ForwardsApi,
+      StickyContentInPanel, ContentPadding
 
 ## 4. Documentation
 
@@ -63,3 +66,29 @@
       (`pnpm test:storybook:dev packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx`)
 - [x] 7.4 Lint passes
       (`pnpm lint -- packages/nimbus/src/components/scroll-area/`)
+
+## 8. Post-release hotfix (PR #1389)
+
+- [x] 8.1 Override Zag's inline `min-width: fit-content` on the content
+      slot so `width: 100%` siblings size to the viewport instead of the
+      widest descendant
+- [x] 8.2 Change default `orientation` from `"vertical"` to `"both"` so
+      descendant overflow on either axis always surfaces a visible
+      scrollbar indicator
+- [x] 8.3 Clip the opposite axis on the viewport via inline style for
+      strict `orientation="vertical"` / `"horizontal"` so descendants
+      cannot scroll silently
+- [x] 8.4 Give the content wrapper `height: 100%` for default and
+      `vertical` orientations so consumers can vertically center shorter
+      children with flex/grid + `height: 100%`
+- [x] 8.5 Fix recipe so each scrollbar hides based on its own axis data
+      attribute (was: hid only when neither axis overflowed)
+- [x] 8.6 Remove `overflow`, `overflowX`, `overflowY` from
+      `ScrollAreaProps` at the type level
+- [x] 8.7 Reduce `ids` shape to `root`, `viewport`, `content` — the only
+      keys honored by the underlying state machine
+- [x] 8.8 Add stories locking in the new invariants:
+      `DefaultSurfacesBothScrollbars`, `DefaultChildSizing`,
+      `StrictOrientations`, `ContentFillsViewport`
+- [x] 8.9 Remove stories subsumed by the above: `SmokeTest`,
+      `VerticalOnly`, `HorizontalOnly`, `BothAxes`

--- a/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.dev.mdx
@@ -39,8 +39,18 @@ Use the `orientation` prop to control which scrollbar axes are rendered:
 const App = () => (
   <Stack gap="600">
     <Box>
-      <Text fontSize="sm" mb="200" fontWeight="bold">vertical (default)</Text>
-      <ScrollArea maxH="120px" w="300px" variant="always">
+      <Text fontSize="sm" mb="200" fontWeight="bold">both (default)</Text>
+      <ScrollArea maxH="120px" maxW="300px" variant="always">
+        <Box whiteSpace="nowrap">
+          {Array.from({ length: 15 }, (_, i) => (
+            <Text key={i} fontSize="sm">{"Both axes content ".repeat(15)}</Text>
+          ))}
+        </Box>
+      </ScrollArea>
+    </Box>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">vertical</Text>
+      <ScrollArea maxH="120px" w="300px" orientation="vertical" variant="always">
         {Array.from({ length: 15 }, (_, i) => (
           <Text key={i} fontSize="sm">Line {i + 1}</Text>
         ))}
@@ -52,16 +62,6 @@ const App = () => (
         <Box whiteSpace="nowrap">
           {Array.from({ length: 5 }, (_, i) => (
             <Text key={i} fontSize="sm">{"Long horizontal content ".repeat(15)}</Text>
-          ))}
-        </Box>
-      </ScrollArea>
-    </Box>
-    <Box>
-      <Text fontSize="sm" mb="200" fontWeight="bold">both</Text>
-      <ScrollArea maxH="120px" maxW="300px" orientation="both" variant="always">
-        <Box whiteSpace="nowrap">
-          {Array.from({ length: 15 }, (_, i) => (
-            <Text key={i} fontSize="sm">{"Both axes content ".repeat(15)}</Text>
           ))}
         </Box>
       </ScrollArea>

--- a/packages/nimbus/src/components/scroll-area/scroll-area.mdx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.mdx
@@ -39,14 +39,25 @@ Get familiar with the features.
 
 ### Orientation
 
-Control which axes are scrollable. The default is vertical.
+Control which axes are scrollable. The default is `both`, so overflow on
+either axis surfaces a visible scrollbar.
 
 ```jsx live
 const App = () => (
   <Stack gap="600">
     <Box>
-      <Text fontSize="sm" mb="200" fontWeight="bold">Vertical (default)</Text>
-      <ScrollArea maxH="120px" w="300px" variant="always">
+      <Text fontSize="sm" mb="200" fontWeight="bold">Both (default)</Text>
+      <ScrollArea maxH="120px" maxW="300px" variant="always">
+        <Box whiteSpace="nowrap">
+          {Array.from({ length: 15 }, (_, i) => (
+            <Text key={i} fontSize="sm">{"Bidirectional content ".repeat(15)}</Text>
+          ))}
+        </Box>
+      </ScrollArea>
+    </Box>
+    <Box>
+      <Text fontSize="sm" mb="200" fontWeight="bold">Vertical</Text>
+      <ScrollArea maxH="120px" w="300px" orientation="vertical" variant="always">
         {Array.from({ length: 15 }, (_, i) => (
           <Text key={i} fontSize="sm">Line {i + 1}: Sample content for vertical scrolling.</Text>
         ))}
@@ -58,16 +69,6 @@ const App = () => (
         <Box whiteSpace="nowrap">
           {Array.from({ length: 5 }, (_, i) => (
             <Text key={i} fontSize="sm">{"Horizontal content ".repeat(15)}</Text>
-          ))}
-        </Box>
-      </ScrollArea>
-    </Box>
-    <Box>
-      <Text fontSize="sm" mb="200" fontWeight="bold">Both axes</Text>
-      <ScrollArea maxH="120px" maxW="300px" orientation="both" variant="always">
-        <Box whiteSpace="nowrap">
-          {Array.from({ length: 15 }, (_, i) => (
-            <Text key={i} fontSize="sm">{"Bidirectional content ".repeat(15)}</Text>
           ))}
         </Box>
       </ScrollArea>

--- a/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.recipe.ts
@@ -53,7 +53,14 @@ export const scrollAreaSlotRecipe = defineSlotRecipe({
       // Paint above viewport content (e.g. sticky headers with z-index)
       zIndex: "1",
       margin: "var(--scroll-area-scrollbar-margin)",
-      "&:not([data-overflow-x], [data-overflow-y])": {
+      // Hide each scrollbar when its own axis isn't overflowing. Zag sets
+      // `data-overflow-x` / `data-overflow-y` on the scrollbar reflecting the
+      // current viewport state, so a vertical scrollbar with no Y overflow
+      // (and vice versa) should not paint even if the other axis overflows.
+      "&[data-orientation=vertical]:not([data-overflow-y])": {
+        display: "none",
+      },
+      "&[data-orientation=horizontal]:not([data-overflow-x])": {
         display: "none",
       },
       bg: "neutral.4",

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -392,6 +392,164 @@ export const VerticalWithHorizontalOverflow: Story = {
 };
 
 // ============================================================
+// Horizontal counterpart of VerticalWithHorizontalOverflow. Row of cards
+// rendered under both the default `"both"` orientation and explicit
+// `"horizontal"` orientation, covering intrinsic-height, over-sized, and
+// full-height children.
+// ============================================================
+const HorizontalWithVerticalOverflowCards = () =>
+  Array.from({ length: 6 }, (_, i) => {
+    const setting =
+      i === 0 ? 'h="260px"' : i === 1 ? "no height prop" : 'h="100%"';
+    const headline =
+      i === 0
+        ? "Intentionally taller than the viewport to demonstrate a child that legitimately exceeds the scroll area height"
+        : i === 1
+          ? "Intrinsic auto height — block sizes to its own content, shorter than the viewport"
+          : "Explicit full height — the common pattern for row items that should always match the scroll area's visible height";
+    const outcome =
+      i === 0
+        ? "expected: overflows, vertical scrollbar surfaces under orientation=both"
+        : i === 1
+          ? "expected: shorter than viewport, aligned to the top"
+          : "expected: fills viewport height regardless of any over-sized sibling";
+    return (
+      <Box
+        key={i}
+        h={i === 0 ? "260px" : i === 1 ? undefined : "100%"}
+        w="220px"
+        flexShrink="0"
+        alignSelf="flex-start"
+        p="300"
+        border="solid-25"
+        borderColor="neutral.6"
+        borderRadius="200"
+        bg="neutral.2"
+      >
+        <Text fontSize="xs" color="neutral.11">
+          {setting}
+        </Text>
+        <Text fontSize="sm" fontWeight="bold" truncate>
+          {headline}
+        </Text>
+        <Text fontSize="xs" color="neutral.11">
+          {outcome}
+        </Text>
+      </Box>
+    );
+  });
+
+export const HorizontalWithVerticalOverflow: Story = {
+  render: () => (
+    <Box display="flex" flexDirection="column" gap="600">
+      <Box>
+        <Text fontSize="sm" fontWeight="bold" mb="100">
+          orientation=&quot;both&quot; (default)
+        </Text>
+        <Text fontSize="xs" color="neutral.11" mb="300">
+          The first item is h=260px, so it overflows the viewport. A vertical
+          scrollbar appears and the item is scrollable. Other h=100% siblings
+          stay at viewport height.
+        </Text>
+        <ScrollArea
+          h="200px"
+          w="500px"
+          ids={{ viewport: "test-viewport-h-both" }}
+        >
+          <Box display="flex" gap="200" h="200px">
+            <HorizontalWithVerticalOverflowCards />
+          </Box>
+        </ScrollArea>
+      </Box>
+      <Box>
+        <Text fontSize="sm" fontWeight="bold" mb="100">
+          orientation=&quot;horizontal&quot;
+        </Text>
+        <Text fontSize="xs" color="neutral.11" mb="300">
+          Same content, but the vertical axis is actively clipped. The tall
+          first item is cut at the viewport edge, no vertical scrollbar appears,
+          and the horizontal scroll still works.
+        </Text>
+        <ScrollArea
+          h="200px"
+          w="500px"
+          orientation="horizontal"
+          ids={{ viewport: "test-viewport-h-horizontal" }}
+        >
+          <Box display="flex" gap="200" h="200px">
+            <HorizontalWithVerticalOverflowCards />
+          </Box>
+        </ScrollArea>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    const getInstance = (viewportId: string) => {
+      const viewport = doc.getElementById(viewportId) as HTMLElement;
+      const root = viewport.closest('[data-part="root"]') as HTMLElement;
+      const content = viewport.querySelector(
+        '[data-part="content"]'
+      ) as HTMLElement;
+      const row = content.querySelector(":scope > div") as HTMLElement;
+      const cards = Array.from(
+        row.querySelectorAll(":scope > div")
+      ) as HTMLElement[];
+      const scrollbars = Array.from(
+        root.querySelectorAll('[data-part="scrollbar"]')
+      ) as HTMLElement[];
+      const visibleVerticalScrollbar = scrollbars.find(
+        (sb) =>
+          sb.getAttribute("data-orientation") === "vertical" &&
+          window.getComputedStyle(sb).display !== "none"
+      );
+      return { viewport, cards, visibleVerticalScrollbar };
+    };
+
+    await step(
+      "Both instances keep h=100% siblings at viewport height",
+      async () => {
+        await waitFor(() => {
+          for (const id of [
+            "test-viewport-h-both",
+            "test-viewport-h-horizontal",
+          ]) {
+            const { viewport, cards } = getInstance(id);
+            cards.slice(2).forEach((card) => {
+              expect(card.offsetHeight).toBe(viewport.clientHeight);
+            });
+          }
+        });
+      }
+    );
+
+    await step(
+      "orientation=both: tall card overflows and vertical scrollbar is shown",
+      async () => {
+        const { viewport, cards, visibleVerticalScrollbar } = getInstance(
+          "test-viewport-h-both"
+        );
+        expect(cards[0].offsetHeight).toBeGreaterThan(viewport.clientHeight);
+        expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+        expect(visibleVerticalScrollbar).toBeTruthy();
+      }
+    );
+
+    await step(
+      "orientation=horizontal: tall card is clipped and no vertical scrollbar is shown",
+      async () => {
+        const { viewport, visibleVerticalScrollbar } = getInstance(
+          "test-viewport-h-horizontal"
+        );
+        expect(window.getComputedStyle(viewport).overflowY).toBe("hidden");
+        expect(visibleVerticalScrollbar).toBeUndefined();
+      }
+    );
+  },
+};
+
+// ============================================================
 // Horizontal only scrolling
 // ============================================================
 export const HorizontalOnly: Story = {

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -252,7 +252,10 @@ export const VerticalWithHorizontalOverflow: Story = {
       {Array.from({ length: 6 }, (_, i) => (
         <Box
           key={i}
-          w="100%"
+          // First card deliberately exceeds the viewport to demonstrate the
+          // "both" default surfacing a horizontal scrollbar when a child
+          // legitimately requests more width than the scroll area has.
+          w={i === 0 ? "150%" : "100%"}
           p="300"
           mb="200"
           border="solid-25"
@@ -277,50 +280,73 @@ export const VerticalWithHorizontalOverflow: Story = {
   play: async ({ canvasElement, step }) => {
     const doc = canvasElement.ownerDocument;
 
+    await step("Content wrapper is pinned to the viewport width", async () => {
+      await waitFor(() => {
+        const viewport = doc.getElementById(
+          "test-viewport-vert-with-horiz-overflow"
+        ) as HTMLElement;
+        const content = viewport.querySelector(
+          '[data-part="content"]'
+        ) as HTMLElement;
+        expect(content.clientWidth).toBe(viewport.clientWidth);
+      });
+    });
+
     await step(
-      "w=100% children are sized to the viewport, not to the widest sibling",
+      "w=100% siblings stay at viewport width even when another child is wider",
       async () => {
-        await waitFor(() => {
-          const viewport = doc.getElementById(
-            "test-viewport-vert-with-horiz-overflow"
-          ) as HTMLElement;
-          const content = viewport.querySelector(
-            '[data-part="content"]'
-          ) as HTMLElement;
-          expect(content.clientWidth).toBe(viewport.clientWidth);
-          const firstCard = content.querySelector(
-            ":scope > div"
-          ) as HTMLElement;
-          expect(firstCard.offsetWidth).toBe(content.clientWidth);
+        const viewport = doc.getElementById(
+          "test-viewport-vert-with-horiz-overflow"
+        ) as HTMLElement;
+        const content = viewport.querySelector(
+          '[data-part="content"]'
+        ) as HTMLElement;
+        const cards = Array.from(
+          content.querySelectorAll(":scope > div")
+        ) as HTMLElement[];
+        // First card is explicitly wider (w="150%").
+        expect(cards[0].offsetWidth).toBeGreaterThan(viewport.clientWidth);
+        // Remaining w="100%" cards are not stretched to match the wide sibling.
+        cards.slice(1).forEach((card) => {
+          expect(card.offsetWidth).toBe(viewport.clientWidth);
         });
       }
     );
 
     await step(
-      "Long title truncates inside the card instead of overflowing",
+      "Long title truncates inside the card instead of painting past it",
       async () => {
         const viewport = doc.getElementById(
           "test-viewport-vert-with-horiz-overflow"
         ) as HTMLElement;
+        // Use the second card — first is intentionally overflowing.
         const title = viewport.querySelector(
-          ":scope [data-part='content'] > div p:nth-child(2)"
+          ":scope [data-part='content'] > div:nth-child(2) p:nth-child(2)"
         ) as HTMLElement;
         expect(title).toBeTruthy();
         const titleStyles = window.getComputedStyle(title);
         expect(titleStyles.textOverflow).toBe("ellipsis");
         expect(titleStyles.whiteSpace).toMatch(/nowrap/);
-        // The title is clipped by its own box, not painting past it.
         expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
       }
     );
 
     await step(
-      "No horizontal overflow at the viewport level when titles truncate",
+      "Explicit over-sized child surfaces a horizontal scrollbar",
       async () => {
         const viewport = doc.getElementById(
           "test-viewport-vert-with-horiz-overflow"
         ) as HTMLElement;
-        expect(viewport.scrollWidth).toBe(viewport.clientWidth);
+        expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
+        const scrollbars = canvasElement.querySelectorAll(
+          '[data-part="scrollbar"]'
+        );
+        const horizontalScrollbar = Array.from(scrollbars).find(
+          (sb) =>
+            sb.getAttribute("data-orientation") === "horizontal" &&
+            window.getComputedStyle(sb).display !== "none"
+        );
+        expect(horizontalScrollbar).toBeTruthy();
       }
     );
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -212,6 +212,76 @@ export const VerticalOnly: Story = {
 };
 
 // ============================================================
+// Orientation="vertical" with content that also overflows horizontally.
+//
+// Replicates a bug where horizontal overflow is silently scrollable via
+// trackpad/keyboard but no horizontal scrollbar indicator is shown, because
+// Zag always sets `min-width: fit-content` inline on the content slot while
+// our wrapper only renders the vertical scrollbar.
+// ============================================================
+export const VerticalWithHorizontalOverflow: Story = {
+  render: () => (
+    <ScrollArea
+      maxH="300px"
+      w="320px"
+      ids={{ viewport: "test-viewport-vert-with-horiz-overflow" }}
+    >
+      {Array.from({ length: 6 }, (_, i) => (
+        <Box
+          key={i}
+          w="100%"
+          p="300"
+          mb="200"
+          border="solid-25"
+          borderColor="neutral.6"
+          borderRadius="200"
+          bg="neutral.2"
+        >
+          <Text fontSize="xs" color="neutral.11">
+            #{20538 + i}
+          </Text>
+          <Text fontSize="sm" fontWeight="bold" whiteSpace="nowrap">
+            FEC-{765 + i}: Import
+            no-direct-currency-for-price-selection-in-all-cart-items
+          </Text>
+          <Text fontSize="xs" color="neutral.11">
+            merchant-center-frontend
+          </Text>
+        </Box>
+      ))}
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    await step(
+      "Content overflows the viewport on the horizontal axis",
+      async () => {
+        await waitFor(() => {
+          const viewport = doc.getElementById(
+            "test-viewport-vert-with-horiz-overflow"
+          ) as HTMLElement;
+          expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
+        });
+      }
+    );
+
+    await step(
+      "Bug: no horizontal scrollbar is rendered despite the overflow",
+      async () => {
+        const scrollbars = canvasElement.querySelectorAll(
+          '[data-part="scrollbar"]'
+        );
+        const horizontalScrollbar = Array.from(scrollbars).find(
+          (sb) => sb.getAttribute("data-orientation") === "horizontal"
+        );
+        expect(horizontalScrollbar).toBeUndefined();
+      }
+    );
+  },
+};
+
+// ============================================================
 // Horizontal only scrolling
 // ============================================================
 export const HorizontalOnly: Story = {

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -315,6 +315,76 @@ export const NonOverflowing: Story = {
 };
 
 // ============================================================
+// ContentFillsViewport: short children can be vertically centered
+// ============================================================
+// When children are shorter than the viewport, the content slot fills the
+// viewport so consumers can vertically center a single child with flex.
+// Without this, content would be intrinsic-height and centering would
+// resolve against the child's own height — leaving it pinned to the top.
+export const ContentFillsViewport: Story = {
+  render: () => (
+    <ScrollArea
+      h="400px"
+      w="400px"
+      ids={{
+        viewport: "test-viewport-centering",
+        content: "test-content-centering",
+      }}
+    >
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        h="100%"
+        id="centered-child"
+      >
+        <Text fontSize="sm">Centered message</Text>
+      </Box>
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    await step("Content slot fills viewport vertically", async () => {
+      await waitFor(() => {
+        const viewport = doc.getElementById(
+          "test-viewport-centering"
+        ) as HTMLElement;
+        const content = doc.getElementById(
+          "test-content-centering"
+        ) as HTMLElement;
+        expect(viewport).toBeTruthy();
+        expect(content).toBeTruthy();
+        expect(viewport.clientHeight).toBe(400);
+        expect(content.clientHeight).toBe(viewport.clientHeight);
+      });
+    });
+
+    await step("Child is vertically centered in viewport", async () => {
+      const viewport = doc.getElementById(
+        "test-viewport-centering"
+      ) as HTMLElement;
+      const child = doc.getElementById("centered-child") as HTMLElement;
+      const viewportRect = viewport.getBoundingClientRect();
+      const childRect = child.getBoundingClientRect();
+      const viewportMid = viewportRect.top + viewportRect.height / 2;
+      const childMid = childRect.top + childRect.height / 2;
+      expect(Math.abs(viewportMid - childMid)).toBeLessThanOrEqual(1);
+    });
+
+    await step("Viewport is not overflowing", async () => {
+      await waitFor(() => {
+        const viewport = doc.getElementById(
+          "test-viewport-centering"
+        ) as HTMLElement;
+        expect(viewport).not.toHaveAttribute("tabindex");
+        expect(viewport).not.toHaveAttribute("data-overflow-y");
+      });
+    });
+  },
+};
+
+// ============================================================
 // Keyboard focus ring: Tab focuses viewport, ring appears on root
 // ============================================================
 export const KeyboardFocusRing: Story = {

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -80,6 +80,22 @@ export const Default: Story = {
       expect(scrollbar).toHaveAttribute("data-orientation", "vertical");
     });
 
+    await step(
+      "Horizontal scrollbar is hidden when only Y overflows",
+      async () => {
+        await waitFor(() => {
+          const scrollbars = Array.from(
+            canvasElement.querySelectorAll('[data-part="scrollbar"]')
+          );
+          const horizontal = scrollbars.find(
+            (sb) => sb.getAttribute("data-orientation") === "horizontal"
+          );
+          expect(horizontal).toBeTruthy();
+          expect(window.getComputedStyle(horizontal!).display).toBe("none");
+        });
+      }
+    );
+
     await step("Thumb is rendered inside scrollbar", async () => {
       const thumb = canvasElement.querySelector('[data-part="thumb"]');
       expect(thumb).toBeTruthy();
@@ -139,6 +155,109 @@ export const DefaultSurfacesBothScrollbars: Story = {
       const corner = canvasElement.querySelector('[data-part="corner"]');
       expect(corner).toBeTruthy();
     });
+  },
+};
+
+// ============================================================
+// DefaultBoxParity: the "ScrollArea behaves like a Box with overflow:auto"
+// claim, executable. Renders a ScrollArea and an equivalent Box overflow=auto
+// side by side with identical children and asserts matching child geometry.
+// ============================================================
+const BoxParityChildren = () => (
+  <Box display="flex" flexDirection="column" gap="200">
+    <Box w="100%" h="40px" bg="neutral.3" id="parity-w-100" />
+    <Box w="fit-content" px="300" py="200" bg="neutral.3" id="parity-fit">
+      <Text fontSize="xs">fit-content</Text>
+    </Box>
+    <Box w="200px" h="40px" bg="neutral.3" id="parity-pixel" />
+    <Box display="flex" gap="100" id="parity-flex-row">
+      <Box flex="1" h="40px" bg="neutral.3" />
+      <Box flex="2" h="40px" bg="neutral.4" />
+    </Box>
+    <Box whiteSpace="nowrap" id="parity-nowrap">
+      <Text fontSize="sm">
+        {"intentionally-long-unwrappable-token-".repeat(6)}
+      </Text>
+    </Box>
+  </Box>
+);
+
+export const DefaultBoxParity: Story = {
+  render: () => (
+    <Box display="flex" gap="600" alignItems="flex-start">
+      <Box>
+        <Text fontSize="sm" fontWeight="bold" mb="100">
+          ScrollArea (orientation unset)
+        </Text>
+        <Box id="parity-scrollarea-wrap">
+          <ScrollArea
+            maxH="300px"
+            w="320px"
+            ids={{ viewport: "test-viewport-parity-scrollarea" }}
+          >
+            <BoxParityChildren />
+          </ScrollArea>
+        </Box>
+      </Box>
+      <Box>
+        <Text fontSize="sm" fontWeight="bold" mb="100">
+          &lt;Box overflow=&quot;auto&quot;&gt;
+        </Text>
+        <Box
+          id="parity-box-wrap"
+          maxH="300px"
+          w="320px"
+          overflow="auto"
+          tabIndex={0}
+          aria-label="Box-overflow-auto parity comparison"
+        >
+          <BoxParityChildren />
+        </Box>
+      </Box>
+    </Box>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    await step(
+      "Each labelled child has matching geometry in both containers",
+      async () => {
+        await waitFor(() => {
+          const scrollArea = doc.getElementById(
+            "parity-scrollarea-wrap"
+          ) as HTMLElement;
+          const boxWrap = doc.getElementById("parity-box-wrap") as HTMLElement;
+          const ids = [
+            "parity-w-100",
+            "parity-fit",
+            "parity-pixel",
+            "parity-flex-row",
+          ];
+          ids.forEach((id) => {
+            const inScrollArea = scrollArea.querySelector(
+              `#${id}`
+            ) as HTMLElement;
+            const inBox = boxWrap.querySelector(`#${id}`) as HTMLElement;
+            expect(inScrollArea).toBeTruthy();
+            expect(inBox).toBeTruthy();
+            expect(inScrollArea.offsetWidth).toBe(inBox.offsetWidth);
+            expect(inScrollArea.offsetHeight).toBe(inBox.offsetHeight);
+          });
+        });
+      }
+    );
+
+    await step(
+      "w=100% child does not stretch to match the nowrap sibling",
+      async () => {
+        const viewport = doc.getElementById(
+          "test-viewport-parity-scrollarea"
+        ) as HTMLElement;
+        const wFull = viewport.querySelector("#parity-w-100") as HTMLElement;
+        expect(wFull.offsetWidth).toBe(viewport.clientWidth);
+        expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
+      }
+    );
   },
 };
 
@@ -670,20 +789,40 @@ export const Sizes: Story = {
 // ============================================================
 // External control via useScrollArea + value prop
 // ============================================================
-export const ExternalControl: Story = {
-  render: () => {
-    const scrollArea = useScrollArea({
-      ids: { viewport: "test-viewport" },
-    });
-
-    return (
-      <Box>
-        <ScrollArea maxH="200px" w="400px" value={scrollArea}>
-          <OverflowingContent />
-        </ScrollArea>
+const ExternalControlHarness = () => {
+  const scrollArea = useScrollArea({
+    ids: { viewport: "test-viewport" },
+  });
+  return (
+    <Box>
+      <Box display="flex" gap="200" mb="200">
+        <button
+          type="button"
+          data-testid="external-scroll-to-100"
+          onClick={() => scrollArea.scrollTo({ top: 100 })}
+        >
+          scrollTo top=100
+        </button>
+        <button
+          type="button"
+          data-testid="external-scroll-to-bottom"
+          onClick={() => scrollArea.scrollToEdge({ edge: "bottom" })}
+        >
+          scrollToEdge bottom
+        </button>
+        <span data-testid="external-has-overflow-y">
+          {String(scrollArea.hasOverflowY)}
+        </span>
       </Box>
-    );
-  },
+      <ScrollArea maxH="200px" w="400px" value={scrollArea}>
+        <OverflowingContent />
+      </ScrollArea>
+    </Box>
+  );
+};
+
+export const ExternalControl: Story = {
+  render: () => <ExternalControlHarness />,
   play: async ({ canvasElement, step }) => {
     const doc = canvasElement.ownerDocument;
 
@@ -698,6 +837,193 @@ export const ExternalControl: Story = {
     await step("Viewport has tabIndex when overflowing", async () => {
       const viewport = doc.getElementById("test-viewport") as HTMLElement;
       expect(viewport).toHaveAttribute("tabindex", "0");
+    });
+
+    await step(
+      "hasOverflowY from the hook reflects viewport state",
+      async () => {
+        const readout = canvasElement.querySelector(
+          '[data-testid="external-has-overflow-y"]'
+        ) as HTMLElement;
+        expect(readout.textContent).toBe("true");
+      }
+    );
+
+    await step("scrollTo moves the viewport scroll position", async () => {
+      const viewport = doc.getElementById("test-viewport") as HTMLElement;
+      const button = canvasElement.querySelector(
+        '[data-testid="external-scroll-to-100"]'
+      ) as HTMLButtonElement;
+      expect(viewport.scrollTop).toBe(0);
+      await userEvent.click(button);
+      await waitFor(() => {
+        expect(viewport.scrollTop).toBeGreaterThan(0);
+      });
+    });
+
+    await step("scrollToEdge bottom scrolls to the end", async () => {
+      const viewport = doc.getElementById("test-viewport") as HTMLElement;
+      const button = canvasElement.querySelector(
+        '[data-testid="external-scroll-to-bottom"]'
+      ) as HTMLButtonElement;
+      await userEvent.click(button);
+      await waitFor(() => {
+        expect(
+          viewport.scrollTop + viewport.clientHeight
+        ).toBeGreaterThanOrEqual(viewport.scrollHeight - 1);
+      });
+    });
+  },
+};
+
+// ============================================================
+// DynamicContent: adding children after mount flips the data-overflow and
+// tabIndex state. Regression test for useScrollAreaContext reactivity.
+// ============================================================
+const DynamicContentHarness = () => {
+  const [rows, setRows] = React.useState(2);
+  return (
+    <Box>
+      <Box display="flex" gap="200" mb="200">
+        <button
+          type="button"
+          data-testid="dynamic-add"
+          onClick={() => setRows((n) => n + 20)}
+        >
+          add rows
+        </button>
+        <button
+          type="button"
+          data-testid="dynamic-reset"
+          onClick={() => setRows(2)}
+        >
+          reset
+        </button>
+      </Box>
+      <ScrollArea
+        maxH="200px"
+        w="400px"
+        ids={{ viewport: "test-viewport-dynamic" }}
+      >
+        {Array.from({ length: rows }, (_, i) => (
+          <Text key={i} fontSize="sm">
+            Row {i + 1}
+          </Text>
+        ))}
+      </ScrollArea>
+    </Box>
+  );
+};
+
+export const DynamicContent: Story = {
+  render: () => <DynamicContentHarness />,
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    await step("Initial state: no overflow, no tabIndex", async () => {
+      await waitFor(() => {
+        const viewport = doc.getElementById(
+          "test-viewport-dynamic"
+        ) as HTMLElement;
+        expect(viewport).toBeTruthy();
+        expect(viewport.scrollHeight).toBe(viewport.clientHeight);
+        expect(viewport).not.toHaveAttribute("tabindex");
+      });
+    });
+
+    await step(
+      "After adding rows: overflow detected and tabIndex flips to 0",
+      async () => {
+        await userEvent.click(
+          canvasElement.querySelector(
+            '[data-testid="dynamic-add"]'
+          ) as HTMLButtonElement
+        );
+        await waitFor(() => {
+          const viewport = doc.getElementById(
+            "test-viewport-dynamic"
+          ) as HTMLElement;
+          expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+          expect(viewport).toHaveAttribute("tabindex", "0");
+        });
+      }
+    );
+
+    await step("After resetting: tabIndex is removed again", async () => {
+      await userEvent.click(
+        canvasElement.querySelector(
+          '[data-testid="dynamic-reset"]'
+        ) as HTMLButtonElement
+      );
+      await waitFor(() => {
+        const viewport = doc.getElementById(
+          "test-viewport-dynamic"
+        ) as HTMLElement;
+        expect(viewport.scrollHeight).toBe(viewport.clientHeight);
+        expect(viewport).not.toHaveAttribute("tabindex");
+      });
+    });
+  },
+};
+
+// ============================================================
+// ForwardsApi: public-API surface tests — root ref, ids map, and polymorphic
+// `as`. Each is advertised by the types; these prove they actually work.
+// ============================================================
+const ForwardsApiHarness = () => {
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    if (rootRef.current) {
+      rootRef.current.setAttribute("data-ref-landed", "true");
+    }
+  }, []);
+  return (
+    <ScrollArea
+      as="section"
+      ref={rootRef}
+      maxH="200px"
+      w="400px"
+      ids={{
+        root: "test-forwards-root",
+        viewport: "test-forwards-viewport",
+        content: "test-forwards-content",
+      }}
+    >
+      <OverflowingContent />
+    </ScrollArea>
+  );
+};
+
+export const ForwardsApi: Story = {
+  render: () => <ForwardsApiHarness />,
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    await step("Root ref lands on the root element", async () => {
+      await waitFor(() => {
+        const root = doc.getElementById("test-forwards-root") as HTMLElement;
+        expect(root).toBeTruthy();
+        expect(root).toHaveAttribute("data-ref-landed", "true");
+        expect(root).toHaveAttribute("data-part", "root");
+      });
+    });
+
+    await step(
+      "Polymorphic `as` renders root as the requested tag",
+      async () => {
+        const root = doc.getElementById("test-forwards-root") as HTMLElement;
+        expect(root.tagName).toBe("SECTION");
+      }
+    );
+
+    await step("All ids in the `ids` map reach the DOM", async () => {
+      for (const id of [
+        "test-forwards-root",
+        "test-forwards-viewport",
+        "test-forwards-content",
+      ]) {
+        expect(doc.getElementById(id)).toBeTruthy();
+      }
     });
   },
 };
@@ -806,139 +1132,144 @@ export const StickyContentInPanel: Story = {
 // ============================================================
 // Content padding: padding props forwarded to inner Content slot
 // ============================================================
+const paddingPropCases = [
+  {
+    prop: "p",
+    viewportId: "test-pad-p",
+    expected: { top: true, right: true, bottom: true, left: true },
+  },
+  {
+    prop: "px",
+    viewportId: "test-pad-px",
+    expected: { top: false, right: true, bottom: false, left: true },
+  },
+  {
+    prop: "py",
+    viewportId: "test-pad-py",
+    expected: { top: true, right: false, bottom: true, left: false },
+  },
+  {
+    prop: "pt",
+    viewportId: "test-pad-pt",
+    expected: { top: true, right: false, bottom: false, left: false },
+  },
+  {
+    prop: "pb",
+    viewportId: "test-pad-pb",
+    expected: { top: false, right: false, bottom: true, left: false },
+  },
+  {
+    prop: "ps",
+    viewportId: "test-pad-ps",
+    expected: { top: false, right: false, bottom: false, left: true },
+  },
+  {
+    prop: "pe",
+    viewportId: "test-pad-pe",
+    expected: { top: false, right: true, bottom: false, left: false },
+  },
+  {
+    prop: "paddingInline",
+    viewportId: "test-pad-paddingInline",
+    expected: { top: false, right: true, bottom: false, left: true },
+  },
+  {
+    prop: "paddingBlock",
+    viewportId: "test-pad-paddingBlock",
+    expected: { top: true, right: false, bottom: true, left: false },
+  },
+] as const;
+
 export const ContentPadding: Story = {
   render: () => (
-    <Box display="flex" gap="600" flexWrap="wrap">
-      {(["always", "hover"] as const).map((variant) => (
-        <Box key={variant}>
-          <Text fontSize="sm" mb="200" fontWeight="bold">
-            variant=&quot;{variant}&quot;
+    <Box display="flex" gap="400" flexWrap="wrap">
+      {paddingPropCases.map(({ prop, viewportId }) => (
+        <Box key={prop}>
+          <Text fontSize="xs" mb="100" color="neutral.11">
+            {prop}=&quot;400&quot;
           </Text>
-          <Box display="flex" gap="400">
-            <Box>
-              <Text fontSize="xs" mb="100" color="neutral.11">
-                No padding
-              </Text>
-              <ScrollArea
-                maxH="200px"
-                w="300px"
-                variant={variant}
-                bg="neutral.2"
-              >
-                <OverflowingContent />
-              </ScrollArea>
-            </Box>
-            <Box>
-              <Text fontSize="xs" mb="100" color="neutral.11">
-                p=&quot;400&quot; (forwarded to content)
-              </Text>
-              <ScrollArea
-                maxH="200px"
-                w="300px"
-                variant={variant}
-                bg="neutral.2"
-                p="400"
-              >
-                <OverflowingContent />
-              </ScrollArea>
-            </Box>
-          </Box>
+          <ScrollArea
+            maxH="200px"
+            w="260px"
+            bg="neutral.2"
+            ids={{ viewport: viewportId }}
+            {...{ [prop]: "400" }}
+          >
+            <OverflowingContent />
+          </ScrollArea>
         </Box>
       ))}
-    </Box>
-  ),
-  play: async ({ canvasElement, step }) => {
-    await step("Padding is applied to the content slot, not root", async () => {
-      // 2 variants × 2 padding states = 4 ScrollArea instances
-      await waitFor(() => {
-        const roots = canvasElement.querySelectorAll('[data-part="root"]');
-        expect(roots).toHaveLength(4);
-      });
-
-      const contents = canvasElement.querySelectorAll('[data-part="content"]');
-      expect(contents).toHaveLength(4);
-
-      // Padded content elements (index 1 and 3) should have non-zero padding
-      const paddedContent = contents[1] as HTMLElement;
-      const paddedStyles = window.getComputedStyle(paddedContent);
-      expect(paddedStyles.paddingTop).not.toBe("0px");
-
-      // Unpadded content elements (index 0 and 2) should have no padding
-      const unpaddedContent = contents[0] as HTMLElement;
-      const unpaddedStyles = window.getComputedStyle(unpaddedContent);
-      expect(unpaddedStyles.paddingTop).toBe("0px");
-    });
-  },
-};
-
-// ============================================================
-// Smoke test: all combinations render without errors
-// ============================================================
-export const SmokeTest: Story = {
-  render: () => (
-    <Box display="flex" gap="400" flexWrap="wrap">
       <Box>
-        <Text fontSize="sm">Vertical overflow</Text>
-        <ScrollArea maxH="80px" w="180px" variant="always">
-          <OverflowingContent />
-        </ScrollArea>
-      </Box>
-
-      <Box>
-        <Text fontSize="sm">Horizontal overflow</Text>
-        <ScrollArea maxW="180px" orientation="horizontal" variant="always">
-          <WideContent />
-        </ScrollArea>
-      </Box>
-
-      <Box>
-        <Text fontSize="sm">Both axes</Text>
+        <Text fontSize="xs" mb="100" color="neutral.11">
+          no padding (control)
+        </Text>
         <ScrollArea
-          maxH="80px"
-          maxW="180px"
-          orientation="both"
-          variant="always"
-        >
-          <WideContent />
-        </ScrollArea>
-      </Box>
-
-      <Box>
-        <Text fontSize="sm">Non-overflowing</Text>
-        <ScrollArea maxH="200px" w="180px" variant="always">
-          <ShortContent />
-        </ScrollArea>
-      </Box>
-
-      <Box>
-        <Text fontSize="sm">Hover variant</Text>
-        <ScrollArea maxH="80px" w="180px" variant="hover">
-          <OverflowingContent />
-        </ScrollArea>
-      </Box>
-
-      <Box>
-        <Text fontSize="sm">Custom styling</Text>
-        <ScrollArea
-          maxH="80px"
-          w="180px"
+          maxH="200px"
+          w="260px"
           bg="neutral.2"
-          borderRadius="300"
-          variant="always"
+          ids={{ viewport: "test-pad-none" }}
         >
-          <Box p="200">
-            <OverflowingContent />
-          </Box>
+          <OverflowingContent />
         </ScrollArea>
       </Box>
     </Box>
   ),
   play: async ({ canvasElement, step }) => {
-    await step("All variants render without errors", async () => {
-      await waitFor(() => {
-        const roots = canvasElement.querySelectorAll('[data-part="root"]');
-        expect(roots).toHaveLength(6);
-      });
-    });
+    const doc = canvasElement.ownerDocument;
+
+    await step(
+      "Control case: no padding on root or content when no padding prop is set",
+      async () => {
+        await waitFor(() => {
+          const viewport = doc.getElementById("test-pad-none") as HTMLElement;
+          const root = viewport.closest('[data-part="root"]') as HTMLElement;
+          const content = viewport.querySelector(
+            '[data-part="content"]'
+          ) as HTMLElement;
+          const rootStyles = window.getComputedStyle(root);
+          const contentStyles = window.getComputedStyle(content);
+          (
+            [
+              "paddingTop",
+              "paddingRight",
+              "paddingBottom",
+              "paddingLeft",
+            ] as const
+          ).forEach((side) => {
+            expect(rootStyles[side]).toBe("0px");
+            expect(contentStyles[side]).toBe("0px");
+          });
+        });
+      }
+    );
+
+    for (const { prop, viewportId, expected } of paddingPropCases) {
+      await step(
+        `${prop} is forwarded to content and not applied to root`,
+        async () => {
+          const viewport = doc.getElementById(viewportId) as HTMLElement;
+          const root = viewport.closest('[data-part="root"]') as HTMLElement;
+          const content = viewport.querySelector(
+            '[data-part="content"]'
+          ) as HTMLElement;
+          const rootStyles = window.getComputedStyle(root);
+          const contentStyles = window.getComputedStyle(content);
+          const sides = [
+            ["paddingTop", expected.top],
+            ["paddingRight", expected.right],
+            ["paddingBottom", expected.bottom],
+            ["paddingLeft", expected.left],
+          ] as const;
+          sides.forEach(([side, shouldBePadded]) => {
+            expect(rootStyles[side]).toBe("0px");
+            if (shouldBePadded) {
+              expect(contentStyles[side]).not.toBe("0px");
+            } else {
+              expect(contentStyles[side]).toBe("0px");
+            }
+          });
+        }
+      );
+    }
   },
 };

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -233,120 +233,144 @@ export const VerticalOnly: Story = {
 };
 
 // ============================================================
-// Full-width cards with truncated long titles.
-//
-// Zag always writes `min-width: fit-content` inline on the content slot so
-// horizontal scroll works. Without our fix the wrapper would grow to fit the
-// widest child, so `w="100%"` cards would inherit the longest title's width
-// and clip past the viewport. With the fix the wrapper is pinned to the
-// viewport, cards fill it cleanly, and per-card `truncate` ellipsizes long
-// titles in place.
+// Full-width cards with one deliberately over-sized child, rendered side by
+// side under both the default `"both"` orientation and explicit `"vertical"`
+// orientation. Demonstrates how each handles the same content:
+// - `"both"`: the wide card overflows and the horizontal scrollbar surfaces.
+// - `"vertical"`: the wide card is clipped at the viewport, no horizontal
+//   scrollbar, and `w=100%` siblings still stay at viewport width.
 // ============================================================
+const VerticalWithHorizontalOverflowCards = () =>
+  Array.from({ length: 6 }, (_, i) => (
+    <Box
+      key={i}
+      w={i === 0 ? "150%" : "100%"}
+      p="300"
+      mb="200"
+      border="solid-25"
+      borderColor="neutral.6"
+      borderRadius="200"
+      bg="neutral.2"
+    >
+      <Text fontSize="xs" color="neutral.11">
+        #{20538 + i}
+      </Text>
+      <Text fontSize="sm" fontWeight="bold" truncate>
+        FEC-{765 + i}: Import
+        no-direct-currency-for-price-selection-in-all-cart-items
+      </Text>
+      <Text fontSize="xs" color="neutral.11">
+        merchant-center-frontend
+      </Text>
+    </Box>
+  ));
+
 export const VerticalWithHorizontalOverflow: Story = {
   render: () => (
-    <ScrollArea
-      maxH="300px"
-      w="320px"
-      ids={{ viewport: "test-viewport-vert-with-horiz-overflow" }}
-    >
-      {Array.from({ length: 6 }, (_, i) => (
-        <Box
-          key={i}
-          // First card deliberately exceeds the viewport to demonstrate the
-          // "both" default surfacing a horizontal scrollbar when a child
-          // legitimately requests more width than the scroll area has.
-          w={i === 0 ? "150%" : "100%"}
-          p="300"
-          mb="200"
-          border="solid-25"
-          borderColor="neutral.6"
-          borderRadius="200"
-          bg="neutral.2"
+    <Box display="flex" gap="600" alignItems="flex-start">
+      <Box w="320px">
+        <Text fontSize="sm" fontWeight="bold" mb="100">
+          orientation=&quot;both&quot; (default)
+        </Text>
+        <Text fontSize="xs" color="neutral.11" mb="300">
+          The first card is w=150%, so it overflows the viewport. A horizontal
+          scrollbar appears and the card is scrollable. Other w=100% siblings
+          stay at viewport width.
+        </Text>
+        <ScrollArea
+          maxH="300px"
+          w="320px"
+          ids={{ viewport: "test-viewport-both" }}
         >
-          <Text fontSize="xs" color="neutral.11">
-            #{20538 + i}
-          </Text>
-          <Text fontSize="sm" fontWeight="bold" truncate>
-            FEC-{765 + i}: Import
-            no-direct-currency-for-price-selection-in-all-cart-items
-          </Text>
-          <Text fontSize="xs" color="neutral.11">
-            merchant-center-frontend
-          </Text>
-        </Box>
-      ))}
-    </ScrollArea>
+          <VerticalWithHorizontalOverflowCards />
+        </ScrollArea>
+      </Box>
+      <Box w="320px">
+        <Text fontSize="sm" fontWeight="bold" mb="100">
+          orientation=&quot;vertical&quot;
+        </Text>
+        <Text fontSize="xs" color="neutral.11" mb="300">
+          Same content, but the horizontal axis is actively clipped. The wide
+          first card is cut at the viewport edge, no horizontal scrollbar
+          appears, and the vertical scroll still works.
+        </Text>
+        <ScrollArea
+          maxH="300px"
+          w="320px"
+          orientation="vertical"
+          ids={{ viewport: "test-viewport-vertical" }}
+        >
+          <VerticalWithHorizontalOverflowCards />
+        </ScrollArea>
+      </Box>
+    </Box>
   ),
   play: async ({ canvasElement, step }) => {
     const doc = canvasElement.ownerDocument;
 
-    await step("Content wrapper is pinned to the viewport width", async () => {
-      await waitFor(() => {
-        const viewport = doc.getElementById(
-          "test-viewport-vert-with-horiz-overflow"
-        ) as HTMLElement;
-        const content = viewport.querySelector(
-          '[data-part="content"]'
-        ) as HTMLElement;
-        expect(content.clientWidth).toBe(viewport.clientWidth);
-      });
-    });
+    const getInstance = (viewportId: string) => {
+      const viewport = doc.getElementById(viewportId) as HTMLElement;
+      const root = viewport.closest('[data-part="root"]') as HTMLElement;
+      const content = viewport.querySelector(
+        '[data-part="content"]'
+      ) as HTMLElement;
+      const cards = Array.from(
+        content.querySelectorAll(":scope > div")
+      ) as HTMLElement[];
+      const scrollbars = Array.from(
+        root.querySelectorAll('[data-part="scrollbar"]')
+      ) as HTMLElement[];
+      const visibleHorizontalScrollbar = scrollbars.find(
+        (sb) =>
+          sb.getAttribute("data-orientation") === "horizontal" &&
+          window.getComputedStyle(sb).display !== "none"
+      );
+      return { viewport, content, cards, visibleHorizontalScrollbar };
+    };
 
     await step(
-      "w=100% siblings stay at viewport width even when another child is wider",
+      "Both instances pin their content wrapper to viewport width",
       async () => {
-        const viewport = doc.getElementById(
-          "test-viewport-vert-with-horiz-overflow"
-        ) as HTMLElement;
-        const content = viewport.querySelector(
-          '[data-part="content"]'
-        ) as HTMLElement;
-        const cards = Array.from(
-          content.querySelectorAll(":scope > div")
-        ) as HTMLElement[];
-        // First card is explicitly wider (w="150%").
-        expect(cards[0].offsetWidth).toBeGreaterThan(viewport.clientWidth);
-        // Remaining w="100%" cards are not stretched to match the wide sibling.
-        cards.slice(1).forEach((card) => {
-          expect(card.offsetWidth).toBe(viewport.clientWidth);
+        await waitFor(() => {
+          for (const id of ["test-viewport-both", "test-viewport-vertical"]) {
+            const { viewport, content } = getInstance(id);
+            expect(content.clientWidth).toBe(viewport.clientWidth);
+          }
         });
       }
     );
 
     await step(
-      "Long title truncates inside the card instead of painting past it",
+      "Both instances keep w=100% siblings at viewport width",
       async () => {
-        const viewport = doc.getElementById(
-          "test-viewport-vert-with-horiz-overflow"
-        ) as HTMLElement;
-        // Use the second card — first is intentionally overflowing.
-        const title = viewport.querySelector(
-          ":scope [data-part='content'] > div:nth-child(2) p:nth-child(2)"
-        ) as HTMLElement;
-        expect(title).toBeTruthy();
-        const titleStyles = window.getComputedStyle(title);
-        expect(titleStyles.textOverflow).toBe("ellipsis");
-        expect(titleStyles.whiteSpace).toMatch(/nowrap/);
-        expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+        for (const id of ["test-viewport-both", "test-viewport-vertical"]) {
+          const { viewport, cards } = getInstance(id);
+          cards.slice(1).forEach((card) => {
+            expect(card.offsetWidth).toBe(viewport.clientWidth);
+          });
+        }
       }
     );
 
     await step(
-      "Explicit over-sized child surfaces a horizontal scrollbar",
+      "orientation=both: wide card overflows and horizontal scrollbar is shown",
       async () => {
-        const viewport = doc.getElementById(
-          "test-viewport-vert-with-horiz-overflow"
-        ) as HTMLElement;
+        const { viewport, cards, visibleHorizontalScrollbar } =
+          getInstance("test-viewport-both");
+        expect(cards[0].offsetWidth).toBeGreaterThan(viewport.clientWidth);
         expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
-        const scrollbars = canvasElement.querySelectorAll(
-          '[data-part="scrollbar"]'
+        expect(visibleHorizontalScrollbar).toBeTruthy();
+      }
+    );
+
+    await step(
+      "orientation=vertical: wide card is clipped and no horizontal scrollbar is shown",
+      async () => {
+        const { viewport, visibleHorizontalScrollbar } = getInstance(
+          "test-viewport-vertical"
         );
-        const horizontalScrollbar = Array.from(scrollbars).find(
-          (sb) =>
-            sb.getAttribute("data-orientation") === "horizontal" &&
-            window.getComputedStyle(sb).display !== "none"
-        );
-        expect(horizontalScrollbar).toBeTruthy();
+        expect(window.getComputedStyle(viewport).overflowX).toBe("hidden");
+        expect(visibleHorizontalScrollbar).toBeUndefined();
       }
     );
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -233,14 +233,14 @@ export const VerticalOnly: Story = {
 };
 
 // ============================================================
-// Default orientation with content that overflows on both axes.
+// Full-width cards with truncated long titles.
 //
-// Because Zag always sets `min-width: fit-content` inline on the content slot,
-// content can grow past the viewport horizontally even when only vertical
-// scrolling is "intended". The default orientation is `"both"` so the
-// horizontal scrollbar shows up automatically instead of silently scrolling.
-// To strictly clip the other axis, pass `orientation="vertical"` (see the
-// `VerticalOnly` story).
+// Zag always writes `min-width: fit-content` inline on the content slot so
+// horizontal scroll works. Without our fix the wrapper would grow to fit the
+// widest child, so `w="100%"` cards would inherit the longest title's width
+// and clip past the viewport. With the fix the wrapper is pinned to the
+// viewport, cards fill it cleanly, and per-card `truncate` ellipsizes long
+// titles in place.
 // ============================================================
 export const VerticalWithHorizontalOverflow: Story = {
   render: () => (
@@ -263,7 +263,7 @@ export const VerticalWithHorizontalOverflow: Story = {
           <Text fontSize="xs" color="neutral.11">
             #{20538 + i}
           </Text>
-          <Text fontSize="sm" fontWeight="bold" whiteSpace="nowrap">
+          <Text fontSize="sm" fontWeight="bold" truncate>
             FEC-{765 + i}: Import
             no-direct-currency-for-price-selection-in-all-cart-items
           </Text>
@@ -278,44 +278,49 @@ export const VerticalWithHorizontalOverflow: Story = {
     const doc = canvasElement.ownerDocument;
 
     await step(
-      "Content overflows the viewport on the horizontal axis",
+      "w=100% children are sized to the viewport, not to the widest sibling",
       async () => {
         await waitFor(() => {
           const viewport = doc.getElementById(
             "test-viewport-vert-with-horiz-overflow"
           ) as HTMLElement;
-          expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
+          const content = viewport.querySelector(
+            '[data-part="content"]'
+          ) as HTMLElement;
+          expect(content.clientWidth).toBe(viewport.clientWidth);
+          const firstCard = content.querySelector(
+            ":scope > div"
+          ) as HTMLElement;
+          expect(firstCard.offsetWidth).toBe(content.clientWidth);
         });
       }
     );
 
     await step(
-      "Horizontal scrollbar is rendered so overflow is not silent",
-      async () => {
-        const scrollbars = canvasElement.querySelectorAll(
-          '[data-part="scrollbar"]'
-        );
-        const horizontalScrollbar = Array.from(scrollbars).find(
-          (sb) => sb.getAttribute("data-orientation") === "horizontal"
-        );
-        expect(horizontalScrollbar).toBeTruthy();
-      }
-    );
-
-    await step(
-      "w=100% children are sized to the viewport, not to the widest sibling",
+      "Long title truncates inside the card instead of overflowing",
       async () => {
         const viewport = doc.getElementById(
           "test-viewport-vert-with-horiz-overflow"
         ) as HTMLElement;
-        const content = viewport.querySelector(
-          '[data-part="content"]'
+        const title = viewport.querySelector(
+          ":scope [data-part='content'] > div p:nth-child(2)"
         ) as HTMLElement;
-        expect(content.clientWidth).toBe(viewport.clientWidth);
-        const firstCard = content.querySelector(":scope > div") as HTMLElement;
-        // Card's border-box fills the content wrapper (which is the viewport
-        // width), not the widest nowrap child.
-        expect(firstCard.offsetWidth).toBe(content.clientWidth);
+        expect(title).toBeTruthy();
+        const titleStyles = window.getComputedStyle(title);
+        expect(titleStyles.textOverflow).toBe("ellipsis");
+        expect(titleStyles.whiteSpace).toMatch(/nowrap/);
+        // The title is clipped by its own box, not painting past it.
+        expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+      }
+    );
+
+    await step(
+      "No horizontal overflow at the viewport level when titles truncate",
+      async () => {
+        const viewport = doc.getElementById(
+          "test-viewport-vert-with-horiz-overflow"
+        ) as HTMLElement;
+        expect(viewport.scrollWidth).toBe(viewport.clientWidth);
       }
     );
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -358,40 +358,6 @@ export const KeyboardFocusRing: Story = {
 };
 
 // ============================================================
-// Vertical only scrolling
-// ============================================================
-export const VerticalOnly: Story = {
-  render: () => (
-    <ScrollArea
-      maxH="200px"
-      w="400px"
-      orientation="vertical"
-      ids={{ viewport: "test-viewport-vert-only" }}
-    >
-      <OverflowingContent />
-    </ScrollArea>
-  ),
-  play: async ({ canvasElement, step }) => {
-    const doc = canvasElement.ownerDocument;
-
-    await step("Detects vertical overflow", async () => {
-      await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport-vert-only");
-        expect(viewport).toHaveAttribute("data-overflow-y");
-      });
-    });
-
-    await step("Only vertical scrollbar rendered", async () => {
-      const scrollbars = canvasElement.querySelectorAll(
-        '[data-part="scrollbar"]'
-      );
-      expect(scrollbars).toHaveLength(1);
-      expect(scrollbars[0]).toHaveAttribute("data-orientation", "vertical");
-    });
-  },
-};
-
-// ============================================================
 // StrictOrientations: single-axis orientations actively clip the opposite
 // axis while preserving predictable sibling sizing. One panel per strict
 // orientation, each with an intentionally over-sized child, an intrinsic
@@ -584,66 +550,6 @@ export const StrictOrientations: Story = {
 };
 
 // ============================================================
-// Horizontal only scrolling
-// ============================================================
-export const HorizontalOnly: Story = {
-  render: () => (
-    <ScrollArea
-      maxW="400px"
-      orientation="horizontal"
-      ids={{ viewport: "test-viewport-horiz-only" }}
-    >
-      <WideContent />
-    </ScrollArea>
-  ),
-  play: async ({ canvasElement, step }) => {
-    const doc = canvasElement.ownerDocument;
-
-    await step("Detects horizontal overflow", async () => {
-      await waitFor(() => {
-        const viewport = doc.getElementById("test-viewport-horiz-only");
-        expect(viewport).toHaveAttribute("data-overflow-x");
-      });
-    });
-
-    await step("Only horizontal scrollbar rendered", async () => {
-      const scrollbars = canvasElement.querySelectorAll(
-        '[data-part="scrollbar"]'
-      );
-      expect(scrollbars).toHaveLength(1);
-      expect(scrollbars[0]).toHaveAttribute("data-orientation", "horizontal");
-    });
-  },
-};
-
-// ============================================================
-// Both axes scrolling
-// ============================================================
-export const BothAxes: Story = {
-  render: () => (
-    <ScrollArea maxH="200px" maxW="400px" orientation="both">
-      <OverflowingContent />
-      <WideContent />
-    </ScrollArea>
-  ),
-  play: async ({ canvasElement, step }) => {
-    await step("Both scrollbars rendered", async () => {
-      await waitFor(() => {
-        const scrollbars = canvasElement.querySelectorAll(
-          '[data-part="scrollbar"]'
-        );
-        expect(scrollbars).toHaveLength(2);
-      });
-    });
-
-    await step("Corner element rendered", async () => {
-      const corner = canvasElement.querySelector('[data-part="corner"]');
-      expect(corner).toBeTruthy();
-    });
-  },
-};
-
-// ============================================================
 // Always visible scrollbar variant
 // ============================================================
 export const AlwaysVisible: Story = {
@@ -728,26 +634,83 @@ export const AlwaysVisible: Story = {
 };
 
 // ============================================================
-// Custom styling: style props on root, content padding via Box
+// Custom styling: non-padding style props are routed to the root, not to
+// the viewport or the content slot.
 // ============================================================
 export const CustomStyling: Story = {
   render: () => (
-    <ScrollArea maxH="200px" w="400px" bg="neutral.2" borderRadius="300">
-      <Box p="200">
-        <OverflowingContent />
-      </Box>
-    </ScrollArea>
+    <Box>
+      <Text fontSize="xs" color="neutral.11" mb="200" maxW="500px">
+        Non-padding style props (<code>bg</code>, <code>border</code>,{" "}
+        <code>borderRadius</code>, <code>boxShadow</code>, <code>m</code>) land
+        on the root. The viewport and content slot stay visually untouched so
+        overlay scrollbars paint correctly over the themed root.
+      </Text>
+      <ScrollArea
+        maxH="200px"
+        w="400px"
+        bg="neutral.2"
+        borderRadius="300"
+        border="solid-25"
+        borderColor="primary.9"
+        boxShadow="4"
+        m="200"
+        ids={{ viewport: "test-viewport-custom" }}
+      >
+        <Box p="200">
+          <OverflowingContent />
+        </Box>
+      </ScrollArea>
+    </Box>
   ),
   play: async ({ canvasElement, step }) => {
-    await step("Root accepts Chakra style props", async () => {
-      await waitFor(() => {
-        const root = canvasElement.querySelector(
-          '[data-part="root"]'
-        ) as HTMLElement;
-        const styles = window.getComputedStyle(root);
-        expect(styles.borderRadius).not.toBe("0px");
-      });
-    });
+    const doc = canvasElement.ownerDocument;
+
+    const getParts = () => {
+      const viewport = doc.getElementById(
+        "test-viewport-custom"
+      ) as HTMLElement;
+      const root = viewport.closest('[data-part="root"]') as HTMLElement;
+      const content = viewport.querySelector(
+        '[data-part="content"]'
+      ) as HTMLElement;
+      return {
+        root,
+        viewport,
+        content,
+        rootStyle: window.getComputedStyle(root),
+        viewportStyle: window.getComputedStyle(viewport),
+        contentStyle: window.getComputedStyle(content),
+      };
+    };
+
+    await step(
+      "Root reflects every style prop with non-default values",
+      async () => {
+        await waitFor(() => {
+          const { rootStyle } = getParts();
+          expect(rootStyle.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+          expect(rootStyle.borderRadius).not.toBe("0px");
+          expect(rootStyle.borderTopWidth).not.toBe("0px");
+          expect(rootStyle.borderTopColor).not.toBe("rgba(0, 0, 0, 0)");
+          expect(rootStyle.boxShadow).not.toBe("none");
+          expect(rootStyle.marginTop).not.toBe("0px");
+        });
+      }
+    );
+
+    await step(
+      "Viewport and content slot do not inherit root-only style props",
+      async () => {
+        const { viewportStyle, contentStyle } = getParts();
+        expect(viewportStyle.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+        expect(viewportStyle.borderTopWidth).toBe("0px");
+        expect(viewportStyle.boxShadow).toBe("none");
+        expect(contentStyle.backgroundColor).toBe("rgba(0, 0, 0, 0)");
+        expect(contentStyle.borderTopWidth).toBe("0px");
+        expect(contentStyle.marginTop).toBe("0px");
+      }
+    );
   },
 };
 

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -186,9 +186,17 @@ export const VerticalOnly: Story = {
     <ScrollArea
       maxH="200px"
       w="400px"
+      orientation="vertical"
       ids={{ viewport: "test-viewport-vert-only" }}
     >
-      <OverflowingContent />
+      <Box w="100%">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Text key={i} fontSize="sm" whiteSpace="nowrap">
+            Row {i + 1}:{" "}
+            {"intentionally-wider-than-viewport-content ".repeat(3)}
+          </Text>
+        ))}
+      </Box>
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
@@ -208,16 +216,31 @@ export const VerticalOnly: Story = {
       expect(scrollbars).toHaveLength(1);
       expect(scrollbars[0]).toHaveAttribute("data-orientation", "vertical");
     });
+
+    await step("Horizontal overflow is actively suppressed", async () => {
+      const viewport = doc.getElementById(
+        "test-viewport-vert-only"
+      ) as HTMLElement;
+      // Viewport clips the x-axis so overflowing children can't be scrolled to.
+      expect(window.getComputedStyle(viewport).overflowX).toBe("hidden");
+      // Content wrapper is sized to the viewport, not to its widest child.
+      const content = viewport.querySelector(
+        '[data-part="content"]'
+      ) as HTMLElement;
+      expect(content.clientWidth).toBe(viewport.clientWidth);
+    });
   },
 };
 
 // ============================================================
-// Orientation="vertical" with content that also overflows horizontally.
+// Default orientation with content that overflows on both axes.
 //
-// Replicates a bug where horizontal overflow is silently scrollable via
-// trackpad/keyboard but no horizontal scrollbar indicator is shown, because
-// Zag always sets `min-width: fit-content` inline on the content slot while
-// our wrapper only renders the vertical scrollbar.
+// Because Zag always sets `min-width: fit-content` inline on the content slot,
+// content can grow past the viewport horizontally even when only vertical
+// scrolling is "intended". The default orientation is `"both"` so the
+// horizontal scrollbar shows up automatically instead of silently scrolling.
+// To strictly clip the other axis, pass `orientation="vertical"` (see the
+// `VerticalOnly` story).
 // ============================================================
 export const VerticalWithHorizontalOverflow: Story = {
   render: () => (
@@ -267,7 +290,7 @@ export const VerticalWithHorizontalOverflow: Story = {
     );
 
     await step(
-      "Bug: no horizontal scrollbar is rendered despite the overflow",
+      "Horizontal scrollbar is rendered so overflow is not silent",
       async () => {
         const scrollbars = canvasElement.querySelectorAll(
           '[data-part="scrollbar"]'
@@ -275,7 +298,24 @@ export const VerticalWithHorizontalOverflow: Story = {
         const horizontalScrollbar = Array.from(scrollbars).find(
           (sb) => sb.getAttribute("data-orientation") === "horizontal"
         );
-        expect(horizontalScrollbar).toBeUndefined();
+        expect(horizontalScrollbar).toBeTruthy();
+      }
+    );
+
+    await step(
+      "w=100% children are sized to the viewport, not to the widest sibling",
+      async () => {
+        const viewport = doc.getElementById(
+          "test-viewport-vert-with-horiz-overflow"
+        ) as HTMLElement;
+        const content = viewport.querySelector(
+          '[data-part="content"]'
+        ) as HTMLElement;
+        expect(content.clientWidth).toBe(viewport.clientWidth);
+        const firstCard = content.querySelector(":scope > div") as HTMLElement;
+        // Card's border-box fills the content wrapper (which is the viewport
+        // width), not the widest nowrap child.
+        expect(firstCard.offsetWidth).toBe(content.clientWidth);
       }
     );
   },
@@ -460,7 +500,7 @@ export const Sizes: Story = {
           <Text fontSize="sm" mb="200" fontWeight="bold">
             size=&quot;{size}&quot;
           </Text>
-          <ScrollArea maxH="150px" w="250px" size={size}>
+          <ScrollArea maxH="150px" w="250px" size={size} orientation="vertical">
             <OverflowingContent />
           </ScrollArea>
         </Box>

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -111,14 +111,21 @@ export const Default: Story = {
 // ============================================================
 export const DefaultSurfacesBothScrollbars: Story = {
   render: () => (
-    <ScrollArea
-      maxH="200px"
-      maxW="400px"
-      ids={{ viewport: "test-viewport-default-both" }}
-    >
-      <OverflowingContent />
-      <WideContent />
-    </ScrollArea>
+    <Box>
+      <Text fontSize="xs" color="neutral.11" mb="200">
+        When no <code>orientation</code> prop is set and content overflows on
+        both axes, both scrollbars and the corner are rendered. Guards against
+        the default silently reverting to a single-axis value.
+      </Text>
+      <ScrollArea
+        maxH="200px"
+        maxW="400px"
+        ids={{ viewport: "test-viewport-default-both" }}
+      >
+        <OverflowingContent />
+        <WideContent />
+      </ScrollArea>
+    </Box>
   ),
   play: async ({ canvasElement, step }) => {
     const doc = canvasElement.ownerDocument;
@@ -159,102 +166,100 @@ export const DefaultSurfacesBothScrollbars: Story = {
 };
 
 // ============================================================
-// DefaultBoxParity: the "ScrollArea behaves like a Box with overflow:auto"
-// claim, executable. Renders a ScrollArea and an equivalent Box overflow=auto
-// side by side with identical children and asserts matching child geometry.
+// DefaultChildSizing: the default orientation produces predictable child
+// geometry — a w=100% sibling stays at viewport width even next to a
+// legitimately over-sized child, a fit-content child sizes to its own
+// contents, and a pixel child is sized literally. Guards the core bug fix
+// that pinned the content wrapper to viewport width.
 // ============================================================
-const BoxParityChildren = () => (
-  <Box display="flex" flexDirection="column" gap="200">
-    <Box w="100%" h="40px" bg="neutral.3" id="parity-w-100" />
-    <Box w="fit-content" px="300" py="200" bg="neutral.3" id="parity-fit">
-      <Text fontSize="xs">fit-content</Text>
-    </Box>
-    <Box w="200px" h="40px" bg="neutral.3" id="parity-pixel" />
-    <Box display="flex" gap="100" id="parity-flex-row">
-      <Box flex="1" h="40px" bg="neutral.3" />
-      <Box flex="2" h="40px" bg="neutral.4" />
-    </Box>
-    <Box whiteSpace="nowrap" id="parity-nowrap">
-      <Text fontSize="sm">
-        {"intentionally-long-unwrappable-token-".repeat(6)}
-      </Text>
-    </Box>
-  </Box>
-);
-
-export const DefaultBoxParity: Story = {
+export const DefaultChildSizing: Story = {
   render: () => (
-    <Box display="flex" gap="600" alignItems="flex-start">
-      <Box>
-        <Text fontSize="sm" fontWeight="bold" mb="100">
-          ScrollArea (orientation unset)
-        </Text>
-        <Box id="parity-scrollarea-wrap">
-          <ScrollArea
-            maxH="300px"
-            w="320px"
-            ids={{ viewport: "test-viewport-parity-scrollarea" }}
-          >
-            <BoxParityChildren />
-          </ScrollArea>
+    <Box>
+      <Text fontSize="xs" color="neutral.11" mb="200" maxW="320px">
+        Asserts the core child-sizing contract under the default orientation: a{" "}
+        <code>w=100%</code> sibling stays at viewport width even next to a
+        nowrap descendant that forces horizontal overflow, a{" "}
+        <code>fit-content</code> child sizes to its own contents, and a pixel
+        child is honored literally.
+      </Text>
+      <ScrollArea
+        maxH="300px"
+        w="320px"
+        ids={{ viewport: "test-viewport-child-sizing" }}
+      >
+        <Box display="flex" flexDirection="column" gap="200">
+          <Box w="100%" h="40px" bg="neutral.3" id="sizing-w-100" />
+          <Box w="fit-content" px="300" py="200" bg="neutral.3" id="sizing-fit">
+            <Text fontSize="xs">fit-content</Text>
+          </Box>
+          <Box w="200px" h="40px" bg="neutral.3" id="sizing-pixel" />
+          <Box display="flex" gap="100" id="sizing-flex-row">
+            <Box flex="1" h="40px" bg="neutral.3" />
+            <Box flex="2" h="40px" bg="neutral.4" />
+          </Box>
+          <Box whiteSpace="nowrap" id="sizing-nowrap">
+            <Text fontSize="sm">
+              {"intentionally-long-unwrappable-token-".repeat(6)}
+            </Text>
+          </Box>
         </Box>
-      </Box>
-      <Box>
-        <Text fontSize="sm" fontWeight="bold" mb="100">
-          &lt;Box overflow=&quot;auto&quot;&gt;
-        </Text>
-        <Box
-          id="parity-box-wrap"
-          maxH="300px"
-          w="320px"
-          overflow="auto"
-          tabIndex={0}
-          aria-label="Box-overflow-auto parity comparison"
-        >
-          <BoxParityChildren />
-        </Box>
-      </Box>
+      </ScrollArea>
     </Box>
   ),
   play: async ({ canvasElement, step }) => {
     const doc = canvasElement.ownerDocument;
 
     await step(
-      "Each labelled child has matching geometry in both containers",
+      "w=100% child matches viewport width regardless of an over-sized sibling",
       async () => {
         await waitFor(() => {
-          const scrollArea = doc.getElementById(
-            "parity-scrollarea-wrap"
+          const viewport = doc.getElementById(
+            "test-viewport-child-sizing"
           ) as HTMLElement;
-          const boxWrap = doc.getElementById("parity-box-wrap") as HTMLElement;
-          const ids = [
-            "parity-w-100",
-            "parity-fit",
-            "parity-pixel",
-            "parity-flex-row",
-          ];
-          ids.forEach((id) => {
-            const inScrollArea = scrollArea.querySelector(
-              `#${id}`
-            ) as HTMLElement;
-            const inBox = boxWrap.querySelector(`#${id}`) as HTMLElement;
-            expect(inScrollArea).toBeTruthy();
-            expect(inBox).toBeTruthy();
-            expect(inScrollArea.offsetWidth).toBe(inBox.offsetWidth);
-            expect(inScrollArea.offsetHeight).toBe(inBox.offsetHeight);
-          });
+          const wFull = viewport.querySelector("#sizing-w-100") as HTMLElement;
+          expect(wFull.offsetWidth).toBe(viewport.clientWidth);
         });
       }
     );
 
+    await step("fit-content child sizes to its own contents", async () => {
+      const viewport = doc.getElementById(
+        "test-viewport-child-sizing"
+      ) as HTMLElement;
+      const fit = viewport.querySelector("#sizing-fit") as HTMLElement;
+      expect(fit.offsetWidth).toBeGreaterThan(0);
+      expect(fit.offsetWidth).toBeLessThan(viewport.clientWidth);
+    });
+
+    await step("Explicit pixel width is honored literally", async () => {
+      const viewport = doc.getElementById(
+        "test-viewport-child-sizing"
+      ) as HTMLElement;
+      const pixel = viewport.querySelector("#sizing-pixel") as HTMLElement;
+      expect(pixel.offsetWidth).toBe(200);
+    });
+
     await step(
-      "w=100% child does not stretch to match the nowrap sibling",
+      "Flex row composes flex=1 and flex=2 ratios at viewport width",
       async () => {
         const viewport = doc.getElementById(
-          "test-viewport-parity-scrollarea"
+          "test-viewport-child-sizing"
         ) as HTMLElement;
-        const wFull = viewport.querySelector("#parity-w-100") as HTMLElement;
-        expect(wFull.offsetWidth).toBe(viewport.clientWidth);
+        const flexRow = viewport.querySelector(
+          "#sizing-flex-row"
+        ) as HTMLElement;
+        expect(flexRow.offsetWidth).toBe(viewport.clientWidth);
+        const [first, second] = Array.from(flexRow.children) as HTMLElement[];
+        expect(second.offsetWidth).toBeGreaterThan(first.offsetWidth);
+      }
+    );
+
+    await step(
+      "A nowrap descendant still creates viewport overflow so the horizontal scrollbar surfaces",
+      async () => {
+        const viewport = doc.getElementById(
+          "test-viewport-child-sizing"
+        ) as HTMLElement;
         expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
       }
     );
@@ -795,6 +800,12 @@ const ExternalControlHarness = () => {
   });
   return (
     <Box>
+      <Text fontSize="xs" color="neutral.11" mb="200" maxW="500px">
+        An externally created scroll-area machine is passed to the{" "}
+        <code>value</code> prop. Buttons call <code>scrollTo</code> and{" "}
+        <code>scrollToEdge</code> on the hook; the readout reflects{" "}
+        <code>hasOverflowY</code>.
+      </Text>
       <Box display="flex" gap="200" mb="200">
         <button
           type="button"
@@ -811,7 +822,7 @@ const ExternalControlHarness = () => {
           scrollToEdge bottom
         </button>
         <span data-testid="external-has-overflow-y">
-          {String(scrollArea.hasOverflowY)}
+          hasOverflowY: {String(scrollArea.hasOverflowY)}
         </span>
       </Box>
       <ScrollArea maxH="200px" w="400px" value={scrollArea}>
@@ -845,7 +856,7 @@ export const ExternalControl: Story = {
         const readout = canvasElement.querySelector(
           '[data-testid="external-has-overflow-y"]'
         ) as HTMLElement;
-        expect(readout.textContent).toBe("true");
+        expect(readout.textContent).toContain("true");
       }
     );
 
@@ -884,6 +895,11 @@ const DynamicContentHarness = () => {
   const [rows, setRows] = React.useState(2);
   return (
     <Box>
+      <Text fontSize="xs" color="neutral.11" mb="200" maxW="500px">
+        Adding or removing children after mount must flip the{" "}
+        <code>data-overflow-*</code> attributes and the viewport's{" "}
+        <code>tabindex</code>. Guards the reactivity of overflow detection.
+      </Text>
       <Box display="flex" gap="200" mb="200">
         <button
           type="button"
@@ -978,19 +994,27 @@ const ForwardsApiHarness = () => {
     }
   }, []);
   return (
-    <ScrollArea
-      as="section"
-      ref={rootRef}
-      maxH="200px"
-      w="400px"
-      ids={{
-        root: "test-forwards-root",
-        viewport: "test-forwards-viewport",
-        content: "test-forwards-content",
-      }}
-    >
-      <OverflowingContent />
-    </ScrollArea>
+    <Box>
+      <Text fontSize="xs" color="neutral.11" mb="200" maxW="500px">
+        Proves the public-API surface actually works: the root <code>ref</code>{" "}
+        lands on the root element, <code>as=&quot;section&quot;</code> renders
+        the root as a <code>&lt;section&gt;</code>, and every key in the{" "}
+        <code>ids</code> map reaches the DOM.
+      </Text>
+      <ScrollArea
+        as="section"
+        ref={rootRef}
+        maxH="200px"
+        w="400px"
+        ids={{
+          root: "test-forwards-root",
+          viewport: "test-forwards-viewport",
+          content: "test-forwards-content",
+        }}
+      >
+        <OverflowingContent />
+      </ScrollArea>
+    </Box>
   );
 };
 
@@ -1182,35 +1206,42 @@ const paddingPropCases = [
 
 export const ContentPadding: Story = {
   render: () => (
-    <Box display="flex" gap="400" flexWrap="wrap">
-      {paddingPropCases.map(({ prop, viewportId }) => (
-        <Box key={prop}>
+    <Box>
+      <Text fontSize="xs" color="neutral.11" mb="300" maxW="600px">
+        Every padding prop is forwarded to the inner{" "}
+        <code>[data-part=&quot;content&quot;]</code> slot so the scrollbar
+        overlays the padded area, not the gutter. Root always has zero padding.
+      </Text>
+      <Box display="flex" gap="400" flexWrap="wrap">
+        {paddingPropCases.map(({ prop, viewportId }) => (
+          <Box key={prop}>
+            <Text fontSize="xs" mb="100" color="neutral.11">
+              {prop}=&quot;400&quot;
+            </Text>
+            <ScrollArea
+              maxH="200px"
+              w="260px"
+              bg="neutral.2"
+              ids={{ viewport: viewportId }}
+              {...{ [prop]: "400" }}
+            >
+              <OverflowingContent />
+            </ScrollArea>
+          </Box>
+        ))}
+        <Box>
           <Text fontSize="xs" mb="100" color="neutral.11">
-            {prop}=&quot;400&quot;
+            no padding (control)
           </Text>
           <ScrollArea
             maxH="200px"
             w="260px"
             bg="neutral.2"
-            ids={{ viewport: viewportId }}
-            {...{ [prop]: "400" }}
+            ids={{ viewport: "test-pad-none" }}
           >
             <OverflowingContent />
           </ScrollArea>
         </Box>
-      ))}
-      <Box>
-        <Text fontSize="xs" mb="100" color="neutral.11">
-          no padding (control)
-        </Text>
-        <ScrollArea
-          maxH="200px"
-          w="260px"
-          bg="neutral.2"
-          ids={{ viewport: "test-pad-none" }}
-        >
-          <OverflowingContent />
-        </ScrollArea>
       </Box>
     </Box>
   ),

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -241,29 +241,44 @@ export const VerticalOnly: Story = {
 //   scrollbar, and `w=100%` siblings still stay at viewport width.
 // ============================================================
 const VerticalWithHorizontalOverflowCards = () =>
-  Array.from({ length: 6 }, (_, i) => (
-    <Box
-      key={i}
-      w={i === 0 ? "150%" : "100%"}
-      p="300"
-      mb="200"
-      border="solid-25"
-      borderColor="neutral.6"
-      borderRadius="200"
-      bg="neutral.2"
-    >
-      <Text fontSize="xs" color="neutral.11">
-        #{20538 + i}
-      </Text>
-      <Text fontSize="sm" fontWeight="bold" truncate>
-        FEC-{765 + i}: Import
-        no-direct-currency-for-price-selection-in-all-cart-items
-      </Text>
-      <Text fontSize="xs" color="neutral.11">
-        merchant-center-frontend
-      </Text>
-    </Box>
-  ));
+  Array.from({ length: 6 }, (_, i) => {
+    const setting =
+      i === 0 ? 'w="150%"' : i === 1 ? "no width prop" : 'w="100%"';
+    const headline =
+      i === 0
+        ? "Intentionally wider than the viewport to demonstrate a child that legitimately exceeds the scroll area width"
+        : i === 1
+          ? "Intrinsic auto width — block fills the parent content box the same way an explicit 100% does, without setting any size"
+          : "Explicit full width — the common pattern for list rows that should always match the scroll area's visible width";
+    const outcome =
+      i === 0
+        ? "expected: overflows, horizontal scrollbar surfaces under orientation=both"
+        : i === 1
+          ? "expected: fills viewport, stays aligned with w=100% siblings"
+          : "expected: fills viewport regardless of any over-sized sibling";
+    return (
+      <Box
+        key={i}
+        w={i === 0 ? "150%" : i === 1 ? undefined : "100%"}
+        p="300"
+        mb="200"
+        border="solid-25"
+        borderColor="neutral.6"
+        borderRadius="200"
+        bg="neutral.2"
+      >
+        <Text fontSize="xs" color="neutral.11">
+          {setting}
+        </Text>
+        <Text fontSize="sm" fontWeight="bold" truncate>
+          {headline}
+        </Text>
+        <Text fontSize="xs" color="neutral.11">
+          {outcome}
+        </Text>
+      </Box>
+    );
+  });
 
 export const VerticalWithHorizontalOverflow: Story = {
   render: () => (

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -88,6 +88,61 @@ export const Default: Story = {
 };
 
 // ============================================================
+// DefaultSurfacesBothScrollbars: regression test that the default orientation
+// renders a scrollbar for each overflowing axis without `orientation` being
+// explicitly set. Guards against a silent regression of the default back to
+// a single-axis value.
+// ============================================================
+export const DefaultSurfacesBothScrollbars: Story = {
+  render: () => (
+    <ScrollArea
+      maxH="200px"
+      maxW="400px"
+      ids={{ viewport: "test-viewport-default-both" }}
+    >
+      <OverflowingContent />
+      <WideContent />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const doc = canvasElement.ownerDocument;
+
+    await step("Both axes overflow", async () => {
+      await waitFor(() => {
+        const viewport = doc.getElementById(
+          "test-viewport-default-both"
+        ) as HTMLElement;
+        expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+        expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
+      });
+    });
+
+    await step(
+      "Both scrollbars are rendered and visible with no orientation set",
+      async () => {
+        const scrollbars = Array.from(
+          canvasElement.querySelectorAll('[data-part="scrollbar"]')
+        );
+        const orientations = scrollbars.map((sb) =>
+          sb.getAttribute("data-orientation")
+        );
+        expect(orientations).toEqual(
+          expect.arrayContaining(["vertical", "horizontal"])
+        );
+        scrollbars.forEach((sb) => {
+          expect(window.getComputedStyle(sb).display).not.toBe("none");
+        });
+      }
+    );
+
+    await step("Corner element is rendered", async () => {
+      const corner = canvasElement.querySelector('[data-part="corner"]');
+      expect(corner).toBeTruthy();
+    });
+  },
+};
+
+// ============================================================
 // NonOverflowing: renders correctly with short content
 // ============================================================
 export const NonOverflowing: Story = {
@@ -189,14 +244,7 @@ export const VerticalOnly: Story = {
       orientation="vertical"
       ids={{ viewport: "test-viewport-vert-only" }}
     >
-      <Box w="100%">
-        {Array.from({ length: 6 }, (_, i) => (
-          <Text key={i} fontSize="sm" whiteSpace="nowrap">
-            Row {i + 1}:{" "}
-            {"intentionally-wider-than-viewport-content ".repeat(3)}
-          </Text>
-        ))}
-      </Box>
+      <OverflowingContent />
     </ScrollArea>
   ),
   play: async ({ canvasElement, step }) => {
@@ -216,268 +264,127 @@ export const VerticalOnly: Story = {
       expect(scrollbars).toHaveLength(1);
       expect(scrollbars[0]).toHaveAttribute("data-orientation", "vertical");
     });
-
-    await step("Horizontal overflow is actively suppressed", async () => {
-      const viewport = doc.getElementById(
-        "test-viewport-vert-only"
-      ) as HTMLElement;
-      // Viewport clips the x-axis so overflowing children can't be scrolled to.
-      expect(window.getComputedStyle(viewport).overflowX).toBe("hidden");
-      // Content wrapper is sized to the viewport, not to its widest child.
-      const content = viewport.querySelector(
-        '[data-part="content"]'
-      ) as HTMLElement;
-      expect(content.clientWidth).toBe(viewport.clientWidth);
-    });
   },
 };
 
 // ============================================================
-// Full-width cards with one deliberately over-sized child, rendered side by
-// side under both the default `"both"` orientation and explicit `"vertical"`
-// orientation. Demonstrates how each handles the same content:
-// - `"both"`: the wide card overflows and the horizontal scrollbar surfaces.
-// - `"vertical"`: the wide card is clipped at the viewport, no horizontal
-//   scrollbar, and `w=100%` siblings still stay at viewport width.
+// StrictOrientations: single-axis orientations actively clip the opposite
+// axis while preserving predictable sibling sizing. One panel per strict
+// orientation, each with an intentionally over-sized child, an intrinsic
+// child, and full-size children — so w=100% / h=100% siblings stay at
+// viewport size regardless of the over-sized sibling.
 // ============================================================
-const VerticalWithHorizontalOverflowCards = () =>
-  Array.from({ length: 6 }, (_, i) => {
-    const setting =
-      i === 0 ? 'w="150%"' : i === 1 ? "no width prop" : 'w="100%"';
-    const headline =
-      i === 0
-        ? "Intentionally wider than the viewport to demonstrate a child that legitimately exceeds the scroll area width"
-        : i === 1
-          ? "Intrinsic auto width — block fills the parent content box the same way an explicit 100% does, without setting any size"
-          : "Explicit full width — the common pattern for list rows that should always match the scroll area's visible width";
-    const outcome =
-      i === 0
-        ? "expected: overflows, horizontal scrollbar surfaces under orientation=both"
-        : i === 1
-          ? "expected: fills viewport, stays aligned with w=100% siblings"
-          : "expected: fills viewport regardless of any over-sized sibling";
-    return (
-      <Box
-        key={i}
-        w={i === 0 ? "150%" : i === 1 ? undefined : "100%"}
-        p="300"
-        mb="200"
-        border="solid-25"
-        borderColor="neutral.6"
-        borderRadius="200"
-        bg="neutral.2"
-      >
-        <Text fontSize="xs" color="neutral.11">
-          {setting}
-        </Text>
-        <Text fontSize="sm" fontWeight="bold" truncate>
-          {headline}
-        </Text>
-        <Text fontSize="xs" color="neutral.11">
-          {outcome}
-        </Text>
-      </Box>
-    );
-  });
+const StrictOrientationCard = ({
+  axis,
+  index,
+}: {
+  axis: "width" | "height";
+  index: number;
+}) => {
+  const sizeProp = axis === "width" ? "w" : "h";
+  const overSize = axis === "width" ? "150%" : "260px";
+  const setting =
+    index === 0
+      ? `${sizeProp}="${overSize}"`
+      : index === 1
+        ? `no ${sizeProp} prop`
+        : `${sizeProp}="100%"`;
+  const headline =
+    index === 0
+      ? `Intentionally ${axis === "width" ? "wider" : "taller"} than the viewport to demonstrate a child that legitimately exceeds the scroll area ${axis}`
+      : index === 1
+        ? `Intrinsic auto ${axis} — block sizes to its own content, ${axis === "width" ? "same effective width as an explicit 100%" : "shorter than the viewport"}`
+        : `Explicit full ${axis} — the common pattern for items that should always match the scroll area's visible ${axis}`;
+  const outcome =
+    index === 0
+      ? `expected: clipped at the viewport edge under strict orientation`
+      : index === 1
+        ? `expected: fills viewport ${axis}`
+        : `expected: fills viewport ${axis} regardless of any over-sized sibling`;
+  return (
+    <Box
+      w={
+        axis === "width"
+          ? index === 0
+            ? "150%"
+            : index === 1
+              ? undefined
+              : "100%"
+          : "220px"
+      }
+      h={
+        axis === "height"
+          ? index === 0
+            ? "260px"
+            : index === 1
+              ? undefined
+              : "100%"
+          : undefined
+      }
+      flexShrink={axis === "height" ? "0" : undefined}
+      alignSelf={axis === "height" ? "flex-start" : undefined}
+      p="300"
+      mb={axis === "width" ? "200" : undefined}
+      border="solid-25"
+      borderColor="neutral.6"
+      borderRadius="200"
+      bg="neutral.2"
+    >
+      <Text fontSize="xs" color="neutral.11">
+        {setting}
+      </Text>
+      <Text fontSize="sm" fontWeight="bold" truncate>
+        {headline}
+      </Text>
+      <Text fontSize="xs" color="neutral.11">
+        {outcome}
+      </Text>
+    </Box>
+  );
+};
 
-export const VerticalWithHorizontalOverflow: Story = {
+export const StrictOrientations: Story = {
   render: () => (
     <Box display="flex" gap="600" alignItems="flex-start">
-      <Box w="320px">
-        <Text fontSize="sm" fontWeight="bold" mb="100">
-          orientation=&quot;both&quot; (default)
-        </Text>
-        <Text fontSize="xs" color="neutral.11" mb="300">
-          The first card is w=150%, so it overflows the viewport. A horizontal
-          scrollbar appears and the card is scrollable. Other w=100% siblings
-          stay at viewport width.
-        </Text>
-        <ScrollArea
-          maxH="300px"
-          w="320px"
-          ids={{ viewport: "test-viewport-both" }}
-        >
-          <VerticalWithHorizontalOverflowCards />
-        </ScrollArea>
-      </Box>
       <Box w="320px">
         <Text fontSize="sm" fontWeight="bold" mb="100">
           orientation=&quot;vertical&quot;
         </Text>
         <Text fontSize="xs" color="neutral.11" mb="300">
-          Same content, but the horizontal axis is actively clipped. The wide
-          first card is cut at the viewport edge, no horizontal scrollbar
-          appears, and the vertical scroll still works.
+          Horizontal axis is clipped. The w=150% card is cut at the viewport
+          edge with no horizontal scrollbar, and w=100% siblings stay at
+          viewport width.
         </Text>
         <ScrollArea
           maxH="300px"
           w="320px"
           orientation="vertical"
-          ids={{ viewport: "test-viewport-vertical" }}
+          ids={{ viewport: "test-viewport-strict-vertical" }}
         >
-          <VerticalWithHorizontalOverflowCards />
+          {Array.from({ length: 6 }, (_, i) => (
+            <StrictOrientationCard key={i} axis="width" index={i} />
+          ))}
         </ScrollArea>
       </Box>
-    </Box>
-  ),
-  play: async ({ canvasElement, step }) => {
-    const doc = canvasElement.ownerDocument;
-
-    const getInstance = (viewportId: string) => {
-      const viewport = doc.getElementById(viewportId) as HTMLElement;
-      const root = viewport.closest('[data-part="root"]') as HTMLElement;
-      const content = viewport.querySelector(
-        '[data-part="content"]'
-      ) as HTMLElement;
-      const cards = Array.from(
-        content.querySelectorAll(":scope > div")
-      ) as HTMLElement[];
-      const scrollbars = Array.from(
-        root.querySelectorAll('[data-part="scrollbar"]')
-      ) as HTMLElement[];
-      const visibleHorizontalScrollbar = scrollbars.find(
-        (sb) =>
-          sb.getAttribute("data-orientation") === "horizontal" &&
-          window.getComputedStyle(sb).display !== "none"
-      );
-      return { viewport, content, cards, visibleHorizontalScrollbar };
-    };
-
-    await step(
-      "Both instances pin their content wrapper to viewport width",
-      async () => {
-        await waitFor(() => {
-          for (const id of ["test-viewport-both", "test-viewport-vertical"]) {
-            const { viewport, content } = getInstance(id);
-            expect(content.clientWidth).toBe(viewport.clientWidth);
-          }
-        });
-      }
-    );
-
-    await step(
-      "Both instances keep w=100% siblings at viewport width",
-      async () => {
-        for (const id of ["test-viewport-both", "test-viewport-vertical"]) {
-          const { viewport, cards } = getInstance(id);
-          cards.slice(1).forEach((card) => {
-            expect(card.offsetWidth).toBe(viewport.clientWidth);
-          });
-        }
-      }
-    );
-
-    await step(
-      "orientation=both: wide card overflows and horizontal scrollbar is shown",
-      async () => {
-        const { viewport, cards, visibleHorizontalScrollbar } =
-          getInstance("test-viewport-both");
-        expect(cards[0].offsetWidth).toBeGreaterThan(viewport.clientWidth);
-        expect(viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
-        expect(visibleHorizontalScrollbar).toBeTruthy();
-      }
-    );
-
-    await step(
-      "orientation=vertical: wide card is clipped and no horizontal scrollbar is shown",
-      async () => {
-        const { viewport, visibleHorizontalScrollbar } = getInstance(
-          "test-viewport-vertical"
-        );
-        expect(window.getComputedStyle(viewport).overflowX).toBe("hidden");
-        expect(visibleHorizontalScrollbar).toBeUndefined();
-      }
-    );
-  },
-};
-
-// ============================================================
-// Horizontal counterpart of VerticalWithHorizontalOverflow. Row of cards
-// rendered under both the default `"both"` orientation and explicit
-// `"horizontal"` orientation, covering intrinsic-height, over-sized, and
-// full-height children.
-// ============================================================
-const HorizontalWithVerticalOverflowCards = () =>
-  Array.from({ length: 6 }, (_, i) => {
-    const setting =
-      i === 0 ? 'h="260px"' : i === 1 ? "no height prop" : 'h="100%"';
-    const headline =
-      i === 0
-        ? "Intentionally taller than the viewport to demonstrate a child that legitimately exceeds the scroll area height"
-        : i === 1
-          ? "Intrinsic auto height — block sizes to its own content, shorter than the viewport"
-          : "Explicit full height — the common pattern for row items that should always match the scroll area's visible height";
-    const outcome =
-      i === 0
-        ? "expected: overflows, vertical scrollbar surfaces under orientation=both"
-        : i === 1
-          ? "expected: shorter than viewport, aligned to the top"
-          : "expected: fills viewport height regardless of any over-sized sibling";
-    return (
-      <Box
-        key={i}
-        h={i === 0 ? "260px" : i === 1 ? undefined : "100%"}
-        w="220px"
-        flexShrink="0"
-        alignSelf="flex-start"
-        p="300"
-        border="solid-25"
-        borderColor="neutral.6"
-        borderRadius="200"
-        bg="neutral.2"
-      >
-        <Text fontSize="xs" color="neutral.11">
-          {setting}
-        </Text>
-        <Text fontSize="sm" fontWeight="bold" truncate>
-          {headline}
-        </Text>
-        <Text fontSize="xs" color="neutral.11">
-          {outcome}
-        </Text>
-      </Box>
-    );
-  });
-
-export const HorizontalWithVerticalOverflow: Story = {
-  render: () => (
-    <Box display="flex" flexDirection="column" gap="600">
-      <Box>
-        <Text fontSize="sm" fontWeight="bold" mb="100">
-          orientation=&quot;both&quot; (default)
-        </Text>
-        <Text fontSize="xs" color="neutral.11" mb="300">
-          The first item is h=260px, so it overflows the viewport. A vertical
-          scrollbar appears and the item is scrollable. Other h=100% siblings
-          stay at viewport height.
-        </Text>
-        <ScrollArea
-          h="200px"
-          w="500px"
-          ids={{ viewport: "test-viewport-h-both" }}
-        >
-          <Box display="flex" gap="200" h="200px">
-            <HorizontalWithVerticalOverflowCards />
-          </Box>
-        </ScrollArea>
-      </Box>
-      <Box>
+      <Box w="500px">
         <Text fontSize="sm" fontWeight="bold" mb="100">
           orientation=&quot;horizontal&quot;
         </Text>
         <Text fontSize="xs" color="neutral.11" mb="300">
-          Same content, but the vertical axis is actively clipped. The tall
-          first item is cut at the viewport edge, no vertical scrollbar appears,
-          and the horizontal scroll still works.
+          Vertical axis is clipped. The h=260px item is cut at the viewport edge
+          with no vertical scrollbar, and h=100% siblings stay at viewport
+          height.
         </Text>
         <ScrollArea
           h="200px"
           w="500px"
           orientation="horizontal"
-          ids={{ viewport: "test-viewport-h-horizontal" }}
+          ids={{ viewport: "test-viewport-strict-horizontal" }}
         >
           <Box display="flex" gap="200" h="200px">
-            <HorizontalWithVerticalOverflowCards />
+            {Array.from({ length: 6 }, (_, i) => (
+              <StrictOrientationCard key={i} axis="height" index={i} />
+            ))}
           </Box>
         </ScrollArea>
       </Box>
@@ -486,64 +393,67 @@ export const HorizontalWithVerticalOverflow: Story = {
   play: async ({ canvasElement, step }) => {
     const doc = canvasElement.ownerDocument;
 
-    const getInstance = (viewportId: string) => {
+    const getCards = (viewportId: string, axis: "width" | "height") => {
       const viewport = doc.getElementById(viewportId) as HTMLElement;
-      const root = viewport.closest('[data-part="root"]') as HTMLElement;
       const content = viewport.querySelector(
         '[data-part="content"]'
       ) as HTMLElement;
-      const row = content.querySelector(":scope > div") as HTMLElement;
+      const container =
+        axis === "height"
+          ? (content.querySelector(":scope > div") as HTMLElement)
+          : content;
       const cards = Array.from(
-        row.querySelectorAll(":scope > div")
+        container.querySelectorAll(":scope > div")
       ) as HTMLElement[];
       const scrollbars = Array.from(
-        root.querySelectorAll('[data-part="scrollbar"]')
+        viewport
+          .closest('[data-part="root"]')!
+          .querySelectorAll('[data-part="scrollbar"]')
       ) as HTMLElement[];
-      const visibleVerticalScrollbar = scrollbars.find(
-        (sb) =>
-          sb.getAttribute("data-orientation") === "vertical" &&
-          window.getComputedStyle(sb).display !== "none"
-      );
-      return { viewport, cards, visibleVerticalScrollbar };
+      return { viewport, cards, scrollbars };
     };
 
     await step(
-      "Both instances keep h=100% siblings at viewport height",
+      "orientation=vertical: w=100% siblings stay at viewport width and x-axis is clipped",
       async () => {
         await waitFor(() => {
-          for (const id of [
-            "test-viewport-h-both",
-            "test-viewport-h-horizontal",
-          ]) {
-            const { viewport, cards } = getInstance(id);
-            cards.slice(2).forEach((card) => {
-              expect(card.offsetHeight).toBe(viewport.clientHeight);
-            });
-          }
+          const { viewport, cards, scrollbars } = getCards(
+            "test-viewport-strict-vertical",
+            "width"
+          );
+          expect(cards[0].offsetWidth).toBeGreaterThan(viewport.clientWidth);
+          cards.slice(1).forEach((card) => {
+            expect(card.offsetWidth).toBe(viewport.clientWidth);
+          });
+          expect(window.getComputedStyle(viewport).overflowX).toBe("hidden");
+          const visibleHorizontal = scrollbars.find(
+            (sb) =>
+              sb.getAttribute("data-orientation") === "horizontal" &&
+              window.getComputedStyle(sb).display !== "none"
+          );
+          expect(visibleHorizontal).toBeUndefined();
         });
       }
     );
 
     await step(
-      "orientation=both: tall card overflows and vertical scrollbar is shown",
+      "orientation=horizontal: h=100% siblings stay at viewport height and y-axis is clipped",
       async () => {
-        const { viewport, cards, visibleVerticalScrollbar } = getInstance(
-          "test-viewport-h-both"
+        const { viewport, cards, scrollbars } = getCards(
+          "test-viewport-strict-horizontal",
+          "height"
         );
         expect(cards[0].offsetHeight).toBeGreaterThan(viewport.clientHeight);
-        expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
-        expect(visibleVerticalScrollbar).toBeTruthy();
-      }
-    );
-
-    await step(
-      "orientation=horizontal: tall card is clipped and no vertical scrollbar is shown",
-      async () => {
-        const { viewport, visibleVerticalScrollbar } = getInstance(
-          "test-viewport-h-horizontal"
-        );
+        cards.slice(2).forEach((card) => {
+          expect(card.offsetHeight).toBe(viewport.clientHeight);
+        });
         expect(window.getComputedStyle(viewport).overflowY).toBe("hidden");
-        expect(visibleVerticalScrollbar).toBeUndefined();
+        const visibleVertical = scrollbars.find(
+          (sb) =>
+            sb.getAttribute("data-orientation") === "vertical" &&
+            window.getComputedStyle(sb).display !== "none"
+        );
+        expect(visibleVertical).toBeUndefined();
       }
     );
   },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -39,7 +39,7 @@ const ScrollAreaParts = ({
   const contentAxisLock =
     orientation === "horizontal"
       ? { minHeight: 0, height: "100%" }
-      : { minWidth: "100%", width: "100%" };
+      : { minWidth: "100%", width: "100%", height: "100%" };
 
   // Belt-and-suspenders: clip the suppressed axis on the viewport so a child
   // with an explicit fixed size larger than the viewport can't escape either.

--- a/packages/nimbus/src/components/scroll-area/scroll-area.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.tsx
@@ -20,17 +20,49 @@ type ScrollAreaPartsProps = Pick<
  */
 const ScrollAreaParts = ({
   children,
-  orientation = "vertical",
+  orientation = "both",
   viewportRef,
   contentPaddingProps,
 }: ScrollAreaPartsProps) => {
   const { hasOverflowX, hasOverflowY } = useScrollAreaContext();
   const tabIndex = hasOverflowX || hasOverflowY ? 0 : undefined;
 
+  // Zag always writes `min-width: fit-content` inline on the content slot so
+  // horizontal scroll works. That makes the wrapper grow to fit its widest
+  // child, which stretches every `width: 100%` sibling to that same overgrown
+  // width. For `vertical` and `both` orientations we want the wrapper to stay
+  // at viewport width so `width: 100%` children behave naturally — any
+  // descendant that still overflows (e.g. `white-space: nowrap` text) shows
+  // up as viewport scroll via descendant overflow, which is exactly what the
+  // horizontal scrollbar in `both` is for. `horizontal` keeps Zag's
+  // fit-content so a row of items can scroll as usual.
+  const contentAxisLock =
+    orientation === "horizontal"
+      ? { minHeight: 0, height: "100%" }
+      : { minWidth: "100%", width: "100%" };
+
+  // Belt-and-suspenders: clip the suppressed axis on the viewport so a child
+  // with an explicit fixed size larger than the viewport can't escape either.
+  // Inline `style` is required because Zag writes `overflow: auto` inline and
+  // recipe-generated classes can't outspecify inline styles.
+  const viewportAxisClip =
+    orientation === "vertical"
+      ? { overflowX: "hidden" as const }
+      : orientation === "horizontal"
+        ? { overflowY: "hidden" as const }
+        : undefined;
+
   return (
     <>
-      <ChakraScrollArea.Viewport ref={viewportRef} tabIndex={tabIndex}>
-        <ChakraScrollArea.Content {...contentPaddingProps}>
+      <ChakraScrollArea.Viewport
+        ref={viewportRef}
+        tabIndex={tabIndex}
+        style={viewportAxisClip}
+      >
+        <ChakraScrollArea.Content
+          {...contentPaddingProps}
+          style={contentAxisLock}
+        >
           {children}
         </ChakraScrollArea.Content>
       </ChakraScrollArea.Viewport>
@@ -71,7 +103,7 @@ export const ScrollArea = (props: ScrollAreaProps) => {
     ref,
     viewportRef,
     children,
-    orientation = "vertical",
+    orientation = "both",
     value,
     ...restProps
   } = props;

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -86,13 +86,15 @@ export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootSlotProps> & {
    * Custom element IDs for ScrollArea's internal parts.
    * Use when you need DOM access via `getElementById` (e.g.,
    * `ids={{ viewport: 'my-viewport' }}`).
+   *
+   * Only `root`, `viewport`, and `content` are honored by the underlying
+   * state machine. Scrollbar and thumb elements are located by data
+   * attributes and cannot be renamed via ids.
    */
   ids?: Partial<{
     root: string;
     viewport: string;
     content: string;
-    scrollbar: string;
-    thumb: string;
   }>;
 };
 
@@ -104,6 +106,4 @@ export type ScrollAreaElementIds = Partial<{
   root: string;
   viewport: string;
   content: string;
-  scrollbar: string;
-  thumb: string;
 }>;

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -35,12 +35,23 @@ type ScrollAreaRecipeProps = {
 
 type ScrollAreaRootSlotProps = HTMLChakraProps<"div", ScrollAreaRecipeProps>;
 
+/**
+ * Style props that would collide with ScrollArea's internal overflow control.
+ * The root has `overflow: hidden` from the recipe, the viewport owns
+ * `overflow: auto` / axis clipping, and `orientation` drives the strict
+ * clipping — consumers setting these would silently break scroll behavior.
+ */
+type ConflictingProps = "overflow" | "overflowX" | "overflowY";
+
 // ============================================================
 // MAIN PROPS
 // ============================================================
 
 /** Props for the `ScrollArea` component. */
-export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootSlotProps> & {
+export type ScrollAreaProps = Omit<
+  OmitInternalProps<ScrollAreaRootSlotProps>,
+  ConflictingProps
+> & {
   /** Content to render inside the scrollable area. */
   children: React.ReactNode;
   /**

--- a/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.types.ts
@@ -56,7 +56,12 @@ export type ScrollAreaProps = OmitInternalProps<ScrollAreaRootSlotProps> & {
   viewportRef?: React.Ref<HTMLDivElement>;
   /**
    * Which scrollbar axes to render.
-   * @default "vertical"
+   *
+   * When set to `"vertical"` or `"horizontal"`, the opposite axis is actively
+   * suppressed: Zag's inline `min-width: fit-content` (or `min-height`) is
+   * overridden on the content slot and the viewport clips the other axis.
+   * This prevents silent overflow with no visible scrollbar indicator.
+   * @default "both"
    */
   orientation?: "vertical" | "horizontal" | "both";
   /**


### PR DESCRIPTION
## Summary

Child elements with `width: 100%` inside a `ScrollArea` were rendering wider than the scroll area's visible width whenever a sibling had an intrinsic width larger than the viewport. Root cause: an inline `min-width: fit-content` set by the underlying Zag state machine made the internal wrapper grow to its widest child, so `width: 100%` siblings resolved against that overgrown wrapper instead of the viewport. The wrapper also had intrinsic height, so a single child couldn't be vertically centered — `alignItems: center` + `height: 100%` resolved against the child's own height and pinned it to the top.

<img width="472" height="385" alt="image" src="https://github.com/user-attachments/assets/b0ca8402-9606-47e0-9c55-f9139d5d6fc8" />



## Fix

- Override Zag's `min-width: fit-content` on the content slot so the wrapper stays at viewport width.
- Give the content wrapper `height: 100%` for `vertical` / `both` so consumers can vertically center a shorter child with flex/grid + `height: 100%`. Tall children still surface via viewport `scrollHeight`, so scrolling is unaffected.
- Change the default `orientation` from `"vertical"` to `"both"` — overflow now surfaces a visible scrollbar instead of being silently trackpad-only.
- Strict `"vertical"` / `"horizontal"` orientations actively clip the opposite axis.
- Fix a pre-existing recipe bug where scrollbars hid based on the wrong axis.
- Omit `overflow*` from `ScrollAreaProps` (the component owns overflow internally) and drop `scrollbar` / `thumb` from the `ids` shape (Zag ignores them).

## Tests

Story set trimmed and retargeted at Nimbus-owned behavior. Notable: `DefaultChildSizing` asserts the sibling-sizing invariants, `ContentFillsViewport` covers the new centering capability, `StrictOrientations` covers the clipping contract, `DefaultSurfacesBothScrollbars` guards the default change. Removed `SmokeTest`, `VerticalOnly`, `HorizontalOnly`, `BothAxes` as subsumed by the above.

## Docs

- Correct the \"default is vertical\" claim in the designer and developer mdx and reorder examples so the `both` default appears first.
- Update the still-open OpenSpec proposal (`add-scroll-area-component`) to reflect the new defaults, invariants, and prop-surface changes.

## Test plan

- [x] \`pnpm --filter @commercetools/nimbus typecheck\`
- [x] \`pnpm test:storybook:dev\` for scroll-area — 15/15 pass
- [ ] \`pnpm --filter @commercetools/nimbus build\` + \`pnpm test:storybook\`