### PR TITLE
fix(tests): stabilize flaky pinned-header and data-table perf assertions

### DIFF
--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -4599,9 +4599,46 @@ const SelectionContextProbe = React.memo(function SelectionContextProbe() {
 export const PerfLargeDatasetResponsiveness: Story = {
   render: () => {
     const largeRows = React.useMemo(() => generatePerfRows(170), []);
+    const renderCountsRef = React.useRef<Record<string, number>>({});
+
+    // Instrument the Name column so each row stamps its own render count
+    // onto a data attribute. The selection-toggle step asserts on these
+    // counts instead of wall-clock time, which is too noisy on shared CI
+    // runners to threshold reliably.
+    const instrumentedColumns: DataTableColumnItem[] = React.useMemo(
+      () => [
+        {
+          id: "name",
+          header: "Name",
+          accessor: (row: Record<string, unknown>) => row.name as ReactNode,
+          isSortable: true,
+          render: ({ row, value }) => {
+            const rowId = (row as DataTableRowItem).id;
+            renderCountsRef.current[rowId] =
+              (renderCountsRef.current[rowId] || 0) + 1;
+            return (
+              <span
+                data-testid={`perf-rc-${rowId}`}
+                data-render-count={renderCountsRef.current[rowId]}
+              >
+                {value as string}
+              </span>
+            );
+          },
+        },
+        {
+          id: "category",
+          header: "Category",
+          accessor: (row: Record<string, unknown>) => row.category as ReactNode,
+          isSortable: true,
+        },
+      ],
+      []
+    );
+
     return (
       <DataTable
-        columns={perfColumns}
+        columns={instrumentedColumns}
         rows={largeRows}
         selectionMode="multiple"
         allowsSorting
@@ -4612,29 +4649,51 @@ export const PerfLargeDatasetResponsiveness: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Selection toggle with ~170 rows is responsive", async () => {
-      const checkboxes = canvas.getAllByRole("checkbox");
-      const start = performance.now();
-      await userEvent.click(checkboxes[1]);
-      const duration = performance.now() - start;
+    await step(
+      "Selection toggle with ~170 rows does not re-render unaffected rows",
+      async () => {
+        // Sample rows distributed across the dataset. If row memoization
+        // regresses (e.g., a parent re-renders every row on each selection
+        // change) these counts will increment when the first checkbox is
+        // toggled.
+        const sampleIds = ["50", "100", "150"];
+        const initialCounts = sampleIds.map((id) =>
+          Number(
+            canvas
+              .getByTestId(`perf-rc-${id}`)
+              .getAttribute("data-render-count")
+          )
+        );
 
-      await waitFor(() => {
-        expect(checkboxes[1]).toBeChecked();
-      });
-      expect(duration).toBeLessThan(2000);
-    });
+        const checkboxes = canvas.getAllByRole("checkbox");
+        await userEvent.click(checkboxes[1]);
 
-    await step("Sorting ~170 rows is responsive", async () => {
+        await waitFor(() => {
+          expect(checkboxes[1]).toBeChecked();
+        });
+
+        sampleIds.forEach((id, i) => {
+          const afterCount = Number(
+            canvas
+              .getByTestId(`perf-rc-${id}`)
+              .getAttribute("data-render-count")
+          );
+          expect(afterCount).toBe(initialCounts[i]);
+        });
+      }
+    );
+
+    await step("Sorting ~170 rows completes and sets aria-sort", async () => {
+      // Sorting reorders rows, so a render-count assertion would not be
+      // meaningful here. This step stays as a smoke test that the
+      // interaction completes and the column header reflects sort state.
       const categoryHeader = canvas.getByText("Category");
-      const start = performance.now();
       await userEvent.click(categoryHeader);
-      const duration = performance.now() - start;
 
       await waitFor(() => {
         const header = categoryHeader.closest('[role="columnheader"]');
         expect(header).toHaveAttribute("aria-sort");
       });
-      expect(duration).toBeLessThan(3000);
     });
   },
 };

--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -4562,21 +4562,6 @@ const generatePerfRows = (count: number): DataTableRowItem[] =>
     category: `Category ${(i % 5) + 1}`,
   }));
 
-const perfColumns: DataTableColumnItem[] = [
-  {
-    id: "name",
-    header: "Name",
-    accessor: (row: Record<string, unknown>) => row.name as ReactNode,
-    isSortable: true,
-  },
-  {
-    id: "category",
-    header: "Category",
-    accessor: (row: Record<string, unknown>) => row.category as ReactNode,
-    isSortable: true,
-  },
-];
-
 const PinnedIdsProbe = () => {
   const ctx = DataTable.useDataTableContext();
   return (

--- a/packages/nimbus/src/patterns/dialogs/confirmation-dialog/confirmation-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/confirmation-dialog/confirmation-dialog.stories.tsx
@@ -754,7 +754,15 @@ export const LongContent: Story = {
       async () => {
         const lastParagraph = canvas.getByText(/^Paragraph 25:/);
         const header = canvas.getByRole("heading", { name: "Accept terms" });
-        const headerTopBeforeScroll = header.getBoundingClientRect().top;
+        const dialog = canvas.getByRole("dialog");
+        // Measure the header offset relative to the dialog rather than the
+        // viewport — scrollIntoView can scroll ancestor scroll containers
+        // (including the page), which shifts viewport-relative coordinates
+        // by a sub-pixel amount even when the header is correctly pinned
+        // inside the dialog.
+        const headerOffsetBeforeScroll =
+          header.getBoundingClientRect().top -
+          dialog.getBoundingClientRect().top;
 
         lastParagraph.scrollIntoView({ block: "end" });
 
@@ -764,8 +772,11 @@ export const LongContent: Story = {
           expect(paragraphRect.bottom).toBeGreaterThan(0);
         });
 
-        expect(header.getBoundingClientRect().top).toBeCloseTo(
-          headerTopBeforeScroll,
+        const headerOffsetAfterScroll =
+          header.getBoundingClientRect().top -
+          dialog.getBoundingClientRect().top;
+        expect(headerOffsetAfterScroll).toBeCloseTo(
+          headerOffsetBeforeScroll,
           0
         );
       }

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
@@ -740,7 +740,15 @@ export const LongForm: Story = {
         const header = canvas.getByRole("heading", {
           name: "Edit configuration",
         });
-        const headerTopBeforeScroll = header.getBoundingClientRect().top;
+        const dialog = canvas.getByRole("dialog");
+        // Measure the header offset relative to the dialog rather than the
+        // viewport — scrollIntoView can scroll ancestor scroll containers
+        // (including the page), which shifts viewport-relative coordinates
+        // by a sub-pixel amount even when the header is correctly pinned
+        // inside the dialog.
+        const headerOffsetBeforeScroll =
+          header.getBoundingClientRect().top -
+          dialog.getBoundingClientRect().top;
 
         lastField.scrollIntoView({ block: "end" });
 
@@ -750,8 +758,11 @@ export const LongForm: Story = {
           expect(fieldRect.bottom).toBeGreaterThan(0);
         });
 
-        expect(header.getBoundingClientRect().top).toBeCloseTo(
-          headerTopBeforeScroll,
+        const headerOffsetAfterScroll =
+          header.getBoundingClientRect().top -
+          dialog.getBoundingClientRect().top;
+        expect(headerOffsetAfterScroll).toBeCloseTo(
+          headerOffsetBeforeScroll,
           0
         );
       }


### PR DESCRIPTION
## Summary

Two flaky tests have been blocking CI on `main` and feature branches with the same shape of failure — tight numerical thresholds on inherently noisy measurements. Both are fixed by replacing the noisy measurement with a deterministic one that still preserves the test's regression-catching intent.

### 1. Dialog "pinned header during scroll" assertions

`form-dialog > Long Form` and `confirmation-dialog > Long Content` compared `header.getBoundingClientRect().top` before/after `scrollIntoView` with `toBeCloseTo(..., 0)` (tolerance 0.5px). `scrollIntoView({ block: "end" })` scrolls every ancestor scroll container — including the page — so the dialog and its (correctly pinned) header shifted in viewport coordinates by ~1.85px.

Fix: measure `header.top` **relative to the dialog**, not the viewport. Invariant under incidental page scroll; still fails if the header actually scrolls inside the dialog body.

Sample observed failure: `expected 108.44 to be close to 110.30, difference 1.86, expected 0.5`.

### 2. `PerfLargeDatasetResponsiveness` wall-clock assertion

`expect(duration).toBeLessThan(2000)` / `toBeLessThan(3000)` with `performance.now()` around `userEvent.click` on 170 rows. Shared CI runners produced 2705ms / 3458ms — failing without any component change.

This was the only `Perf*` story in the file using wall-clock time; siblings `PerfRowMemoization` and `PerfSelectionContextIsolation` already use a render-count probe pattern.

Fix:
- **Selection step:** instrument the Name column to stamp a per-row render count onto a data attribute, sample three rows (50, 100, 150), click row 1's checkbox, assert sampled counts didn't change. Catches the actual regression that matters ("selection change re-renders every row") without depending on runner speed.
- **Sorting step:** kept as a smoke test (click header → `aria-sort` appears). Sorting reorders all rows by design, so a render-count assert wouldn't fit.

The passing render-count assertion also confirms DataTable's row memoization is currently correct.

## Test plan

- [x] `pnpm test:storybook:dev` against affected stories — 31/31 passing for data-table, 17/17 passing for both dialogs
- [x] Three back-to-back local runs per file to confirm stability
- [ ] CI's `Build and Test` workflow passes on this branch