### PR TITLE
fix(avatar): align avatarLabelGeneric default with shipped locale data

### DIFF
--- a/packages/nimbus/src/components/avatar/avatar.docs.spec.tsx
+++ b/packages/nimbus/src/components/avatar/avatar.docs.spec.tsx
@@ -125,8 +125,8 @@ describe("Avatar - Missing names", () => {
     );
 
     const avatar = screen.getByRole("figure");
-    // Generic localized aria-label ("User avatar" in English)
-    expect(avatar).toHaveAttribute("aria-label", "User avatar");
+    // Generic localized aria-label ("Generic user avatar" in English)
+    expect(avatar).toHaveAttribute("aria-label", "Generic user avatar");
     // Person icon is rendered as the visual fallback
     expect(avatar.querySelector("svg")).not.toBeNull();
     // No initials text is rendered

--- a/packages/nimbus/src/components/avatar/avatar.i18n.ts
+++ b/packages/nimbus/src/components/avatar/avatar.i18n.ts
@@ -8,6 +8,6 @@ export const messages = {
     id: "Nimbus.Avatar.avatarLabelGeneric",
     description:
       "Generic aria-label for the avatar component, used when no first or last name is available to interpolate (e.g. partial user records).",
-    defaultMessage: "User avatar",
+    defaultMessage: "Generic user avatar",
   },
 };

--- a/packages/nimbus/src/components/avatar/avatar.stories.tsx
+++ b/packages/nimbus/src/components/avatar/avatar.stories.tsx
@@ -11,7 +11,7 @@ import { DisplayColorPalettes } from "@/utils/display-color-palettes";
 
 // English default for the `avatarLabelGeneric` i18n key — used when no name
 // is available to interpolate into the standard avatarLabel template.
-const GENERIC_LABEL = "User avatar";
+const GENERIC_LABEL = "Generic user avatar";
 
 /**
  * Storybook metadata configuration


### PR DESCRIPTION
## Summary

CI on `main` has been red since #1434 because the `avatarLabelGeneric` i18n key shipped with mismatched strings:

- `avatar.i18n.ts` `defaultMessage`: `"User avatar"`
- All locale data files (`packages/i18n/data/{core,en,de,es,fr-FR,pt-BR}.json`): `"Generic user avatar"`
- Compiled `intl/*.ts` files (consumed by the component at runtime): `"Generic user avatar"`
- `avatar.docs.spec.tsx` + four stories in `avatar.stories.tsx`: assert `"User avatar"`

The component renders `"Generic user avatar"` (from the compiled output), so the assertions never matched. Six storybook tests + one docs spec test fail on every push.

This PR aligns the source default and the test assertions with the string that's already in every locale file and in the published release — `"Generic user avatar"`. Three source files change; no locale or compiled files need to be touched.

- `packages/nimbus/src/components/avatar/avatar.i18n.ts` — `defaultMessage` → `"Generic user avatar"`
- `packages/nimbus/src/components/avatar/avatar.docs.spec.tsx` — assertion + comment updated
- `packages/nimbus/src/components/avatar/avatar.stories.tsx` — `GENERIC_LABEL` constant + comment updated

`pnpm extract-intl` produces no further diffs after this change. No consumer-visible change (the rendered aria-label was already `"Generic user avatar"`).

No changeset added — the published behavior is unchanged.

## Test plan

- [x] `pnpm test:dev packages/nimbus/src/components/avatar/avatar.docs.spec.tsx packages/nimbus/src/components/avatar/avatar.stories.tsx` — 22/22 pass locally
- [x] `pnpm extract-intl` — no diff after the fix
- [ ] CI green on this branch