### PR TITLE
fix(bundle): add timestamp to comment

### DIFF
--- a/.github/actions/bundle-size/post-bundle-size-comment.mjs
+++ b/.github/actions/bundle-size/post-bundle-size-comment.mjs
@@ -45,8 +45,9 @@ const data = JSON.parse(readFileSync(JSON_FILE, "utf-8"));
 const lines = [];
 lines.push("<!-- bundle-sizes-comment -->");
 const timestamp = new Date().toISOString().replace("T", " ").slice(0, 19);
-lines.push(`## Bundle Size Report <sub>Last updated: ${timestamp} UTC</sub>`);
+lines.push("## Bundle Size Report");
 lines.push("");
+lines.push(`<sub>Last updated: ${timestamp} UTC</sub>`);
 lines.push("| Package | Format | Current | Baseline | Delta | Status |");
 lines.push("|---------|--------|--------:|---------:|------:|--------|");
 

--- a/.github/actions/bundle-size/post-bundle-size-comment.mjs
+++ b/.github/actions/bundle-size/post-bundle-size-comment.mjs
@@ -87,6 +87,10 @@ for (const [pkg, formats] of Object.entries(data.packages)) {
   sizes[pkg] = { dist: formats.dist.current };
 }
 lines.push("");
+lines.push(
+  `<sub>Last updated: ${new Date().toISOString().replace("T", " ").slice(0, 19)} UTC</sub>`
+);
+lines.push("");
 lines.push(`<!-- bundle-sizes-data-v1: ${JSON.stringify(sizes)} -->`);
 
 const bodyFile = "/tmp/comment-body.txt";

--- a/.github/actions/bundle-size/post-bundle-size-comment.mjs
+++ b/.github/actions/bundle-size/post-bundle-size-comment.mjs
@@ -44,7 +44,8 @@ const data = JSON.parse(readFileSync(JSON_FILE, "utf-8"));
 
 const lines = [];
 lines.push("<!-- bundle-sizes-comment -->");
-lines.push("## Bundle Size Report");
+const timestamp = new Date().toISOString().replace("T", " ").slice(0, 19);
+lines.push(`## Bundle Size Report <sub>Last updated: ${timestamp} UTC</sub>`);
 lines.push("");
 lines.push("| Package | Format | Current | Baseline | Delta | Status |");
 lines.push("|---------|--------|--------:|---------:|------:|--------|");
@@ -86,10 +87,6 @@ const sizes = {};
 for (const [pkg, formats] of Object.entries(data.packages)) {
   sizes[pkg] = { dist: formats.dist.current };
 }
-lines.push("");
-lines.push(
-  `<sub>Last updated: ${new Date().toISOString().replace("T", " ").slice(0, 19)} UTC</sub>`
-);
 lines.push("");
 lines.push(`<!-- bundle-sizes-data-v1: ${JSON.stringify(sizes)} -->`);
 


### PR DESCRIPTION
Adds a line to the bundle size comment that shows the last updated timestamp in UTC, improving traceability of bundle size reports.