### PR TITLE
fix: notify tx team workflow

### DIFF
--- a/.github/workflows/notify-localization-team.yml
+++ b/.github/workflows/notify-localization-team.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Post localization reminder
         run: |
           EXISTING=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
             --json comments \
             --jq '[.comments[] | select(.body | contains("localization ticket"))] | length')
 
@@ -24,7 +25,7 @@ jobs:
             exit 0
           fi
 
-          gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'EOF'
+          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$(cat <<'EOF'
           **Localization reminder:** This PR adds or modifies \`.i18n.ts\` files.
 
           Please create a Jira ticket for the localization manager to initiate translation of any new or updated strings in Transifex. See [LOC-1766](https://commercetools.atlassian.net/browse/LOC-1766) as an example.


### PR DESCRIPTION
Fixes an issue where gh CLI falls back to git remote to identify the repo, which fails with "not a git repository" when no checkout step has run. 

Adding --repo ${{ github.repository }} to both gh pr view and gh pr comment makes them target the repo explicitly