### PR TITLE
FEC-728- Enhance Tx workflow to reduce gaps

### DIFF
--- a/.github/scripts/merge-transifex-bot-prs.sh
+++ b/.github/scripts/merge-transifex-bot-prs.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "$PRS" ]; then
+  echo "No open Transifex bot PRs found."
+  exit 0
+fi
+
+git config user.name "ct-changesets[bot]"
+git config user.email "ct-changesets[bot]@users.noreply.github.com"
+
+for PR_NUM in $PRS; do
+  echo "Processing PR #$PR_NUM..."
+
+  # For workflow_dispatch, check out the PR branch
+  if [ "$EVENT_NAME" != "pull_request" ]; then
+    BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
+    git fetch origin "$BRANCH"
+    git checkout "$BRANCH"
+  fi
+
+  # Skip if any changed files are not JSON
+  NON_JSON=$(gh pr view "$PR_NUM" \
+    --json files \
+    --jq '[.files[].path | select(endswith(".json") | not)] | length')
+  if [ "$NON_JSON" -gt 0 ]; then
+    echo "PR #$PR_NUM has non-JSON files. Skipping."
+    continue
+  fi
+
+  # Skip if any commits are from non-bot authors
+  NON_BOT=$(gh pr view "$PR_NUM" \
+    --json commits \
+    --jq "[.commits[].authors[] | select(.login != \"$TRANSIFEX_BOT_AUTHOR\")] | length")
+  if [ "$NON_BOT" -gt 0 ]; then
+    echo "PR #$PR_NUM has commits from non-bot authors. Skipping."
+    continue
+  fi
+
+  # Compile on the PR branch and commit
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Dry run — skipping compile and commit for PR #$PR_NUM."
+  else
+    pnpm --filter @commercetools/nimbus-i18n build
+    git add packages/nimbus/src/components/
+    if git diff --cached --quiet; then
+      echo "No compiled output changes for PR #$PR_NUM."
+    else
+      git commit -m "chore(intl): compile translation updates from Transifex"
+      git push origin HEAD
+      echo "Pushed compiled output to PR #$PR_NUM branch."
+    fi
+  fi
+
+  # Approve if not already approved
+  APPROVED=$(gh pr view "$PR_NUM" \
+    --json reviews \
+    --jq '[.reviews[] | select(.state == "APPROVED")] | length')
+  if [ "$APPROVED" -eq 0 ]; then
+    if [ "$DRY_RUN" = "true" ]; then
+      echo "Dry run — skipping approval of PR #$PR_NUM."
+    else
+      gh pr review "$PR_NUM" --approve \
+        --body "Auto-approved by merge-transifex-bot-prs workflow."
+      echo "Approved PR #$PR_NUM."
+    fi
+  fi
+
+  # Add audit label and merge
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Dry run — skipping label and merge of PR #$PR_NUM."
+  else
+    gh pr edit "$PR_NUM" --add-label "tx-auto-merge"
+    gh pr merge "$PR_NUM" --merge --auto
+    echo "Merged PR #$PR_NUM into main."
+  fi
+done

--- a/.github/workflows/merge-transifex-bot-prs.yml
+++ b/.github/workflows/merge-transifex-bot-prs.yml
@@ -1,8 +1,8 @@
 name: Merge Transifex Bot PRs
 
 on:
-  schedule:
-    - cron: '0 5 * * 1,3,5' # At 05:00 AM UTC on Monday, Wednesday, Friday
+  pull_request:
+    types: [opened]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -16,9 +16,10 @@ env:
 
 jobs:
   automerge-transifex-prs:
-    name: Find, Merge, and Compile Transifex Bot PRs
+    name: Merge and Compile Transifex Bot PR
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event.pull_request.user.login == 'transifex-integration[bot]' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Generate GitHub token (via CT Changesets App)
@@ -47,17 +48,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --filter @commercetools/nimbus-i18n...
 
-      - name: Find, merge, and compile Transifex bot PRs
+      - name: Merge and compile Transifex bot PR
         run: |
           DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
-          MERGED=false
 
-          PRS=$(gh pr list \
-            --author "${{ env.TRANSIFEX_BOT_AUTHOR }}" \
-            --state open \
-            --base main \
-            --json number \
-            --jq '.[].number')
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PRS="${{ github.event.pull_request.number }}"
+          else
+            PRS=$(gh pr list \
+              --author "${{ env.TRANSIFEX_BOT_AUTHOR }}" \
+              --state open \
+              --base main \
+              --json number \
+              --jq '.[].number')
+          fi
 
           if [ -z "$PRS" ]; then
             echo "No open Transifex bot PRs found."
@@ -99,43 +103,32 @@ jobs:
               fi
             fi
 
-            # Add audit label and merge
+            # Add audit label, merge, and compile
             if [ "$DRY_RUN" = "true" ]; then
-              echo "Dry run — skipping label and merge of PR #$PR_NUM."
+              echo "Dry run — skipping label, merge, and compile of PR #$PR_NUM."
             else
               gh pr edit "$PR_NUM" --add-label "tx-auto-merge"
               echo "Labeled PR #$PR_NUM."
               gh pr merge "$PR_NUM" --merge
               echo "Merged PR #$PR_NUM."
-              MERGED=true
+
+              # Pull merged changes
+              git pull origin main
+
+              # Compile i18n messages
+              pnpm --filter @commercetools/nimbus-i18n build
+
+              # Commit compiled output if anything changed
+              git config user.name "ct-changesets[bot]"
+              git config user.email "ct-changesets[bot]@users.noreply.github.com"
+              git add -u packages/nimbus/src/components/
+              if git diff --cached --quiet; then
+                echo "No compiled output changes to commit for PR #$PR_NUM."
+              else
+                git commit -m "chore(intl): compile translation updates from Transifex (PR #$PR_NUM)"
+                git push origin main
+              fi
             fi
           done
-
-          # Also implicitly skips compile during dry run since MERGED is never set to true
-          if [ "$MERGED" = false ]; then
-            echo "No PRs were merged."
-            exit 0
-          fi
-
-          # Pull merged changes
-          git pull origin main
-
-          # Compile i18n messages
-          pnpm --filter @commercetools/nimbus-i18n build
-
-          # Commit compiled output if anything changed
-          git config user.name "ct-changesets[bot]"
-          git config user.email "ct-changesets[bot]@users.noreply.github.com"
-          git add -u packages/nimbus/src/components/
-          if git diff --cached --quiet; then
-            echo "No compiled output changes to commit."
-            exit 0
-          fi
-          if [ "$DRY_RUN" = "true" ]; then
-            echo "Dry run — skipping commit of compiled output."
-          else
-            git commit -m "chore(intl): compile translation updates from Transifex"
-            git push origin main
-          fi
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}

--- a/.github/workflows/merge-transifex-bot-prs.yml
+++ b/.github/workflows/merge-transifex-bot-prs.yml
@@ -1,0 +1,141 @@
+name: Merge Transifex Bot PRs
+
+on:
+  schedule:
+    - cron: '0 5 * * 1,3,5' # At 05:00 AM UTC on Monday, Wednesday, Friday
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (validate and log without merging or committing)'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  TRANSIFEX_BOT_AUTHOR: transifex-integration[bot]
+
+jobs:
+  automerge-transifex-prs:
+    name: Find, Merge, and Compile Transifex Bot PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.generate_github_token.outputs.token }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.12'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --filter @commercetools/nimbus-i18n...
+
+      - name: Find, merge, and compile Transifex bot PRs
+        run: |
+          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+          MERGED=false
+
+          PRS=$(gh pr list \
+            --author "${{ env.TRANSIFEX_BOT_AUTHOR }}" \
+            --state open \
+            --base main \
+            --json number \
+            --jq '.[].number')
+
+          if [ -z "$PRS" ]; then
+            echo "No open Transifex bot PRs found."
+            exit 0
+          fi
+
+          for PR_NUM in $PRS; do
+            echo "Processing PR #$PR_NUM..."
+
+            # Skip if any changed files are not JSON
+            NON_JSON=$(gh pr view "$PR_NUM" \
+              --json files \
+              --jq '[.files[].path | select(endswith(".json") | not)] | length')
+            if [ "$NON_JSON" -gt 0 ]; then
+              echo "PR #$PR_NUM has non-JSON files. Skipping."
+              continue
+            fi
+
+            # Skip if any commits are from non-bot authors
+            NON_BOT=$(gh pr view "$PR_NUM" \
+              --json commits \
+              --jq "[.commits[].authors[] | select(.login != \"${{ env.TRANSIFEX_BOT_AUTHOR }}\")] | length")
+            if [ "$NON_BOT" -gt 0 ]; then
+              echo "PR #$PR_NUM has commits from non-bot authors. Skipping."
+              continue
+            fi
+
+            # Approve if not already approved
+            APPROVED=$(gh pr view "$PR_NUM" \
+              --json reviews \
+              --jq '[.reviews[] | select(.state == "APPROVED")] | length')
+            if [ "$APPROVED" -eq 0 ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "Dry run — skipping approval of PR #$PR_NUM."
+              else
+                gh pr review "$PR_NUM" --approve \
+                  --body "Auto-approved by merge-transifex-bot-prs workflow."
+                echo "Approved PR #$PR_NUM."
+              fi
+            fi
+
+            # Add audit label and merge
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "Dry run — skipping label and merge of PR #$PR_NUM."
+            else
+              gh pr edit "$PR_NUM" --add-label "tx-auto-merge"
+              echo "Labeled PR #$PR_NUM."
+              gh pr merge "$PR_NUM" --merge
+              echo "Merged PR #$PR_NUM."
+              MERGED=true
+            fi
+          done
+
+          # Also implicitly skips compile during dry run since MERGED is never set to true
+          if [ "$MERGED" = false ]; then
+            echo "No PRs were merged."
+            exit 0
+          fi
+
+          # Pull merged changes
+          git pull origin main
+
+          # Compile i18n messages
+          pnpm --filter @commercetools/nimbus-i18n build
+
+          # Commit compiled output if anything changed
+          git config user.name "ct-changesets[bot]"
+          git config user.email "ct-changesets[bot]@users.noreply.github.com"
+          git add -u packages/nimbus/src/components/
+          if git diff --cached --quiet; then
+            echo "No compiled output changes to commit."
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run — skipping commit of compiled output."
+          else
+            git commit -m "chore(intl): compile translation updates from Transifex"
+            git push origin main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}

--- a/.github/workflows/merge-transifex-bot-prs.yml
+++ b/.github/workflows/merge-transifex-bot-prs.yml
@@ -53,92 +53,21 @@ jobs:
 
       - name: Compile, merge Transifex bot PR
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
-
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PRS="${{ github.event.pull_request.number }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PRS="$PR_NUMBER"
           else
             PRS=$(gh pr list \
-              --author "${{ env.TRANSIFEX_BOT_AUTHOR }}" \
+              --author "$TRANSIFEX_BOT_AUTHOR" \
               --state open \
               --base main \
               --json number \
               --jq '.[].number')
           fi
-
-          if [ -z "$PRS" ]; then
-            echo "No open Transifex bot PRs found."
-            exit 0
-          fi
-
-          git config user.name "ct-changesets[bot]"
-          git config user.email "ct-changesets[bot]@users.noreply.github.com"
-
-          for PR_NUM in $PRS; do
-            echo "Processing PR #$PR_NUM..."
-
-            # For workflow_dispatch, check out the PR branch
-            if [ "${{ github.event_name }}" != "pull_request" ]; then
-              BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
-              git fetch origin "$BRANCH"
-              git checkout "$BRANCH"
-            fi
-
-            # Skip if any changed files are not JSON
-            NON_JSON=$(gh pr view "$PR_NUM" \
-              --json files \
-              --jq '[.files[].path | select(endswith(".json") | not)] | length')
-            if [ "$NON_JSON" -gt 0 ]; then
-              echo "PR #$PR_NUM has non-JSON files. Skipping."
-              continue
-            fi
-
-            # Skip if any commits are from non-bot authors
-            NON_BOT=$(gh pr view "$PR_NUM" \
-              --json commits \
-              --jq "[.commits[].authors[] | select(.login != \"${{ env.TRANSIFEX_BOT_AUTHOR }}\")] | length")
-            if [ "$NON_BOT" -gt 0 ]; then
-              echo "PR #$PR_NUM has commits from non-bot authors. Skipping."
-              continue
-            fi
-
-            # Compile on the PR branch and commit
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "Dry run — skipping compile and commit for PR #$PR_NUM."
-            else
-              pnpm --filter @commercetools/nimbus-i18n build
-              git add packages/nimbus/src/components/
-              if git diff --cached --quiet; then
-                echo "No compiled output changes for PR #$PR_NUM."
-              else
-                git commit -m "chore(intl): compile translation updates from Transifex"
-                git push origin HEAD
-                echo "Pushed compiled output to PR #$PR_NUM branch."
-              fi
-            fi
-
-            # Approve if not already approved
-            APPROVED=$(gh pr view "$PR_NUM" \
-              --json reviews \
-              --jq '[.reviews[] | select(.state == "APPROVED")] | length')
-            if [ "$APPROVED" -eq 0 ]; then
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "Dry run — skipping approval of PR #$PR_NUM."
-              else
-                gh pr review "$PR_NUM" --approve \
-                  --body "Auto-approved by merge-transifex-bot-prs workflow."
-                echo "Approved PR #$PR_NUM."
-              fi
-            fi
-
-            # Add audit label and merge
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "Dry run — skipping label and merge of PR #$PR_NUM."
-            else
-              gh pr edit "$PR_NUM" --add-label "tx-auto-merge"
-              gh pr merge "$PR_NUM" --merge --auto
-              echo "Merged PR #$PR_NUM into main."
-            fi
-          done
+          export PRS
+          bash .github/scripts/merge-transifex-bot-prs.sh
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TRANSIFEX_BOT_AUTHOR: ${{ env.TRANSIFEX_BOT_AUTHOR }}

--- a/.github/workflows/merge-transifex-bot-prs.yml
+++ b/.github/workflows/merge-transifex-bot-prs.yml
@@ -3,6 +3,8 @@ name: Merge Transifex Bot PRs
 on:
   pull_request:
     types: [opened]
+    paths:
+      - 'packages/i18n/data/**'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -33,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ steps.generate_github_token.outputs.token }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
@@ -48,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --filter @commercetools/nimbus-i18n...
 
-      - name: Merge and compile Transifex bot PR
+      - name: Compile, merge Transifex bot PR
         run: |
           DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
 
@@ -68,8 +71,18 @@ jobs:
             exit 0
           fi
 
+          git config user.name "ct-changesets[bot]"
+          git config user.email "ct-changesets[bot]@users.noreply.github.com"
+
           for PR_NUM in $PRS; do
             echo "Processing PR #$PR_NUM..."
+
+            # For workflow_dispatch, check out the PR branch
+            if [ "${{ github.event_name }}" != "pull_request" ]; then
+              BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
+              git fetch origin "$BRANCH"
+              git checkout "$BRANCH"
+            fi
 
             # Skip if any changed files are not JSON
             NON_JSON=$(gh pr view "$PR_NUM" \
@@ -89,6 +102,21 @@ jobs:
               continue
             fi
 
+            # Compile on the PR branch and commit
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "Dry run — skipping compile and commit for PR #$PR_NUM."
+            else
+              pnpm --filter @commercetools/nimbus-i18n build
+              git add -u packages/nimbus/src/components/
+              if git diff --cached --quiet; then
+                echo "No compiled output changes for PR #$PR_NUM."
+              else
+                git commit -m "chore(intl): compile translation updates from Transifex"
+                git push origin HEAD
+                echo "Pushed compiled output to PR #$PR_NUM branch."
+              fi
+            fi
+
             # Approve if not already approved
             APPROVED=$(gh pr view "$PR_NUM" \
               --json reviews \
@@ -103,31 +131,13 @@ jobs:
               fi
             fi
 
-            # Add audit label, merge, and compile
+            # Add audit label and merge
             if [ "$DRY_RUN" = "true" ]; then
-              echo "Dry run — skipping label, merge, and compile of PR #$PR_NUM."
+              echo "Dry run — skipping label and merge of PR #$PR_NUM."
             else
               gh pr edit "$PR_NUM" --add-label "tx-auto-merge"
-              echo "Labeled PR #$PR_NUM."
-              gh pr merge "$PR_NUM" --merge
-              echo "Merged PR #$PR_NUM."
-
-              # Pull merged changes
-              git pull origin main
-
-              # Compile i18n messages
-              pnpm --filter @commercetools/nimbus-i18n build
-
-              # Commit compiled output if anything changed
-              git config user.name "ct-changesets[bot]"
-              git config user.email "ct-changesets[bot]@users.noreply.github.com"
-              git add -u packages/nimbus/src/components/
-              if git diff --cached --quiet; then
-                echo "No compiled output changes to commit for PR #$PR_NUM."
-              else
-                git commit -m "chore(intl): compile translation updates from Transifex (PR #$PR_NUM)"
-                git push origin main
-              fi
+              gh pr merge "$PR_NUM" --merge --auto
+              echo "Merged PR #$PR_NUM into main."
             fi
           done
         env:

--- a/.github/workflows/merge-transifex-bot-prs.yml
+++ b/.github/workflows/merge-transifex-bot-prs.yml
@@ -107,7 +107,7 @@ jobs:
               echo "Dry run — skipping compile and commit for PR #$PR_NUM."
             else
               pnpm --filter @commercetools/nimbus-i18n build
-              git add -u packages/nimbus/src/components/
+              git add packages/nimbus/src/components/
               if git diff --cached --quiet; then
                 echo "No compiled output changes for PR #$PR_NUM."
               else

--- a/.github/workflows/notify-localization-team.yml
+++ b/.github/workflows/notify-localization-team.yml
@@ -1,0 +1,34 @@
+name: Notify Localization Team
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '**/*.i18n.ts'
+
+jobs:
+  remind-localization-ticket:
+    name: Remind to create localization ticket
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'transifex-integration[bot]'
+
+    steps:
+      - name: Post localization reminder
+        run: |
+          EXISTING=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --json comments \
+            --jq '[.comments[] | select(.body | contains("localization ticket"))] | length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Reminder already posted, skipping."
+            exit 0
+          fi
+
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'EOF'
+          **Localization reminder:** This PR adds or modifies \`.i18n.ts\` files.
+
+          Please create a Jira ticket for the localization manager to initiate translation of any new or updated strings in Transifex. See [LOC-1766](https://commercetools.atlassian.net/browse/LOC-1766) as an example.
+          EOF
+          )"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/file-type-guidelines/i18n.md
+++ b/docs/file-type-guidelines/i18n.md
@@ -79,7 +79,9 @@ export const messages = {
 
 1. `.i18n.ts` files → extracted by custom script (`pnpm extract-intl`) →
    `packages/i18n/data/core.json`
-2. Translation workflow → `data/*.json` files translated via Transifex
+2. Translation workflow → Transifex translates and opens a PR with updated
+   `data/*.json` files → `merge-transifex-bot-prs` workflow automatically
+   compiles, commits, and merges
 3. Build pipeline → compiles messages → generates `*.messages.ts` dictionaries
 4. Components → import and use `*.messages.ts` at runtime
 

--- a/packages/i18n/CLAUDE.md
+++ b/packages/i18n/CLAUDE.md
@@ -133,10 +133,12 @@ runtime**.
 
 1. Messages are extracted to `data/core.json` and pushed to Transifex
 2. Translators provide translations for all supported locales
-3. Translations are pulled back to `data/[locale].json` (Transifex format)
-4. Build pipeline compiles messages:
-   `pnpm --filter @commercetools/nimbus-i18n build`
-5. Generated `*.messages.ts` files are committed to the repository
+3. Transifex automatically opens a PR with updated `data/[locale].json` files
+4. The `merge-transifex-bot-prs` GitHub Actions workflow takes over
+   automatically:
+   - Runs `pnpm --filter @commercetools/nimbus-i18n build` to compile messages
+   - Commits the generated `*.messages.ts` files to the PR branch
+   - Approves and merges the PR once all checks pass
 
 ### 4. Usage in Components
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -386,6 +386,8 @@ flowchart TD
   keys, a ticket must be created to notify the localization manager. This
   initiates the professional translation coordination process and ensures proper
   review, context provision, and quality assurance for all translatable content.
+  The `notify-localization-team` GitHub Actions workflow will automatically post
+  a reminder comment on any PR that modifies `.i18n.ts` files.
 
 **Complete Workflow:**
 
@@ -394,7 +396,9 @@ flowchart TD
 3. Commit and merge changes to `main` branch
 4. GitHub-Transifex integration (via `transifex.yml`) automatically syncs
    changes to Transifex
-5. **Create ticket** for localization manager to coordinate translation work
+5. **Create ticket** for localization manager to coordinate translation work _(a
+   reminder comment is automatically posted on the PR by
+   `notify-localization-team`)_
 6. Localization manager coordinates professional translation through Transifex
 7. Transifex automatically creates a pull request when translations are complete
 8. The `merge-transifex-bot-prs` GitHub Actions workflow automatically compiles

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -305,7 +305,9 @@ consumers do not need to install or use this package directly.
    through the Transifex platform
 6. **Automated PR Creation**: Once translations are complete, Transifex
    automatically creates a pull request with updated translation files
-7. **Compilation**: Translated files are compiled using the build pipeline
+7. **Automated Compilation & Merge**: The `merge-transifex-bot-prs` GitHub
+   Actions workflow detects the PR, compiles translated files into TypeScript
+   message files, commits the output to the PR branch, and auto-merges to `main`
 8. **Runtime Usage**: Components import and use compiled `*.messages.ts` files
 
 ```mermaid
@@ -317,6 +319,7 @@ flowchart TD
     LocTicket["📋 Localization Manager<br/>(Manual ticket creation<br/>for new/updated keys)"]
     GitHubIntegration["⚙️ GitHub-Transifex Integration<br/>(Automated via transifex.yml)"]
     AutoPR["🤖 Automated PR<br/>(Created by Transifex<br/>when translations ready)"]
+    AutoWorkflow["⚡ merge-transifex-bot-prs<br/>(GitHub Actions)<br/>compile → commit → merge"]
     TranslatedData["📦 Translated Data<br/>data/en.json<br/>data/de.json<br/>data/es.json<br/>data/fr-FR.json<br/>data/pt-BR.json"]
 
     Start -->|"Custom extraction script<br/>(pnpm extract-intl)"| Extract
@@ -328,7 +331,8 @@ flowchart TD
     LocTicket -.->|"Coordinates<br/>translation"| Transifex
 
     Transifex -->|"Translations complete"| AutoPR
-    AutoPR -->|"Merge PR"| TranslatedData
+    AutoPR -->|"Triggers automatically"| AutoWorkflow
+    AutoWorkflow -->|"Compiles & merges"| TranslatedData
 
     TranslatedData --> BuildPipeline
 
@@ -356,6 +360,7 @@ flowchart TD
     style Transifex fill:#f3e5f5,color:#000000
     style LocTicket fill:#ffe0b2,color:#000000
     style AutoPR fill:#c5cae9,color:#000000
+    style AutoWorkflow fill:#a5d6a7,color:#000000
     style TranslatedData fill:#e8f5e9,color:#000000
     style BuildPipeline fill:#fafafa,color:#000000
     style Runtime fill:#e1f5fe,color:#000000
@@ -392,5 +397,6 @@ flowchart TD
 5. **Create ticket** for localization manager to coordinate translation work
 6. Localization manager coordinates professional translation through Transifex
 7. Transifex automatically creates a pull request when translations are complete
-8. Merge PR to integrate translated files into the codebase
-9. Run build pipeline to compile messages for component usage
+8. The `merge-transifex-bot-prs` GitHub Actions workflow automatically compiles
+   the translations, commits the compiled output to the PR branch, and merges to
+   `main` — no manual steps required


### PR DESCRIPTION
Adds automated Tx PR handling via `.github/workflows/merge-transifex-bot-prs.yml`                                                                             
                                                                                                                                                                              
Previously, when Tx sent back a translation PR, two manual steps were required & one was sometimes missed: 
- Running `pnpm --filter @commercetools/nimbus-i18n build` to compile the translated JSON into TS msg files & 
- Merging the PR

This workflow attempts automates this part of the process.                                  
                                                                                                                                                                              
**How the magic happens**                                                                                                                                                                
                                                        
**Trigger:** Fires automatically when any PR touching `packages/i18n/data/**` is opened. The job is skipped unless the PR author is transifex-integration[bot]. Also triggerable manually via workflow_dispatch with an optional dry-run mode.
                                                                                                                                                                              
**Per-PR process:**                                           
  1. Checks out the PR branch directly                    
  2. Validates the PR (only JSON files changed, only bot commits)
  3. Runs `pnpm --filter @commercetools/nimbus-i18n build` & commits the compiled TS output back to the PR branch
  4. Approves the PR                                                                                                                                                          
  5. Adds label `tx-auto-merge` & enables auto-merge. The merge to main happens automatically once all required checks pass    
  
  
but wait, there's more!
  
Also adds `.github/workflows/notify-localization-team.yml`
                                                                                                                                                                              
When a dev opens or updates a PR that touches any *`.i18n.ts` file, this workflow automatically posts a comment reminding them to create a Jira ticket for the localization team (with a ref example). Skips Transifex bot PRs and only posts once per PR to avoid spam. 
  
  **Note that this was heavily inspired by the mc-fe's workflow. Adjusted logic to fit Nimbus' charms.