### PR TITLE
ci(release): reset working tree before canary publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,10 @@ jobs:
         if: steps.changesets.outputs.published != 'true' && github.ref ==
           'refs/heads/main'
         run: |
-          git checkout main
+          set -euo pipefail
+          git fetch origin main
+          git reset --hard origin/main
+          git clean -fd
           pnpm changeset version --snapshot canary
           pnpm changeset publish --tag canary
         env:


### PR DESCRIPTION
## Summary

The canary step in the release workflow silently operates on a dirty working tree left behind by `changesets/action@v1.7.0` in `commitMode: github-api`, which can cause it to publish production version numbers under the `canary` dist-tag.

### What happens without this fix

1. `changesets/action` runs the `version:` command **locally** (bumping `package.json` versions, deleting `.changeset/*.md`).
2. In `commitMode: github-api`, the action commits those changes via the GitHub API rather than `git commit`/`git push`, but **never resets the working tree** afterward.
3. The next step, `Publishing canary releases to npm registry`, runs `git checkout main`, which fails silently on the dirty state (bash has no `set -e` in the run block).
4. `changeset version --snapshot canary` sees no changesets (they're already deleted locally) and exits.
5. `changeset publish --tag canary` reads the bumped versions in `package.json` and publishes them under the `canary` dist-tag — leaking the not-yet-released production version.

This was first observed in `merchant-center-application-kit` — same pattern, same fix.

### Fix

Hard-reset to `origin/main` and clean untracked files before running canary, plus `set -euo pipefail` so any future silent failure in this block becomes a hard stop:

```yaml
run: |
  set -euo pipefail
  git fetch origin main
  git reset --hard origin/main
  git clean -fd
  pnpm changeset version --snapshot canary
  pnpm changeset publish --tag canary
```

This is a latent bug in `changesets/action` (not resetting after running `version:` in `commitMode: github-api`) — worth reporting upstream — but the workflow fix is independent and straightforward.

## Test plan

- [ ] Next release run: canary step resets cleanly (look for the `git reset --hard` output) and either (a) produces real `X.Y.Z-canary-TIMESTAMP` versions when changesets exist, or (b) the snapshot is a no-op when there are none (instead of publishing real versions as canary).
- [ ] The npm `canary` dist-tag no longer advances to production version numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)