### PR TITLE
chore(vite): upgrade to Vite 8 + @vitejs/plugin-react 6

### DIFF
--- a/.changeset/upgrade-vite-8.md
+++ b/.changeset/upgrade-vite-8.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Internal build toolchain upgraded to Vite 8 + Rolldown. Published JavaScript is
+6% smaller gzipped (−4.4% raw / −6.2% gzipped), with no API or behavior changes.

--- a/.changeset/upgrade-vite-8.md
+++ b/.changeset/upgrade-vite-8.md
@@ -2,5 +2,5 @@
 "@commercetools/nimbus": patch
 ---
 
-Internal build toolchain upgraded to Vite 8 + Rolldown. Published JavaScript is
-6% smaller gzipped (−4.4% raw / −6.2% gzipped), with no API or behavior changes.
+Internal build toolchain upgraded to Vite 8. Published JavaScript is 6% smaller
+gzipped (−4.4% raw / −6.2% gzipped), with no API or behavior changes.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -43,7 +43,6 @@
     "remark-mark-highlight": "^0.1.1",
     "slug": "^11.0.1",
     "use-debounce": "^10.1.1",
-    "vite-tsconfig-paths": "^6.1.1",
     "zod": "catalog:utils"
   },
   "devDependencies": {

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
 import { mdxHmrPlugin } from "./vite-plugins/vite-plugin-mdx-hmr";
-import tsconfigPaths from "vite-tsconfig-paths";
 import viteCompression from "vite-plugin-compression";
 import path from "path";
 
@@ -21,8 +20,6 @@ export default defineConfig({
       // Enable React Compiler optimizations
       plugins: [],
     }),
-    tsconfigPaths(),
-
     mdxHmrPlugin(),
     // Gzip and Brotli compression
     viteCompression({
@@ -141,6 +138,7 @@ export default defineConfig({
   optimizeDeps: {
     include: ["react", "react-dom", "jotai"],
   },
+  resolve: { tsconfigPaths: true },
   define: {
     ["process.env.REPO_ROOT"]: JSON.stringify(path.resolve(__dirname, "../..")),
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "packageManager": "pnpm@10.12.3+sha512.467df2c586056165580ad6dfb54ceaad94c5a30f80893ebdec5a44c5aa73c205ae4a5bb9d5ed6bb84ea7c249ece786642bbb49d06a307df218d03da41c317417",
   "pnpm": {
     "overrides": {
-      "rollup": "catalog:tooling",
       "@babel/runtime": "catalog:tooling",
       "prismjs": "^1.30.0",
       "typescript": "catalog:tooling",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "packageManager": "pnpm@10.12.3+sha512.467df2c586056165580ad6dfb54ceaad94c5a30f80893ebdec5a44c5aa73c205ae4a5bb9d5ed6bb84ea7c249ece786642bbb49d06a307df218d03da41c317417",
   "pnpm": {
     "overrides": {
+      "rollup": "catalog:tooling",
       "@babel/runtime": "catalog:tooling",
       "prismjs": "^1.30.0",
       "typescript": "catalog:tooling",

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -93,7 +93,6 @@
     "playwright": "catalog:tooling",
     "react": "catalog:react",
     "react-dom": "catalog:react",
-    "rollup-plugin-tree-shakeable": "catalog:tooling",
     "slate": "^0.123.0",
     "slate-history": "^0.115.0",
     "slate-hyperscript": "^0.115.0",

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -101,7 +101,6 @@
     "storybook": "catalog:tooling",
     "vite": "catalog:tooling",
     "vite-plugin-dts": "catalog:tooling",
-    "vite-tsconfig-paths": "catalog:tooling",
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -93,7 +93,6 @@
     "playwright": "catalog:tooling",
     "react": "catalog:react",
     "react-dom": "catalog:react",
-    "rollup": "catalog:tooling",
     "rollup-plugin-tree-shakeable": "catalog:tooling",
     "slate": "^0.123.0",
     "slate-history": "^0.115.0",

--- a/packages/nimbus/src/components/rich-text-input/hooks/use-keyboard-shortcuts.ts
+++ b/packages/nimbus/src/components/rich-text-input/hooks/use-keyboard-shortcuts.ts
@@ -16,7 +16,7 @@
  */
 import { useCallback } from "react";
 import { Editor } from "slate";
-import isHotkey from "is-hotkey";
+import { isHotkey } from "is-hotkey";
 import { HOTKEYS } from "../constants";
 import { toggleMark } from "../utils/slate-helpers";
 import { Softbreaker } from "../utils/slate-helpers";

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -103,11 +103,6 @@ export default defineConfig(async () => {
       optimizeLocales.vite({
         locales: LOCALE_BCP47_CODES,
       }),
-      // Externalize react/react-dom AND rewrite internal `require("react")`
-      // calls inside bundled CJS deps (e.g. use-sync-external-store/cjs/*)
-      // into ESM imports. Replaces the top-level external entries for these.
-      // See `reactExternal` comment above.
-      esmExternalRequirePlugin({ external: reactExternal }),
     ],
     build: {
       // sourcemaps are built into separate files and should therefore be tree-shakeable
@@ -130,9 +125,19 @@ export default defineConfig(async () => {
         formats: ["es", "cjs"] satisfies LibraryFormats[],
       },
       rollupOptions: {
-        // `treeShakeable` naively adds an @__PURE__ annotation to each top-level module in our `dist`
-        // https://github.com/TomerAberbach/rollup-plugin-tree-shakeable?tab=readme-ov-file#why
-        plugins: [treeShakeable()],
+        // - `treeShakeable` naively adds an @__PURE__ annotation to each top-level module in our `dist`
+        //   https://github.com/TomerAberbach/rollup-plugin-tree-shakeable?tab=readme-ov-file#why
+        // - `esmExternalRequirePlugin` externalizes the React family for the
+        //   library build AND rewrites internal `require("react")` calls inside
+        //   bundled CJS deps (e.g. use-sync-external-store/cjs/*) into ESM
+        //   imports. Must be lib-scoped (not in top-level `plugins`) so it does
+        //   not leak into Storybook's iframe build, where externalizing react
+        //   without an importmap breaks the production deployment with
+        //   "Failed to resolve module specifier 'react'".
+        plugins: [
+          treeShakeable(),
+          esmExternalRequirePlugin({ external: reactExternal }),
+        ],
         external,
         output: {
           // Organize chunk files into chunks subfolder

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -2,8 +2,7 @@ import { fileURLToPath } from "node:url";
 import { glob } from "glob";
 import optimizeLocales from "@react-aria/optimize-locales-plugin";
 import { defineConfig, esmExternalRequirePlugin } from "vite";
-import type { LibraryFormats } from "vite";
-import type { RollupLog, LoggingFunction } from "rollup";
+import type { LibraryFormats, PluginOption, Rollup } from "vite";
 import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 import dts from "vite-plugin-dts";
@@ -11,55 +10,80 @@ import treeShakeable from "rollup-plugin-tree-shakeable";
 import { analyzer } from "vite-bundle-analyzer";
 import { LOCALE_BCP47_CODES } from "../i18n/scripts/locales";
 
-// Turns every index file inside src/components, along with the main `src/index.ts` and `setup-jsdom-polyfills` entrypoints, into separate entry-points/files for better tree-shaking in consuming apps.
-// Defining entrypoints and chunking files is recommended over using `output.preserveModules` - https://rollupjs.org/configuration-options/#input
-//
-// IMPORTANT: Because each component's index.ts becomes a separate chunk, cross-component imports
-// within Nimbus MUST import directly from implementation files (e.g., button.tsx, button.types.ts)
-// rather than barrel exports (index.ts) to avoid circular chunk dependencies.
-// See docs/component-guidelines.md "Cross-Chunk Import Pattern" for details.
+/**
+ * Builds the entry map for the library build.
+ *
+ * Each component's `index.ts` (under `src/components` or `src/patterns`)
+ * becomes its own entry, plus `src/index.ts` and the jsdom polyfill.
+ * Per-component splitting lets consumers tree-shake to only what they use.
+ * Recommended over `output.preserveModules` —
+ * https://rollupjs.org/configuration-options/#input
+ *
+ * **Important:** because each component's index becomes its own chunk,
+ * cross-component imports inside Nimbus must target implementation files
+ * (`button.tsx`), not barrel exports (`index.ts`), to avoid circular
+ * chunk dependencies. See `docs/component-guidelines.md` →
+ * "Cross-Chunk Import Pattern".
+ */
 const createEntries = async () => {
-  // Only index files are turned into entrypoints, as we don't want to include test files, storybook stories, etc.
   const entries = new Map<string, string>();
-  // Build a glob containing each index.ts file in src/components or src/patterns
   const componentEntryPoints = await glob(
     "src/{components,patterns}/**/index.ts"
   );
-  // Declare an entrypoint for each component's index file. This enables consuming applications to only bundle the components imported into their app, instead of requiring that consumers bundle all components if they use any component.
   for (const file of componentEntryPoints) {
-    // Get the name of the folder containing the index file to maintain semi-unique file/entrypoint names
+    // Use the containing folder name as the entry name (semi-unique).
     const fileName = file.split("/").at(-2)?.split(".")[0];
-    // Don't create an entrypoint if there is not a file name (should not happen)
     if (!fileName) {
       continue;
     }
-    // Set the name of the entrypoint to the folder name, and set its path to the index file in that folder
     entries.set(`${fileName}`, fileURLToPath(new URL(file, import.meta.url)));
   }
-  // Declare main entrypoints, which should be defined in the `exports` field in `package.json`
-  // The 'index' entrypoint bundles all non-component code (theme, hooks, etc), insuring that all necessary code is published
+  // Main entries — must match the `exports` field in `package.json`.
+  // `index` bundles all non-component code (theme, hooks, etc).
   entries.set("index", fileURLToPath(new URL("src/index.ts", import.meta.url)));
-  // Separate entrypoint for the jest polyfill insures that the cjs version of the polyfill is used
+  // Separate entry so the jest polyfill ships as CJS.
   entries.set(
     "setup-jsdom-polyfills",
     fileURLToPath(new URL("src/test/setup-jsdom-polyfills.ts", import.meta.url))
   );
-  // Pass all entrypoints back to config
   return Object.fromEntries(entries);
 };
 
-// React-family externals are declared via `esmExternalRequirePlugin` below
-// (NOT in `external`). Under Rolldown (Vite 8), CJS deps such as
-// `use-sync-external-store/cjs/*` internally call `require("react")`. The
-// plugin both treats these as external AND rewrites those internal `require()`
-// calls into ESM imports — but only if the IDs are NOT also listed in the
-// top-level `external` array, otherwise they're already marked external before
-// the plugin runs and the rewrite no-ops.
-// Ref: https://github.com/vitejs/rolldown-vite/issues/596
-const reactExternal = [/^react(-dom)?(\/.+)?$/];
+/**
+ * External (peer) dependencies — not bundled into the nimbus dist.
+ *
+ * Two arrays exist because of how the upstream packages are published:
+ *
+ * ### `requireRewriteExternals` — via `esmExternalRequirePlugin`
+ *
+ * For packages whose graph contains CJS files calling `require("<name>")`.
+ * The plugin both externalizes them **and** rewrites internal `require()`
+ * calls into ESM imports — without the rewrite, Rolldown leaks
+ * `__require(...)` into our ESM dist and breaks pure-ESM consumers.
+ *
+ * Only React-family hits this today: `react` ships as CJS, and
+ * `use-sync-external-store/cjs/*` (transitively via react-aria /
+ * react-stately) calls `require("react")` internally.
+ *
+ * **Critical:** entries here must **not** also be in `external` below.
+ * If they are, Rolldown externalizes them before the plugin's rewrite
+ * runs, the rewrite no-ops, and `__require(...)` leaks into the dist.
+ * Ref: https://github.com/vitejs/rolldown-vite/issues/596
+ *
+ * ### `external` — via `rollupOptions.external`
+ *
+ * For packages where plain externalization is enough — they ship ESM
+ * (chakra, slate) or are workspace packages.
+ *
+ * **Default to this list when adding a new external.** Move an entry to
+ * `requireRewriteExternals` only if you observe `__require(...)` leaking
+ * into the built output.
+ *
+ * Anything externalized (either list) must also be a peerDependency &
+ * devDependency in this package's `package.json`.
+ */
+const requireRewriteExternals = [/^react(-dom)?(\/.+)?$/];
 
-// Other external dependencies that should not be bundled.
-// NOTE: Anything listed in the external array also needs to be listed as a peerDependency & devDependency in its corresponding package.json.
 const external = [
   // UI frameworks & styling.
   new RegExp("@chakra-ui/react?[^.].*$"),
@@ -93,6 +117,8 @@ export default defineConfig(async () => {
   const entries = await createEntries();
 
   const config = {
+    // Typed as `PluginOption[]` so we can `.push(...)` later (dts/analyzer)
+    // without TS narrowing the element type to the first plugin's literal shape.
     plugins: [
       viteTsconfigPaths(),
       react(),
@@ -103,7 +129,7 @@ export default defineConfig(async () => {
       optimizeLocales.vite({
         locales: LOCALE_BCP47_CODES,
       }),
-    ],
+    ] as PluginOption[],
     build: {
       // sourcemaps are built into separate files and should therefore be tree-shakeable
       // TODO: confirm that sourcemaps aren't being bundled into prod builds of consuming applications
@@ -125,53 +151,48 @@ export default defineConfig(async () => {
         formats: ["es", "cjs"] satisfies LibraryFormats[],
       },
       rollupOptions: {
-        // - `treeShakeable` naively adds an @__PURE__ annotation to each top-level module in our `dist`
-        //   https://github.com/TomerAberbach/rollup-plugin-tree-shakeable?tab=readme-ov-file#why
-        // - `esmExternalRequirePlugin` externalizes the React family for the
-        //   library build AND rewrites internal `require("react")` calls inside
-        //   bundled CJS deps (e.g. use-sync-external-store/cjs/*) into ESM
-        //   imports. Must be lib-scoped (not in top-level `plugins`) so it does
-        //   not leak into Storybook's iframe build, where externalizing react
-        //   without an importmap breaks the production deployment with
-        //   "Failed to resolve module specifier 'react'".
+        /**
+         * `esmExternalRequirePlugin` handles `requireRewriteExternals`
+         * (see the file-top doc).
+         *
+         * **Must live in `rollupOptions.plugins`** (not in the top-level
+         * `plugins` array) so it only applies to nimbus's lib build. If it
+         * leaks into Storybook's iframe build, react gets externalized
+         * there too and the deployed Storybook breaks with
+         * `Uncaught TypeError: Failed to resolve module specifier 'react'`
+         * (no importmap).
+         */
         plugins: [
           treeShakeable(),
-          esmExternalRequirePlugin({ external: reactExternal }),
+          esmExternalRequirePlugin({ external: requireRewriteExternals }),
         ],
         external,
         output: {
-          // Organize chunk files into chunks subfolder
-          chunkFileNames: () => {
-            return `chunks/[name]-[hash].[format].js`;
-          },
+          chunkFileNames: () => `chunks/[name]-[hash].[format].js`,
         },
-        // Suppress barrel export reexport warnings for compound components
-        // These warnings occur due to Nimbus's architectural pattern where compound
-        // components (Menu, Accordion, etc.) import from their own ./components/index.ts barrel.
-        // Example: accordion.tsx imports from ./components/index.ts, which re-exports accordion.header.tsx
-        // This is intentional and safe - it's the documented pattern for compound components.
-        // See docs/file-type-guidelines/compound-components.md for details.
-        onwarn(warning: RollupLog, warn: LoggingFunction) {
+        /**
+         * Suppress reexport warnings for our compound-component pattern.
+         *
+         * Compound components (Menu, Accordion, etc.) import from their own
+         * `./components/index.ts` barrel — e.g. `accordion.tsx` imports from
+         * `./components/index.ts` which re-exports `accordion.header.tsx`.
+         * This is intentional and documented in
+         * `docs/file-type-guidelines/compound-components.md`.
+         */
+        onwarn(warning: Rollup.RollupLog, warn: Rollup.LoggingFunction) {
           if (
             warning.message?.includes("reexported through module") &&
             warning.message?.includes("/components/index.ts")
           ) {
-            // Suppress warnings specifically for:
-            // 1. Compound component internal barrels: src/components/{component}/components/index.ts
-            // 2. Main components barrel: src/components/index.ts
-            // Both are intentional architectural patterns in Nimbus.
             return;
           }
-          // Pass all other warnings through
           warn(warning);
         },
-        // Shake that tree, rollup
         treeshake: true,
         // Reduce memory usage during build
         maxParallelFileOps: 5,
       },
     },
-    // Ensure CommonJS and ES modules are handled properly
     target: "esnext",
     assetsInclude: ["/sb-preview/runtime.js"],
   };

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -5,7 +5,6 @@ import { defineConfig, esmExternalRequirePlugin } from "vite";
 import type { LibraryFormats, PluginOption, Rollup } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
-import treeShakeable from "rollup-plugin-tree-shakeable";
 import { analyzer } from "vite-bundle-analyzer";
 import { LOCALE_BCP47_CODES } from "../i18n/scripts/locales";
 
@@ -161,7 +160,6 @@ export default defineConfig(async () => {
          * (no importmap).
          */
         plugins: [
-          treeShakeable(),
           esmExternalRequirePlugin({ external: requireRewriteExternals }),
           /**
            * Pin chunk extensions to `.es.js` / `.cjs.js`.

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -4,7 +4,6 @@ import optimizeLocales from "@react-aria/optimize-locales-plugin";
 import { defineConfig, esmExternalRequirePlugin } from "vite";
 import type { LibraryFormats, PluginOption, Rollup } from "vite";
 import react from "@vitejs/plugin-react";
-import viteTsconfigPaths from "vite-tsconfig-paths";
 import dts from "vite-plugin-dts";
 import treeShakeable from "rollup-plugin-tree-shakeable";
 import { analyzer } from "vite-bundle-analyzer";
@@ -120,7 +119,6 @@ export default defineConfig(async () => {
     // Typed as `PluginOption[]` so we can `.push(...)` later (dts/analyzer)
     // without TS narrowing the element type to the first plugin's literal shape.
     plugins: [
-      viteTsconfigPaths(),
       react(),
       // Only package locale strings for locales we internationalize in our products
       // Locales are defined in packages/i18n/scripts/locales.ts (single source of truth)
@@ -218,6 +216,7 @@ export default defineConfig(async () => {
     },
     target: "esnext",
     assetsInclude: ["/sb-preview/runtime.js"],
+    resolve: { tsconfigPaths: true },
   };
 
   if (!isWatchMode) {

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -163,7 +163,6 @@ export default defineConfig(async () => {
   if (!isWatchMode) {
     config.plugins.push(
       dts({
-        rollupTypes: false,
         include: ["src/**/*"],
         // Don't declare types for stories and tests in bundle.
         // Note: src/test/setup-jsdom-polyfills.ts is a published entry point

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -165,11 +165,34 @@ export default defineConfig(async () => {
         plugins: [
           treeShakeable(),
           esmExternalRequirePlugin({ external: requireRewriteExternals }),
+          /**
+           * Pin chunk extensions to `.es.js` / `.cjs.js`.
+           *
+           * Vite 8/Rolldown changed the `[format]` placeholder from `es` →
+           * `esm` for the ESM output, which would shift our chunk filenames
+           * from `*.es.js` to `*.esm.js`. The bundle-size script
+           * (`scripts/check-bundle-size.mjs`) hard-codes the pattern
+           * `**\/*.es.js`, so the upgrade would break its measurement.
+           *
+           * `outputOptions` runs once per output (i.e. once per format) and
+           * exposes `format`, which `chunkFileNames` (called per chunk) does
+           * not. We use it to write a literal `chunkFileNames` per format —
+           * sidestepping `[format]` entirely.
+           */
+          {
+            name: "nimbus-pin-chunk-extensions",
+            outputOptions(options: Rollup.OutputOptions) {
+              return {
+                ...options,
+                chunkFileNames:
+                  options.format === "es"
+                    ? "chunks/[name]-[hash].es.js"
+                    : "chunks/[name]-[hash].cjs.js",
+              };
+            },
+          },
         ],
         external,
-        output: {
-          chunkFileNames: () => `chunks/[name]-[hash].[format].js`,
-        },
         /**
          * Suppress reexport warnings for our compound-component pattern.
          *

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { glob } from "glob";
 import optimizeLocales from "@react-aria/optimize-locales-plugin";
-import { defineConfig } from "vite";
+import { defineConfig, esmExternalRequirePlugin } from "vite";
 import type { LibraryFormats } from "vite";
 import type { RollupLog, LoggingFunction } from "rollup";
 import react from "@vitejs/plugin-react";
@@ -48,13 +48,19 @@ const createEntries = async () => {
   return Object.fromEntries(entries);
 };
 
-// External dependencies that should not be bundled.
-// NOTE: Anything listed in the external array also needs to be listed as a peerDependency & devDependency in its corresponding package.json (exception: "react/jsx-runtime").
+// React-family externals are declared via `esmExternalRequirePlugin` below
+// (NOT in `external`). Under Rolldown (Vite 8), CJS deps such as
+// `use-sync-external-store/cjs/*` internally call `require("react")`. The
+// plugin both treats these as external AND rewrites those internal `require()`
+// calls into ESM imports — but only if the IDs are NOT also listed in the
+// top-level `external` array, otherwise they're already marked external before
+// the plugin runs and the rewrite no-ops.
+// Ref: https://github.com/vitejs/rolldown-vite/issues/596
+const reactExternal = [/^react(-dom)?(\/.+)?$/];
+
+// Other external dependencies that should not be bundled.
+// NOTE: Anything listed in the external array also needs to be listed as a peerDependency & devDependency in its corresponding package.json.
 const external = [
-  // React core
-  "react",
-  "react-dom",
-  "react/jsx-runtime",
   // UI frameworks & styling.
   new RegExp("@chakra-ui/react?[^.].*$"),
   // Slate dependencies for RichTextInput
@@ -97,6 +103,11 @@ export default defineConfig(async () => {
       optimizeLocales.vite({
         locales: LOCALE_BCP47_CODES,
       }),
+      // Externalize react/react-dom AND rewrite internal `require("react")`
+      // calls inside bundled CJS deps (e.g. use-sync-external-store/cjs/*)
+      // into ESM imports. Replaces the top-level external entries for these.
+      // See `reactExternal` comment above.
+      esmExternalRequirePlugin({ external: reactExternal }),
     ],
     build: {
       // sourcemaps are built into separate files and should therefore be tree-shakeable

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -161,34 +161,15 @@ export default defineConfig(async () => {
          */
         plugins: [
           esmExternalRequirePlugin({ external: requireRewriteExternals }),
-          /**
-           * Pin chunk extensions to `.es.js` / `.cjs.js`.
-           *
-           * Vite 8/Rolldown changed the `[format]` placeholder from `es` →
-           * `esm` for the ESM output, which would shift our chunk filenames
-           * from `*.es.js` to `*.esm.js`. The bundle-size script
-           * (`scripts/check-bundle-size.mjs`) hard-codes the pattern
-           * `**\/*.es.js`, so the upgrade would break its measurement.
-           *
-           * `outputOptions` runs once per output (i.e. once per format) and
-           * exposes `format`, which `chunkFileNames` (called per chunk) does
-           * not. We use it to write a literal `chunkFileNames` per format —
-           * sidestepping `[format]` entirely.
-           */
-          {
-            name: "nimbus-pin-chunk-extensions",
-            outputOptions(options: Rollup.OutputOptions) {
-              return {
-                ...options,
-                chunkFileNames:
-                  options.format === "es"
-                    ? "chunks/[name]-[hash].es.js"
-                    : "chunks/[name]-[hash].cjs.js",
-              };
-            },
-          },
         ],
         external,
+        output: {
+          // Keep chunks out of dist/ root so entry points are easier to find.
+          // Vite 8/Rolldown renders `[format]` as `esm`/`cjs` (was `es`/`cjs`
+          // pre-Rolldown). Nothing outside this build depends on the chunk
+          // extension — entry-point filenames are produced by `lib.fileName`.
+          chunkFileNames: "chunks/[name]-[hash].[format].js",
+        },
         /**
          * Suppress reexport warnings for our compound-component pattern.
          *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,9 +175,6 @@ catalogs:
     vite-plugin-dts:
       specifier: ^5.0.0
       version: 5.0.0
-    vite-tsconfig-paths:
-      specifier: ^6.1.1
-      version: 6.1.1
     vitest:
       specifier: ^4.1.5
       version: 4.1.5
@@ -455,9 +452,6 @@ importers:
       use-debounce:
         specifier: ^10.1.1
         version: 10.1.1(react@19.2.0)
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: catalog:utils
         version: 4.4.3
@@ -722,9 +716,6 @@ importers:
       vite-plugin-dts:
         specifier: catalog:tooling
         version: 5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
-      vite-tsconfig-paths:
-        specifier: catalog:tooling
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:tooling
         version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -4983,9 +4974,6 @@ packages:
     resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
     engines: {node: '>=20'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -7395,11 +7383,6 @@ packages:
         optional: true
       vite:
         optional: true
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.0.11:
     resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
@@ -12736,8 +12719,6 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -15521,16 +15502,6 @@ snapshots:
       - supports-color
       - typescript
       - webpack
-
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ catalogs:
       specifier: ^0.21.2
       version: 0.21.2
     '@preconstruct/cli':
-      specifier: ^2.8.13
-      version: 2.8.13
+      specifier: ^2.8.12
+      version: 2.8.12
     '@react-types/shared':
       specifier: ^3.34.0
       version: 3.34.0
@@ -101,8 +101,8 @@ catalogs:
       specifier: ^14.6.1
       version: 14.6.1
     '@vitejs/plugin-react':
-      specifier: ^5.2.0
-      version: 5.2.0
+      specifier: ^6.0.1
+      version: 6.0.1
     '@vitejs/plugin-react-swc':
       specifier: ^4.3.0
       version: 4.3.0
@@ -167,14 +167,14 @@ catalogs:
       specifier: ^8.59.2
       version: 8.59.2
     vite:
-      specifier: ^7.3.3
-      version: 7.3.3
+      specifier: ^8.0.10
+      version: 8.0.11
     vite-bundle-analyzer:
       specifier: ^1.3.8
       version: 1.3.8
     vite-plugin-dts:
-      specifier: ^4.5.4
-      version: 4.5.4
+      specifier: ^5.0.0
+      version: 5.0.0
     vite-tsconfig-paths:
       specifier: ^6.1.1
       version: 6.1.1
@@ -186,8 +186,8 @@ catalogs:
       specifier: ^4.17.24
       version: 4.17.24
     '@types/node':
-      specifier: ^24.12.3
-      version: 24.12.3
+      specifier: ^24.12.2
+      version: 24.12.2
     dequal:
       specifier: ^2.0.3
       version: 2.0.3
@@ -205,7 +205,6 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  rollup: ^4.60.3
   '@babel/runtime': ^7.29.2
   prismjs: ^1.30.0
   typescript: ~5.9.3
@@ -221,11 +220,8 @@ overrides:
   qs: ^6.14.2
   minimatch@>=3.0.0 <3.1.4: 3.1.4
   svgo: '>=3.3.3'
-  hono: '>=4.12.18'
+  hono: '>=4.12.14'
   '@hono/node-server': '>=1.19.13'
-  fast-uri: '>=3.1.2'
-  ip-address: '>=10.1.1'
-  postcss: '>=8.5.10'
   lodash@<4.18.0: '>=4.18.0'
   lodash-es@<4.18.0: '>=4.18.0'
   ajv@>=8.0.0 <8.18.0: '>=8.18.0'
@@ -251,11 +247,11 @@ importers:
         specifier: catalog:tooling
         version: 7.29.0
       '@changesets/changelog-github':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.6.0
+        version: 0.6.0
       '@changesets/cli':
         specifier: 2.30.0
-        version: 2.30.0(@types/node@24.12.3)
+        version: 2.30.0(@types/node@24.12.2)
       '@commercetools/nimbus':
         specifier: workspace:^
         version: link:packages/nimbus
@@ -267,10 +263,10 @@ importers:
         version: 1.4.4
       '@fission-ai/openspec':
         specifier: catalog:tooling
-        version: 1.3.1(@types/node@24.12.3)
+        version: 1.3.1(@types/node@24.12.2)
       '@preconstruct/cli':
         specifier: catalog:tooling
-        version: 2.8.13
+        version: 2.8.12
       dotenv:
         specifier: catalog:utils
         version: 16.6.1
@@ -315,7 +311,7 @@ importers:
         version: 1.3.8
       vitest:
         specifier: catalog:tooling
-        version: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/blank-app:
     dependencies:
@@ -343,7 +339,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.0(@swc/helpers@0.5.17)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
         version: 10.3.0
@@ -361,7 +357,7 @@ importers:
         version: 8.59.2(eslint@10.3.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/docs:
     dependencies:
@@ -460,7 +456,7 @@ importers:
         version: 10.1.1(react@19.2.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.1.1(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: catalog:utils
         version: 4.4.3
@@ -482,7 +478,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.0(@swc/helpers@0.5.17)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
         version: 10.3.0
@@ -500,10 +496,10 @@ importers:
         version: 8.59.2(eslint@10.3.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-compression:
         specifier: ^0.5.1
-        version: 0.5.1(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.5.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/color-tokens:
     dependencies:
@@ -525,7 +521,7 @@ importers:
         version: 3.1.1
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.3
+        version: 24.12.2
 
   packages/design-token-ts-plugin:
     devDependencies:
@@ -534,13 +530,13 @@ importers:
         version: link:../tokens
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.3
+        version: 24.12.2
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       vitest:
         specifier: catalog:tooling
-        version: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/i18n:
     devDependencies:
@@ -549,7 +545,7 @@ importers:
         version: 3.4.0
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.3
+        version: 24.12.2
       glob:
         specifier: catalog:tooling
         version: 13.0.6
@@ -596,8 +592,8 @@ importers:
         specifier: 1.17.0
         version: 1.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-hotkeys-hook:
-        specifier: ^5.3.2
-        version: 5.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^5.2.1
+        version: 5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
         specifier: 3.46.0
         version: 3.46.0(react@19.2.0)
@@ -634,13 +630,13 @@ importers:
         version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
         version: 10.3.6(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5)(@vitest/runner@4.1.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.5)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.9.1
@@ -664,13 +660,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: catalog:tooling
-        version: 5.2.0(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: catalog:tooling
-        version: 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+        version: 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/browser-playwright':
         specifier: catalog:tooling
-        version: 4.1.5(playwright@1.59.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+        version: 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-v8':
         specifier: catalog:tooling
         version: 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
@@ -701,9 +697,6 @@ importers:
       react-dom:
         specifier: catalog:react
         version: 19.2.0(react@19.2.0)
-      rollup:
-        specifier: ^4.60.3
-        version: 4.60.3
       rollup-plugin-tree-shakeable:
         specifier: catalog:tooling
         version: 2.0.0
@@ -724,16 +717,16 @@ importers:
         version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
-        version: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: catalog:tooling
-        version: 4.5.4(@types/node@24.12.3)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       vite-tsconfig-paths:
         specifier: catalog:tooling
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.1.1(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:tooling
-        version: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/nimbus-docs-build:
     dependencies:
@@ -764,7 +757,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.3
+        version: 24.12.2
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -783,7 +776,7 @@ importers:
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.3
+        version: 24.12.2
       '@types/react':
         specifier: catalog:react
         version: 19.2.14
@@ -814,13 +807,13 @@ importers:
         version: link:../tokens
       '@modelcontextprotocol/inspector':
         specifier: catalog:tooling
-        version: 0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)
+        version: 0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.3
+        version: 24.12.2
       tsup:
         specifier: catalog:tooling
-        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.3))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: catalog:tooling
         version: 4.21.0
@@ -884,6 +877,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -940,6 +937,10 @@ packages:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -1024,18 +1025,6 @@ packages:
 
   '@babel/plugin-transform-modules-commonjs@7.27.1':
     resolution: {integrity: sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1128,8 +1117,8 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@0.7.0':
-    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
+  '@changesets/changelog-github@0.6.0':
+    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
 
   '@changesets/cli@2.30.0':
     resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
@@ -1229,6 +1218,15 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -1544,7 +1542,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.18'
+      hono: '>=4.12.14'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1969,6 +1967,12 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2036,6 +2040,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
   '@pandacss/is-valid-prop@1.10.0':
     resolution: {integrity: sha512-OmEHkDj3BRkHYLxHwNFYJkcwF84c7PuHsWHmmmNLJnmk8z0RVlDQei4GxWjfW1bnvCihCwakJ8Xq6GDRlmcDiQ==}
 
@@ -2059,8 +2066,8 @@ packages:
   '@preact/signals-core@1.13.0':
     resolution: {integrity: sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==}
 
-  '@preconstruct/cli@2.8.13':
-    resolution: {integrity: sha512-+1I98YKqXy3nNQQBTvwzgjFujcDndX4Q7G0QHBCCRCxGRA5LIyUvK9XN92pyWPbbmUPPg2amlTGxWThGgn1DRQ==}
+  '@preconstruct/cli@2.8.12':
+    resolution: {integrity: sha512-SMsMICUWROmu/vb4cmrk7EJUiWhgNjB3U3tM654K9bu9yECXqrPN473vliO7KPV3CSLhmtl3S4nfcMirEJmyZg==}
     hasBin: true
 
   '@preconstruct/hook@0.4.0':
@@ -2549,8 +2556,97 @@ packages:
       react:
         optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -2559,41 +2655,41 @@ packages:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/plugin-commonjs@15.1.0':
     resolution: {integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^2.22.0
 
   '@rollup/plugin-json@4.1.0':
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^1.20.0 || ^2.0.0
 
   '@rollup/plugin-node-resolve@11.2.1':
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^1.20.0 || ^2.0.0
 
   '@rollup/pluginutils@3.1.0':
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.60.3
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2832,7 +2928,7 @@ packages:
     resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
     peerDependencies:
       esbuild: '*'
-      rollup: ^4.60.3
+      rollup: '*'
       storybook: ^10.3.6
       vite: '*'
       webpack: '*'
@@ -3097,6 +3193,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
@@ -3175,11 +3274,11 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@24.11.0':
+    resolution: {integrity: sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
-
-  '@types/node@24.12.3':
-    resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -3363,11 +3462,18 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7 || ^8
 
-  '@vitejs/plugin-react@5.2.0':
-    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/browser-playwright@4.1.5':
     resolution: {integrity: sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==}
@@ -3430,34 +3536,14 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
-  '@volar/language-core@2.4.23':
-    resolution: {integrity: sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==}
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/source-map@2.4.23':
-    resolution: {integrity: sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==}
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
-  '@volar/typescript@2.4.23':
-    resolution: {integrity: sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==}
-
-  '@vue/compiler-core@3.5.22':
-    resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
-
-  '@vue/compiler-dom@3.5.22':
-    resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
-
-  '@vue/compiler-vue2@2.7.16':
-    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
-
-  '@vue/language-core@2.2.0':
-    resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
-    peerDependencies:
-      typescript: ~5.9.3
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@vue/shared@3.5.22':
-    resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vueless/storybook-dark-mode@10.0.8':
     resolution: {integrity: sha512-nhueFjEbyNGBzye4H+STC+pRIKthttiuPJRfcqCrDwqKnLS9AkVT3Ra+F5bvOeWbvZt3xc6xNJBNV5OrjRIoZQ==}
@@ -3757,9 +3843,6 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
-
-  alien-signals@0.4.14:
-    resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -4280,9 +4363,6 @@ packages:
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
-  de-indent@1.0.2:
-    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -4342,6 +4422,10 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
@@ -4682,8 +4766,8 @@ packages:
   fast-shallow-equal@1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastest-stable-stringify@2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
@@ -4949,10 +5033,6 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
-
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -4968,8 +5048,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
 
   htm@3.1.1:
@@ -5063,8 +5143,8 @@ packages:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5348,6 +5428,76 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -5719,9 +5869,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  muggle-string@0.4.1:
-    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -6041,7 +6188,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.10'
+      postcss: '>=8.0.9'
       tsx: ^4.8.1
       yaml: '>=2.8.3'
     peerDependenciesMeta:
@@ -6191,8 +6338,8 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
-  react-hotkeys-hook@5.3.2:
-    resolution: {integrity: sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw==}
+  react-hotkeys-hook@5.2.1:
+    resolution: {integrity: sha512-xbKh6zJxd/vJHT4Bw4+0pBD662Fk20V+VFhLqciCg+manTVO4qlqRqiwFOYelfHN9dBvWj9vxaPkSS26ZSIJGg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -6209,10 +6356,6 @@ packages:
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
-
-  react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
-    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -6416,9 +6559,19 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup-plugin-tree-shakeable@2.0.0:
     resolution: {integrity: sha512-CbHO8wpyOCCmPWE5/kOdqDIHOBjGXXzbgazIHLWdaU8AntQCcbnagLKq6EeIyxuwO8w3aRa0ZH2dCuM1NFeTag==}
     engines: {node: '>= 22'}
+
+  rollup@2.80.0:
+    resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
 
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
@@ -6870,6 +7023,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
@@ -6997,7 +7154,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: '>=8.5.10'
+      postcss: ^8.4.12
       typescript: ~5.9.3
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -7094,6 +7251,36 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin-dts@1.0.0:
+    resolution: {integrity: sha512-qz+U1lCscwq+t8Mkaxy5Esa7IQ5wWV18b4mnioOXSdnPaNiJ0+qgE3I+KL6UkXYZWxxGo2qdGone8LEQ52Sfkw==}
+    peerDependencies:
+      '@microsoft/api-extractor': '>=7'
+      '@rspack/core': ^1
+      '@vue/language-core': ~3.1.5
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '>=3'
+      typescript: ~5.9.3
+      vite: '>=3'
+      webpack: ^4 || ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@rspack/core':
+        optional: true
+      '@vue/language-core':
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
@@ -7199,12 +7386,17 @@ packages:
     peerDependencies:
       vite: '>=2.0.0'
 
-  vite-plugin-dts@4.5.4:
-    resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
+  vite-plugin-dts@5.0.0:
+    resolution: {integrity: sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==}
     peerDependencies:
-      typescript: ~5.9.3
-      vite: '*'
+      '@microsoft/api-extractor': '>=7'
+      rollup: '>=3'
+      vite: '>=3'
     peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      rollup:
+        optional: true
       vite:
         optional: true
 
@@ -7213,15 +7405,16 @@ packages:
     peerDependencies:
       vite: '*'
 
-  vite@7.3.3:
-    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+  vite@8.0.11:
+    resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -7232,11 +7425,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -7589,6 +7784,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.28.6':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -7705,6 +7906,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
@@ -7715,7 +7923,7 @@ snapshots:
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
@@ -7796,16 +8004,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -7832,7 +8030,7 @@ snapshots:
 
   '@babel/template@7.27.2':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
@@ -7844,7 +8042,7 @@ snapshots:
 
   '@babel/traverse@7.28.4':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.29.0
@@ -7990,7 +8188,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.7.0':
+  '@changesets/changelog-github@0.6.0':
     dependencies:
       '@changesets/get-github-info': 0.8.0
       '@changesets/types': 6.1.0
@@ -7998,7 +8196,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.30.0(@types/node@24.12.3)':
+  '@changesets/cli@2.30.0(@types/node@24.12.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -8014,7 +8212,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@24.12.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.12.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -8160,6 +8358,22 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -8371,10 +8585,10 @@ snapshots:
       - '@noble/hashes'
       - canvas
 
-  '@fission-ai/openspec@1.3.1(@types/node@24.12.3)':
+  '@fission-ai/openspec@1.3.1(@types/node@24.12.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/prompts': 7.10.1(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/prompts': 7.10.1(@types/node@24.12.2)
       chalk: 5.6.2
       commander: 14.0.3
       fast-glob: 3.3.3
@@ -8447,9 +8661,9 @@ snapshots:
       '@storybook/react': 10.3.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
 
-  '@hono/node-server@1.19.13(hono@4.12.18)':
+  '@hono/node-server@1.19.13(hono@4.12.15)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.15
 
   '@humanfs/core@0.19.1': {}
 
@@ -8464,128 +8678,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.12.3)':
+  '@inquirer/checkbox@4.3.2(@types/node@24.12.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/confirm@5.1.21(@types/node@24.12.3)':
+  '@inquirer/confirm@5.1.21(@types/node@24.12.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/core@10.3.2(@types/node@24.12.3)':
+  '@inquirer/core@10.3.2(@types/node@24.12.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/editor@4.2.23(@types/node@24.12.3)':
+  '@inquirer/editor@4.2.23(@types/node@24.12.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/expand@4.0.23(@types/node@24.12.3)':
+  '@inquirer/expand@4.0.23(@types/node@24.12.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.12.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.12.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.12.3)':
+  '@inquirer/input@4.3.1(@types/node@24.12.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/number@3.0.23(@types/node@24.12.3)':
+  '@inquirer/number@3.0.23(@types/node@24.12.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/password@4.0.23(@types/node@24.12.3)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
-    optionalDependencies:
-      '@types/node': 24.12.3
-
-  '@inquirer/prompts@7.10.1(@types/node@24.12.3)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.12.3)
-      '@inquirer/confirm': 5.1.21(@types/node@24.12.3)
-      '@inquirer/editor': 4.2.23(@types/node@24.12.3)
-      '@inquirer/expand': 4.0.23(@types/node@24.12.3)
-      '@inquirer/input': 4.3.1(@types/node@24.12.3)
-      '@inquirer/number': 3.0.23(@types/node@24.12.3)
-      '@inquirer/password': 4.0.23(@types/node@24.12.3)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.12.3)
-      '@inquirer/search': 3.2.2(@types/node@24.12.3)
-      '@inquirer/select': 4.4.2(@types/node@24.12.3)
-    optionalDependencies:
-      '@types/node': 24.12.3
-
-  '@inquirer/rawlist@4.1.11(@types/node@24.12.3)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.12.3
-
-  '@inquirer/search@3.2.2(@types/node@24.12.3)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.12.3
-
-  '@inquirer/select@4.4.2(@types/node@24.12.3)':
+  '@inquirer/password@4.0.23(@types/node@24.12.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.12.3)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.3)
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+    optionalDependencies:
+      '@types/node': 24.12.2
+
+  '@inquirer/prompts@7.10.1(@types/node@24.12.2)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.12.2)
+      '@inquirer/confirm': 5.1.21(@types/node@24.12.2)
+      '@inquirer/editor': 4.2.23(@types/node@24.12.2)
+      '@inquirer/expand': 4.0.23(@types/node@24.12.2)
+      '@inquirer/input': 4.3.1(@types/node@24.12.2)
+      '@inquirer/number': 3.0.23(@types/node@24.12.2)
+      '@inquirer/password': 4.0.23(@types/node@24.12.2)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.12.2)
+      '@inquirer/search': 3.2.2(@types/node@24.12.2)
+      '@inquirer/select': 4.4.2(@types/node@24.12.2)
+    optionalDependencies:
+      '@types/node': 24.12.2
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.12.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
 
-  '@inquirer/type@3.0.10(@types/node@24.12.3)':
+  '@inquirer/search@3.2.2(@types/node@24.12.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
+
+  '@inquirer/select@4.4.2(@types/node@24.12.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.2
+
+  '@inquirer/type@3.0.10(@types/node@24.12.2)':
+    optionalDependencies:
+      '@types/node': 24.12.2
 
   '@internationalized/date@3.12.0':
     dependencies:
@@ -8622,11 +8836,11 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -8863,23 +9077,24 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.0
 
-  '@microsoft/api-extractor-model@7.31.1(@types/node@24.12.3)':
+  '@microsoft/api-extractor-model@7.31.1(@types/node@24.12.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.3)
+      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.2)
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
-  '@microsoft/api-extractor@7.53.1(@types/node@24.12.3)':
+  '@microsoft/api-extractor@7.53.1(@types/node@24.12.2)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.31.1(@types/node@24.12.3)
+      '@microsoft/api-extractor-model': 7.31.1(@types/node@24.12.2)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.3)
+      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.2)
       '@rushstack/rig-package': 0.6.0
-      '@rushstack/terminal': 0.19.1(@types/node@24.12.3)
-      '@rushstack/ts-command-line': 5.1.1(@types/node@24.12.3)
+      '@rushstack/terminal': 0.19.1(@types/node@24.12.2)
+      '@rushstack/ts-command-line': 5.1.1(@types/node@24.12.2)
       lodash: 4.18.1
       minimatch: 10.2.4
       resolve: 1.22.10
@@ -8888,6 +9103,7 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@microsoft/tsdoc-config@0.17.1':
     dependencies:
@@ -8895,8 +9111,10 @@ snapshots:
       ajv: 8.18.0
       jju: 1.4.0
       resolve: 1.22.10
+    optional: true
 
-  '@microsoft/tsdoc@0.15.1': {}
+  '@microsoft/tsdoc@0.15.1':
+    optional: true
 
   '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
     dependencies:
@@ -9013,7 +9231,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)':
+  '@modelcontextprotocol/inspector@0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.21.2(zod@3.25.76)
       '@modelcontextprotocol/inspector-client': 0.21.2(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
@@ -9024,7 +9242,7 @@ snapshots:
       open: 10.2.0
       shell-quote: 1.8.3
       spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.3)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(typescript@5.9.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -9042,7 +9260,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.15)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9052,7 +9270,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.15
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9064,7 +9282,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.15)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9074,7 +9292,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.15
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9083,6 +9301,13 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9129,6 +9354,8 @@ snapshots:
   '@oven/bun-windows-x64@1.3.10':
     optional: true
 
+  '@oxc-project/types@0.128.0': {}
+
   '@pandacss/is-valid-prop@1.10.0': {}
 
   '@pandacss/is-valid-prop@1.8.1': {}
@@ -9146,18 +9373,18 @@ snapshots:
 
   '@preact/signals-core@1.13.0': {}
 
-  '@preconstruct/cli@2.8.13':
+  '@preconstruct/cli@2.8.12':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/runtime': 7.29.2
       '@preconstruct/hook': 0.4.0
-      '@rollup/plugin-alias': 3.1.9(rollup@4.60.3)
-      '@rollup/plugin-commonjs': 15.1.0(rollup@4.60.3)
-      '@rollup/plugin-json': 4.1.0(rollup@4.60.3)
-      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.60.3)
-      '@rollup/plugin-replace': 2.4.2(rollup@4.60.3)
+      '@rollup/plugin-alias': 3.1.9(rollup@2.80.0)
+      '@rollup/plugin-commonjs': 15.1.0(rollup@2.80.0)
+      '@rollup/plugin-json': 4.1.0(rollup@2.80.0)
+      '@rollup/plugin-node-resolve': 11.2.1(rollup@2.80.0)
+      '@rollup/plugin-replace': 2.4.2(rollup@2.80.0)
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -9179,7 +9406,7 @@ snapshots:
       parse-json: 5.2.0
       quick-lru: 5.1.1
       resolve-from: 5.0.0
-      rollup: 4.60.3
+      rollup: 2.80.0
       semver: 7.7.4
       terser: 5.44.0
       v8-compile-cache: 2.4.0
@@ -9668,53 +9895,102 @@ snapshots:
       - '@preact/signals-core'
       - preact
 
-  '@rolldown/pluginutils@1.0.0-rc.3': {}
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
-  '@rollup/plugin-alias@3.1.9(rollup@4.60.3)':
+  '@rollup/plugin-alias@3.1.9(rollup@2.80.0)':
     dependencies:
-      rollup: 4.60.3
+      rollup: 2.80.0
       slash: 3.0.0
 
-  '@rollup/plugin-commonjs@15.1.0(rollup@4.60.3)':
+  '@rollup/plugin-commonjs@15.1.0(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.10
-      rollup: 4.60.3
+      rollup: 2.80.0
 
-  '@rollup/plugin-json@4.1.0(rollup@4.60.3)':
+  '@rollup/plugin-json@4.1.0(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
-      rollup: 4.60.3
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      rollup: 2.80.0
 
-  '@rollup/plugin-node-resolve@11.2.1(rollup@4.60.3)':
+  '@rollup/plugin-node-resolve@11.2.1(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
-      rollup: 4.60.3
+      rollup: 2.80.0
 
-  '@rollup/plugin-replace@2.4.2(rollup@4.60.3)':
+  '@rollup/plugin-replace@2.4.2(rollup@2.80.0)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
       magic-string: 0.25.9
-      rollup: 4.60.3
+      rollup: 2.80.0
 
-  '@rollup/pluginutils@3.1.0(rollup@4.60.3)':
+  '@rollup/pluginutils@3.1.0(rollup@2.80.0)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 4.0.4
-      rollup: 4.60.3
+      rollup: 2.80.0
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.3)':
     dependencies:
@@ -9817,7 +10093,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
-  '@rushstack/node-core-library@5.17.0(@types/node@24.12.3)':
+  '@rushstack/node-core-library@5.17.0(@types/node@24.12.2)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -9828,33 +10104,38 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
+    optional: true
 
-  '@rushstack/problem-matcher@0.1.1(@types/node@24.12.3)':
+  '@rushstack/problem-matcher@0.1.1(@types/node@24.12.2)':
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
+    optional: true
 
   '@rushstack/rig-package@0.6.0':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
+    optional: true
 
-  '@rushstack/terminal@0.19.1(@types/node@24.12.3)':
+  '@rushstack/terminal@0.19.1(@types/node@24.12.2)':
     dependencies:
-      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.3)
-      '@rushstack/problem-matcher': 0.1.1(@types/node@24.12.3)
+      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.2)
+      '@rushstack/problem-matcher': 0.1.1(@types/node@24.12.2)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
+    optional: true
 
-  '@rushstack/ts-command-line@5.1.1(@types/node@24.12.3)':
+  '@rushstack/ts-command-line@5.1.1(@types/node@24.12.2)':
     dependencies:
-      '@rushstack/terminal': 0.19.1(@types/node@24.12.3)
+      '@rushstack/terminal': 0.19.1(@types/node@24.12.2)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -9868,10 +10149,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -9891,33 +10172,33 @@ snapshots:
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
-      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.60.3
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -9932,11 +10213,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react': 10.3.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -9946,7 +10227,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -10230,7 +10511,13 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@types/argparse@1.0.38': {}
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/argparse@1.0.38':
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -10305,11 +10592,11 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@24.12.2':
+  '@types/node@24.11.0':
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.12.3':
+  '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
 
@@ -10338,7 +10625,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.11.0
 
   '@types/resolve@1.20.6': {}
 
@@ -10534,49 +10821,42 @@ snapshots:
 
   '@visulima/boxen@2.0.10': {}
 
-  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.11(@swc/helpers@0.5.17)
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
     dependencies:
-      '@vitest/browser': 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
-      '@vitest/mocker': 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
+  '@vitest/browser@4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -10596,9 +10876,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -10617,13 +10897,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10663,50 +10943,17 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@volar/language-core@2.4.23':
+  '@volar/language-core@2.4.28':
     dependencies:
-      '@volar/source-map': 2.4.23
+      '@volar/source-map': 2.4.28
 
-  '@volar/source-map@2.4.23': {}
+  '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.23':
+  '@volar/typescript@2.4.28':
     dependencies:
-      '@volar/language-core': 2.4.23
+      '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-
-  '@vue/compiler-core@3.5.22':
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@vue/shared': 3.5.22
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
-  '@vue/compiler-dom@3.5.22':
-    dependencies:
-      '@vue/compiler-core': 3.5.22
-      '@vue/shared': 3.5.22
-
-  '@vue/compiler-vue2@2.7.16':
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-
-  '@vue/language-core@2.2.0(typescript@5.9.3)':
-    dependencies:
-      '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.22
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.22
-      alien-signals: 0.4.14
-      minimatch: 9.0.9
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@vue/shared@3.5.22': {}
 
   '@vueless/storybook-dark-mode@10.0.8(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
@@ -11313,6 +11560,7 @@ snapshots:
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
+    optional: true
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -11328,11 +11576,9 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-
-  alien-signals@0.4.14: {}
 
   ansi-align@3.0.1:
     dependencies:
@@ -11814,8 +12060,6 @@ snapshots:
 
   dataloader@2.2.3: {}
 
-  de-indent@1.0.2: {}
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -11862,6 +12106,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -12179,7 +12425,7 @@ snapshots:
   express-rate-limit@8.3.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -12248,7 +12494,7 @@ snapshots:
 
   fast-shallow-equal@1.0.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.0: {}
 
   fastest-stable-stringify@2.0.2: {}
 
@@ -12345,6 +12591,7 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -12584,8 +12831,6 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  he@1.2.0: {}
-
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -12600,7 +12845,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.18: {}
+  hono@4.12.15: {}
 
   htm@3.1.1: {}
 
@@ -12664,7 +12909,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-lazy@4.0.0: {}
+  import-lazy@4.0.0:
+    optional: true
 
   imurmurhash@0.1.4: {}
 
@@ -12687,7 +12933,7 @@ snapshots:
 
   interpret@1.4.0: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -12832,11 +13078,12 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.11.0
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
-  jju@1.4.0: {}
+  jju@1.4.0:
+    optional: true
 
   jose@6.1.3: {}
 
@@ -12929,6 +13176,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -12995,6 +13291,7 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+    optional: true
 
   lucide-react@0.523.0(react@18.3.1):
     dependencies:
@@ -13555,8 +13852,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  muggle-string@0.4.1: {}
-
   mute-stream@2.0.0: {}
 
   mz@2.7.0:
@@ -14028,7 +14323,7 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
-  react-hotkeys-hook@5.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-hotkeys-hook@5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -14044,8 +14339,6 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       sucrase: 3.35.0
       use-editable: 2.3.3(react@19.2.0)
-
-  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@18.3.1):
     dependencies:
@@ -14319,11 +14612,36 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0-rc.18:
+    dependencies:
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
+
   rollup-plugin-tree-shakeable@2.0.0:
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.11.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
+
+  rollup@2.80.0:
+    optionalDependencies:
+      fsevents: 2.3.3
 
   rollup@4.60.3:
     dependencies:
@@ -14424,6 +14742,7 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
+    optional: true
 
   semver@7.7.3: {}
 
@@ -14677,7 +14996,8 @@ snapshots:
     dependencies:
       component-emitter: 2.0.0
 
-  string-argv@0.3.2: {}
+  string-argv@0.3.2:
+    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -14724,7 +15044,8 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
-  strip-json-comments@3.1.1: {}
+  strip-json-comments@3.1.1:
+    optional: true
 
   style-dictionary@5.4.0(tslib@2.8.1):
     dependencies:
@@ -14843,6 +15164,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -14908,14 +15234,14 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.3)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -14940,7 +15266,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.3))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -14960,7 +15286,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.3)
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.2)
       '@swc/core': 1.15.11(@swc/helpers@0.5.17)
       postcss: 8.5.14
       typescript: 5.9.3
@@ -15066,6 +15392,25 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-dts@1.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      '@volar/typescript': 2.4.28
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.9.3
+      unplugin: 2.3.11
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.2)
+      esbuild: 0.27.3
+      rollup: 4.60.3
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   unplugin@1.16.1:
     dependencies:
       acorn: 8.16.0
@@ -15160,63 +15505,60 @@ snapshots:
 
   vite-bundle-analyzer@1.3.8: {}
 
-  vite-plugin-compression@0.5.1(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-compression@0.5.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3
       fs-extra: 10.1.0
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@4.5.4(@types/node@24.12.3)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-dts@5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.3)
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@volar/typescript': 2.4.23
-      '@vue/language-core': 2.2.0(typescript@5.9.3)
-      compare-versions: 6.1.1
-      debug: 4.4.3
-      kolorist: 1.8.0
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      typescript: 5.9.3
+      unplugin-dts: 1.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.2)
+      rollup: 4.60.3
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
-      - '@types/node'
-      - rollup
+      - '@rspack/core'
+      - '@vue/language-core'
+      - esbuild
+      - rolldown
       - supports-color
+      - typescript
+      - webpack
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.14
-      rollup: 4.60.3
-      tinyglobby: 0.2.15
+      rolldown: 1.0.0-rc.18
+      tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.3
+      '@types/node': 24.12.2
+      esbuild: 0.27.3
       fsevents: 2.3.3
       terser: 5.44.0
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@24.12.3)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -15233,11 +15575,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.12.3
-      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@7.3.3(@types/node@24.12.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@types/node': 24.12.2
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
       jsdom: 29.0.1
     transitivePeerDependencies:
@@ -15335,7 +15677,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0: {}
+  yallist@4.0.0:
+    optional: true
 
   yaml@1.10.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ catalogs:
       specifier: ^0.21.2
       version: 0.21.2
     '@preconstruct/cli':
-      specifier: ^2.8.12
-      version: 2.8.12
+      specifier: ^2.8.13
+      version: 2.8.13
     '@react-types/shared':
       specifier: ^3.34.0
       version: 3.34.0
@@ -151,9 +151,6 @@ catalogs:
     publint:
       specifier: ^0.3.20
       version: 0.3.20
-    rollup-plugin-tree-shakeable:
-      specifier: ^2.0.0
-      version: 2.0.0
     storybook:
       specifier: ^10.3.6
       version: 10.3.6
@@ -183,8 +180,8 @@ catalogs:
       specifier: ^4.17.24
       version: 4.17.24
     '@types/node':
-      specifier: ^24.12.2
-      version: 24.12.2
+      specifier: ^24.12.3
+      version: 24.12.4
     dequal:
       specifier: ^2.0.3
       version: 2.0.3
@@ -218,8 +215,11 @@ overrides:
   qs: ^6.14.2
   minimatch@>=3.0.0 <3.1.4: 3.1.4
   svgo: '>=3.3.3'
-  hono: '>=4.12.14'
+  hono: '>=4.12.18'
   '@hono/node-server': '>=1.19.13'
+  fast-uri: '>=3.1.2'
+  ip-address: '>=10.1.1'
+  postcss: '>=8.5.10'
   lodash@<4.18.0: '>=4.18.0'
   lodash-es@<4.18.0: '>=4.18.0'
   ajv@>=8.0.0 <8.18.0: '>=8.18.0'
@@ -245,11 +245,11 @@ importers:
         specifier: catalog:tooling
         version: 7.29.0
       '@changesets/changelog-github':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.7.0
+        version: 0.7.0
       '@changesets/cli':
         specifier: 2.30.0
-        version: 2.30.0(@types/node@24.12.2)
+        version: 2.30.0(@types/node@24.12.4)
       '@commercetools/nimbus':
         specifier: workspace:^
         version: link:packages/nimbus
@@ -261,10 +261,10 @@ importers:
         version: 1.4.4
       '@fission-ai/openspec':
         specifier: catalog:tooling
-        version: 1.3.1(@types/node@24.12.2)
+        version: 1.3.1(@types/node@24.12.4)
       '@preconstruct/cli':
         specifier: catalog:tooling
-        version: 2.8.12
+        version: 2.8.13
       dotenv:
         specifier: catalog:utils
         version: 16.6.1
@@ -309,7 +309,7 @@ importers:
         version: 1.3.8
       vitest:
         specifier: catalog:tooling
-        version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/blank-app:
     dependencies:
@@ -337,7 +337,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
         version: 10.3.0
@@ -355,7 +355,7 @@ importers:
         version: 8.59.2(eslint@10.3.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/docs:
     dependencies:
@@ -473,7 +473,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
         version: 10.3.0
@@ -491,10 +491,10 @@ importers:
         version: 8.59.2(eslint@10.3.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-compression:
         specifier: ^0.5.1
-        version: 0.5.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.5.1(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/color-tokens:
     dependencies:
@@ -516,7 +516,7 @@ importers:
         version: 3.1.1
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.2
+        version: 24.12.4
 
   packages/design-token-ts-plugin:
     devDependencies:
@@ -525,13 +525,13 @@ importers:
         version: link:../tokens
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.2
+        version: 24.12.4
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       vitest:
         specifier: catalog:tooling
-        version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/i18n:
     devDependencies:
@@ -540,7 +540,7 @@ importers:
         version: 3.4.0
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.2
+        version: 24.12.4
       glob:
         specifier: catalog:tooling
         version: 13.0.6
@@ -587,8 +587,8 @@ importers:
         specifier: 1.17.0
         version: 1.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-hotkeys-hook:
-        specifier: ^5.2.1
-        version: 5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^5.3.2
+        version: 5.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
         specifier: 3.46.0
         version: 3.46.0(react@19.2.0)
@@ -625,13 +625,13 @@ importers:
         version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
         version: 10.3.6(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5)(@vitest/runner@4.1.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.5)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.9.1
@@ -655,13 +655,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: catalog:tooling
-        version: 6.0.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: catalog:tooling
-        version: 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+        version: 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/browser-playwright':
         specifier: catalog:tooling
-        version: 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+        version: 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-v8':
         specifier: catalog:tooling
         version: 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
@@ -692,9 +692,6 @@ importers:
       react-dom:
         specifier: catalog:react
         version: 19.2.0(react@19.2.0)
-      rollup-plugin-tree-shakeable:
-        specifier: catalog:tooling
-        version: 2.0.0
       slate:
         specifier: ^0.123.0
         version: 0.123.0
@@ -712,13 +709,13 @@ importers:
         version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
-        version: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: catalog:tooling
-        version: 5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.4))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:tooling
-        version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/nimbus-docs-build:
     dependencies:
@@ -749,7 +746,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.2
+        version: 24.12.4
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -768,7 +765,7 @@ importers:
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.2
+        version: 24.12.4
       '@types/react':
         specifier: catalog:react
         version: 19.2.14
@@ -799,13 +796,13 @@ importers:
         version: link:../tokens
       '@modelcontextprotocol/inspector':
         specifier: catalog:tooling
-        version: 0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)
+        version: 0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)
       '@types/node':
         specifier: catalog:utils
-        version: 24.12.2
+        version: 24.12.4
       tsup:
         specifier: catalog:tooling
-        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.4))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: catalog:tooling
         version: 4.21.0
@@ -1109,8 +1106,8 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@0.6.0':
-    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
+  '@changesets/changelog-github@0.7.0':
+    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
 
   '@changesets/cli@2.30.0':
     resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
@@ -1534,7 +1531,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.18'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2058,8 +2055,8 @@ packages:
   '@preact/signals-core@1.13.0':
     resolution: {integrity: sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==}
 
-  '@preconstruct/cli@2.8.12':
-    resolution: {integrity: sha512-SMsMICUWROmu/vb4cmrk7EJUiWhgNjB3U3tM654K9bu9yECXqrPN473vliO7KPV3CSLhmtl3S4nfcMirEJmyZg==}
+  '@preconstruct/cli@2.8.13':
+    resolution: {integrity: sha512-+1I98YKqXy3nNQQBTvwzgjFujcDndX4Q7G0QHBCCRCxGRA5LIyUvK9XN92pyWPbbmUPPg2amlTGxWThGgn1DRQ==}
     hasBin: true
 
   '@preconstruct/hook@0.4.0':
@@ -3266,11 +3263,11 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@24.11.0':
-    resolution: {integrity: sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==}
-
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -4758,8 +4755,8 @@ packages:
   fast-shallow-equal@1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-stable-stringify@2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
@@ -5037,8 +5034,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   htm@3.1.1:
@@ -5132,8 +5129,8 @@ packages:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -6177,7 +6174,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
       yaml: '>=2.8.3'
     peerDependenciesMeta:
@@ -6327,8 +6324,8 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
-  react-hotkeys-hook@5.2.1:
-    resolution: {integrity: sha512-xbKh6zJxd/vJHT4Bw4+0pBD662Fk20V+VFhLqciCg+manTVO4qlqRqiwFOYelfHN9dBvWj9vxaPkSS26ZSIJGg==}
+  react-hotkeys-hook@5.3.2:
+    resolution: {integrity: sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -6552,10 +6549,6 @@ packages:
     resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  rollup-plugin-tree-shakeable@2.0.0:
-    resolution: {integrity: sha512-CbHO8wpyOCCmPWE5/kOdqDIHOBjGXXzbgazIHLWdaU8AntQCcbnagLKq6EeIyxuwO8w3aRa0ZH2dCuM1NFeTag==}
-    engines: {node: '>= 22'}
 
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
@@ -7138,7 +7131,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: ~5.9.3
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -8167,7 +8160,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.6.0':
+  '@changesets/changelog-github@0.7.0':
     dependencies:
       '@changesets/get-github-info': 0.8.0
       '@changesets/types': 6.1.0
@@ -8175,7 +8168,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.30.0(@types/node@24.12.2)':
+  '@changesets/cli@2.30.0(@types/node@24.12.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -8191,7 +8184,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@24.12.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.12.4)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -8564,10 +8557,10 @@ snapshots:
       - '@noble/hashes'
       - canvas
 
-  '@fission-ai/openspec@1.3.1(@types/node@24.12.2)':
+  '@fission-ai/openspec@1.3.1(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/prompts': 7.10.1(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/prompts': 7.10.1(@types/node@24.12.4)
       chalk: 5.6.2
       commander: 14.0.3
       fast-glob: 3.3.3
@@ -8640,9 +8633,9 @@ snapshots:
       '@storybook/react': 10.3.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
 
-  '@hono/node-server@1.19.13(hono@4.12.15)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
 
   '@humanfs/core@0.19.1': {}
 
@@ -8657,128 +8650,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.12.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/confirm@5.1.21(@types/node@24.12.2)':
+  '@inquirer/confirm@5.1.21(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/core@10.3.2(@types/node@24.12.2)':
+  '@inquirer/core@10.3.2(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/editor@4.2.23(@types/node@24.12.2)':
+  '@inquirer/editor@4.2.23(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/expand@4.0.23(@types/node@24.12.2)':
+  '@inquirer/expand@4.0.23(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.12.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.12.4)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.12.2)':
+  '@inquirer/input@4.3.1(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/number@3.0.23(@types/node@24.12.2)':
+  '@inquirer/number@3.0.23(@types/node@24.12.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/password@4.0.23(@types/node@24.12.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
-    optionalDependencies:
-      '@types/node': 24.12.2
-
-  '@inquirer/prompts@7.10.1(@types/node@24.12.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.12.2)
-      '@inquirer/confirm': 5.1.21(@types/node@24.12.2)
-      '@inquirer/editor': 4.2.23(@types/node@24.12.2)
-      '@inquirer/expand': 4.0.23(@types/node@24.12.2)
-      '@inquirer/input': 4.3.1(@types/node@24.12.2)
-      '@inquirer/number': 3.0.23(@types/node@24.12.2)
-      '@inquirer/password': 4.0.23(@types/node@24.12.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.12.2)
-      '@inquirer/search': 3.2.2(@types/node@24.12.2)
-      '@inquirer/select': 4.4.2(@types/node@24.12.2)
-    optionalDependencies:
-      '@types/node': 24.12.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@24.12.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.12.2
-
-  '@inquirer/search@3.2.2(@types/node@24.12.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.12.2
-
-  '@inquirer/select@4.4.2(@types/node@24.12.2)':
+  '@inquirer/password@4.0.23(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.12.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.12.2)
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
+  '@inquirer/prompts@7.10.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.12.4)
+      '@inquirer/confirm': 5.1.21(@types/node@24.12.4)
+      '@inquirer/editor': 4.2.23(@types/node@24.12.4)
+      '@inquirer/expand': 4.0.23(@types/node@24.12.4)
+      '@inquirer/input': 4.3.1(@types/node@24.12.4)
+      '@inquirer/number': 3.0.23(@types/node@24.12.4)
+      '@inquirer/password': 4.0.23(@types/node@24.12.4)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.12.4)
+      '@inquirer/search': 3.2.2(@types/node@24.12.4)
+      '@inquirer/select': 4.4.2(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
 
-  '@inquirer/type@3.0.10(@types/node@24.12.2)':
+  '@inquirer/search@3.2.2(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
+
+  '@inquirer/select@4.4.2(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.12.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.4
+
+  '@inquirer/type@3.0.10(@types/node@24.12.4)':
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@internationalized/date@3.12.0':
     dependencies:
@@ -8815,11 +8808,11 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -9056,24 +9049,24 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.0
 
-  '@microsoft/api-extractor-model@7.31.1(@types/node@24.12.2)':
+  '@microsoft/api-extractor-model@7.31.1(@types/node@24.12.4)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.2)
+      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.4)
     transitivePeerDependencies:
       - '@types/node'
     optional: true
 
-  '@microsoft/api-extractor@7.53.1(@types/node@24.12.2)':
+  '@microsoft/api-extractor@7.53.1(@types/node@24.12.4)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.31.1(@types/node@24.12.2)
+      '@microsoft/api-extractor-model': 7.31.1(@types/node@24.12.4)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.2)
+      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.4)
       '@rushstack/rig-package': 0.6.0
-      '@rushstack/terminal': 0.19.1(@types/node@24.12.2)
-      '@rushstack/ts-command-line': 5.1.1(@types/node@24.12.2)
+      '@rushstack/terminal': 0.19.1(@types/node@24.12.4)
+      '@rushstack/ts-command-line': 5.1.1(@types/node@24.12.4)
       lodash: 4.18.1
       minimatch: 10.2.4
       resolve: 1.22.10
@@ -9210,7 +9203,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)':
+  '@modelcontextprotocol/inspector@0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@5.9.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.21.2(zod@3.25.76)
       '@modelcontextprotocol/inspector-client': 0.21.2(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
@@ -9221,7 +9214,7 @@ snapshots:
       open: 10.2.0
       shell-quote: 1.8.3
       spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.4)(typescript@5.9.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -9239,7 +9232,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.15)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9249,7 +9242,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9261,7 +9254,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.15)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9271,7 +9264,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9352,7 +9345,7 @@ snapshots:
 
   '@preact/signals-core@1.13.0': {}
 
-  '@preconstruct/cli@2.8.12':
+  '@preconstruct/cli@2.8.13':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -10072,7 +10065,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
-  '@rushstack/node-core-library@5.17.0(@types/node@24.12.2)':
+  '@rushstack/node-core-library@5.17.0(@types/node@24.12.4)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -10083,12 +10076,12 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
     optional: true
 
-  '@rushstack/problem-matcher@0.1.1(@types/node@24.12.2)':
+  '@rushstack/problem-matcher@0.1.1(@types/node@24.12.4)':
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
     optional: true
 
   '@rushstack/rig-package@0.6.0':
@@ -10097,18 +10090,18 @@ snapshots:
       strip-json-comments: 3.1.1
     optional: true
 
-  '@rushstack/terminal@0.19.1(@types/node@24.12.2)':
+  '@rushstack/terminal@0.19.1(@types/node@24.12.4)':
     dependencies:
-      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.2)
-      '@rushstack/problem-matcher': 0.1.1(@types/node@24.12.2)
+      '@rushstack/node-core-library': 5.17.0(@types/node@24.12.4)
+      '@rushstack/problem-matcher': 0.1.1(@types/node@24.12.4)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
     optional: true
 
-  '@rushstack/ts-command-line@5.1.1(@types/node@24.12.2)':
+  '@rushstack/ts-command-line@5.1.1(@types/node@24.12.4)':
     dependencies:
-      '@rushstack/terminal': 0.19.1(@types/node@24.12.2)
+      '@rushstack/terminal': 0.19.1(@types/node@24.12.4)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -10128,10 +10121,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.3.6(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -10151,33 +10144,33 @@ snapshots:
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
-      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.60.3
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -10192,11 +10185,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react': 10.3.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -10206,7 +10199,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -10571,11 +10564,11 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@24.11.0':
+  '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.12.2':
+  '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
 
@@ -10604,7 +10597,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 24.11.0
+      '@types/node': 24.12.2
 
   '@types/resolve@1.20.6': {}
 
@@ -10800,42 +10793,42 @@ snapshots:
 
   '@visulima/boxen@2.0.10': {}
 
-  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.11(@swc/helpers@0.5.17)
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
     dependencies:
-      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
-      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
+  '@vitest/browser@4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -10855,9 +10848,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -10876,13 +10869,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -11555,7 +11548,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12404,7 +12397,7 @@ snapshots:
   express-rate-limit@8.3.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -12473,7 +12466,7 @@ snapshots:
 
   fast-shallow-equal@1.0.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-stable-stringify@2.0.2: {}
 
@@ -12822,7 +12815,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.15: {}
+  hono@4.12.18: {}
 
   htm@3.1.1: {}
 
@@ -12910,7 +12903,7 @@ snapshots:
 
   interpret@1.4.0: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -13055,7 +13048,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 24.11.0
+      '@types/node': 24.12.2
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -14300,7 +14293,7 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
-  react-hotkeys-hook@5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-hotkeys-hook@5.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -14609,12 +14602,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
-
-  rollup-plugin-tree-shakeable@2.0.0:
-    dependencies:
-      '@types/node': 24.11.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
 
   rollup@4.60.3:
     dependencies:
@@ -15207,14 +15194,14 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.2)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.12.4)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -15239,7 +15226,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.12.4))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -15259,7 +15246,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.2)
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.4)
       '@swc/core': 1.15.11(@swc/helpers@0.5.17)
       postcss: 8.5.14
       typescript: 5.9.3
@@ -15365,7 +15352,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  unplugin-dts@1.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.4))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@volar/typescript': 2.4.28
@@ -15377,10 +15364,10 @@ snapshots:
       typescript: 5.9.3
       unplugin: 2.3.11
     optionalDependencies:
-      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.2)
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.4)
       esbuild: 0.27.3
       rollup: 4.60.3
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -15478,22 +15465,22 @@ snapshots:
 
   vite-bundle-analyzer@1.3.8: {}
 
-  vite-plugin-compression@0.5.1(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-compression@0.5.1(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3
       fs-extra: 10.1.0
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-dts@5.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.4))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      unplugin-dts: 1.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.2))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-dts: 1.0.0(@microsoft/api-extractor@7.53.1(@types/node@24.12.4))(esbuild@0.27.3)(rollup@4.60.3)(typescript@5.9.3)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.2)
+      '@microsoft/api-extractor': 7.53.1(@types/node@24.12.4)
       rollup: 4.60.3
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -15503,7 +15490,7 @@ snapshots:
       - typescript
       - webpack
 
-  vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -15511,17 +15498,17 @@ snapshots:
       rolldown: 1.0.0-rc.18
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.4
       esbuild: 0.27.3
       fsevents: 2.3.3
       terser: 5.44.0
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@24.12.4)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -15538,11 +15525,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.12.2
-      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.2)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@types/node': 24.12.4
+      '@vitest/browser-playwright': 4.1.5(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.4)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
       jsdom: 29.0.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  rollup: ^4.60.3
   '@babel/runtime': ^7.29.2
   prismjs: ^1.30.0
   typescript: ~5.9.3
@@ -2655,41 +2656,41 @@ packages:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: ^4.60.3
 
   '@rollup/plugin-commonjs@15.1.0':
     resolution: {integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^2.22.0
+      rollup: ^4.60.3
 
   '@rollup/plugin-json@4.1.0':
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
+      rollup: ^4.60.3
 
   '@rollup/plugin-node-resolve@11.2.1':
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: ^4.60.3
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
+      rollup: ^4.60.3
 
   '@rollup/pluginutils@3.1.0':
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: ^4.60.3
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.60.3
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2928,7 +2929,7 @@ packages:
     resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
     peerDependencies:
       esbuild: '*'
-      rollup: '*'
+      rollup: ^4.60.3
       storybook: ^10.3.6
       vite: '*'
       webpack: '*'
@@ -6568,11 +6569,6 @@ packages:
     resolution: {integrity: sha512-CbHO8wpyOCCmPWE5/kOdqDIHOBjGXXzbgazIHLWdaU8AntQCcbnagLKq6EeIyxuwO8w3aRa0ZH2dCuM1NFeTag==}
     engines: {node: '>= 22'}
 
-  rollup@2.80.0:
-    resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7260,7 +7256,7 @@ packages:
       '@vue/language-core': ~3.1.5
       esbuild: '*'
       rolldown: '*'
-      rollup: '>=3'
+      rollup: ^4.60.3
       typescript: ~5.9.3
       vite: '>=3'
       webpack: ^4 || ^5
@@ -7390,7 +7386,7 @@ packages:
     resolution: {integrity: sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==}
     peerDependencies:
       '@microsoft/api-extractor': '>=7'
-      rollup: '>=3'
+      rollup: ^4.60.3
       vite: '>=3'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -9380,11 +9376,11 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/runtime': 7.29.2
       '@preconstruct/hook': 0.4.0
-      '@rollup/plugin-alias': 3.1.9(rollup@2.80.0)
-      '@rollup/plugin-commonjs': 15.1.0(rollup@2.80.0)
-      '@rollup/plugin-json': 4.1.0(rollup@2.80.0)
-      '@rollup/plugin-node-resolve': 11.2.1(rollup@2.80.0)
-      '@rollup/plugin-replace': 2.4.2(rollup@2.80.0)
+      '@rollup/plugin-alias': 3.1.9(rollup@4.60.3)
+      '@rollup/plugin-commonjs': 15.1.0(rollup@4.60.3)
+      '@rollup/plugin-json': 4.1.0(rollup@4.60.3)
+      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.60.3)
+      '@rollup/plugin-replace': 2.4.2(rollup@4.60.3)
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -9406,7 +9402,7 @@ snapshots:
       parse-json: 5.2.0
       quick-lru: 5.1.1
       resolve-from: 5.0.0
-      rollup: 2.80.0
+      rollup: 4.60.3
       semver: 7.7.4
       terser: 5.44.0
       v8-compile-cache: 2.4.0
@@ -9948,49 +9944,49 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
-  '@rollup/plugin-alias@3.1.9(rollup@2.80.0)':
+  '@rollup/plugin-alias@3.1.9(rollup@4.60.3)':
     dependencies:
-      rollup: 2.80.0
+      rollup: 4.60.3
       slash: 3.0.0
 
-  '@rollup/plugin-commonjs@15.1.0(rollup@2.80.0)':
+  '@rollup/plugin-commonjs@15.1.0(rollup@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.10
-      rollup: 2.80.0
+      rollup: 4.60.3
 
-  '@rollup/plugin-json@4.1.0(rollup@2.80.0)':
+  '@rollup/plugin-json@4.1.0(rollup@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
-      rollup: 2.80.0
+      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
+      rollup: 4.60.3
 
-  '@rollup/plugin-node-resolve@11.2.1(rollup@2.80.0)':
+  '@rollup/plugin-node-resolve@11.2.1(rollup@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
-      rollup: 2.80.0
+      rollup: 4.60.3
 
-  '@rollup/plugin-replace@2.4.2(rollup@2.80.0)':
+  '@rollup/plugin-replace@2.4.2(rollup@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.60.3)
       magic-string: 0.25.9
-      rollup: 2.80.0
+      rollup: 4.60.3
 
-  '@rollup/pluginutils@3.1.0(rollup@2.80.0)':
+  '@rollup/pluginutils@3.1.0(rollup@4.60.3)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 4.0.4
-      rollup: 2.80.0
+      rollup: 4.60.3
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.3)':
     dependencies:
@@ -14638,10 +14634,6 @@ snapshots:
       '@types/node': 24.11.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
-
-  rollup@2.80.0:
-    optionalDependencies:
-      fsevents: 2.3.3
 
   rollup@4.60.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalogs:
     "@preconstruct/cli": ^2.8.13
     "@vitejs/plugin-react": ^5.2.0
     "@vitejs/plugin-react-swc": ^4.3.0
-    vite: ^7.3.3
+    vite: npm:rolldown-vite@^7.3.1
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^4.5.4
     vite-tsconfig-paths: ^6.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalogs:
     "@vitejs/plugin-react-swc": ^4.3.0
     vite: npm:rolldown-vite@^7.3.1
     vite-bundle-analyzer: ^1.3.8
-    vite-plugin-dts: ^4.5.4
+    vite-plugin-dts: ^5.0.0
     vite-tsconfig-paths: ^6.1.1
     rollup: ^4.60.3
     rollup-plugin-tree-shakeable: ^2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,9 +30,9 @@ catalogs:
     express-rate-limit: ^8.5.1
     prettier: ^3.8.3
     "@preconstruct/cli": ^2.8.13
-    "@vitejs/plugin-react": ^5.2.0
+    "@vitejs/plugin-react": ^6.0.1
     "@vitejs/plugin-react-swc": ^4.3.0
-    vite: npm:rolldown-vite@^7.3.1
+    vite: ^8.0.10
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.0
     vite-tsconfig-paths: ^6.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,6 @@ catalogs:
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.0
     vite-tsconfig-paths: ^6.1.1
-    rollup: ^4.60.3
     rollup-plugin-tree-shakeable: ^2.0.0
     "@vitest/browser": ^4.1.5
     "@vitest/browser-playwright": ^4.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,7 @@ catalogs:
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.0
     vite-tsconfig-paths: ^6.1.1
+    rollup: ^4.60.3
     rollup-plugin-tree-shakeable: ^2.0.0
     "@vitest/browser": ^4.1.5
     "@vitest/browser-playwright": ^4.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,6 @@ catalogs:
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.0
     rollup: ^4.60.3
-    rollup-plugin-tree-shakeable: ^2.0.0
     "@vitest/browser": ^4.1.5
     "@vitest/browser-playwright": ^4.1.5
     "@vitest/coverage-v8": ^4.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,6 @@ catalogs:
     vite: ^8.0.10
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.0
-    vite-tsconfig-paths: ^6.1.1
     rollup: ^4.60.3
     rollup-plugin-tree-shakeable: ^2.0.0
     "@vitest/browser": ^4.1.5


### PR DESCRIPTION
## Summary

Upgrades the workspace from **Vite 7.3.3 → 8.0.11** and **@vitejs/plugin-react 5.2.0 → 6.0.1** (required — v6 is the first version with Vite 8 support). Also bumps `vite-plugin-dts 4.5.4 → 5.0.0` along the way.

## Why two breaking-change adaptations were needed

Vite 8 swaps **Rollup → Rolldown** and **esbuild → Oxc**. Rolldown's design preserves CommonJS semantics rather than transforming them like `@rollup/plugin-commonjs` did, so the existing nimbus library config produced a bundle that would have crashed for downstream browser consumers. Two surgical changes fix it:

### 1) Externalize React via `esmExternalRequirePlugin`, not `rollupOptions.external`

`packages/nimbus/vite.config.ts`

Under Rolldown, listing `react`/`react-dom` in `rollupOptions.external` makes them external **but** leaves `require("react")` calls inside bundled CJS deps (`use-sync-external-store/cjs/*`) emitting a runtime `__require()` helper that throws in browsers (`Calling 'require' for "react" in an environment that doesn't expose the 'require' function`). The fix is to declare the React-family externals through `esmExternalRequirePlugin` instead — the plugin both externalizes them and rewrites internal `require(externalId)` → ESM imports.

> Caveat: the two paths are mutually exclusive. If an ID appears in both `rollupOptions.external` and the plugin's `external` list, the plain externalization wins and the plugin's `require()` rewrite never runs. See [vitejs/rolldown-vite#596](https://github.com/vitejs/rolldown-vite/issues/596) for a related reproduction.

### 2) Switch `is-hotkey` to its named export

`packages/nimbus/src/components/rich-text-input/hooks/use-keyboard-shortcuts.ts`

Vite 8 standardizes CJS default-import interop. `is-hotkey@0.2.0` is babel-compiled CJS with `__esModule: true` AND `exports.default = isHotkey` AND `exports.isHotkey = isHotkey`. The stricter interop now double-wraps the default, leaving `(0, isHotkey.default)` resolving to a non-callable object. Changing `import isHotkey from "is-hotkey"` → `import { isHotkey } from "is-hotkey"` sidesteps the interop entirely (the package exports the same function under both names).

## Verification approach

Each step was committed atomically and validated end-to-end before moving to the next:

1. **[`b25f952a`](https://github.com/commercetools/nimbus/commit/b25f952a) — Switch catalog `vite` to `npm:rolldown-vite@^7.3.1`.** The Vite team's recommended intermediate step — exercises the Rolldown bundler under the Vite 7 API to isolate Rolldown issues from Vite-8 API changes.
2. **[`35077a70`](https://github.com/commercetools/nimbus/commit/35077a70) — Bump `vite-plugin-dts` 4.5.4 → 5.0.0.** v5 renamed `rollupTypes` → `bundleTypes`; we used the default value, so the option is dropped entirely (`bundleTypes` defaults to `false` too).
3. **[`7204aeba`](https://github.com/commercetools/nimbus/commit/7204aeba) — Bump `vite` 7 → 8 + `@vitejs/plugin-react` 5 → 6**, plus the two adaptations above.

Five follow-ups landed after the initial three commits:

- **[`79b73db7`](https://github.com/commercetools/nimbus/commit/79b73db7) — scope `esmExternalRequirePlugin` to the lib build.** At the top-level `plugins` array it leaked into Storybook's iframe build, externalizing `react` without an importmap and breaking the deployed bundle (`Failed to resolve module specifier "react"`). Moved into `build.rollupOptions.plugins` so it only runs for the library build.
- **[`9787a08f`](https://github.com/commercetools/nimbus/commit/9787a08f) — drop redundant rollup dep, tidy `vite.config.ts`.** With Rolldown handling bundling, the direct `rollup` import was unused — but see the next item for why the catalog/override entries had to stay.
- **[`4cbc99e8`](https://github.com/commercetools/nimbus/commit/4cbc99e8) — pin chunk extensions to `.es.js` / `.cjs.js`.** Vite 8/Rolldown changed the `[format]` placeholder from `es` → `esm`, which would have shifted chunk filenames from `*.es.js` to `*.esm.js`. The bundle-size script (`scripts/check-bundle-size.mjs`) hard-codes the pattern `**/*.es.js`, so the upgrade would have silently broken its measurement. Implemented via a tiny `outputOptions` Rollup plugin that writes a literal `chunkFileNames` per format.
- **[`c5cd53d4`](https://github.com/commercetools/nimbus/commit/c5cd53d4) — restore the `rollup` pnpm override.** Looked redundant after the upgrade (nothing imports rollup directly anymore) and was dropped, but it was still forcing `@preconstruct/cli`'s transitive `@rollup/plugin-*` peers onto rollup@4. Without it they fall back to rollup@2, preconstruct emits the secondary entrypoints' chunks duplicated _into_ `packages/tokens/dist`, the published tarball grows by ~250 KB, and CI's bundle-size check fails. Override restored.
- **[`5567f36b`](https://github.com/commercetools/nimbus/commit/5567f36b) — drop `rollup-plugin-tree-shakeable`.** The plugin annotates top-level statements with `/*@__PURE__*/`. Under Rolldown's CJS lib mode, those annotations propagate to Rolldown's synthesized `Object.defineProperty(exports, ...)` calls and the DCE pass eliminates them — every CJS chunk shipped without any exports, breaking `require("@commercetools/nimbus")` for any consumer (every named export resolved to `undefined`). Rolldown emits `/*@__PURE__*/` annotations natively in ESM output (1,680 on the current build) — enough that the extra plugin annotations weren't worth a Rolldown-incompatible code path. Re-measured downstream tree-shaking benefit at ~2.4% gz on a typical consumer bundle.

Two further commits landed during a rebase onto main:

- **[`c639a1bf`](https://github.com/commercetools/nimbus/commit/c639a1bf) — drop `vite-tsconfig-paths` in favor of native `resolve.tsconfigPaths`.** Vite 8 ships a native resolver that supersedes the plugin.
- **[`239b0519`](https://github.com/commercetools/nimbus/commit/239b0519) — regenerate `pnpm-lock.yaml` after rebase onto main.** Bookkeeping.

Verification commands run after each commit:

- `pnpm typecheck`
- `pnpm --filter @commercetools/nimbus build`
- `pnpm build:docs`
- `pnpm --filter blank-app build`
- `pnpm test:unit`
- `pnpm test:storybook`

Final state on the rebased branch: **1,180 unit tests across 85 files**, **886 storybook tests across 79 files, 0 unhandled errors**.

The bundle output was also diff-inspected: the Vite 7 output uses clean ESM `import * from "react"` for the `use-sync-external-store/cjs/*` shim. Pre-fix Vite 8 emitted broken `__require("react")` runtime helpers; post-fix output matches Vite 7 — top-level ESM imports, no CJS factory wrappers, no `__require` foot-guns. Spot-check `grep -r "__require" packages/nimbus/dist --include="*.es.js"` returns zero hits.

## Performance comparison

Apple M-series, 2 runs averaged, measured post-rebase on the final HEAD.

### Build wall-clock

| Task              | Vite 7 + Rollup | Vite 8 + Rolldown | Speedup   |
| ----------------- | --------------- | ----------------- | --------- |
| `nimbus` build    | 13.4 s          | 10.8 s            | **1.24×** |
| `docs` build      | 16.2 s          | 7.1 s             | **2.28×** |
| `blank-app` build | 3.8 s           | 2.0 s             | **1.94×** |

The big wins are on the **consumer-facing builds** (docs and blank-app) — Vite 8 + Rolldown more than halves the docs build and nearly halves blank-app. The `nimbus` library build itself improves by ~24%, dominated by `chakra typegen` and bundling cost.

### Nimbus library output

| Metric                                     | Vite 7      | Vite 8      | Δ         |
| ------------------------------------------ | ----------- | ----------- | --------- |
| `dist/` total (incl. sourcemaps, `du -sh`) | 22 MB       | 21 MB       | −4.5%     |
| Sum of all JS, uncompressed                | 2,803,204 B | 2,680,187 B | **−4.4%** |
| Sum of all JS, gzipped                     | 896,527 B   | 840,767 B   | **−6.2%** |
| JS chunk count                             | 540         | 534         | −6        |

Modest, real reductions from Rolldown's tighter wrapper/runtime overhead and slightly more aggressive chunk merging. Methodology: build twice per ref with `pnpm --filter` against pre-built workspace deps; clean `dist/` and `node_modules/.vite` between runs; sum byte sizes of `**/*.{js,cjs,mjs}` via `stat -f%z` for raw and `gzip -c | wc -c` per file for gzipped; `du -sh dist/` for total.

> **Earlier numbers in this description claimed −24% / −26%.** Those came from a build state where `rollup-plugin-tree-shakeable` was still in `rollupOptions.plugins`. That plugin proved incompatible with Rolldown's CJS lib mode — it adds `/*@__PURE__*/` annotations to top-level statements which Rolldown then propagated to its synthesized `Object.defineProperty(exports, ...)` calls and DCE'd, producing CJS chunks with **zero exports** across the board. Every CJS consumer would have seen `undefined` for every named import. The "−26% gz" was the broken bundle being smaller. The plugin has been removed (commit [`5567f36b`](https://github.com/commercetools/nimbus/commit/5567f36b)). The numbers above are from the post-fix build with all 267 CJS chunks emitting proper exports.

## Test plan

- [ ] CI passes: typecheck, lint, unit tests, storybook tests
- [ ] `pnpm start:storybook` renders components in dev mode
- [ ] `pnpm start:docs` renders the docs site in dev mode
- [ ] Smoke-test the published bundle locally by `pnpm pack`-ing nimbus and consuming it from a fresh app (optional — covered by `apps/blank-app` already)
