### PR TITLE
FEC-913: add pnpm bundle-sizes:trend for size attribution

### DIFF
--- a/.github/actions/bundle-size/fetch-bundle-baseline.mjs
+++ b/.github/actions/bundle-size/fetch-bundle-baseline.mjs
@@ -43,7 +43,7 @@ function writeOutput(key, value) {
 }
 
 const prNumber = gh(
-  `api "repos/${REPO}/pulls?state=closed&labels=bundle-sizes&per_page=5&sort=updated&direction=desc" --jq '[.[] | select(.merged_at != null)] | .[0].number // empty'`
+  `api "repos/${REPO}/issues?state=closed&labels=bundle-sizes&per_page=5&sort=updated&direction=desc" --jq '[.[] | select(.pull_request.merged_at != null)] | .[0].number // empty'`
 );
 
 if (!prNumber) {

--- a/docs/bundle-size-monitoring.md
+++ b/docs/bundle-size-monitoring.md
@@ -180,9 +180,15 @@ pnpm bundle-sizes:trend
 # Limit to the last 5
 pnpm bundle-sizes:trend --limit 5
 
+# Output raw JSON (pipeable to jq or other scripts)
+pnpm bundle-sizes:trend --json
+
 # Show usage
 pnpm bundle-sizes:trend --help
 ```
+
+Each PR requires a separate API call to fetch its comments, so higher `--limit`
+values will be slower.
 
 Example output:
 

--- a/docs/bundle-size-monitoring.md
+++ b/docs/bundle-size-monitoring.md
@@ -14,6 +14,9 @@ pnpm check:bundle-size
 
 # Update the baseline after an intentional size change
 node scripts/update-bundle-sizes.mjs
+
+# View bundle size trend across recent merged PRs
+pnpm bundle-sizes:trend
 ```
 
 ## How It Works
@@ -162,3 +165,35 @@ const THRESHOLD = 0.05; // 5%
 
 If we find the threshold too sensitive or too lenient after a few weeks of use,
 adjust it and commit the change.
+
+## Viewing the Trend
+
+The `bundle-sizes:trend` command reconstructs a historical view of bundle sizes
+from merged PR comments. Each merged PR with the `bundle-sizes` label has a
+machine-readable data block in its bot comment — this command queries those
+comments and prints a chronological table with per-package sizes and deltas.
+
+```bash
+# Show trend for the last 20 merged PRs (default)
+pnpm bundle-sizes:trend
+
+# Limit to the last 5
+pnpm bundle-sizes:trend --limit 5
+
+# Show usage
+pnpm bundle-sizes:trend --help
+```
+
+Example output:
+
+```
+┌─────────┬─────────┬──────────────────────┬──────────────┬─────────────┬──────────┐
+│ (index) │ PR      │ Title                │ Merged       │ nimbus (KB) │ nimbus Δ │
+├─────────┼─────────┼──────────────────────┼──────────────┼─────────────┼──────────┤
+│ 0       │ '#1499' │ 'FEC-912: comment…'  │ '2026-05-15' │ '16583.0'   │ '—'      │
+│ 1       │ '#1498' │ 'chore(ci): add …'   │ '2026-05-16' │ '16588.2'   │ '+5.1'   │
+└─────────┴─────────┴──────────────────────┴──────────────┴─────────────┴──────────┘
+```
+
+Requires the [GitHub CLI](https://cli.github.com) (`gh`) to be installed and
+authenticated. The script is read-only — it only queries the API, never writes.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "test:storybook:dev": "pnpm vitest run --config vitest.dev.config.ts --project=storybook-dev",
     "check:bundle-size": "node .github/actions/bundle-size/check-bundle-size.mjs",
     "check:package-shape": "node scripts/check-package-shape.mjs",
-    "update:bundle-sizes": "node scripts/update-bundle-sizes.mjs"
+    "update:bundle-sizes": "node scripts/update-bundle-sizes.mjs",
+    "bundle-sizes:trend": "node scripts/bundle-sizes-trend.mjs"
   },
   "packageManager": "pnpm@10.12.3+sha512.467df2c586056165580ad6dfb54ceaad94c5a30f80893ebdec5a44c5aa73c205ae4a5bb9d5ed6bb84ea7c249ece786642bbb49d06a307df218d03da41c317417",
   "pnpm": {

--- a/scripts/bundle-sizes-trend.mjs
+++ b/scripts/bundle-sizes-trend.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+
+try {
+  execSync("gh --version", { stdio: "ignore" });
+} catch {
+  console.error(
+    "Error: GitHub CLI (gh) is not installed.\n" +
+      "Install it from https://cli.github.com and run `gh auth login`."
+  );
+  process.exit(1);
+}
+
+const DEFAULT_LIMIT = 20;
+const DATA_BLOCK_RE = /<!-- bundle-sizes-data-v(\d+): ({.*?}) -->/;
+
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`Usage: bundle-sizes-trend [options]
+
+Show bundle size trend from merged PR comments.
+
+Options:
+  --limit N   Number of merged PRs to query (default: ${DEFAULT_LIMIT})
+  --help, -h  Show this help message`);
+  process.exit(0);
+}
+
+const limitIdx = args.indexOf("--limit");
+const limit =
+  limitIdx !== -1 ? Number.parseInt(args[limitIdx + 1], 10) : DEFAULT_LIMIT;
+
+if (Number.isNaN(limit) || limit < 1) {
+  console.error("Error: --limit must be a positive integer.");
+  process.exit(1);
+}
+
+function gh(args) {
+  return execSync(`gh ${args}`, {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+function detectRepo() {
+  try {
+    return gh("repo view --json nameWithOwner --jq .nameWithOwner");
+  } catch {
+    console.error(
+      "Error: could not detect repository. Make sure you are in a git repo with a GitHub remote."
+    );
+    process.exit(1);
+  }
+}
+
+const repo = detectRepo();
+
+const prsJson = gh(
+  `api "repos/${repo}/pulls?state=closed&labels=bundle-sizes&per_page=${limit}&sort=updated&direction=desc" --jq '[.[] | select(.merged_at != null) | {number, title, merged_at}]'`
+);
+
+const prs = JSON.parse(prsJson);
+
+if (prs.length === 0) {
+  console.log(
+    "No trend data found; has the comment-chain workflow been set up?"
+  );
+  process.exit(0);
+}
+
+const entries = [];
+
+for (const pr of prs) {
+  const commentBody = gh(
+    `api "repos/${repo}/issues/${pr.number}/comments" --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("bundle-sizes-comment"))] | .[0].body // empty'`
+  );
+
+  if (!commentBody) continue;
+
+  const match = commentBody.match(DATA_BLOCK_RE);
+  if (!match) continue;
+
+  const version = Number.parseInt(match[1], 10);
+  if (version !== 1) {
+    console.warn(
+      `Warning: skipping PR #${pr.number} — unrecognized data block version ${version}`
+    );
+    continue;
+  }
+
+  try {
+    const sizes = JSON.parse(match[2]);
+    entries.push({
+      number: pr.number,
+      title: pr.title,
+      mergedAt: pr.merged_at,
+      sizes,
+    });
+  } catch {
+    console.warn(
+      `Warning: skipping PR #${pr.number} — could not parse data block`
+    );
+  }
+}
+
+if (entries.length === 0) {
+  console.log(
+    "No trend data found; merged PRs exist but none contain a parseable data block."
+  );
+  process.exit(0);
+}
+
+// Oldest first so deltas read chronologically
+entries.reverse();
+
+const allPackages = [
+  ...new Set(entries.flatMap((e) => Object.keys(e.sizes))),
+].sort();
+
+const rows = entries.map((entry, i) => {
+  const row = {
+    PR: `#${entry.number}`,
+    Title:
+      entry.title.length > 40 ? entry.title.slice(0, 37) + "..." : entry.title,
+    Merged: entry.mergedAt.slice(0, 10),
+  };
+
+  for (const pkg of allPackages) {
+    const shortName = pkg.replace("@commercetools/", "");
+    const bytes = entry.sizes[pkg]?.dist;
+    const kb = bytes != null ? (bytes / 1024).toFixed(1) : "—";
+    row[`${shortName} (KB)`] = kb;
+
+    let delta = "—";
+    if (i > 0) {
+      const prevBytes = entries[i - 1].sizes[pkg]?.dist;
+      if (bytes != null && prevBytes != null) {
+        const diff = bytes - prevBytes;
+        if (diff === 0) {
+          delta = "0";
+        } else {
+          const sign = diff > 0 ? "+" : "";
+          delta = `${sign}${(diff / 1024).toFixed(1)}`;
+        }
+      }
+    }
+    row[`${shortName} Δ`] = delta;
+  }
+
+  return row;
+});
+
+console.table(rows);

--- a/scripts/bundle-sizes-trend.mjs
+++ b/scripts/bundle-sizes-trend.mjs
@@ -14,6 +14,7 @@ Show bundle size trend from merged PR comments.
 
 Options:
   --limit N   Number of merged PRs to query (default: ${DEFAULT_LIMIT})
+  --json      Output raw JSON instead of a table
   --help, -h  Show this help message`);
   process.exit(0);
 }
@@ -28,6 +29,7 @@ try {
   process.exit(1);
 }
 
+const jsonOutput = args.includes("--json");
 const limitIdx = args.indexOf("--limit");
 const limit =
   limitIdx !== -1 ? Number.parseInt(args[limitIdx + 1], 10) : DEFAULT_LIMIT;
@@ -114,6 +116,11 @@ if (entries.length === 0) {
 
 // Oldest first so deltas read chronologically
 entries.reverse();
+
+if (jsonOutput) {
+  console.log(JSON.stringify(entries, null, 2));
+  process.exit(0);
+}
 
 const allPackages = [
   ...new Set(entries.flatMap((e) => Object.keys(e.sizes))),

--- a/scripts/bundle-sizes-trend.mjs
+++ b/scripts/bundle-sizes-trend.mjs
@@ -2,16 +2,6 @@
 
 import { execSync } from "node:child_process";
 
-try {
-  execSync("gh --version", { stdio: "ignore" });
-} catch {
-  console.error(
-    "Error: GitHub CLI (gh) is not installed.\n" +
-      "Install it from https://cli.github.com and run `gh auth login`."
-  );
-  process.exit(1);
-}
-
 const DEFAULT_LIMIT = 20;
 const DATA_BLOCK_RE = /<!-- bundle-sizes-data-v(\d+): ({.*?}) -->/;
 
@@ -26,6 +16,16 @@ Options:
   --limit N   Number of merged PRs to query (default: ${DEFAULT_LIMIT})
   --help, -h  Show this help message`);
   process.exit(0);
+}
+
+try {
+  execSync("gh --version", { stdio: "ignore" });
+} catch {
+  console.error(
+    "Error: GitHub CLI (gh) is not installed.\n" +
+      "Install it from https://cli.github.com and run `gh auth login`."
+  );
+  process.exit(1);
 }
 
 const limitIdx = args.indexOf("--limit");

--- a/scripts/bundle-sizes-trend.mjs
+++ b/scripts/bundle-sizes-trend.mjs
@@ -34,15 +34,17 @@ const limitIdx = args.indexOf("--limit");
 const limit =
   limitIdx !== -1 ? Number.parseInt(args[limitIdx + 1], 10) : DEFAULT_LIMIT;
 
-if (Number.isNaN(limit) || limit < 1) {
-  console.error("Error: --limit must be a positive integer.");
+const MAX_LIMIT = 100;
+
+if (Number.isNaN(limit) || limit < 1 || limit > MAX_LIMIT) {
+  console.error(`Error: --limit must be between 1 and ${MAX_LIMIT}.`);
   process.exit(1);
 }
 
 function gh(args) {
   return execSync(`gh ${args}`, {
     encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
+    stdio: ["pipe", "pipe", "inherit"],
   }).trim();
 }
 
@@ -60,7 +62,7 @@ function detectRepo() {
 const repo = detectRepo();
 
 const prsJson = gh(
-  `api "repos/${repo}/pulls?state=closed&labels=bundle-sizes&per_page=${limit}&sort=updated&direction=desc" --jq '[.[] | select(.merged_at != null) | {number, title, merged_at}]'`
+  `api "repos/${repo}/issues?state=closed&labels=bundle-sizes&per_page=${limit}&sort=updated&direction=desc" --jq '[.[] | select(.pull_request.merged_at != null) | {number, title, merged_at: .pull_request.merged_at}]'`
 );
 
 const prs = JSON.parse(prsJson);


### PR DESCRIPTION
## Summary

- Adds `scripts/bundle-sizes-trend.mjs`, a read-only CLI that queries merged PRs with the `bundle-sizes` label, parses the machine-readable data block from each bot comment, and prints a chronological `console.table` with per-package sizes (KB) and deltas
- Adds `pnpm bundle-sizes:trend` script entry to `package.json`
- Supports `--limit N` to control how many PRs to query (default: 20)
- Supports `--help` / `-h` for usage info
- Gracefully handles: no labeled PRs, missing/unparseable data blocks, unrecognized data block versions, and missing `gh` CLI
- Documents the new command in `docs/bundle-size-monitoring.md`
- **Bugfix:** Switches `fetch-bundle-baseline.mjs` from the `/pulls` endpoint to the `/issues` endpoint for label-based queries. The GitHub REST API `/pulls` endpoint does not reliably filter by label — closed-without-merge Dependabot PRs (without the `bundle-sizes` label) were filling the `per_page=5` window, causing the script to fall back to the bootstrap baseline even though labeled merged PRs exist.

Closes FEC-913

## Test plan

- [x] `pnpm bundle-sizes:trend --help` prints usage info
- [x] `pnpm bundle-sizes:trend` on a repo with no labeled merged PRs prints "no trend data found" message
- [x] `pnpm bundle-sizes:trend` on a repo with labeled merged PRs prints a table with PR number, title, merge date, per-package sizes, and deltas
- [x] `pnpm bundle-sizes:trend --limit 5` limits output to 5 rows
- [x] `fetch-bundle-baseline.mjs` now correctly resolves baseline from comment chain instead of falling back to bootstrap
- [x] Lint passes clean
