### PR TITLE
fix(switch): add size variant prop to SwitchProps type def

### DIFF
--- a/packages/nimbus/src/components/switch/switch.types.tsx
+++ b/packages/nimbus/src/components/switch/switch.types.tsx
@@ -51,4 +51,9 @@ export type SwitchProps = OmitInternalProps<
      * Ref forwarding to the input element
      */
     ref?: React.Ref<HTMLInputElement>;
+    /**
+     * Size variant of the switch
+     * @default "md"
+     */
+    size?: "sm" | "md";
   };


### PR DESCRIPTION
Fixes #1418 — Switch: size prop missing from public type
                                                                                                                                                                             
**Issue**                                        
                                                                                                                                                                           
Consumers on v2.10.0 reported their IDE throwing a TS error when passing `size` to `<Switch>`, despite the prop being documented and the component accepting it at

  ▎ Property 'size' does not exist on type '... & OmitInternalProps<SwitchRootSlotProps, ...>'                                                                               
   
**Root cause**                                                                                                                                                                 
                                               
`SwitchProps` exposed `size` only indirectly via `SlotRecipeProps<"nimbusSwitch">`, which resolves correctly only when Chakra UI's theme typegen has been run in the consuming project. 
Without it, TS falls back to `{ recipe?: SlotRecipeDefinition }`, a type with no size key, therefore making the prop invisible to consumers.
                                                                                                                                                                             
**Fix**                                          

Added `size?: "sm" | "md"` explicitly to `SwitchProps`, following the same pattern used by other Nimbus components (eg `Button`). This makes the prop unconditionally visible - regardless of whether the consumer has run theme typegen.
                                                                                                                                                                             

⚠️  Suspected to be a wider impact that needs additional research for proper resolve. 
In addition to `Switch`, the same pattern of relying on Chakra's generated files exist in the following components: 
`Heading` -> `size`
`Accordion.Root` -> `size`
`Table.Root` -> `size, variant`
`List.Root` -> `variant`
`Code(?)` -> `variant, size`
`Separator` -> `orientation` 

********
Testing approach:

1. Added `<Switch size="sm">` to `apps/blank-app` as a consumer test case                                                                                                      
2. Simulated the consumer environment by commenting out the nimbusSwitch entry in
  `packages/nimbus/node_modules/@chakra-ui/react/dist/types/styled-system/generated/recipes.gen.d.ts` (the file Chakra generates via build-theme-typings, which a real external consumer's project would not have populated with nimbus recipes)
3. Confirmed the TS2322 error was reproduced                                                                                    
4. Rebuilt the nimbus package to apply the fix to dist/
5. Re-ran typecheck —> no errors

