### PR TITLE
fix(modal page test): fix flaky modal page test

### DIFF
--- a/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
+++ b/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
@@ -555,6 +555,20 @@ export const StackedModalPages: Story = {
     });
 
     await step("Escape closes only the topmost level", async () => {
+      // Wait for focus to settle in the topmost dialog before pressing Escape.
+      // The back button in the "Create Attribute" modal has autoFocus — without
+      // this assertion, the Escape event can fire before React Aria's focus
+      // management completes, causing it to be handled by the wrong overlay.
+      await waitFor(
+        () => {
+          expect(
+            canvas.getByRole("button", {
+              name: /go back to select attribute/i,
+            })
+          ).toHaveFocus();
+        },
+        { timeout: 3000 }
+      );
       await userEvent.keyboard("{Escape}");
       await waitFor(
         () => {


### PR DESCRIPTION
This pull request improves the reliability of the modal stack story test by ensuring that focus management is complete before simulating an Escape key press. This prevents the Escape event from being handled by the wrong modal overlay due to asynchronous focus shifts.

**Testing reliability improvements:**

* Added a `waitFor` assertion to ensure the back button in the "Create Attribute" modal has focus before pressing Escape, preventing test flakiness caused by React Aria's asynchronous focus management. (`packages/nimbus/src/components/modal-page/modal-page.stories.tsx`)