### PR TITLE
docs: codify slot-factory call-site rule and perf-debugging discipline

### DIFF
--- a/.claude/skills/writing-slots/SKILL.md
+++ b/.claude/skills/writing-slots/SKILL.md
@@ -177,6 +177,84 @@ export type SlotComponent<
 >;
 ```
 
+## Factory Call Site (CRITICAL)
+
+**`createRecipeContext`, `createSlotRecipeContext`, `withProvider`,
+`withContext`, and any equivalent factory that returns a React component MUST
+be invoked at module scope.**
+
+The component identity returned by these factories is what React uses to
+reconcile the rendered subtree. Re-invoking a factory inside a component or
+function body produces a new component identity on every render, which forces
+React to unmount and remount the entire styled subtree each time the parent
+renders. When the slot wraps a React Aria collection primitive (`TagList`,
+`ListBox`, `GridList`, `Menu`), the collection is also rebuilt from scratch
+on every render. The cost scales with subtree size and only manifests at
+high item counts, so the bug commonly evades small-scale review.
+
+```typescript
+// menu.slots.tsx
+import {
+  createSlotRecipeContext,
+  type HTMLChakraProps,
+} from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "../utils/slot-types";
+
+// Factory invoked once, at module scope.
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusMenu",
+});
+
+// Each slot is also defined once, at module scope.
+export type MenuRootSlotProps = HTMLChakraProps<"div">;
+export const MenuRootSlot: SlotComponent<HTMLDivElement, MenuRootSlotProps> =
+  withProvider<HTMLDivElement, MenuRootSlotProps>("div", "root");
+```
+
+### Generic-Typed Slot Wrappers
+
+When a slot must expose a generic type parameter to consumers (for example
+`<T extends object>` to type collection items), define the slot once at
+module scope with the generic erased to a concrete type, and preserve the
+generic only at the wrapper's type boundary. The runtime component is
+identical for every `T` — React Aria collection components do not branch on
+the item type at runtime — so this pattern is type-safe and keeps the
+styled-component identity stable across renders.
+
+```typescript
+// tag-group.slots.tsx
+import type { ReactElement } from "react";
+import {
+  createSlotRecipeContext,
+  type HTMLChakraProps,
+} from "@chakra-ui/react/styled-system";
+import { TagList as RaTagList } from "react-aria-components";
+import type { SlotComponent } from "../utils/slot-types";
+import type {
+  TagGroupTagListComponent,
+  TagGroupTagListProps,
+} from "./tag-group.types";
+
+const { withContext } = createSlotRecipeContext({ key: "nimbusTagGroup" });
+
+// Define the slot once at module scope, with the generic erased to `object`.
+const TagListSlotInner: SlotComponent<
+  HTMLDivElement,
+  TagGroupTagListProps<object>
+> = withContext<HTMLDivElement, TagGroupTagListProps<object>>(
+  RaTagList,
+  "tagList"
+);
+
+// The wrapper preserves the generic at the type boundary and delegates to the
+// stable inner component at runtime.
+export const TagGroupTagListSlot = <T extends object>(
+  props: TagGroupTagListProps<T>
+): ReactElement<TagGroupTagListProps<T>, TagGroupTagListComponent<T>> => {
+  return <TagListSlotInner {...(props as TagGroupTagListProps<object>)} />;
+};
+```
+
 ## File Structure Patterns
 
 ### Pattern 1: Standard Recipe (Single Slot)
@@ -522,6 +600,9 @@ You MUST validate against these requirements:
 - [ ] Child slots use `withContext` (for multi-slot)
 - [ ] Single-slot uses `withContext`
 - [ ] Context parameters correct (element type, slot name)
+- [ ] **All factory calls (`createRecipeContext`, `createSlotRecipeContext`,
+      `withProvider`, `withContext`) are at module scope, never inside a
+      component or function body**
 
 #### Type Safety
 
@@ -529,6 +610,9 @@ You MUST validate against these requirements:
 - [ ] TypeScript generics match element types
 - [ ] Slot names match recipe slot definitions
 - [ ] Props interfaces appropriate for element type
+- [ ] **Generic-typed slot wrappers define the inner slot once at module
+      scope with the generic erased to a concrete type, and preserve the
+      generic only at the wrapper's type boundary**
 
 #### Integration
 

--- a/docs/file-type-guidelines/architecture-decisions.md
+++ b/docs/file-type-guidelines/architecture-decisions.md
@@ -65,6 +65,38 @@ import { Button as RaButton } from "react-aria-components";
 import { Select as RaSelect } from "react-aria-components";
 ```
 
+### Preserving WAI-ARIA Composite Widget Patterns
+
+React Aria primitives such as `TagGroup`, `ListBox`, `GridList`, `Menu`, and
+`Table` implement WAI-ARIA composite-widget patterns deliberately. These
+patterns provide:
+
+- A single Tab stop for the entire widget, with arrow-key navigation between
+  items
+- `Delete` / `Backspace` on a focused row triggers `onRemove` and moves focus to
+  a neighbor automatically
+- Focus restoration after item removal
+- RTL-aware arrow-key direction
+
+The cost of these patterns is invisible at small item counts but becomes
+critical at scale. A multi-select with 170 selected tags rendered under the
+`grid` / `row` pattern is a single Tab stop with arrow navigation; the same UI
+flattened to `role="list"` plus a per-item `<button>` requires 170 Tab presses
+to traverse, makes `Delete` a no-op, and drops focus to `<body>` after each
+removal.
+
+When an optimization or styling change is tempted to drop a React Aria
+composite-widget primitive in favor of flatter ARIA roles, the bar is:
+
+1. Profile data showing the primitive itself is the dominant cost
+2. A documented plan that preserves the keyboard-navigation and
+   focus-restoration contract
+3. Review by the accessibility owner of record
+
+Absent these, retain the React Aria primitive and address the performance issue
+at a lower layer (see
+[Performance Investigation Discipline](#performance-investigation-discipline)).
+
 ## Recipe & Slot Decision Matrix
 
 ### When to Create Recipes/Slots
@@ -402,6 +434,44 @@ code lives (`src/components/` vs `src/patterns/`) and what file infrastructure
 is needed.
 
 See the full guide: **[Component vs Pattern](./component-vs-pattern.md)**
+
+## Performance Investigation Discipline
+
+When a performance issue is reported in a high-level component, identify and fix
+the cost at the lowest layer where it lives before changing the consumer. The
+dominant cost is usually one or two layers below the symptom — in a styling
+factory, a slot wrapper, a recipe, or a React Aria primitive — not in the
+consumer's own render code.
+
+### Process
+
+1. Reproduce with a representative load (high item counts, frequent updates) and
+   capture a profile.
+2. Inspect mount / unmount churn first. A subtree that unmounts and remounts on
+   every render typically signals a stale component identity (e.g., a
+   styled-component factory invoked inside a render path — see
+   [Slots: MUST Invoke Slot Factories at Module Scope](./slots.md#must-invoke-slot-factories-at-module-scope))
+   rather than legitimate work.
+3. Walk the cost from the consumer down through wrappers, slot factories, recipe
+   contexts, and React Aria primitives. Apply the fix at the layer where the
+   cost actually lives. Other consumers of the same primitive benefit
+   automatically.
+
+### Why Re-implementing Inside the Consumer Is the Last Resort
+
+Re-implementing rendering inside a high-level consumer (for example, rebuilding
+collection rendering inside ComboBox) creates a fork of the underlying
+primitive. The fork:
+
+- Hides the original bug from every other consumer of that primitive
+- Drifts from upstream React Aria fixes for accessibility, RTL, and focus
+  management
+- Frequently regresses keyboard accessibility silently (see
+  [Preserving WAI-ARIA Composite Widget Patterns](#preserving-wai-aria-composite-widget-patterns))
+- Adds a maintenance surface the design system was supposed to absorb
+
+If the design-system primitive is genuinely the bottleneck and cannot be fixed
+without breaking its public contract, escalate the discussion before forking.
 
 ## Related Guidelines
 

--- a/docs/file-type-guidelines/slots.md
+++ b/docs/file-type-guidelines/slots.md
@@ -66,6 +66,82 @@ export const ButtonRoot: SlotComponent<HTMLButtonElement, ButtonRootProps> =
   withContext<HTMLButtonElement, ButtonRootProps>("button", "root");
 ```
 
+### MUST Invoke Slot Factories at Module Scope
+
+`createRecipeContext`, `createSlotRecipeContext`, `withProvider`, `withContext`,
+and any equivalent factory that returns a React component MUST be invoked at
+module scope. The identity of the component returned by these factories is what
+React uses to reconcile the rendered subtree. Re-invoking a factory inside a
+component or function body produces a new component identity on every render,
+which forces React to unmount and remount the entire styled subtree each time
+the parent renders. When the slot wraps a React Aria collection primitive
+(`TagList`, `ListBox`, `GridList`, `Menu`), the collection is also rebuilt from
+scratch on every render. The cost scales with subtree size and only manifests at
+high item counts, so the bug commonly evades small-scale review.
+
+```typescript
+// menu.slots.tsx
+import {
+  createSlotRecipeContext,
+  type HTMLChakraProps,
+} from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "../utils/slot-types";
+
+// Factory invoked once, at module scope.
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusMenu",
+});
+
+// Each slot is also defined once, at module scope.
+export type MenuRootSlotProps = HTMLChakraProps<"div">;
+export const MenuRootSlot: SlotComponent<HTMLDivElement, MenuRootSlotProps> =
+  withProvider<HTMLDivElement, MenuRootSlotProps>("div", "root");
+```
+
+### Threading Generics Through Slot Wrappers
+
+When a slot needs to expose a generic type parameter to consumers (for example
+`<T extends object>` to type collection items), define the slot once at module
+scope with the generic erased to a concrete type, and preserve the generic only
+at the wrapper's type boundary. The runtime component is identical for every `T`
+— React Aria collection components do not branch on the item type at runtime —
+so this pattern is type-safe and keeps the styled-component identity stable
+across renders.
+
+```typescript
+// tag-group.slots.tsx
+import type { ReactElement } from "react";
+import {
+  createSlotRecipeContext,
+  type HTMLChakraProps,
+} from "@chakra-ui/react/styled-system";
+import { TagList as RaTagList } from "react-aria-components";
+import type { SlotComponent } from "../utils/slot-types";
+import type {
+  TagGroupTagListComponent,
+  TagGroupTagListProps,
+} from "./tag-group.types";
+
+const { withContext } = createSlotRecipeContext({ key: "nimbusTagGroup" });
+
+// Define the slot once at module scope, with the generic erased to `object`.
+const TagListSlotInner: SlotComponent<
+  HTMLDivElement,
+  TagGroupTagListProps<object>
+> = withContext<HTMLDivElement, TagGroupTagListProps<object>>(
+  RaTagList,
+  "tagList"
+);
+
+// The wrapper preserves the generic at the type boundary and delegates to the
+// stable inner component at runtime.
+export const TagGroupTagListSlot = <T extends object>(
+  props: TagGroupTagListProps<T>
+): ReactElement<TagGroupTagListProps<T>, TagGroupTagListComponent<T>> => {
+  return <TagListSlotInner {...(props as TagGroupTagListProps<object>)} />;
+};
+```
+
 ## SlotComponent Utility Type
 
 The `SlotComponent<TElement, TProps>` utility type provides explicit return type
@@ -338,6 +414,12 @@ export const ButtonRoot: SlotComponent<HTMLButtonElement, ButtonRootProps> =
 - [ ] Root slot uses `withProvider` (for multi-slot components)
 - [ ] Child slots use `withContext` (for multi-slot components)
 - [ ] Single-slot components use `withContext`
+- [ ] **All slot factory calls (`createRecipeContext`,
+      `createSlotRecipeContext`, `withProvider`, `withContext`) are at module
+      scope, never inside a component or function body**
+- [ ] **Generic-typed slot wrappers define the inner slot once at module scope
+      with the generic erased to a concrete type, and preserve the generic only
+      at the wrapper's type boundary**
 - [ ] Recipe `key` string used in context creation (matches the registered
       recipe key in `theme/slot-recipes/index.ts`)
 - [ ] `asChild` pattern used with React Aria when needed


### PR DESCRIPTION
## Summary

Codifies four learnings from the FEC-908 ComboBox perf debug ([PR #1485](https://github.com/commercetools/nimbus/pull/1485)) into durable guidance, so future component work avoids the same caveats.

The original bug: `TagGroupTagListSlot` invoked `withContext` inside the component function body, producing a fresh styled-component identity on every render. React unmounted/remounted the entire `<TagList>` subtree on every parent render, and React Aria rebuilt its collection from scratch. Hot path for high-tag-count usage; invisible at low counts. The first response was to fork tag rendering inside ComboBox with simpler ARIA roles, which would have shipped a real keyboard-a11y regression at scale (170 Tab presses to skip past the ComboBox; `Delete` becoming a no-op).

This PR captures the principles that came out of that debug as guidance.

## Changes

### `docs/file-type-guidelines/slots.md`

Two new entries under "Critical Requirements":

- **MUST Invoke Slot Factories at Module Scope** — `createRecipeContext`, `createSlotRecipeContext`, `withProvider`, `withContext` and equivalents must be called at module scope. Explains why (component identity, unmount/remount thrash, RAC collection rebuild) and includes a positive `menu.slots.tsx` example.
- **Threading Generics Through Slot Wrappers** — when a slot needs `<T extends object>`, define the slot once at module scope with the generic erased to `object`, and preserve the generic only at the wrapper's type boundary. Includes the canonical `tag-group.slots.tsx` pattern.

Validation Checklist gets two new items covering both rules.

### `docs/file-type-guidelines/architecture-decisions.md`

- **Preserving WAI-ARIA Composite Widget Patterns** (under "React Aria Integration Matrix") — explains what RAC's composite-widget primitives (`TagGroup`, `ListBox`, `GridList`, `Menu`, `Table`) provide (single Tab stop, arrow navigation, `Delete` on focused row, focus restoration) and the bar required to drop one in favor of flatter ARIA roles.
- **Performance Investigation Discipline** (new top-level section) — fix the cost at the lowest layer where it lives (slot factory, recipe, RAC primitive) before forking the consumer. Lists the trade-offs of forking (drift from upstream, hidden bug for other consumers, silent a11y regressions, ongoing maintenance).

### `.claude/skills/writing-slots/SKILL.md`

Mirrors the slots.md additions so the writing-slots skill enforces the rules on new and updated slot files. Includes the same module-scope rule, the generic-erasure pattern, and two new validation checklist items.

## Why two PRs

[PR #1485](https://github.com/commercetools/nimbus/pull/1485) is the actual fix and lives on a ComboBox-perf branch. This PR is purely documentation/process and is independently reviewable, so it lands on its own merge cycle and isn't blocked by review of the perf change.

## Test plan

- [x] All new code examples are positive (production-ready, no anti-patterns)
- [x] All claimed behaviors verified against the FEC-908 debug findings
- [x] Skill checklist updates align with new doc rules
- [ ] Reviewer sanity check: any existing slot files that violate the new rule? (None found in a quick scan, but worth a second pair of eyes)