### PR TITLE
fix(Separator): missing `orientation` prop

### DIFF
--- a/.changeset/ninety-pugs-share.md
+++ b/.changeset/ninety-pugs-share.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Fix `SeparatorProps` missing `orientation` props.

--- a/packages/nimbus/src/components/separator/separator.types.ts
+++ b/packages/nimbus/src/components/separator/separator.types.ts
@@ -9,7 +9,10 @@ import type {
 // RECIPE PROPS
 // ============================================================
 
-type SeparatorRecipeProps = RecipeProps<"nimbusSeparator"> & UnstyledProp;
+type SeparatorRecipeProps = {
+  /** Orientation of the separator */
+  orientation?: RecipeProps<"nimbusSeparator">["orientation"];
+} & UnstyledProp;
 
 // ============================================================
 // SLOT PROPS


### PR DESCRIPTION
The `orientation` prop is documented in https://nimbus-documentation.vercel.app/components/navigation/toolbar/guidelines#toolbar-in-use but when using it on another repo, I get a TS error.