### PR TITLE
FEC-881- CC signed commit

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_commit_signing: true
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
- Adds `use_commit_signing: true` to the CC Action workflow
- Fixes the block that prevented Claude from pushing commits to this repo, which requires verified/signed commits
- Uses GH API commit signing ([Option 1 from the Anthropic docs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md#option-1-github-api-commit-signing-use_commit_signing)) , simplest option that requires no additional secrets or key management                                                      
                                                                                                                                                                             

                                                                                                                                                                             
Test plan                                          
- After merge, trigger Claude on an issue and confirm it can create a branch, commit, and open a PR without the signed commits error                                 