### PR TITLE
perf(tag-group): fix render-time bug causing ComboBox multi-select lag

### DIFF
--- a/.changeset/taggroup-taglist-slot-perf.md
+++ b/.changeset/taggroup-taglist-slot-perf.md
@@ -1,0 +1,10 @@
+---
+"@commercetools/nimbus": patch
+---
+
+`TagGroup`: fix a render-time bug where `TagGroupTagListSlot` instantiated its
+styled component inside the component function, producing a new component
+identity on every render. This caused React to unmount and remount the entire
+tag list (and React Aria to rebuild its collection from scratch) on every parent
+render — severely impacting performance when many tags were rendered (e.g. in a
+multi-select ComboBox).

--- a/packages/nimbus/src/components/combobox/combobox.i18n.ts
+++ b/packages/nimbus/src/components/combobox/combobox.i18n.ts
@@ -19,9 +19,4 @@ export const messages = {
     description: "aria-label for combobox menu options",
     defaultMessage: "Options menu",
   },
-  removeTag: {
-    id: "Nimbus.ComboBox.removeTag",
-    description: "aria-label for remove tag button in multi-select ComboBox",
-    defaultMessage: "Remove tag {tagName}",
-  },
 };

--- a/packages/nimbus/src/components/combobox/combobox.recipe.ts
+++ b/packages/nimbus/src/components/combobox/combobox.recipe.ts
@@ -12,7 +12,6 @@ export const comboBoxSlotRecipe = defineSlotRecipe({
     "leadingElement",
     "content",
     "tagGroup",
-    "tag",
     "input",
     "popover",
     "listBox",
@@ -116,24 +115,6 @@ export const comboBoxSlotRecipe = defineSlotRecipe({
     },
     tagGroup: {
       display: "contents",
-    },
-    tag: {
-      colorPalette: "primary",
-      display: "flex",
-      alignItems: "center",
-      gap: "100",
-      borderRadius: "200",
-      background: "colorPalette.3",
-      fontSize: "var(--tag-font-size)",
-      lineHeight: "var(--tag-line-height)",
-      minH: "var(--tag-min-h)",
-      paddingX: "var(--tag-px)",
-      paddingY: "var(--tag-py, 0)",
-      maxW: "100%",
-      "&[data-disabled]": {
-        layerStyle: "disabled",
-        pointerEvents: "none",
-      },
     },
     input: {
       flex: "0 0 auto",
@@ -254,13 +235,6 @@ export const comboBoxSlotRecipe = defineSlotRecipe({
         leadingElement: {
           minH: "800",
         },
-        tag: {
-          "--tag-min-h": "sizes.600",
-          "--tag-px": "spacing.200",
-          "--tag-py": "0",
-          "--tag-font-size": "fontSizes.350",
-          "--tag-line-height": "lineHeights.400",
-        },
       },
       // Medium
       md: {
@@ -270,13 +244,6 @@ export const comboBoxSlotRecipe = defineSlotRecipe({
         },
         leadingElement: {
           minH: "1000",
-        },
-        tag: {
-          "--tag-min-h": "sizes.800",
-          "--tag-px": "spacing.200",
-          "--tag-py": "spacing.100",
-          "--tag-font-size": "fontSizes.400",
-          "--tag-line-height": "lineHeights.500",
         },
       },
     },

--- a/packages/nimbus/src/components/combobox/combobox.slots.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.slots.tsx
@@ -6,7 +6,6 @@ import type {
   ComboBoxLeadingElementSlotProps,
   ComboBoxContentSlotProps,
   ComboBoxTagGroupSlotProps,
-  ComboBoxTagSlotProps,
   ComboBoxInputSlotProps,
   ComboBoxPopoverSlotProps,
   ComboBoxListBoxSlotProps,
@@ -49,12 +48,6 @@ export const ComboBoxTagGroupSlot = withContext<
   HTMLDivElement,
   ComboBoxTagGroupSlotProps
 >("div", "tagGroup");
-
-// Tag slot - individual tag element in multi-select (lightweight replacement for TagGroup.Tag)
-export const ComboBoxTagSlot = withContext<
-  HTMLSpanElement,
-  ComboBoxTagSlotProps
->("span", "tag");
 
 // Input slot - wrapper for React Aria Input component
 export const ComboBoxInputSlot = withContext<

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -1990,6 +1990,101 @@ export const KeyboardBackspaceRemovesTag: Story = {
 };
 
 /**
+ * Keyboard: Tag Group Navigation
+ * Tests that the embedded TagGroup in multi-select mode preserves RAC's
+ * accessible keyboard pattern: single Tab stop, arrow navigation between
+ * tags, and Delete/Backspace to remove a focused tag with focus restoration.
+ */
+export const KeyboardTagGroupNavigation: Story = {
+  render: () => {
+    const [selectedKeys, setSelectedKeys] = useState<(string | number)[]>([
+      1, 2, 3, 4,
+    ]);
+
+    return (
+      <ComposedComboBox
+        aria-label="Test combobox"
+        items={simpleOptions}
+        selectionMode="multiple"
+        selectedKeys={selectedKeys}
+        onSelectionChange={setSelectedKeys}
+      />
+    );
+  },
+
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Verify initial tags render as a grid", async () => {
+      const tagGrid = canvas.getByRole("grid");
+      expect(tagGrid).toBeInTheDocument();
+      const tags = within(tagGrid).getAllByRole("row");
+      expect(tags).toHaveLength(4);
+    });
+
+    await step(
+      "Tab enters the tag group and arrow keys navigate between tags",
+      async () => {
+        // Click the input to establish focus, then Shift+Tab into the tag grid
+        const input = canvas.getByRole("combobox");
+        await userEvent.click(input);
+        expect(input).toHaveFocus();
+
+        await userEvent.tab({ shift: true });
+        const tagGrid = canvas.getByRole("grid");
+        expect(tagGrid.contains(document.activeElement)).toBe(true);
+
+        // Navigate to the first tag with Home, then arrow through
+        await userEvent.keyboard("{Home}");
+        expect(document.activeElement?.textContent).toContain("Koala");
+
+        await userEvent.keyboard("{ArrowRight}");
+        expect(document.activeElement?.textContent).toContain("Kangaroo");
+
+        await userEvent.keyboard("{ArrowRight}");
+        expect(document.activeElement?.textContent).toContain("Platypus");
+
+        await userEvent.keyboard("{ArrowLeft}");
+        expect(document.activeElement?.textContent).toContain("Kangaroo");
+      }
+    );
+
+    await step(
+      "Delete removes focused tag and moves focus to neighbor",
+      async () => {
+        // Focus is on Kangaroo from previous step's ArrowLeft
+        expect(document.activeElement?.textContent).toContain("Kangaroo");
+
+        await userEvent.keyboard("{Delete}");
+
+        // Kangaroo should be removed
+        await waitFor(() => {
+          expect(canvas.queryByText("Kangaroo")).not.toBeInTheDocument();
+        });
+
+        // Focus should move to a neighboring tag (not fall to body)
+        const tagGrid = canvas.getByRole("grid");
+        expect(tagGrid.contains(document.activeElement)).toBe(true);
+      }
+    );
+
+    await step(
+      "Backspace removes focused tag from within the tag group",
+      async () => {
+        await userEvent.keyboard("{Backspace}");
+
+        // A tag should be removed — 2 remaining (started with 4, removed 2)
+        await waitFor(() => {
+          const tagGrid = canvas.getByRole("grid");
+          const remaining = within(tagGrid).getAllByRole("row");
+          expect(remaining).toHaveLength(2);
+        });
+      }
+    );
+  },
+};
+
+/**
  * Keyboard: Navigation Without Mouse
  * Tests complete keyboard-only workflow (no mouse interaction)
  */

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -254,7 +254,7 @@ export const MultiSelectCustomOptions: Story = {
       // Find and click remove button for Lion
       const lionTag = await within(await getTagList(canvas.getByRole("group")))
         .getByText("Lion")
-        .closest('[role="listitem"]');
+        .closest('[role="row"]');
       expect(lionTag).toBeInTheDocument();
 
       const removeButton = within(lionTag as HTMLElement).getByRole("button", {
@@ -6118,7 +6118,8 @@ export const PerformanceManySelected: Story = {
 
     await step("Verify all 170 tags are rendered", async () => {
       const tagList = await getTagList(canvasElement);
-      expect(tagList.childNodes.length).toBe(PERF_SELECTED_COUNT);
+      const tags = tagList.querySelectorAll('[role="row"]');
+      expect(tags.length).toBe(PERF_SELECTED_COUNT);
     });
 
     await step("Remove a tag via remove button", async () => {
@@ -6130,7 +6131,8 @@ export const PerformanceManySelected: Story = {
 
       await waitFor(async () => {
         const tagList = await getTagList(canvasElement);
-        expect(tagList.childNodes.length).toBe(PERF_SELECTED_COUNT - 1);
+        const tags = tagList.querySelectorAll('[role="row"]');
+        expect(tags.length).toBe(PERF_SELECTED_COUNT - 1);
       });
     });
 

--- a/packages/nimbus/src/components/combobox/combobox.types.ts
+++ b/packages/nimbus/src/components/combobox/combobox.types.ts
@@ -42,7 +42,6 @@ export type ComboBoxTriggerSlotProps = HTMLChakraProps<"div">;
 export type ComboBoxLeadingElementSlotProps = HTMLChakraProps<"div">;
 export type ComboBoxContentSlotProps = HTMLChakraProps<"div">; // Flex wrapper for tags and input
 export type ComboBoxTagGroupSlotProps = HTMLChakraProps<"div">;
-export type ComboBoxTagSlotProps = HTMLChakraProps<"span">; // Individual tag element in multi-select
 export type ComboBoxInputSlotProps = HTMLChakraProps<"div">; // Wraps React Aria Input
 export type ComboBoxPopoverSlotProps = HTMLChakraProps<"div">;
 export type ComboBoxListBoxSlotProps = HTMLChakraProps<"div">; // Will wrap React Aria ListBox

--- a/packages/nimbus/src/components/combobox/components/combobox.tag-group.tsx
+++ b/packages/nimbus/src/components/combobox/components/combobox.tag-group.tsx
@@ -1,14 +1,14 @@
-import { memo, useCallback, useContext } from "react";
-import { TagGroupContext, ButtonContext } from "react-aria-components";
-import type { Key } from "react-stately";
-import { Close as CloseIcon } from "@commercetools/nimbus-icons";
-import { Box } from "@/components/box";
-import { IconButton } from "@/components/icon-button/icon-button";
+import { useContext } from "react";
+import {
+  TagGroupContext,
+  type ContextValue,
+  type TagGroupProps,
+} from "react-aria-components";
+import { TagGroup } from "@/components";
 import { useComboBoxRootContext } from "./combobox.root-context";
-import { ComboBoxTagGroupSlot, ComboBoxTagSlot } from "../combobox.slots";
+import { ComboBoxTagGroupSlot } from "../combobox.slots";
+import type { ComboBoxTagGroupProps } from "../combobox.types";
 import { extractStyleProps } from "@/utils";
-import { useLocalizedStringFormatter } from "@/hooks";
-import { comboboxMessagesStrings } from "../combobox.messages";
 
 /**
  * # ComboBox.TagGroup (Internal Component)
@@ -16,110 +16,63 @@ import { comboboxMessagesStrings } from "../combobox.messages";
  * Internal component that displays selected items as tags in multi-select mode.
  * Automatically rendered by ComboBox.Trigger - not exposed to consumers.
  *
- * Uses lightweight plain elements instead of React Aria's TagGroup collection
- * system for performance — avoids the collection reconciliation overhead when
- * rendering many selected tags.
- *
  * Consumes React-Aria's TagGroupContext, which is populated by the
  * TagGroupContextProvider in ComboBox.Root with:
  * - items: selected items array from collection
  * - onRemove: handler to remove tags
+ * - size: tag size matching ComboBox size
  * - aria-label: accessible label for the tag group
  * - id: generated in ComboBox.Root
+ * - selectionMode: "none" (tags are not selectable)
+ * - disabledKeys: disabled tag keys
  *
  * Renders null in single-select mode to avoid unnecessary DOM elements.
  *
  * @internal
  * @supportsStyleProps
  */
-
-type LightweightTagProps = {
-  itemKey: Key;
-  itemValue: string;
-  isDisabled: boolean;
-  onRemove?: (keys: Set<Key>) => void;
-};
-
-const LightweightTag = memo(function LightweightTag({
-  itemKey,
-  itemValue,
-  isDisabled,
-  onRemove,
-}: LightweightTagProps) {
-  const msg = useLocalizedStringFormatter(comboboxMessagesStrings);
-
-  const handleRemove = useCallback(() => {
-    onRemove?.(new Set([itemKey]));
-  }, [onRemove, itemKey]);
-
-  return (
-    <ComboBoxTagSlot role="listitem" data-disabled={isDisabled || undefined}>
-      {itemValue}
-      {!isDisabled && onRemove && (
-        <ButtonContext.Provider value={{}}>
-          <IconButton
-            size="2xs"
-            variant="ghost"
-            colorPalette="neutral"
-            onPress={handleRemove}
-            aria-label={msg.format("removeTag", { tagName: itemValue })}
-          >
-            <CloseIcon />
-          </IconButton>
-        </ButtonContext.Provider>
-      )}
-    </ComboBoxTagSlot>
-  );
-});
-
-export const ComboBoxTagGroup = (props: Record<string, unknown>) => {
-  const { selectionMode, getKey, getTextValue, isDisabled, isReadOnly } =
+export const ComboBoxTagGroup = (props: ComboBoxTagGroupProps) => {
+  const { selectionMode, size, getKey, getTextValue, isDisabled, isReadOnly } =
     useComboBoxRootContext();
   const [styleProps, functionalProps] = extractStyleProps(props);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const tagGroupContext = useContext<any>(TagGroupContext);
+  const tagGroupContext =
+    useContext<
+      ContextValue<TagGroupProps & { items?: object[] }, HTMLDivElement>
+    >(TagGroupContext);
 
-  const items: object[] =
+  // Extract items from context, handling both direct values and slotted values
+  const items =
     (tagGroupContext && "items" in tagGroupContext
       ? tagGroupContext.items
       : undefined) ?? [];
 
-  const onRemove: ((keys: Set<Key>) => void) | undefined =
-    tagGroupContext && "onRemove" in tagGroupContext
-      ? tagGroupContext.onRemove
-      : undefined;
-
-  const contextId: string | undefined =
-    tagGroupContext && "id" in tagGroupContext ? tagGroupContext.id : undefined;
-
-  const contextAriaLabel: string | undefined =
-    tagGroupContext && "aria-label" in tagGroupContext
-      ? tagGroupContext["aria-label"]
-      : undefined;
-
+  // Only render in multi-select mode
   if (selectionMode !== "multiple") {
     return null;
   }
 
   return (
-    <ComboBoxTagGroupSlot {...styleProps} {...functionalProps}>
-      <Box
-        role="list"
-        id={contextId}
-        aria-label={contextAriaLabel}
-        display="contents"
-      >
-        {items.map((item) => (
-          <LightweightTag
-            key={getKey(item)}
-            itemKey={getKey(item)}
-            itemValue={getTextValue(item)}
-            isDisabled={isDisabled || isReadOnly}
-            onRemove={onRemove}
-          />
-        ))}
-      </Box>
+    <ComboBoxTagGroupSlot {...styleProps} {...functionalProps} asChild>
+      {/* TagGroup.Root receives id from TagGroupContext set by custom-context */}
+      <TagGroup.Root size={size}>
+        <TagGroup.TagList items={items} display="contents">
+          {(item) => {
+            const itemKey = getKey(item);
+            const itemValue = getTextValue(item);
+            return (
+              <TagGroup.Tag
+                id={itemKey}
+                textValue={itemValue}
+                isDisabled={isDisabled || isReadOnly}
+                maxW="100%"
+              >
+                {itemValue}
+              </TagGroup.Tag>
+            );
+          }}
+        </TagGroup.TagList>
+      </TagGroup.Root>
     </ComboBoxTagGroupSlot>
   );
 };

--- a/packages/nimbus/src/components/combobox/intl/de.ts
+++ b/packages/nimbus/src/components/combobox/intl/de.ts
@@ -7,10 +7,6 @@
 export default {
   clearSelection: `Auswahl löschen`,
   options: `Optionsmenü`,
-  overflowTagCount: (args: Record<string, string | number>) =>
-    `+${args.count} more`,
-  removeTag: (args: Record<string, string | number>) =>
-    `Remove tag ${args.tagName}`,
   selectedValues: `Ausgewählte Werte`,
   toggleOptions: `Optionen anzeigen/ verbergen`,
 };

--- a/packages/nimbus/src/components/tag-group/tag-group.slots.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.slots.tsx
@@ -21,15 +21,20 @@ const { withProvider, withContext } = createSlotRecipeContext({
 export const TagGroupRootSlot: SlotComponent<typeof RaTagGroup, TagGroupProps> =
   withProvider<typeof RaTagGroup, TagGroupProps>(RaTagGroup, "root");
 
+// Defined at module scope — calling withContext inside the component would
+// produce a new component identity on every render, forcing React to unmount
+// and remount the entire TagList subtree (and React Aria to rebuild its
+// collection from scratch) on every parent render. That was a hot-path
+// regression for high tag counts.
+const TagListSlotComponent = withContext<
+  HTMLDivElement,
+  TagGroupTagListProps<object>
+>(RaTagList, "tagList");
+
 export const TagGroupTagListSlot = <T extends object>(
   props: TagGroupTagListProps<T>
 ): ReactElement<TagGroupTagListProps<T>, TagGroupTagListComponent<T>> => {
-  const { ref, ...restProps } = props;
-  const SlotComponent = withContext<HTMLDivElement, TagGroupTagListProps<T>>(
-    RaTagList,
-    "tagList"
-  );
-  return <SlotComponent {...restProps} ref={ref} />;
+  return <TagListSlotComponent {...(props as TagGroupTagListProps<object>)} />;
 };
 
 export const TagGroupTagSlot: TagGroupTagComponent = withContext<


### PR DESCRIPTION
## Summary

Builds on `FEC-908-combobox-perf` ([FEC-908](https://commercetools.atlassian.net/browse/FEC-908)).

`TagGroupTagListSlot` was calling `withContext` inside the component function:

```tsx
export const TagGroupTagListSlot = <T extends object>(props) => {
  const { ref, ...restProps } = props;
  const SlotComponent = withContext<HTMLDivElement, TagGroupTagListProps<T>>(
    RaTagList,
    "tagList",
  ); // runs every render → new component identity
  return <SlotComponent {...restProps} ref={ref} />;
};
```

This produced a fresh styled-component identity on every render, so React unmounted and remounted the entire `<TagList>` subtree each time the parent re-rendered, and React Aria rebuilt its collection from scratch. For a multi-select ComboBox with many selected tags, that compounds on every keystroke. The sibling `TagGroupRootSlot` and `TagGroupTagSlot` are already defined at module scope.

The fix is hoisting that one call to module scope. Once that's in place, the ComboBox-side tag rewrite from the base branch isn't needed any more, so this PR also reverts that part — restoring RAC's `TagGroup` inside ComboBox while keeping every other perf change from the base branch.

## What the revert brings back

The lightweight-tag implementation rendered tags as `role="list"` + a plain `IconButton` per tag, which lost the WAI-ARIA `grid` pattern RAC's `useTag` implements. Two concrete keyboard improvements at the 170-tag scale this ticket targets:

- **Tabbing past the ComboBox.** RAC TagGroup makes the whole group a single Tab stop — one Tab in, one Tab out. With per-tag remove buttons each one is its own Tab stop, so a keyboard user had to press Tab 170 times to reach the next form field.
- **Deleting a specific tag.** With RAC TagGroup, arrow to the tag and press `Delete`/`Backspace`; focus moves to a neighbor afterward so the user can keep deleting. With per-tag remove buttons there was no arrow navigation between tags, `Delete` did nothing, and after a click the destroyed button left focus to fall back to `<body>`.

## Commits

1. `revert(combobox): restore RAC TagGroup, drop lightweight-tag swap` — keeps every other perf change from the base branch (handleBlur ref check, `autoFocus={false}`, `collectionPopulatedRef` in useEffect, `singleSelectedTextValue`, selectedKeys fingerprint, per-context memos, `scrollContentToBottom`, content max-height). Removes the `tag` slot, `ComboBoxTagSlot`, `removeTag` i18n entry, the stale `overflowTagCount` in `intl/de.ts`, and the `[role="listitem"]` test selectors.
2. `perf(tag-group): hoist withContext call out of TagGroupTagListSlot` — the fix, plus a comment explaining why module scope matters here, plus a changeset.

## Test plan

- [x] `pnpm test:dev packages/nimbus/src/components/combobox/combobox.stories.tsx` — 111/111 passing
- [x] `pnpm test:dev packages/nimbus/src/components/tag-group/tag-group.stories.tsx` — 7/7 passing
- [ ] Manual: `PerformanceManySelected` story (170 tags) — keystroke latency, tag removal, dropdown open
- [ ] Manual: `MultiSelectCustomOptions` — arrow-key navigation across tags, focus restoration after remove


[FEC-908]: https://commercetools.atlassian.net/browse/FEC-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ