### PR TITLE
chore(claude): wire utils-and-constants into validation pipeline

### DIFF
--- a/.claude/agents/nimbus-coder.md
+++ b/.claude/agents/nimbus-coder.md
@@ -123,12 +123,13 @@ See
 - Barrel exports and index files
 
 **Pure utility functions (non-React, no JSX) MUST live in a `utils/` subfolder
-of the component**, with one function per file, a sibling `{name}.spec.ts`, and
-a `utils/index.ts` barrel. NEVER export utility functions from
-`{component}.tsx`. See `docs/file-type-guidelines/utils-and-constants.md` and
-existing patterns in `combobox/utils/`, `inline-svg/utils/`,
-`money-input/utils/`. Invoke the `writing-utils-and-constants` skill for these
-files.
+of the component**, organized per the merge rule in
+`docs/file-type-guidelines/utils-and-constants.md#file-organization` (solo files
+for unrelated helpers, family files for cohesive sets), with a sibling
+`{name}.spec.ts` per util file and a `utils/index.ts` barrel. NEVER export
+utility functions from `{component}.tsx`. See existing patterns in
+`combobox/utils/`, `inline-svg/utils/`, `money-input/utils/`. Invoke the
+`writing-utils-and-constants` skill for these files.
 
 **INVOKE skills:**
 

--- a/.claude/agents/nimbus-coder.md
+++ b/.claude/agents/nimbus-coder.md
@@ -78,6 +78,7 @@ is to orchestrate these skills, not replace them.
 | `*.slots.tsx`                   | **writing-slots**                   | ALL slot component work                                    |
 | `*.stories.tsx`                 | **writing-stories**                 | ALL story creation/updates                                 |
 | `*.i18n.ts`                     | **writing-i18n**                    | When component has default aria-labels or user-facing text |
+| `utils/*.ts` + `constants/*.ts` | **writing-utils-and-constants**     | ALL pure helper / constant work in a component             |
 | `*.dev.mdx` + `*.docs.spec.tsx` | **writing-developer-documentation** | ALL developer documentation                                |
 | `*.mdx` (designer)              | **writing-designer-documentation**  | ALL designer documentation                                 |
 
@@ -115,11 +116,19 @@ See
 
 **YOU code directly:**
 
-- Main component implementation files (`{component}.tsx`)
+- Main component implementation files (`{component}.tsx`) — these contain the
+  React component ONLY, never pure helpers
 - Component-specific logic and hooks
-- Utility functions colocated with components
 - Integration of slot components with React Aria
 - Barrel exports and index files
+
+**Pure utility functions (non-React, no JSX) MUST live in a `utils/` subfolder
+of the component**, with one function per file, a sibling `{name}.spec.ts`, and
+a `utils/index.ts` barrel. NEVER export utility functions from
+`{component}.tsx`. See `docs/file-type-guidelines/utils-and-constants.md` and
+existing patterns in `combobox/utils/`, `inline-svg/utils/`,
+`money-input/utils/`. Invoke the `writing-utils-and-constants` skill for these
+files.
 
 **INVOKE skills:**
 

--- a/.claude/agents/nimbus-reviewer.md
+++ b/.claude/agents/nimbus-reviewer.md
@@ -42,6 +42,7 @@ compliance checks.
 | `*.slots.tsx`                   | **writing-slots**                   | `writing-slots validate ComponentName`                   |
 | `*.stories.tsx`                 | **writing-stories**                 | `writing-stories validate ComponentName`                 |
 | `*.i18n.ts`                     | **writing-i18n**                    | `writing-i18n validate ComponentName`                    |
+| `utils/*.ts` + `constants/*.ts` | **writing-utils-and-constants**     | `writing-utils-and-constants validate ComponentName`     |
 | `*.dev.mdx` + `*.docs.spec.tsx` | **writing-developer-documentation** | `writing-developer-documentation validate ComponentName` |
 | `*.mdx` (designer)              | **writing-designer-documentation**  | `writing-designer-documentation validate ComponentName`  |
 

--- a/.claude/skills/writing-main-component/SKILL.md
+++ b/.claude/skills/writing-main-component/SKILL.md
@@ -147,7 +147,7 @@ You MUST validate main component files against these requirements organized by
 category. Each violation MUST be reported with specific line numbers and
 guideline references.
 
-#### Category 1: File Structure & Architecture (6 items)
+#### Category 1: File Structure & Architecture (7 items)
 
 - [ ] **File location**: Component file exists at correct location:
       `packages/nimbus/src/components/{component}/{component}.tsx`
@@ -161,6 +161,15 @@ guideline references.
 - [ ] **DisplayName**: Component has `displayName` set correctly:
   - Single: `Component.displayName = "ComponentName"`
   - Compound part: `ComponentPart.displayName = "Component.Part"`
+- [ ] **No utility exports**: Main component file MUST NOT export pure helper
+      functions (non-React, non-component values). Pure functions live in
+      `utils/{kebab-name}.ts` with a sibling `{kebab-name}.spec.ts` and an
+      `utils/index.ts` barrel — see
+      `docs/file-type-guidelines/utils-and-constants.md` and existing patterns
+      in `combobox/utils/`, `inline-svg/utils/`, `money-input/utils/`.
+      Detection: any `export function name(...)` or
+      `export const name = (...) => ...` where the return value is not JSX is a
+      utility, not a component.
 
 #### Category 2: Component Type & Pattern (7 items)
 
@@ -333,7 +342,7 @@ guideline references.
 - [ ] **Build succeeds**: Component builds without errors:
       `pnpm --filter @commercetools/nimbus build`
 
-### Total Validation Items: 63 across 10 categories
+### Total Validation Items: 64 across 10 categories
 
 ---
 
@@ -367,9 +376,9 @@ When validation completes, you MUST provide a report in this format:
 
 ---
 
-### ✅ Compliant (X/62)
+### ✅ Compliant (X/64)
 
-**Category 1: File Structure & Architecture (X/6)**
+**Category 1: File Structure & Architecture (X/7)**
 
 - [✓] Item description
 - [✓] Item description

--- a/.claude/skills/writing-utils-and-constants/SKILL.md
+++ b/.claude/skills/writing-utils-and-constants/SKILL.md
@@ -1,0 +1,338 @@
+---
+description: Create, update, or validate component-scoped utility functions and constants
+argument-hint: create|update|validate ComponentName [details]
+---
+
+# Writing Utils and Constants Skill
+
+You are a Nimbus utilities specialist. This skill helps you create, update, or
+validate component-scoped pure helper functions in `utils/` and constants in
+`constants/`.
+
+## Critical Requirements
+
+**Pure helper functions MUST NOT be inlined into the main component file
+(`{component}.tsx`).** Every component-scoped utility lives in `utils/` with
+its own file, its own spec, and is re-exported through a barrel.
+
+Patterns enforced:
+
+- One function per file (kebab-case filename matches the function name)
+- Sibling `*.spec.ts` per util (Vitest, JSDOM)
+- `utils/index.ts` barrel re-exporting every util
+- Pure functions only — no React, no JSX, no side effects
+- JSDoc on every export
+- `as const` for constants
+
+---
+
+## Mode Detection
+
+Parse the request to determine the operation:
+
+- **create** — Generate new utility/constant files for a component
+- **update** — Modify existing utilities or move inlined helpers into `utils/`
+- **validate** — Check compliance with guidelines (**PRIMARY USE CASE**)
+
+If no mode is specified, default to **validate**.
+
+---
+
+## Required Research (All Modes)
+
+Before any operation, you MUST read in parallel:
+
+1. **Utils and constants guidelines**:
+   `docs/file-type-guidelines/utils-and-constants.md`
+2. **Unit testing strategy**:
+   `docs/file-type-guidelines/unit-testing.md`
+3. **Existing patterns** (study at least one):
+   - `packages/nimbus/src/components/combobox/utils/` — multi-file utils with
+     specs (`filters.ts` + `filters.spec.ts`, `selection.ts` +
+     `selection.spec.ts`, `collection.ts` + `collection.spec.ts`)
+   - `packages/nimbus/src/components/inline-svg/utils/sanitize-svg.ts` — single
+     util with sibling spec
+   - `packages/nimbus/src/components/money-input/utils/` — utils plus an index
+     barrel re-exporting multiple helpers
+
+---
+
+## File Structure
+
+```
+packages/nimbus/src/components/{component}/
+├── {component}.tsx
+├── utils/
+│   ├── {kebab-name}.ts          # one function per file
+│   ├── {kebab-name}.spec.ts     # sibling unit test
+│   └── index.ts                 # barrel re-export
+├── constants/                   # only when constants are needed
+│   ├── {kebab-name}.ts
+│   └── index.ts
+```
+
+### Naming Convention
+
+- File name is kebab-case of the function/constant: `getInitials` lives in
+  `get-initials.ts`. `MAX_FILE_SIZE` lives in `max-file-size.ts` (or grouped
+  by topic: `validation-limits.ts`).
+- Spec file mirrors the source file with a `.spec.ts` suffix.
+
+---
+
+## Validate Mode
+
+### Validation Checklist
+
+Validate against these requirements. Each violation MUST be reported with the
+specific file path and line number.
+
+#### Category 1: Location & Inlining (3 items)
+
+- [ ] **No inlined utils in main file**: `{component}.tsx` MUST NOT export pure
+      helper functions. Detection: any `export function name(...)` or
+      `export const name = (...) => ...` whose return value is not JSX is a
+      utility and belongs in `utils/`.
+- [ ] **Utils folder exists**: If the component has utilities, they live under
+      `packages/nimbus/src/components/{component}/utils/`.
+- [ ] **Constants folder exists** (if applicable): Constants live under
+      `packages/nimbus/src/components/{component}/constants/`.
+
+#### Category 2: File Organization (4 items)
+
+- [ ] **One function per file**: Each utility lives in its own
+      `{kebab-name}.ts` file. Bundling unrelated helpers in a single file is a
+      violation; bundling closely-related helpers (e.g. several pure
+      collection-traversal helpers) into a topic file is acceptable.
+- [ ] **Kebab-case filename**: File name matches the function/topic name in
+      kebab-case.
+- [ ] **Index barrel**: `utils/index.ts` re-exports every util:
+      `export { getInitials } from "./get-initials";`
+- [ ] **Constants index barrel** (if applicable): `constants/index.ts`
+      re-exports every constant.
+
+#### Category 3: Purity (4 items)
+
+- [ ] **No React imports**: Util files MUST NOT import React, hooks, or any
+      `react-aria` modules. If you need React, it's a hook — move it to
+      `hooks/` instead.
+- [ ] **No JSX**: Util files MUST NOT return JSX. Files containing JSX are
+      components, not utilities.
+- [ ] **No side effects at module level**: Top-level statements must be
+      `import`, `export`, type definitions, or `const` declarations. No
+      mutation, no I/O, no DOM access at module scope.
+- [ ] **Deterministic**: Pure functions — same input always yields same
+      output, no reliance on `Date.now()`, `Math.random()`, or external state
+      (unless explicitly passed as a parameter).
+
+#### Category 4: Documentation (2 items)
+
+- [ ] **JSDoc on every export**: Each exported function/constant has a JSDoc
+      block explaining purpose, parameter contracts, and any non-obvious
+      behavior (e.g. codepoint safety, locale handling).
+- [ ] **No "WHAT" comments**: JSDoc explains WHY/contracts. Don't restate the
+      function signature in prose.
+
+#### Category 5: Type Safety (3 items)
+
+- [ ] **Explicit parameter types**: All parameters typed (TypeScript may
+      infer; the export signature should still be explicit).
+- [ ] **`as const` for constants**: Constants use `as const` assertions for
+      narrowest types.
+- [ ] **No `any`**: No `any` types without an inline comment justifying the
+      use.
+
+#### Category 6: Testing (4 items)
+
+- [ ] **Sibling spec exists**: Every `{name}.ts` has a sibling
+      `{name}.spec.ts` (Vitest, JSDOM).
+- [ ] **Edge case coverage**: Tests cover empty/undefined/null inputs,
+      boundary values, and codepoint-sensitive cases (emoji surrogate pairs,
+      CJK, RTL) where applicable.
+- [ ] **Imports from sibling**: Spec imports the unit under test from
+      `./{name}`, NOT from a barrel or the main component file.
+- [ ] **Tests pass**: `pnpm test:dev packages/nimbus/src/components/{component}/utils/`
+      reports 0 failures.
+
+### Total Validation Items: 20 across 6 categories
+
+---
+
+## Validation Report Format
+
+```markdown
+## Utils & Constants Validation: {ComponentName}
+
+### Status: [✅ PASS | ❌ FAIL | ⚠️ WARNING]
+
+### Files Reviewed
+
+- Utils dir: `packages/nimbus/src/components/{component}/utils/`
+- Constants dir: `packages/nimbus/src/components/{component}/constants/` (if
+  applicable)
+- Main file scanned for inlined helpers:
+  `packages/nimbus/src/components/{component}/{component}.tsx`
+
+---
+
+### ✅ Compliant (X/20)
+
+[Per category breakdown]
+
+---
+
+### ❌ Violations (MUST FIX)
+
+- **`{file}:{line}`**: [violation description]
+  - **Guideline**: [reference to utils-and-constants.md section or this
+    skill's checklist]
+  - **Fix**: [how to resolve, including target file path]
+
+---
+
+### ⚠️ Warnings (SHOULD FIX)
+
+[Same format as violations]
+
+---
+
+### Next Steps
+
+1. Fix all ❌ violations first
+2. Run tests: `pnpm test:dev packages/nimbus/src/components/{component}/utils/`
+3. Re-validate: `writing-utils-and-constants validate {ComponentName}`
+```
+
+---
+
+## Create Mode
+
+### Process
+
+1. Identify the helpers to extract (from a feature spec or from inlined code
+   in `{component}.tsx`).
+2. For each helper:
+   - Create `utils/{kebab-name}.ts` with the function and JSDoc.
+   - Create `utils/{kebab-name}.spec.ts` with edge-case coverage.
+3. Create or update `utils/index.ts` to re-export every helper.
+4. If constants are needed, mirror the same structure under `constants/`.
+5. Update `{component}.tsx` to import from `./utils` (and `./constants`).
+6. Run `pnpm test:dev packages/nimbus/src/components/{component}/utils/` to
+   verify.
+
+### Util File Template
+
+```typescript
+/**
+ * {One-paragraph WHY: contract, edge cases, non-obvious behavior.}
+ */
+export function {functionName}({params}): {ReturnType} {
+  // implementation
+}
+```
+
+### Spec File Template
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { {functionName} } from "./{kebab-name}";
+
+describe("{functionName}", () => {
+  it("{primary contract description}", () => {
+    expect({functionName}({inputs})).toBe({expected});
+  });
+
+  it("handles {edge case}", () => {
+    expect({functionName}({edge inputs})).toBe({expected});
+  });
+
+  // ...edge cases: empty, undefined, boundary, codepoint, etc.
+});
+```
+
+### Constant File Template
+
+```typescript
+/**
+ * {One-paragraph WHY: where this is used, why this value.}
+ */
+export const { CONSTANT_NAME } = { value } as const;
+```
+
+---
+
+## Update Mode
+
+### Common Scenarios
+
+#### Scenario 1: Move inlined helpers out of main component
+
+**Trigger**: Validate mode flagged `export function ...` in `{component}.tsx`.
+
+**Steps**:
+
+1. For each inlined helper, create `utils/{kebab-name}.ts` and copy the
+   function + JSDoc.
+2. If a `{component}.spec.tsx` exists with describe blocks for these
+   functions, split each describe block into its own
+   `utils/{kebab-name}.spec.ts` and update the import path to
+   `./{kebab-name}`.
+3. Create or update `utils/index.ts` with re-exports.
+4. Update `{component}.tsx` to `import { ... } from "./utils";` and remove
+   the inlined definitions.
+5. Delete the now-redundant `{component}.spec.tsx` (or trim it down to
+   anything component-level that legitimately needs JSDOM).
+6. Run `pnpm test:dev packages/nimbus/src/components/{component}/` to verify.
+7. Run `pnpm --filter @commercetools/nimbus typecheck` to verify.
+
+#### Scenario 2: Add a new helper to an existing utils folder
+
+**Steps**:
+
+1. Create `utils/{new-name}.ts` and `utils/{new-name}.spec.ts`.
+2. Add the re-export line to `utils/index.ts`.
+3. Run tests.
+
+---
+
+## Error Recovery
+
+### Error 1: "Can't import from barrel — circular dependency"
+
+**Cause**: A util file imports from `@/components` or another barrel that
+indirectly references the same component.
+
+**Fix**: Utils should be self-contained. If a util needs a type from another
+component, import directly from the implementation file:
+`import type { Foo } from "../../button/button.types";`
+
+### Error 2: "Spec file can't find function"
+
+**Cause**: Spec imports from `./` (folder index) instead of the sibling file.
+
+**Fix**: Specs MUST import from the sibling source file:
+`import { getInitials } from "./get-initials";` (NOT from `./index`).
+
+### Error 3: "JSX in utility file" / TypeScript error on JSX syntax
+
+**Cause**: The "utility" actually returns React elements — it's a component
+or a hook, not a util.
+
+**Fix**: Move it to the appropriate location:
+
+- Returns JSX → component file
+- Uses React hooks but doesn't return JSX → `hooks/` folder, named
+  `use-{name}.ts`
+
+---
+
+## Related Guidelines
+
+- `docs/file-type-guidelines/utils-and-constants.md` — The canonical reference
+- `docs/file-type-guidelines/hooks.md` — When to use hooks instead of utils
+- `docs/file-type-guidelines/unit-testing.md` — Vitest conventions
+- `docs/file-type-guidelines/main-component.md` — What stays in the main file
+
+---
+
+**Execute utils-and-constants operation for component specified in arguments**

--- a/.claude/skills/writing-utils-and-constants/SKILL.md
+++ b/.claude/skills/writing-utils-and-constants/SKILL.md
@@ -113,7 +113,8 @@ specific file path and line number.
       Banned: `helpers.ts`, `utils.ts`, `misc.ts`, or naming a merged file
       after a single export. Promotable and component-coupled helpers do not
       belong in the same file. See
-      [Merge Rule & File Naming](#merge-rule--file-naming) for the procedure.
+      [File Organization](../../../docs/file-type-guidelines/utils-and-constants.md#file-organization)
+      in `utils-and-constants.md` for the full rule.
 - [ ] **Kebab-case filename**: File name matches the function/topic name in
       kebab-case.
 - [ ] **Index barrel**: `utils/index.ts` re-exports every util:

--- a/.claude/skills/writing-utils-and-constants/SKILL.md
+++ b/.claude/skills/writing-utils-and-constants/SKILL.md
@@ -17,12 +17,16 @@ its own file, its own spec, and is re-exported through a barrel.
 
 Patterns enforced:
 
-- One function per file (kebab-case filename matches the function name)
-- Sibling `*.spec.ts` per util (Vitest, JSDOM)
+- One purpose per file; cohesive helpers merge into a single file when they
+  share a meaningful name token, have a factory relationship, or form a direct
+  dependency chain — see [File Organization](../../../docs/file-type-guidelines/utils-and-constants.md#file-organization)
+  in `utils-and-constants.md` for the canonical rule
+- Sibling `*.spec.ts` per util file (one source file = one spec file)
 - `utils/index.ts` barrel re-exporting every util
 - Pure functions only — no React, no JSX, no side effects
 - JSDoc on every export
 - `as const` for constants
+- Don't mix promotable and component-coupled helpers in the same file
 
 ---
 
@@ -63,7 +67,7 @@ Before any operation, you MUST read in parallel:
 packages/nimbus/src/components/{component}/
 ├── {component}.tsx
 ├── utils/
-│   ├── {kebab-name}.ts          # one function per file
+│   ├── {kebab-name}.ts          # one purpose per file (see Merge Rule)
 │   ├── {kebab-name}.spec.ts     # sibling unit test
 │   └── index.ts                 # barrel re-export
 ├── constants/                   # only when constants are needed
@@ -100,10 +104,16 @@ specific file path and line number.
 
 #### Category 2: File Organization (4 items)
 
-- [ ] **One function per file**: Each utility lives in its own
-      `{kebab-name}.ts` file. Bundling unrelated helpers in a single file is a
-      violation; bundling closely-related helpers (e.g. several pure
-      collection-traversal helpers) into a topic file is acceptable.
+- [ ] **One purpose per file**: A solo helper lives in its own
+      `{kebab-name}.ts`. Cohesive helpers merge into a single file when
+      (1) they share a meaningful name token (≥4 chars after dropping generic
+      verbs and connectors), (2) one is a factory for another's signature, or
+      (3) they form a direct dependency chain. Merged files are named for the
+      shared token (agent-noun pluralized: `filters.ts`, `validators.ts`).
+      Banned: `helpers.ts`, `utils.ts`, `misc.ts`, or naming a merged file
+      after a single export. Promotable and component-coupled helpers do not
+      belong in the same file. See
+      [Merge Rule & File Naming](#merge-rule--file-naming) for the procedure.
 - [ ] **Kebab-case filename**: File name matches the function/topic name in
       kebab-case.
 - [ ] **Index barrel**: `utils/index.ts` re-exports every util:
@@ -202,6 +212,53 @@ specific file path and line number.
 2. Run tests: `pnpm test:dev packages/nimbus/src/components/{component}/utils/`
 3. Re-validate: `writing-utils-and-constants validate {ComponentName}`
 ```
+
+---
+
+## Merge Rule Reference
+
+The canonical merge rule — three criteria (shared meaningful name token /
+factory relationship / direct dependency), file-naming formula, coupling
+constraint, scope-agnostic application, promotion guidance, no reverse-merge,
+forward-applied scope, and barrel-stability contract — lives in
+[`docs/file-type-guidelines/utils-and-constants.md` → File Organization](../../../docs/file-type-guidelines/utils-and-constants.md#file-organization).
+That document is the source of truth. Load it before applying the rule (it is
+already in the [Required Research](#required-research-all-modes) list above).
+
+One-line summary for quick reference: **merge into a single family file when
+helpers share a meaningful name token (≥4 chars after dropping generic verbs
+and connectors), when one is a factory for another's signature, or when one
+directly depends on the other. Otherwise solo files. Banned filenames:
+`helpers.ts`, `utils.ts`, `misc.ts`.**
+
+---
+
+## Procedure: Adding a Helper to `utils/`
+
+When adding a new helper:
+
+1. **List existing files** in the folder, with their exports.
+2. **Tokenize the new helper's name** (camelCase boundary).
+3. **For each existing helper**, compute shared content tokens:
+   - Drop connectors (`By`, `For`, `From`, `To`, `With`) and generic verbs
+     (`get`, `is`, `has`, `set`, `add`, `do`, `make`)
+   - Require ≥4 chars
+4. **Check each merge criterion** (shared token / factory relationship /
+   direct dependency) against each existing helper.
+5. **If any criterion fires**, merge into a single file named per the
+   file-naming rule. The PR that adds the connecting helper does the rename
+   and barrel update — not punted as follow-up.
+6. **Update the sibling `*.spec.ts`** the same way (one source file = one
+   spec file).
+7. **Update `utils/index.ts`** barrel.
+8. **Search the component** for any deep imports of renamed files and update
+   them.
+
+The PR that adds a connecting helper performs the rename and barrel update —
+not punted as follow-up. See
+[Scope, Promotion, and Degenerate States](../../../docs/file-type-guidelines/utils-and-constants.md#scope-promotion-and-degenerate-states)
+in the docs for promotion semantics, no-reverse-merge, forward-applied scope,
+and barrel-stability constraints.
 
 ---
 

--- a/.claude/skills/writing-utils-and-constants/SKILL.md
+++ b/.claude/skills/writing-utils-and-constants/SKILL.md
@@ -242,7 +242,8 @@ When adding a new helper:
 2. **Tokenize the new helper's name** (camelCase boundary).
 3. **For each existing helper**, compute shared content tokens:
    - Drop connectors (`By`, `For`, `From`, `To`, `With`) and generic verbs
-     (`get`, `is`, `has`, `set`, `add`, `do`, `make`)
+     (`get`, `is`, `has`, `set`, `add`, `do`, `make`, `build`, `create`,
+     `extract`, `find`, `try`)
    - Require ≥4 chars
 4. **Check each merge criterion** (shared token / factory relationship /
    direct dependency) against each existing helper.

--- a/docs/component-guidelines.md
+++ b/docs/component-guidelines.md
@@ -213,8 +213,9 @@ component-name/
 ├── hooks/                        # Component hooks (if needed)
 │   ├── use-something.ts
 │   └── index.ts
-├── utils/                        # Utilities (if needed)
-│   ├── helpers.ts
+├── utils/                        # Utilities (if needed; see utils-and-constants.md#file-organization)
+│   ├── formatters.ts             # family file (multiple format helpers)
+│   ├── get-initials.ts           # solo helper (no family yet)
 │   ├── component-name.test-data.ts   # Test fixtures/mock data (if needed)
 │   ├── component-name.test-utils.ts  # Test helper functions (if needed)
 │   ├── component-name.test-component.tsx # Test wrapper components (if needed)

--- a/docs/component-templates/index.md
+++ b/docs/component-templates/index.md
@@ -146,7 +146,7 @@ date-picker/
 ├── hooks/
 │   └── use-date-picker.ts
 ├── utils/
-│   └── date-helpers.ts
+│   └── formatters.ts
 ├── constants/
 │   └── calendar-config.ts
 └── date-picker-context.tsx

--- a/docs/file-type-guidelines/barrel-exports.md
+++ b/docs/file-type-guidelines/barrel-exports.md
@@ -104,7 +104,7 @@ export type { SelectProps, SelectOption } from "./select.types";
 
 // These remain private (not exported):
 // - ./hooks/use-select-internal.ts
-// - ./utils/select-helpers.ts
+// - ./utils/select-filters.ts
 // - ./components/select-internal-part.tsx
 ```
 

--- a/docs/file-type-guidelines/main-component.md
+++ b/docs/file-type-guidelines/main-component.md
@@ -366,7 +366,34 @@ export const Menu = {
 };
 ```
 
-### 3. DisplayName Convention
+### 3. Pure Helpers Live in `utils/`, Not in the Main File
+
+The main component file MUST contain only the React component(s) it owns. Any
+`export function name(...)` or `export const name = (...) => ...` whose return
+value is **not JSX** is a utility and MUST live in `utils/{kebab-name}.ts`
+instead. See [Utils & Constants](./utils-and-constants.md) for the file shape.
+
+This applies regardless of whether the helper is used once or many times — the
+moment it's exported, it's part of an API surface and belongs in the
+convention-bearing location. A locally-scoped, non-exported `const helper = ...`
+inside the component function body is acceptable.
+
+```typescript
+// ✅ CORRECT — utility in utils/, component imports it
+// avatar/utils/get-initials.ts
+export function getInitials(firstName?: string, lastName?: string) {
+  /* ... */
+}
+
+// avatar/avatar.tsx
+import { getInitials } from "./utils";
+export const Avatar = (props: AvatarProps) => {
+  const initials = getInitials(props.firstName, props.lastName);
+  /* ... */
+};
+```
+
+### 4. DisplayName Convention
 
 Always set displayName for debugging:
 
@@ -1114,6 +1141,10 @@ export const CustomButton = (props: CustomButtonProps) => {
 - [ ] Types re-exported appropriately
 - [ ] i18n messages imported if component has user-facing text
 - [ ] All aria-labels use msg.format()
+- [ ] **No utility exports** — pure helpers (any `export function` or
+      `export const` whose return value is not JSX) MUST live in
+      `utils/{kebab-name}.ts`, not in the main component file. See
+      [Utils & Constants](./utils-and-constants.md).
 
 ### JSDoc Documentation
 

--- a/docs/file-type-guidelines/utils-and-constants.md
+++ b/docs/file-type-guidelines/utils-and-constants.md
@@ -91,8 +91,14 @@ of these criteria hold. Otherwise the new helper gets its own file.
 
 Tokenize each name by camelCase boundary. Drop **connectors** (`By`, `For`,
 `From`, `To`, `With`) and **generic verbs** (`get`, `is`, `has`, `set`, `add`,
-`do`, `make`). If any remaining content token of ≥4 characters appears in both
-names, merge.
+`do`, `make`, `build`, `create`, `extract`, `find`, `try`). If any remaining
+content token of ≥4 characters appears in both names, merge.
+
+The generic-verb list is intentionally narrow: a verb belongs on it only when it
+carries no domain meaning on its own (`getThing` and `extractThing` say nothing
+about each other beyond "operates on Thing"). When in doubt, leave the verb as a
+content token — false-negative merges create churn but no incorrect groupings;
+false-positive merges put unrelated helpers in the same file.
 
 | Existing          | New             | Shared content tokens | Merge?               |
 | ----------------- | --------------- | --------------------- | -------------------- |

--- a/docs/file-type-guidelines/utils-and-constants.md
+++ b/docs/file-type-guidelines/utils-and-constants.md
@@ -30,8 +30,25 @@ non-React logic and static values.
 ### When Utils/Constants Aren't Needed:
 
 - Logic requires React features (use hooks instead)
-- Values are used only once
-- Simple constants (keep in component file)
+- The value is local to a single function body and never exported (a `const`
+  inside the component function is fine)
+- Simple non-exported constants used in one place
+
+## Same Structure for Global and Component-Scoped Utils
+
+The conventions in this document apply identically to:
+
+- **Component-scoped utils**:
+  `packages/nimbus/src/components/{component}/utils/`
+- **Global utils**: `packages/nimbus/src/utils/`
+
+Same file shape (one util per kebab-case file, sibling `*.spec.ts`, `index.ts`
+barrel, JSDoc, pure functions, `as const` for constants). When a
+component-scoped util turns out to be reusable, promotion to global utils is a
+`git mv` — no rewrite, no shape change. Many component-scoped utils are
+inherently too specific to ever be shared, and that is fine; the structural
+parity exists for the cases where promotion is sensible, not as a forced
+migration path.
 
 ## Directory Structure
 
@@ -128,15 +145,18 @@ parameter and return type definitions.
 
 ## Validation Checklist
 
-- [ ] Utils in `utils/` subfolder
+- [ ] Utils in `utils/` subfolder (component-scoped) or
+      `packages/nimbus/src/utils/` (global)
 - [ ] Constants in `constants/` subfolder
-- [ ] Pure functions (no React features in utils)
+- [ ] **One function per kebab-case file** (`get-initials.ts`, `merge-refs.ts`);
+      related helpers MAY share a topic file when tightly coupled
+- [ ] **Sibling `{name}.spec.ts`** for every util file
+- [ ] Pure functions (no React features in utils, no JSX, no side effects at
+      module scope)
 - [ ] Immutable constants with `as const`
 - [ ] JSDoc documentation for all exports
 - [ ] Type-safe function signatures
-- [ ] No side effects in utils
-- [ ] Index files export all items
-- [ ] Tests for complex utilities
+- [ ] `index.ts` barrel re-exports every item
 - [ ] Meaningful, descriptive names
 
 ---

--- a/docs/file-type-guidelines/utils-and-constants.md
+++ b/docs/file-type-guidelines/utils-and-constants.md
@@ -42,23 +42,25 @@ The conventions in this document apply identically to:
   `packages/nimbus/src/components/{component}/utils/`
 - **Global utils**: `packages/nimbus/src/utils/`
 
-Same file shape (one util per kebab-case file, sibling `*.spec.ts`, `index.ts`
+Same file shape (one purpose per file with the merge rule defined in
+[File Organization](#file-organization) below, sibling `*.spec.ts`, `index.ts`
 barrel, JSDoc, pure functions, `as const` for constants). When a
 component-scoped util turns out to be reusable, promotion to global utils is a
-`git mv` — no rewrite, no shape change. Many component-scoped utils are
-inherently too specific to ever be shared, and that is fine; the structural
-parity exists for the cases where promotion is sensible, not as a forced
-migration path.
+`git mv` — no rewrite, no shape change. Promote whole files, never members;
+splitting a family across scope boundaries is a code smell. Many
+component-scoped utils are inherently too specific to ever be shared, and that
+is fine; the structural parity exists for the cases where promotion is sensible,
+not as a forced migration path.
 
 ## Directory Structure
 
-```
+```text
 component-name/
 ├── component-name.tsx
 ├── utils/
-│   ├── formatters.ts
-│   ├── validators.ts
-│   ├── helpers.ts
+│   ├── formatters.ts        # family file (multiple format helpers)
+│   ├── validators.ts        # family file (multiple validate helpers)
+│   ├── get-initials.ts      # solo helper (no family yet)
 │   └── index.ts
 ├── constants/
 │   ├── defaults.ts
@@ -67,6 +69,110 @@ component-name/
 │   └── index.ts
 └── index.ts
 ```
+
+Family files (`formatters.ts`, `validators.ts`) and solo files
+(`get-initials.ts`) coexist. The shape is determined by the merge rule defined
+in [File Organization](#file-organization) below; grab-bag names like
+`helpers.ts`, `utils.ts`, or `misc.ts` are not allowed.
+
+## File Organization
+
+A `utils/` folder mixes solo files (one helper, one file) and family files
+(multiple cohesive helpers in one file). The choice is mechanical, not
+judgmental.
+
+### One Purpose Per File
+
+A solo helper lives in its own kebab-case file (`get-initials.ts`,
+`merge-refs.ts`). Cohesive helpers merge into a single family file when **any**
+of these criteria hold. Otherwise the new helper gets its own file.
+
+#### Criterion 1: Shared Meaningful Name Token
+
+Tokenize each name by camelCase boundary. Drop **connectors** (`By`, `For`,
+`From`, `To`, `With`) and **generic verbs** (`get`, `is`, `has`, `set`, `add`,
+`do`, `make`). If any remaining content token of ≥4 characters appears in both
+names, merge.
+
+| Existing          | New             | Shared content tokens | Merge?               |
+| ----------------- | --------------- | --------------------- | -------------------- |
+| `filterByText`    | `filterByFuzzy` | `filter`              | ✅ → `filters.ts`    |
+| `parseColor`      | `formatColor`   | `Color`               | ✅ → `color.ts`      |
+| `validateEmail`   | `validatePhone` | `validate`            | ✅ → `validators.ts` |
+| `getNameInitials` | `getFullName`   | `Name`                | ✅ → `name.ts`       |
+| `getInitials`     | `getFullName`   | (only `get`, generic) | ❌ stay separate     |
+| `filterByText`    | `parseColor`    | none                  | ❌ stay separate     |
+
+#### Criterion 2: Factory Relationship
+
+A factory whose return value matches a sibling helper's signature belongs in the
+same file. Example: `createMultiTermFilter()` returns
+`(nodes, input) => filtered`, and `filterByText` matches that signature → same
+file.
+
+#### Criterion 3: Direct Dependency
+
+If helper A imports or calls helper B from the same `utils/` folder, they go in
+the same file.
+
+### File Naming on Merge
+
+The merged file is named for the **shared token, agent-noun form, pluralized**:
+
+- verb-token → agent-noun pluralized: `filter` → `filters.ts`, `parse` →
+  `parsers.ts`, `validate` → `validators.ts`, `format` → `formatters.ts`
+- noun-token → keep singular: `color` → `color.ts`, `currency` → `currency.ts`
+
+**Banned filenames**: `helpers.ts`, `utils.ts`, `misc.ts`, or naming a merged
+file after a single function (`get-initials.ts` does NOT become the home for
+`getFullName`).
+
+### Coupling Rule
+
+**Don't mix promotable and component-coupled helpers in the same file.** If one
+helper's signature uses component-internal types/state and another's doesn't,
+they don't belong in the same file even if name tokens match. Component-coupled
+families use a component-prefixed name (`combobox-filters.ts`); generic families
+use the bare family name (`filters.ts`).
+
+This makes promotability mechanical: a file is promotable to
+`packages/nimbus/src/utils/` iff all its exports use only types visible at the
+global utils layer.
+
+### Scope, Promotion, and Degenerate States
+
+#### Scope-Agnostic
+
+The merge rule is scope-agnostic — same logic applies in
+`components/{name}/utils/` and `packages/nimbus/src/utils/`.
+
+#### Promotion
+
+- **Promote whole files, never members.** Splitting a family across scope
+  boundaries is a code smell — usually it means the family wasn't really a
+  family, or the coupling rule was violated upstream.
+- Promotion is itself a write to a `utils/` folder; the merge rule may fire at
+  the destination (e.g., promoting two solo helpers that share a token merges
+  them at the destination).
+
+#### No Reverse-Merge
+
+If a family file shrinks to one export after deletions, do **not** automatically
+rename it back to a solo file. A single-export family file is a tolerated
+degenerate state — the family may grow back, and reverse-merging on every
+deletion creates churn for nothing.
+
+#### Forward-Applied Only
+
+Existing components with the older convention do **not** need a retroactive
+sweep. The rule fires when someone next touches a `utils/` folder; consistency
+converges over time without a one-shot migration.
+
+#### Barrel Is the Stable Contract
+
+All imports into the package go through `utils/index.ts`. Deep imports of
+specific util filenames are not part of the public contract, so file-level
+renames are non-breaking.
 
 ## Utils Patterns
 
@@ -148,8 +254,11 @@ parameter and return type definitions.
 - [ ] Utils in `utils/` subfolder (component-scoped) or
       `packages/nimbus/src/utils/` (global)
 - [ ] Constants in `constants/` subfolder
-- [ ] **One function per kebab-case file** (`get-initials.ts`, `merge-refs.ts`);
-      related helpers MAY share a topic file when tightly coupled
+- [ ] **One purpose per file**: a solo helper lives in its own kebab-case file
+      (`get-initials.ts`, `merge-refs.ts`); cohesive helpers merge into a single
+      family file per the [File Organization](#file-organization) rule. Banned
+      filenames: `helpers.ts`, `utils.ts`, `misc.ts`. Promotable and
+      component-coupled helpers do not belong in the same file.
 - [ ] **Sibling `{name}.spec.ts`** for every util file
 - [ ] Pure functions (no React features in utils, no JSX, no side effects at
       module scope)


### PR DESCRIPTION
## Summary

Codifies the convention that pure helpers MUST live in `utils/{kebab-name}.ts` (component-scoped or global) rather than being inlined into the main component file, and wires the rule into the agent validation pipeline so it is enforced at write-time and review-time, not just documented. Also defines a mechanical merge rule for when sibling helpers belong in the same family file vs. their own files.

This change is in response to a real review miss: a recent Avatar PR inlined `getInitials` and `getFullName` in `avatar.tsx`. The convention was already documented in `docs/file-type-guidelines/utils-and-constants.md`, but no validation gate enforced it — the reviewer agent's file-type table had no row for `utils/`, and the `writing-main-component` checklist had no "no utility exports" item, so the inlining slipped through both write and review phases.

### What changes

**New skill** — `writing-utils-and-constants`
- Create / update / validate modes
- Validation checklist across 6 categories (location & inlining, file organization, purity, documentation, type safety, testing)
- Templates for util / spec / constant files and an Update Mode scenario for "move inlined helpers out of main component"

**Agent prompts** — `nimbus-coder` and `nimbus-reviewer`
- Add `utils/*.ts` row to the File Type → Skill mapping tables
- Disambiguate the "YOU code directly" guidance in `nimbus-coder` so utils cannot be misread as belonging in `{component}.tsx`
- Replace remaining "one function per file" guidance with a reference to the merge rule

**Existing skill** — `writing-main-component`
- Adds Category 1 item 7: "No utility exports" — flags any `export function` / `export const` in `{component}.tsx` whose return is not JSX

**Docs** — `main-component.md`, `utils-and-constants.md`, `component-guidelines.md`, `component-templates/index.md`, `barrel-exports.md`
- New Critical Rules subsection in `main-component.md` ("Pure Helpers Live in `utils/`, Not in the Main File") with a positive code example and cross-link
- New top-level **Structural Parity** section in `utils-and-constants.md` documenting parity between `packages/nimbus/src/utils/` and `components/{name}/utils/` so promotable helpers can move with `git mv`
- New top-level **File Organization** section in `utils-and-constants.md` defining the mechanical merge rule for solo vs. family files:
  - **Criterion 1**: shared content token ≥4 chars (after dropping connectors `By`/`For`/`From`/`To`/`With` and generic verbs `get`/`is`/`has`/`set`/`add`/`do`/`make`/`build`/`create`/`extract`/`find`/`try`)
  - **Criterion 2**: factory whose return signature matches a sibling
  - **Criterion 3**: direct dependency between siblings
  - Merged file is named for the shared token in agent-noun pluralized form (`filters.ts`, `validators.ts`); banned filenames: `helpers.ts`, `utils.ts`, `misc.ts`
  - Coupling rule prevents mixing promotable and component-coupled helpers in the same file
  - Forward-applied only — no retroactive sweep; barrel keeps file-level renames non-breaking
- Updated checklist in `utils-and-constants.md`: **one purpose per file** (per the merge rule), sibling `*.spec.ts` mandatory, `index.ts` barrel
- Clarified "When Utils/Constants Aren't Needed" so non-exported function-internal `const`s are explicitly acceptable
- Replaced banned `helpers.ts` / suffix-style examples in `component-guidelines.md`, `component-templates/index.md`, and `barrel-exports.md` with rule-conformant filenames

### Out of scope

Existing components that still inline pure helpers, or that use the older `helpers.ts` style, are not migrated in this PR — the merge rule is forward-applied only. The Avatar component was already migrated on its own branch as part of the original Avatar review.

## Test plan

- [ ] CI passes (no code changes — only docs/skills/agent prompts)
- [ ] Spot-check: open the new skill in `.claude/skills/writing-utils-and-constants/SKILL.md` and confirm the validation checklist reads cleanly
- [ ] Spot-check: confirm `docs/file-type-guidelines/main-component.md` Critical Rules section now lists the new rule as #3 and DisplayName Convention is renumbered to #4
- [ ] Spot-check: confirm `docs/file-type-guidelines/utils-and-constants.md` File Organization section's merge-rule examples table renders cleanly
- [ ] Verify the `writing-utils-and-constants` skill is discoverable (appears in the available-skills list when Claude Code starts)