### PR TITLE
chore(tsconfig): exclude build outputs from nimbus tsconfig

### DIFF
--- a/packages/nimbus/tsconfig.json
+++ b/packages/nimbus/tsconfig.json
@@ -35,5 +35,6 @@
       "node_modules/@types"
     ],
     "plugins": [{ "name": "@commercetools/nimbus-design-token-ts-plugin" }]
-  }
+  },
+  "exclude": ["dist", "storybook-static", "coverage", ".turbo", "node_modules"]
 }

--- a/packages/nimbus/tsconfig.json
+++ b/packages/nimbus/tsconfig.json
@@ -36,5 +36,5 @@
     ],
     "plugins": [{ "name": "@commercetools/nimbus-design-token-ts-plugin" }]
   },
-  "exclude": ["dist", "storybook-static", "coverage", ".turbo", "node_modules"]
+  "exclude": ["dist", "storybook-static", "coverage", "node_modules"]
 }


### PR DESCRIPTION
> [!NOTE]
> This PR get's rid of this pesky vs code message:

<img width="475" height="157" alt="image" src="https://github.com/user-attachments/assets/d34f9a23-5db6-436c-b73a-26bba6e5c799" />

## Summary

- Add an `exclude` field to `packages/nimbus/tsconfig.json` covering `dist`, `storybook-static`, `coverage`, and `node_modules` so the editor's TS server stops indexing build/cache outputs.
- Purely an editor-ergonomics change. `tsc --noEmit` already wasn't doing real work on these directories, so CI behavior is unchanged.

## Why this is safe wrt. Chakra typegen

`packages/nimbus`'s `postinstall` (and `build-theme-typings`) runs `chakra typegen`, which writes module-augmentation `.d.ts` files into `node_modules/@chakra-ui/react/dist/types/styled-system/generated/`. Those files are picked up via **module resolution** when source imports from `@chakra-ui/react`, and `exclude` only filters root inputs to the program — it does not affect module resolution. The generated recipe/token/condition typings continue to apply.

## Test plan

- [x] Open the repo in VS Code; confirm the "project too large" hint goes away and TS server feels snappier.
- [x] Hover a `<Box bg="primary.500" />` (or similar) — token autocomplete and recipe variant typings still work, confirming Chakra typegen augmentations are still loaded.
- [x] `pnpm --filter @commercetools/nimbus typecheck` passes (against a properly built workspace — i.e. tokens + nimbus built so `chakra typegen` has populated the generated `.d.ts` files).