### PR TITLE
feat(splitter): add useResponsiveSplitterSizes hook

### DIFF
--- a/.changeset/add-splitter-component.md
+++ b/.changeset/add-splitter-component.md
@@ -11,3 +11,9 @@ Size is uncontrolled by default (`defaultSize`) or controllable in place via the
 `size` prop for responsive, per-breakpoint layouts; a single number round-trips
 to your own storage via `onSizeChangeEnd`. Nest splitters for three or more
 regions. See the docs for the full API.
+
+Also ships `useResponsiveSplitterSizes`, a companion hook for consumers who want
+to express pane sizes in pixels, size tokens, or per-container-width breakpoints
+instead of percentages. It measures the container, translates your config into
+the percentage `Splitter.Root` consumes, clamps to your `minSize` / `maxSize`,
+and can persist the user's settled size across reloads.

--- a/openspec/changes/add-responsive-splitter-sizes-hook/.openspec.yaml
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/add-responsive-splitter-sizes-hook/design.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/design.md
@@ -1,0 +1,226 @@
+## Context
+
+As of commit `ab266b119` the `Splitter` is a single-dimension component: one
+`Splitter.Aside` (the pane you size) and one `Splitter.Main` (the remainder),
+with role designated by component type rather than id. `Splitter.Root` owns one
+number — the aside's percentage `size` (`0–100`; main is `100 − size`) — and
+exposes a controlled, **settle-only** `size` prop alongside `onSizeChangeEnd`.
+Control is reconciled at rest by an effect: internal state stays authoritative
+during a drag, the prop is written into state in place, silently (no callbacks),
+normalized to `[0,100]`, and **not** clamped to `minSize`/`maxSize` (the next
+interaction re-clamps). If the controlled value is not fed back, the splitter
+keeps the last interactive value and behaves uncontrolled from then on (no
+snap-back). Resizing is locked while the aside is collapsed. See
+`hooks/use-splitter-state.ts` and `splitter.types.ts`.
+
+The component is percentage-native and has no pixel code path by design. But the
+most common real layout — a fixed-width sidebar (`320px` nav, icon rail) whose
+split differs per device and survives reload — is naturally expressed in pixels.
+Pixels, responsive resolution, and persistence are consumer- and surface-specific
+policy that does not belong in the component's state machine. The settle-only
+controlled channel is exactly the runtime seam a companion hook needs: pushing a
+new value lands in place, no remount, so pane scroll state survives.
+
+This design was pressure-tested by four independent reviewers (consumer-DX,
+API-minimalism, runtime-correctness, long-term-maintainability) before being
+written down; their findings are folded into the Decisions and Risks below.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A `useResponsiveSplitterSizes` hook that maps a pixel-/token-/percent size
+  config into `{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, ref, orientation } }`.
+- `number` always means pixels; tokens resolve to pixels; `` `${number}%` ``
+  passes through. All pixel/token values convert to a percentage of the measured
+  container so the component stays percentage-only.
+- Optional per-container-width responsiveness via a min-width threshold cascade
+  keyed by pixel/token thresholds, resolved against the splitter's own width.
+- A pixel facade over `minSize` / `maxSize` / `collapsedSize`, with hook-side
+  clamping of the resolved `size`.
+- Versioned, per-band, pixel-first persistence through injectable storage, with
+  `stored[active] ?? default[active]` resolution.
+- Keep the controlled loop closed (no snap-back, no churn) and degrade safely
+  when browser APIs are unavailable.
+
+**Non-Goals:**
+
+- No change to `Splitter.Root` / `Splitter.Aside` / `Splitter.Main` /
+  `Splitter.Handle`.
+- No live per-tick control — control stays settle-only; `onSizeChange` is not
+  used to drive the controlled value.
+- No `resolveAgainst: "viewport"` mode in this version (reserved as an additive
+  seam).
+- No pixel code path inside the component.
+- The hook does not fix or mask the component's first-paint `50/50` flash — that
+  is a separate component change (see Risks).
+
+## Decisions
+
+### D1. A companion hook, not a component feature
+
+The component stays a pure percentage size engine. Pixel math, responsive
+resolution, and persistence live in the hook, composed on the already-shipped
+controlled `size` + `onSizeChangeEnd` pair. **Why:** these are consumer- and
+surface-specific policies; baking them in would put layout truth outside the
+component's state machine and reintroduce the pixel path it deliberately omits.
+*Alternative considered:* a `units`/`responsive` prop on `Splitter.Root` —
+rejected as scope creep coupling the component to pixels, tokens, breakpoints,
+and storage.
+
+### D2. `number` is always pixels (single, position-independent unit rule)
+
+A size value is `number` (pixels), a size token (→ pixels), or `` `${number}%` ``
+(percentage passthrough). A threshold **key** is `number` (pixels) or a size
+token — never a percentage (a percentage threshold of the container against
+itself is meaningless). **Why:** the hook exists to let consumers think in
+pixels; `number = px` is its whole reason for being, and one rule ("a bare
+number is pixels, everywhere") is easier to hold than per-position inference.
+*Known tension (reviewers):* `Splitter.Root`'s own `size`/`minSize`/… props are
+percentages, so a bare number means px in the hook but `%` on the raw component.
+This is accepted deliberately: the hook owns the **full** facade (`size` +
+`minSize`/`maxSize`/`collapsedSize`), so a consumer using the hook never hand-writes
+a raw percentage onto the root, which closes the collision in practice. Docs
+state the rule prominently.
+
+### D3. Container-width threshold keys, with an explicit resolution axis
+
+Responsive config is an object whose keys are container **min-width** thresholds
+(pixel numbers or size tokens), resolved against the splitter's own width via a
+`ResizeObserver`. The active band is the largest threshold `≤` the measured
+width; the smallest entry also applies below it. `resolveAgainst` is **required**
+and is `"container"` in this version. **Why:** the hook resolves against the
+element, so keying by viewport breakpoint *names* would lie about what is
+measured; explicit pixel/token thresholds say what they mean. Making the axis an
+explicit, required option means a later `"viewport"` mode is additive and the
+same keys never silently reinterpret. *Alternative considered:* borrowing
+Chakra's breakpoint **condition names** (`sm`/`md`/…) as keys — rejected as
+viewport-coded and misleading for container resolution, and it would have
+coupled the hook to `theme/breakpoints.ts`.
+
+### D4. Tokens resolve to pixels via a curated union + guard test
+
+`size` tokens accepted as values and keys are the named families only: `3xs`–`8xl`
+and `breakpoint-sm`…`breakpoint-2xl`. They are exposed as a hand-authored
+`SplitterSizeToken` union (not `keyof typeof themeTokens.size`, which also
+contains the numeric scale `25`…`9600` and would both pollute autocomplete and
+make `"400"`-as-token collide with `400`-as-pixels). A unit test asserts every
+union member still exists in `themeTokens.size`. **Why:** tokens give ergonomic
+parity with the rest of the system, but the token names are volatile; a curated
+union keeps autocomplete clean and the existence test turns a token rename from a
+silent runtime miss into a red build. *Alternative considered:* deriving the
+type from the token object — rejected (absorbs renames silently, imports the
+numeric-scale noise).
+
+### D5. Pixel facade over `minSize` / `maxSize` / `collapsedSize`, hook clamps `size`
+
+The hook accepts pixel/token/percent for `minSize`, `maxSize`, and
+`collapsedSize`, translates each to a percentage, and forwards them via
+`rootProps`. It clamps the resolved `size` into `[minSize, maxSize]` **before**
+emitting. **Why:** these are size-dimensional constraints a pixel-thinking
+consumer needs in pixels too, and the component reconciles controlled `size`
+with normalization only — it does **not** re-clamp to min/max until the next
+interaction (`use-splitter-state.ts`), so an unclamped px→% result would render
+out of bounds for a frame. The facade is explicitly scoped to the **size
+dimension only**; it is not a general root pass-through (consumers spread their
+own remaining props onto `Splitter.Root` directly).
+
+### D6. Drive the existing settle-only controlled `size`, equality-gated
+
+The hook returns `size` (controlled) plus `onSizeChangeEnd` and feeds the
+emitted value back. It equality-gates its own emitted `size` with a tolerance
+coarser than the component's internal `1e-6`, so pixel↔percent round-trips
+triggered by `ResizeObserver` ticks cannot push a fresh prop every frame.
+**Why:** the reconcile effect already writes the prop into state in place and
+silently and is double-equality-gated, so a settled push is a no-remount,
+no-flash, no-callback-loop update — but only if the hook does not emit a
+micro-different value on every measurement.
+
+### D7. Versioned, per-band, pixel-first persistence; collapse suppresses writes
+
+Persist `{ v, bands: { [thresholdPx]: { unit, value } } }` under `persistKey`
+via an injectable Storage-like interface (default `localStorage`). On a genuine
+settle the hook writes the active band: pixel/token bands store **pixels**
+(re-derived from the settled percentage and the measured container, so the size
+re-pins on resize), percent bands store a percentage. Bands are keyed by the
+**resolved pixel threshold** (stable across token renames). Resolution is
+`stored[active] ?? configDefault[active]`. `collapsedSize` is never persisted;
+while the aside is collapsed the hook suppresses persistence (keyed off the
+collapse signal, not a value comparison) so the latest expanded size survives
+collapse/expand. **Why:** pixel-first storage keeps the "320px stays 320px"
+promise across drags and reloads; per-band keeps each device's remembered size
+independent; the version envelope lets a future shape change migrate rather than
+silently misread old data. *Alternative considered:* a single shared value
+(can't express per-device memory) and value-equality collapse detection
+(rejected — a legitimate expanded size equal to `collapsedSize` would be dropped).
+
+### D8. Two-phase resolution, within the component's first-paint reality
+
+`%`-only config resolves synchronously; pixel/token config is resolved after the
+first container measurement in a layout effect. **Why:** this is the best the
+hook can do toward a correct first commit. Reviewers verified the component
+itself paints `50/50` first (it seeds `useState(50)` and derives in a mount
+effect gated on pane registration), so the hook cannot guarantee a flash-free
+first frame on its own; the genuine fix is the separate component seeding change.
+The hook therefore aims for "correct as early as measurement allows" and the docs
+state the dependency rather than over-promising.
+
+### D9. Defensive access to browser APIs
+
+`ResizeObserver` and `storage` are feature-detected and wrapped so SSR, older
+runtimes, and storage-denied contexts fall back to config-default resolution
+without throwing. A container width of `0`/non-finite is guarded so pixel→percent
+never divides by zero; resolution retries on the next measurement.
+
+## Risks / Trade-offs
+
+- **First-paint flash is a component behavior the hook can't mask.** The root
+  seeds `50%` and derives in a mount effect, so the first frame is `50/50` for
+  every consumer. → Tracked as a separate component fix (seed `size`/`defaultSize`
+  synchronously). The hook resolves `%` synchronously and pixels in a layout
+  effect, and the docs state the dependency; it does not claim a flash-free first
+  paint.
+- **`number = px` in the hook vs `number = %` on the raw component.** → Mitigated
+  by the hook owning the full size facade, so consumers don't hand-write root
+  percentages; stated prominently in docs.
+- **Pixel values that convert outside `[minSize, maxSize]`.** → The hook clamps
+  the resolved `size` itself before emitting, because the component won't
+  re-clamp controlled `size` until the next interaction.
+- **`ResizeObserver` churn / controlled-loop oscillation.** → The hook
+  equality-gates its emitted `size` with a tolerance coarser than the component's
+  `1e-6`; observe/unobserve is cleanup-symmetric and StrictMode-safe; writes are
+  idempotent.
+- **Band-boundary thrash when the width sits on a threshold.** → A hysteresis
+  deadband around thresholds (and a deterministic band assignment for boundary
+  values) prevents per-frame flapping and split persistence history.
+- **Persisted pixels from a wide session restored into a narrow container.** →
+  The px→% restore is clamped into `[minSize, maxSize]` like any other resolved
+  value before emitting.
+- **`localStorage` quota / corrupt JSON / unavailable.** → All access is
+  try/caught; failures no-op and resolution falls back to defaults; the persisted
+  payload is versioned so shape changes migrate.
+- **Token rename/removal.** → Curated `SplitterSizeToken` union plus an
+  existence test against `themeTokens.size` converts a rename into a build
+  failure.
+- **Container-width measurement vs exact pixels.** → `%` config is exact on first
+  commit; pixel correction runs in a layout effect, bounded to a single pre-paint
+  reconcile (modulo the separate component first-paint fix above).
+
+## Migration Plan
+
+Additive only — a new hook plus barrel/public-API exports and a curated token
+union. No existing API changes, so no consumer migration is required. The
+versioned persistence envelope (`v: 1`) reserves room for future storage-shape
+changes to migrate rather than break. Rollback is removing the new files and
+their exports. The separate component first-paint seeding fix is independent and
+can land before, with, or after this hook.
+
+## Open Questions
+
+- Should the hook expose the resolved active band (e.g. a `rootProps` sibling
+  like `activeThreshold`) for consumers who want to label the current size band?
+  (Deferred unless a concrete need appears.)
+- For the `"viewport"` mode reserved by `resolveAgainst`, do pixel values still
+  measure the container (the only sensible source for px→% conversion) while the
+  *band* is selected by `matchMedia`? (Leaning yes; out of scope here, noted so
+  the seam is designed with it in mind.)

--- a/openspec/changes/add-responsive-splitter-sizes-hook/design.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/design.md
@@ -49,8 +49,8 @@ written down; their findings are folded into the Decisions and Risks below.
   `Splitter.Handle`.
 - No live per-tick control — control stays settle-only; `onSizeChange` is not
   used to drive the controlled value.
-- No `resolveAgainst: "viewport"` mode in this version (reserved as an additive
-  seam).
+- No viewport-relative resolution — the hook always measures the splitter's own
+  container. (There is no `resolveAgainst` option.)
 - No pixel code path inside the component.
 - The hook does not fix or mask the component's first-paint `50/50` flash — that
   is a separate component change (see Risks).
@@ -83,20 +83,22 @@ This is accepted deliberately: the hook owns the **full** facade (`size` +
 a raw percentage onto the root, which closes the collision in practice. Docs
 state the rule prominently.
 
-### D3. Container-width threshold keys, with an explicit resolution axis
+### D3. Container-width threshold keys, container-only resolution
 
 Responsive config is an object whose keys are container **min-width** thresholds
 (pixel numbers or size tokens), resolved against the splitter's own width via a
 `ResizeObserver`. The active band is the largest threshold `≤` the measured
-width; the smallest entry also applies below it. `resolveAgainst` is **required**
-and is `"container"` in this version. **Why:** the hook resolves against the
-element, so keying by viewport breakpoint *names* would lie about what is
-measured; explicit pixel/token thresholds say what they mean. Making the axis an
-explicit, required option means a later `"viewport"` mode is additive and the
-same keys never silently reinterpret. *Alternative considered:* borrowing
-Chakra's breakpoint **condition names** (`sm`/`md`/…) as keys — rejected as
-viewport-coded and misleading for container resolution, and it would have
-coupled the hook to `theme/breakpoints.ts`.
+width; the smallest entry also applies below it. Resolution is **always against
+the container** — there is no `resolveAgainst` option. **Why:** the hook resolves
+against the element, so keying by viewport breakpoint *names* would lie about
+what is measured; explicit pixel/token thresholds say what they mean. Viewport
+resolution was considered and dropped: a one-value option is ceremony, and if a
+viewport variant is ever needed it is better introduced as its own explicitly
+named hook than as a mode flag that silently reinterprets the same threshold
+keys. *Alternative considered:* borrowing Chakra's breakpoint **condition
+names** (`sm`/`md`/…) as keys — rejected as viewport-coded and misleading for
+container resolution, and it would have coupled the hook to
+`theme/breakpoints.ts`.
 
 ### D4. Tokens resolve to pixels via a curated union + guard test
 
@@ -220,7 +222,3 @@ can land before, with, or after this hook.
 - Should the hook expose the resolved active band (e.g. a `rootProps` sibling
   like `activeThreshold`) for consumers who want to label the current size band?
   (Deferred unless a concrete need appears.)
-- For the `"viewport"` mode reserved by `resolveAgainst`, do pixel values still
-  measure the container (the only sensible source for px→% conversion) while the
-  *band* is selected by `matchMedia`? (Leaning yes; out of scope here, noted so
-  the seam is designed with it in mind.)

--- a/openspec/changes/add-responsive-splitter-sizes-hook/proposal.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/proposal.md
@@ -20,7 +20,11 @@ pixel, and persistence concern out of the component.
 - Add `useResponsiveSplitterSizes`, a `Splitter` companion hook that resolves a
   pixel-/token-based, optionally per-container-width size config down to the
   percentage `Splitter.Root` consumes, and returns props to spread onto the
-  root: `{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, ref, orientation } }`.
+  root: `{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, onCollapsedChange, ref, orientation } }`.
+  The forwarded `onCollapsedChange` lets the hook observe collapse (it fires
+  before the collapse-driven settle) so it can suppress persistence while
+  collapsed; an optional `onCollapsedChange` option is called through for
+  consumers who also want to observe collapse.
 - **Unit model (`number` is always pixels).** A size value is one of: a `number`
   (pixels), a size **token** string (`3xs`–`8xl` or `breakpoint-sm`…`breakpoint-2xl`,
   resolving to pixels via `themeTokens.size`), or a `` `${number}%` `` string

--- a/openspec/changes/add-responsive-splitter-sizes-hook/proposal.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/proposal.md
@@ -35,13 +35,9 @@ pixel, and persistence concern out of the component.
   (`size`, and the `minSize` / `maxSize` / `collapsedSize` facade) is either a
   single value (applies at every width) **or** an object whose keys are
   container **min-width thresholds** — a `number` (px) or a size token — forming
-  a min-width cascade resolved against the splitter's **own** measured width
-  (not the viewport). The largest threshold `≤` the measured width wins; the
-  smallest entry also applies below it.
-- **Explicit resolution axis.** `resolveAgainst` is required and is `"container"`
-  in this version (resolved via `ResizeObserver`). The option exists explicitly
-  so a future `"viewport"` mode is purely additive and the container-width keys
-  never silently change meaning.
+  a min-width cascade resolved (via `ResizeObserver`) against the splitter's
+  **own** measured width — never the viewport. The largest threshold `≤` the
+  measured width wins; the smallest entry also applies below it.
 - **Pixel facade over the aside's constraints.** `minSize`, `maxSize`, and
   `collapsedSize` accept the same pixel/token/percent values, are translated to
   percentages the same way, and are forwarded via `rootProps`. The hook clamps
@@ -64,8 +60,8 @@ pixel, and persistence concern out of the component.
   `Splitter.Handle`.
 
 Explicitly **out of scope**: live per-tick (`onSizeChange`) control — control
-stays settle-only; a `resolveAgainst: "viewport"` mode (reserved, not shipped);
-any pixel code path inside the component itself.
+stays settle-only; viewport-relative resolution (the hook always measures the
+splitter's own container); any pixel code path inside the component itself.
 
 **Known dependency, tracked separately:** the component currently seeds its
 first paint at `50%` and derives `size`/`defaultSize` in a mount effect, so the

--- a/openspec/changes/add-responsive-splitter-sizes-hook/proposal.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+The `Splitter` component sizes its single configurable pane (`Splitter.Aside`)
+as a percentage of its container — one number, `0–100`, with `Splitter.Main`
+taking the remainder. That percentage model keeps the component's state machine
+simple, but it is the wrong unit for the most common real layout: a sidebar that
+should be a fixed width (a `320px` nav, an icon rail), and whose right split
+differs per device. Consumers cannot express "320px here, 30% there" today, the
+component has no pixel code path by design, and any value a consumer does pick is
+lost on reload.
+
+The component already exposes the exact runtime seam a companion hook needs: a
+controlled, **settle-only** `size` prop that reconciles in place (no remount, no
+snap-back) plus `onSizeChangeEnd`. A hook can sit in front of that seam and act
+as a pure **pixel/token → percentage translator**, keeping every responsive,
+pixel, and persistence concern out of the component.
+
+## What Changes
+
+- Add `useResponsiveSplitterSizes`, a `Splitter` companion hook that resolves a
+  pixel-/token-based, optionally per-container-width size config down to the
+  percentage `Splitter.Root` consumes, and returns props to spread onto the
+  root: `{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, ref, orientation } }`.
+- **Unit model (`number` is always pixels).** A size value is one of: a `number`
+  (pixels), a size **token** string (`3xs`–`8xl` or `breakpoint-sm`…`breakpoint-2xl`,
+  resolving to pixels via `themeTokens.size`), or a `` `${number}%` `` string
+  (a percentage, passed through untranslated). The hook converts pixels and
+  tokens to a percentage of the **measured container** so the component stays
+  percentage-only.
+- **Responsive config keyed by container width.** Each configurable dimension
+  (`size`, and the `minSize` / `maxSize` / `collapsedSize` facade) is either a
+  single value (applies at every width) **or** an object whose keys are
+  container **min-width thresholds** — a `number` (px) or a size token — forming
+  a min-width cascade resolved against the splitter's **own** measured width
+  (not the viewport). The largest threshold `≤` the measured width wins; the
+  smallest entry also applies below it.
+- **Explicit resolution axis.** `resolveAgainst` is required and is `"container"`
+  in this version (resolved via `ResizeObserver`). The option exists explicitly
+  so a future `"viewport"` mode is purely additive and the container-width keys
+  never silently change meaning.
+- **Pixel facade over the aside's constraints.** `minSize`, `maxSize`, and
+  `collapsedSize` accept the same pixel/token/percent values, are translated to
+  percentages the same way, and are forwarded via `rootProps`. The hook clamps
+  the resolved `size` into `[minSize, maxSize]` **itself** before emitting,
+  because the component reconciles controlled `size` without re-clamping until
+  the next interaction.
+- **Persistence in pixels, per band, versioned.** On a genuine settle the hook
+  stores the size under the active threshold band through an injectable,
+  Storage-like `storage` (default `localStorage`) under a versioned envelope.
+  Pixel/token bands persist **pixels** (so a dragged `320px` re-pins to `320px`
+  across reloads and resizes); percent bands persist a percentage. Resolution is
+  `stored[band] ?? configDefault[band]`. `collapsedSize` is static config and is
+  never persisted; while the aside is collapsed the hook suppresses persistence
+  so the latest expanded size survives collapse/expand.
+- Close the controlled loop without snap-back: feed the resolved value back as
+  `size` and wire `onSizeChangeEnd`, honoring the component's settle-only
+  contract. The hook equality-gates its emitted `size` so pixel↔percent
+  round-trips under `ResizeObserver` churn cannot thrash the controlled prop.
+- No changes to `Splitter.Root` / `Splitter.Aside` / `Splitter.Main` /
+  `Splitter.Handle`.
+
+Explicitly **out of scope**: live per-tick (`onSizeChange`) control — control
+stays settle-only; a `resolveAgainst: "viewport"` mode (reserved, not shipped);
+any pixel code path inside the component itself.
+
+**Known dependency, tracked separately:** the component currently seeds its
+first paint at `50%` and derives `size`/`defaultSize` in a mount effect, so the
+first committed frame is `50/50` for any consumer (hook or not) before it snaps
+to the configured value. That first-paint flash is a standalone component
+behavior fixed independently (seed the size synchronously); the hook does not
+attempt to mask it and this proposal does not depend on the responsive feature
+to fix it.
+
+## Capabilities
+
+### New Capabilities
+
+- `nimbus-use-responsive-splitter-sizes`: A React hook that translates a
+  pixel-/token-based, optionally per-container-width pane-size config into the
+  percentage `Splitter.Root` accepts — with pixel-to-percentage conversion
+  against the measured container, a pixel facade over `minSize` / `maxSize` /
+  `collapsedSize`, hook-side clamping, and versioned per-band persistence in
+  pixels across sessions and resizes.
+
+### Modified Capabilities
+
+<!-- None. The Splitter component's public API is unchanged; the controlled
+`size` prop and `onSizeChangeEnd` this hook relies on already exist. The
+splitter spec itself is still the pending `add-splitter-component` change, not a
+published capability. -->
+
+## Impact
+
+- **New code**:
+  `packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts`,
+  a curated `SplitterSizeToken` union + pure resolution helpers under
+  `components/splitter/utils/`, exported from the splitter barrel
+  (`components/splitter/index.ts`) and surfaced through the package public API.
+- **New tests**: a `.spec.tsx` unit test for the hook and its pure resolvers
+  (JSDOM, per the hooks-are-unit-tested convention), a token-existence guard
+  test, plus a Storybook story demonstrating the responsive + pixel + persisted
+  flow.
+- **Docs**: a usage section in the splitter `.dev.mdx` / `.mdx` covering the
+  pixel/token/responsive + persistence recipe and the `ref` requirement.
+- **Depends on**: the existing controlled `size` + `onSizeChangeEnd` API on
+  `Splitter.Root`; the size tokens in `themeTokens.size`. No new runtime
+  dependencies.
+- **Browser APIs**: `ResizeObserver` and `localStorage` — both accessed
+  defensively so SSR and storage-denied environments degrade to config-default
+  resolution without throwing.

--- a/openspec/changes/add-responsive-splitter-sizes-hook/specs/nimbus-use-responsive-splitter-sizes/spec.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/specs/nimbus-use-responsive-splitter-sizes/spec.md
@@ -3,8 +3,8 @@
 ### Requirement: Resolve a pixel/token/percent size config into root props
 
 The hook SHALL accept a `size` config for the aside expressed as a single value
-or a per-threshold map, plus an explicit `orientation` and `resolveAgainst`, and
-SHALL return a `rootProps` object containing `size`, `minSize`, `maxSize`,
+or a per-threshold map, plus an optional `orientation`, and SHALL return a
+`rootProps` object containing `size`, `minSize`, `maxSize`,
 `collapsedSize`, `onSizeChangeEnd`, `onCollapsedChange`, `ref`, and
 `orientation`, intended to be spread onto `Splitter.Root`. The forwarded
 `onCollapsedChange` lets the hook observe collapse so it can suppress
@@ -67,15 +67,14 @@ Pixel conversion SHALL always measure the splitter's own container. The
 
 ### Requirement: Resolve the active band against the container by min-width threshold
 
-The hook SHALL determine the active band using `resolveAgainst`, which is
-**required** and SHALL be `"container"` in this version. In `"container"` mode
-the hook SHALL observe the referenced `Splitter.Root` element with a
-`ResizeObserver` and select the band whose **min-width threshold** the element's
-measured size satisfies. Thresholds SHALL be expressed as pixel numbers or size
-tokens (never percentages). The active band SHALL be the largest threshold less
-than or equal to the measured size; the smallest configured entry SHALL also
-apply below its threshold. The hook SHALL re-resolve when the active band
-changes.
+The hook SHALL always resolve the active band against the splitter's own
+container (there is no resolution-axis option). It SHALL observe the referenced
+`Splitter.Root` element with a `ResizeObserver` and select the band whose
+**min-width threshold** the element's measured size satisfies. Thresholds SHALL
+be expressed as pixel numbers or size tokens (never percentages). The active
+band SHALL be the largest threshold less than or equal to the measured size; the
+smallest configured entry SHALL also apply below its threshold. The hook SHALL
+re-resolve when the active band changes.
 
 #### Scenario: Container width selects the band
 

--- a/openspec/changes/add-responsive-splitter-sizes-hook/specs/nimbus-use-responsive-splitter-sizes/spec.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/specs/nimbus-use-responsive-splitter-sizes/spec.md
@@ -1,0 +1,230 @@
+## ADDED Requirements
+
+### Requirement: Resolve a pixel/token/percent size config into root props
+
+The hook SHALL accept a `size` config for the aside expressed as a single value
+or a per-threshold map, plus an explicit `orientation` and `resolveAgainst`, and
+SHALL return a `rootProps` object containing `size`, `minSize`, `maxSize`,
+`collapsedSize`, `onSizeChangeEnd`, `ref`, and `orientation`, intended to be
+spread onto `Splitter.Root`. A size value SHALL be one of: a `number`
+(interpreted as **pixels**), a size **token** string (resolving to pixels), or a
+`` `${number}%` `` string (a percentage passed through untranslated). The
+returned `rootProps.size` SHALL always be a valid controlled value: a single
+percentage in `[0, 100]`.
+
+#### Scenario: Config resolves to a controlled size
+
+- **WHEN** the hook is called with a `size` config and its `ref` is attached to
+  a mounted `Splitter.Root`
+- **THEN** `rootProps.size` is a percentage in `[0, 100]` for the active band,
+  and spreading `rootProps` onto `Splitter.Root` drives the controlled
+  (settle-only) size channel without remounting it
+
+#### Scenario: A bare number is always pixels
+
+- **WHEN** a size value is the bare `number` `320`
+- **THEN** the hook treats it as `320px` and converts it to a percentage of the
+  measured container — never as `320%`
+
+#### Scenario: A percent string passes through untranslated
+
+- **WHEN** a size value is the string `"30%"`
+- **THEN** the hook resolves the aside to `30` percent directly, without
+  measuring the container
+
+### Requirement: Convert pixel and token values to percentages against the container
+
+When a resolved value is expressed in pixels or as a size token, the hook SHALL
+convert it to a percentage of the measured `Splitter.Root` width (horizontal
+splitter) or height (vertical splitter) before exposing it as a controlled size.
+Tokens SHALL resolve to pixels via the size-token source before conversion.
+Pixel conversion SHALL always measure the splitter's own container. The
+`Splitter` component SHALL NOT receive pixel values.
+
+#### Scenario: Pixel value becomes a percentage of the container
+
+- **WHEN** the active band resolves the aside to a `px` value and the container
+  measures a known size on the relevant axis
+- **THEN** the hook converts the `px` value to the equivalent percentage of the
+  container and exposes it as `rootProps.size`
+
+#### Scenario: Token value resolves to pixels then to a percentage
+
+- **WHEN** the active band resolves the aside to a size token (e.g.
+  `"breakpoint-sm"`)
+- **THEN** the hook resolves the token to its pixel value and converts that to a
+  percentage of the measured container
+
+#### Scenario: Only curated size tokens are accepted
+
+- **WHEN** a value or threshold key is a string that is not a member of the
+  curated `SplitterSizeToken` set (`3xs`–`8xl`, `breakpoint-sm`…`breakpoint-2xl`)
+  and is not a `` `${number}%` `` value
+- **THEN** the type does not permit it, and at runtime the hook ignores the
+  unresolvable entry and falls back to a valid resolution rather than throwing
+
+### Requirement: Resolve the active band against the container by min-width threshold
+
+The hook SHALL determine the active band using `resolveAgainst`, which is
+**required** and SHALL be `"container"` in this version. In `"container"` mode
+the hook SHALL observe the referenced `Splitter.Root` element with a
+`ResizeObserver` and select the band whose **min-width threshold** the element's
+measured size satisfies. Thresholds SHALL be expressed as pixel numbers or size
+tokens (never percentages). The active band SHALL be the largest threshold less
+than or equal to the measured size; the smallest configured entry SHALL also
+apply below its threshold. The hook SHALL re-resolve when the active band
+changes.
+
+#### Scenario: Container width selects the band
+
+- **WHEN** the observed root element's measured size crosses from one threshold
+  band into another
+- **THEN** the hook re-resolves the active band to the one matching the new
+  measured size and updates `rootProps.size` accordingly
+
+#### Scenario: Below the smallest threshold
+
+- **WHEN** the measured size is smaller than the smallest configured threshold
+- **THEN** the hook resolves using the smallest configured entry
+
+#### Scenario: A single value applies at every width
+
+- **WHEN** `size` is a single value rather than a threshold map
+- **THEN** the hook resolves that value at every measured width without band
+  selection
+
+#### Scenario: Boundary stability
+
+- **WHEN** the measured size sits at or oscillates around a threshold by
+  sub-pixel deltas
+- **THEN** the hook applies hysteresis so the active band does not flap between
+  values frame to frame
+
+### Requirement: Apply a pixel facade over the aside constraints and clamp the size
+
+The hook SHALL accept `minSize`, `maxSize`, and `collapsedSize` in the same
+pixel/token/percent units (each a single value or a per-threshold map), SHALL
+translate them to percentages the same way as `size`, and SHALL forward them via
+`rootProps`. The hook SHALL clamp the resolved `rootProps.size` into the resolved
+`[minSize, maxSize]` window before emitting it.
+
+#### Scenario: Resolved size is clamped into the configured window
+
+- **WHEN** a resolved pixel `size` converts to a percentage below the resolved
+  `minSize` or above the resolved `maxSize`
+- **THEN** the hook clamps `rootProps.size` into `[minSize, maxSize]` before
+  exposing it, rather than relying on the component (which does not re-clamp a
+  controlled size until the next interaction)
+
+#### Scenario: Constraints are forwarded as percentages
+
+- **WHEN** `minSize` / `maxSize` / `collapsedSize` are given in pixels or tokens
+- **THEN** the hook converts each to a percentage of the measured container and
+  exposes them on `rootProps`, so the component receives only percentages
+
+### Requirement: Persist the settled size per band, in pixels, versioned
+
+The hook SHALL persist the settled size keyed by the active threshold band,
+through an injectable `storage` (a `localStorage`-like get/set interface)
+defaulting to `localStorage`, under a consumer-provided `persistKey`. The stored
+payload SHALL be versioned and keyed by the resolved pixel threshold. Pixel/token
+bands SHALL persist a pixel value (re-derived from the settled percentage and the
+measured container); percent bands SHALL persist a percentage. Resolution SHALL
+follow `stored[activeBand] ?? configDefault[activeBand]`. A restored value SHALL
+be clamped into `[minSize, maxSize]` like any other resolved value.
+
+#### Scenario: A settled drag is persisted in pixels under the active band
+
+- **WHEN** a resize settles (the spread `onSizeChangeEnd` fires) in a
+  pixel/token band
+- **THEN** the hook re-derives the pixel width from the settled percentage and
+  the measured container and writes it under that band, leaving other bands
+  untouched
+
+#### Scenario: A pixel pin survives reload and resize
+
+- **WHEN** the user drags to a width in a pixel band, reloads, and the container
+  is a different size
+- **THEN** the hook restores the stored pixel width and re-converts it to a
+  percentage for the new container, so the pinned pixel width is preserved
+
+#### Scenario: Stored value takes precedence over the config default
+
+- **WHEN** the active band has a previously stored value
+- **THEN** the hook resolves to the stored value rather than the configured
+  default for that band
+
+#### Scenario: Persistence degrades gracefully when storage is unavailable
+
+- **WHEN** `storage` access throws, is unavailable (SSR, privacy mode), or holds
+  corrupt/old data
+- **THEN** the hook does not throw and resolves from the configured defaults,
+  using the payload version to migrate where possible
+
+### Requirement: Never persist the collapsed size
+
+The hook SHALL treat `collapsedSize` as static configuration and SHALL NOT
+persist it. While the aside is collapsed the hook SHALL suppress persistence so
+the latest expanded size is preserved across collapse and expand. Suppression
+SHALL be keyed off the collapse signal, not a comparison of the settled value to
+`collapsedSize`.
+
+#### Scenario: Collapsing does not overwrite the stored expanded size
+
+- **WHEN** the aside collapses (a settle fires with the collapsed size) and later
+  expands
+- **THEN** the stored value still reflects the last expanded size, and expanding
+  restores it
+
+#### Scenario: An expanded size equal to the collapsed size is still persisted
+
+- **WHEN** the user drags the expanded aside to a size that happens to equal
+  `collapsedSize` without collapsing
+- **THEN** the hook persists that size, because suppression is keyed off the
+  collapse signal rather than value equality
+
+### Requirement: Maintain the controlled loop without snap-back or churn
+
+The hook SHALL feed its resolved value back as the controlled `size` and SHALL
+wire `onSizeChangeEnd`, honoring the component's settle-only, no-snap-back
+contract: live drag/keyboard motion is owned by the component's internal state
+and the hook reconciles only at rest. The hook SHALL equality-gate its emitted
+`size` with a tolerance coarser than the component's internal epsilon so
+pixel↔percent round-trips under `ResizeObserver` ticks do not push a new prop
+every frame.
+
+#### Scenario: Interaction settles into the controlled value
+
+- **WHEN** the user drags the handle and releases
+- **THEN** the component animates from its internal state during the drag, fires
+  `onSizeChangeEnd` once on release, and the hook persists and feeds the settled
+  value back as `size` without a visible snap-back
+
+#### Scenario: Resize ticks do not thrash the controlled prop
+
+- **WHEN** the container resizes within the same band, causing repeated
+  pixel→percent recomputation
+- **THEN** the hook only emits a new `rootProps.size` when the resolved value
+  changes beyond its equality tolerance, so the controlled prop does not update
+  every frame
+
+### Requirement: Degrade safely without browser APIs or measurement
+
+The hook SHALL feature-detect `ResizeObserver` and `storage` and SHALL guard
+non-positive or non-finite container measurements. When measurement or
+`ResizeObserver` is unavailable, the hook SHALL resolve `%`-only config and fall
+back for pixel/token config without throwing, and SHALL retry resolution once a
+positive measurement becomes available.
+
+#### Scenario: No ResizeObserver available
+
+- **WHEN** `ResizeObserver` is undefined (SSR, older runtimes, JSDOM without a
+  polyfill)
+- **THEN** the hook resolves any `%`-only config and returns a valid
+  `rootProps.size` without throwing
+
+#### Scenario: Container not yet laid out
+
+- **WHEN** the container measures `0` or a non-finite size (e.g. `display:none`)
+- **THEN** the hook does not divide by zero, does not emit a non-finite size, and
+  re-resolves once a positive measurement is observed

--- a/openspec/changes/add-responsive-splitter-sizes-hook/specs/nimbus-use-responsive-splitter-sizes/spec.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/specs/nimbus-use-responsive-splitter-sizes/spec.md
@@ -5,8 +5,10 @@
 The hook SHALL accept a `size` config for the aside expressed as a single value
 or a per-threshold map, plus an explicit `orientation` and `resolveAgainst`, and
 SHALL return a `rootProps` object containing `size`, `minSize`, `maxSize`,
-`collapsedSize`, `onSizeChangeEnd`, `ref`, and `orientation`, intended to be
-spread onto `Splitter.Root`. A size value SHALL be one of: a `number`
+`collapsedSize`, `onSizeChangeEnd`, `onCollapsedChange`, `ref`, and
+`orientation`, intended to be spread onto `Splitter.Root`. The forwarded
+`onCollapsedChange` lets the hook observe collapse so it can suppress
+persistence while collapsed. A size value SHALL be one of: a `number`
 (interpreted as **pixels**), a size **token** string (resolving to pixels), or a
 `` `${number}%` `` string (a percentage passed through untranslated). The
 returned `rootProps.size` SHALL always be a valid controlled value: a single

--- a/openspec/changes/add-responsive-splitter-sizes-hook/tasks.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Types & scaffolding
 
-- [ ] 1.1 Add a curated `SplitterSizeToken` union to `splitter.types.ts`:
+- [x] 1.1 Add a curated `SplitterSizeToken` union to `splitter.types.ts`:
       `3xs`–`8xl` and `breakpoint-sm`…`breakpoint-2xl` (hand-authored, **not**
       `keyof typeof themeTokens.size`). JSDoc the accepted set and why it is
       curated.
-- [ ] 1.2 Add the value/config types: `ResponsiveSplitterSizeValue`
+- [x] 1.2 Add the value/config types: `ResponsiveSplitterSizeValue`
       (`number` px | `SplitterSizeToken` | `` `${number}%` ``),
       `ResponsiveSplitterSizeThreshold` (`number` px | `SplitterSizeToken` —
       no percent), `ResponsiveSplitterSizeConfig`
@@ -16,118 +16,118 @@
       `UseResponsiveSplitterSizesResult`
       (`{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, ref, orientation } }`).
       JSDoc every field; state the `number = px` rule explicitly.
-- [ ] 1.3 Create `hooks/use-responsive-splitter-sizes.ts` with the signature and
+- [x] 1.3 Create `hooks/use-responsive-splitter-sizes.ts` with the signature and
       a typed stub returning a valid (config-default, `%`-resolvable) `rootProps`.
 
 ## 2. Pure resolution helpers (unit-testable in isolation)
 
-- [ ] 2.1 `resolveTokenToPx(token, tokens)` — resolve a `SplitterSizeToken` to a
+- [x] 2.1 `resolveTokenToPx(token, tokens)` — resolve a `SplitterSizeToken` to a
       pixel number via injected `themeTokens.size`; throw/ignore policy for
       unknown tokens defined and documented.
-- [ ] 2.2 `valueToPercent(value, containerPx, tokens)` — pure: `number`→px→%,
+- [x] 2.2 `valueToPercent(value, containerPx, tokens)` — pure: `number`→px→%,
       token→px→%, `` `${n}%` ``→% passthrough; guards `containerPx <= 0` /
       non-finite (returns a sentinel the caller treats as "unresolved").
-- [ ] 2.3 `selectBand(map, measuredPx, tokens, hysteresis)` — resolve all
+- [x] 2.3 `selectBand(map, measuredPx, tokens, hysteresis)` — resolve all
       threshold keys to px, sort ascending, pick the largest `≤ measuredPx`
       (smallest applies below), with a hysteresis deadband around boundaries.
-- [ ] 2.4 `clampPercent(percent, minPercent, maxPercent)` — clamp the resolved
+- [x] 2.4 `clampPercent(percent, minPercent, maxPercent)` — clamp the resolved
       size into the resolved `[minSize, maxSize]` window.
-- [ ] 2.5 `percentToPx(percent, containerPx)` — inverse, for persistence re-derive.
+- [x] 2.5 `percentToPx(percent, containerPx)` — inverse, for persistence re-derive.
 
 ## 3. Container resolution (ResizeObserver)
 
-- [ ] 3.1 Implement `"container"` resolution: a `ResizeObserver` on the
+- [x] 3.1 Implement `"container"` resolution: a `ResizeObserver` on the
       `rootProps.ref` element measuring width (horizontal) / height (vertical),
       driving band selection and pixel→percent conversion.
-- [ ] 3.2 Feature-detect `ResizeObserver`; with none, resolve `%`-only config and
+- [x] 3.2 Feature-detect `ResizeObserver`; with none, resolve `%`-only config and
       fall back for px/token without throwing; retry once a positive measurement
       arrives.
-- [ ] 3.3 Guard width `0`/non-finite; never emit a non-finite size; re-resolve on
+- [x] 3.3 Guard width `0`/non-finite; never emit a non-finite size; re-resolve on
       the next positive measurement.
-- [ ] 3.4 Make `resolveAgainst` required; accept only `"container"` in this
+- [x] 3.4 Make `resolveAgainst` required; accept only `"container"` in this
       version (reserve `"viewport"` as an additive value — not implemented).
-- [ ] 3.5 Observe/unobserve cleanup-symmetric and StrictMode-safe (no leaked
+- [x] 3.5 Observe/unobserve cleanup-symmetric and StrictMode-safe (no leaked
       observers, no double-bind).
 
 ## 4. Two-phase resolution & emit gating
 
-- [ ] 4.1 Resolve `%`-only config synchronously for the earliest correct value;
+- [x] 4.1 Resolve `%`-only config synchronously for the earliest correct value;
       resolve px/token config after the first measurement in a `useLayoutEffect`.
-- [ ] 4.2 Clamp every resolved `size` (live, default, restored) into
+- [x] 4.2 Clamp every resolved `size` (live, default, restored) into
       `[minSize, maxSize]` before emitting.
-- [ ] 4.3 Equality-gate the emitted `rootProps.size` with a tolerance coarser
+- [x] 4.3 Equality-gate the emitted `rootProps.size` with a tolerance coarser
       than the component's `1e-6` so px↔% round-trips under resize ticks do not
       thrash the controlled prop.
-- [ ] 4.4 Translate `minSize`/`maxSize`/`collapsedSize` to percentages and expose
+- [x] 4.4 Translate `minSize`/`maxSize`/`collapsedSize` to percentages and expose
       them on `rootProps`.
 
 ## 5. Persistence
 
-- [ ] 5.1 Versioned storage adapter defaulting to `localStorage`, all access
+- [x] 5.1 Versioned storage adapter defaulting to `localStorage`, all access
       try/caught; read/parse `{ v, bands: { [thresholdPx]: { unit, value } } }`,
       tolerating absent/corrupt/old data (migrate by version where possible).
-- [ ] 5.2 Resolution precedence `stored[activeBand] ?? configDefault[activeBand]`;
+- [x] 5.2 Resolution precedence `stored[activeBand] ?? configDefault[activeBand]`;
       key bands by the resolved pixel threshold (stable across token renames).
-- [ ] 5.3 On settle, write the active band: px/token bands store px (re-derived
+- [x] 5.3 On settle, write the active band: px/token bands store px (re-derived
       via `percentToPx` from the measured container); percent bands store percent.
-- [ ] 5.4 Clamp restored values into `[minSize, maxSize]` before emitting (covers
+- [x] 5.4 Clamp restored values into `[minSize, maxSize]` before emitting (covers
       a wide-session px restored into a narrow container).
-- [ ] 5.5 Never persist `collapsedSize`; suppress persistence while collapsed,
+- [x] 5.5 Never persist `collapsedSize`; suppress persistence while collapsed,
       keyed off the collapse signal (not value equality), so an expanded size
       equal to `collapsedSize` is still persisted.
 
 ## 6. Controlled-loop wiring
 
-- [ ] 6.1 Expose the resolved value as `rootProps.size` (controlled) and keep it
+- [x] 6.1 Expose the resolved value as `rootProps.size` (controlled) and keep it
       stable across renders unless the resolved value changes beyond the gate.
-- [ ] 6.2 Wire `onSizeChangeEnd` to persist (subject to the collapse suppression)
+- [x] 6.2 Wire `onSizeChangeEnd` to persist (subject to the collapse suppression)
       and feed the settled value back; never emit both `size` and `defaultSize`.
-- [ ] 6.3 Re-resolve on band change, relying on the component's in-place,
+- [x] 6.3 Re-resolve on band change, relying on the component's in-place,
       settle-only reconcile (no remount); verify no snap-back.
 
 ## 7. Exports & token guard
 
-- [ ] 7.1 Export the hook and its public types (incl. `SplitterSizeToken`) from
+- [x] 7.1 Export the hook and its public types (incl. `SplitterSizeToken`) from
       `components/splitter/index.ts`.
-- [ ] 7.2 Confirm the splitter barrel is surfaced in the package public API so
+- [x] 7.2 Confirm the splitter barrel is surfaced in the package public API so
       `useResponsiveSplitterSizes` is importable from `@commercetools/nimbus`.
-- [ ] 7.3 Add a token-existence guard test: every `SplitterSizeToken` member
+- [x] 7.3 Add a token-existence guard test: every `SplitterSizeToken` member
       exists in `themeTokens.size` (turns a token rename into a red build).
 
 ## 8. Tests (unit — hooks are JSDOM-tested)
 
-- [ ] 8.1 Pure helpers (§2): `number = px` conversion, token→px→%, `%`
+- [x] 8.1 Pure helpers (§2): `number = px` conversion, token→px→%, `%`
       passthrough, band selection + hysteresis, clamping, px round-trip.
-- [ ] 8.2 Container-mode band selection across simulated width bands (mock
+- [x] 8.2 Container-mode band selection across simulated width bands (mock
       `ResizeObserver`); single-value-applies-everywhere case.
-- [ ] 8.3 Clamping: a px `size` resolving below `minSize` / above `maxSize` is
+- [x] 8.3 Clamping: a px `size` resolving below `minSize` / above `maxSize` is
       clamped before emit; restored wide px in a narrow container is clamped.
-- [ ] 8.4 Persistence: settle writes px under the active band; `stored ?? default`
+- [x] 8.4 Persistence: settle writes px under the active band; `stored ?? default`
       precedence; per-band independence; px pin survives a simulated reload +
       resize; versioned/corrupt/absent data tolerated.
-- [ ] 8.5 Collapse: `collapsedSize` never stored; suppression while collapsed;
+- [x] 8.5 Collapse: `collapsedSize` never stored; suppression while collapsed;
       an expanded size equal to `collapsedSize` still persisted.
-- [ ] 8.6 Emit gating: resize ticks within a band do not push a new `size` unless
+- [x] 8.6 Emit gating: resize ticks within a band do not push a new `size` unless
       it changes beyond the tolerance (no oscillation).
-- [ ] 8.7 Degradation: no `ResizeObserver`, no/throwing `storage`, width `0` —
+- [x] 8.7 Degradation: no `ResizeObserver`, no/throwing `storage`, width `0` —
       no throw, `%`-only still resolves.
 
 ## 9. Story & docs
 
-- [ ] 9.1 Storybook story: the responsive + pixel/token + persisted flow on a
+- [x] 9.1 Storybook story: the responsive + pixel/token + persisted flow on a
       real `Splitter.Root` (play function exercising a settle and a simulated
       band change).
-- [ ] 9.2 Document in the splitter `.dev.mdx` / `.mdx`: the recipe, the
+- [x] 9.2 Document in the splitter `.dev.mdx` / `.mdx`: the recipe, the
       **`number = px`** rule (and the contrast with the component's percentage
       props), container-width threshold keys vs viewport, the curated token set,
       the `ref` requirement, and the px-pin-survives-drag persistence behavior.
 
 ## 10. Verification
 
-- [ ] 10.1 `pnpm --filter @commercetools/nimbus typecheck:strict` passes (no
+- [x] 10.1 `pnpm --filter @commercetools/nimbus typecheck:strict` passes (no
       `any`); `SplitterSizeToken` gives clean autocomplete.
-- [ ] 10.2 `pnpm test:dev` for the new spec passes; `pnpm lint` clean.
-- [ ] 10.3 Build the package and confirm the hook is exported from the published
+- [x] 10.2 `pnpm test:dev` for the new spec passes; `pnpm lint` clean.
+- [x] 10.3 Build the package and confirm the hook is exported from the published
       entry (`pnpm --filter @commercetools/nimbus build`).
 
 ## 11. Tracked separately (not part of this change)

--- a/openspec/changes/add-responsive-splitter-sizes-hook/tasks.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/tasks.md
@@ -1,0 +1,139 @@
+## 1. Types & scaffolding
+
+- [ ] 1.1 Add a curated `SplitterSizeToken` union to `splitter.types.ts`:
+      `3xs`–`8xl` and `breakpoint-sm`…`breakpoint-2xl` (hand-authored, **not**
+      `keyof typeof themeTokens.size`). JSDoc the accepted set and why it is
+      curated.
+- [ ] 1.2 Add the value/config types: `ResponsiveSplitterSizeValue`
+      (`number` px | `SplitterSizeToken` | `` `${number}%` ``),
+      `ResponsiveSplitterSizeThreshold` (`number` px | `SplitterSizeToken` —
+      no percent), `ResponsiveSplitterSizeConfig`
+      (`ResponsiveSplitterSizeValue` | a threshold-keyed map of it),
+      `SplitterSizesStorage` (Storage-like `getItem`/`setItem`),
+      `UseResponsiveSplitterSizesOptions` (`orientation`, `resolveAgainst`
+      (required), `size`, optional `minSize`/`maxSize`/`collapsedSize`,
+      `persistKey`, `storage?`), and the return type
+      `UseResponsiveSplitterSizesResult`
+      (`{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, ref, orientation } }`).
+      JSDoc every field; state the `number = px` rule explicitly.
+- [ ] 1.3 Create `hooks/use-responsive-splitter-sizes.ts` with the signature and
+      a typed stub returning a valid (config-default, `%`-resolvable) `rootProps`.
+
+## 2. Pure resolution helpers (unit-testable in isolation)
+
+- [ ] 2.1 `resolveTokenToPx(token, tokens)` — resolve a `SplitterSizeToken` to a
+      pixel number via injected `themeTokens.size`; throw/ignore policy for
+      unknown tokens defined and documented.
+- [ ] 2.2 `valueToPercent(value, containerPx, tokens)` — pure: `number`→px→%,
+      token→px→%, `` `${n}%` ``→% passthrough; guards `containerPx <= 0` /
+      non-finite (returns a sentinel the caller treats as "unresolved").
+- [ ] 2.3 `selectBand(map, measuredPx, tokens, hysteresis)` — resolve all
+      threshold keys to px, sort ascending, pick the largest `≤ measuredPx`
+      (smallest applies below), with a hysteresis deadband around boundaries.
+- [ ] 2.4 `clampPercent(percent, minPercent, maxPercent)` — clamp the resolved
+      size into the resolved `[minSize, maxSize]` window.
+- [ ] 2.5 `percentToPx(percent, containerPx)` — inverse, for persistence re-derive.
+
+## 3. Container resolution (ResizeObserver)
+
+- [ ] 3.1 Implement `"container"` resolution: a `ResizeObserver` on the
+      `rootProps.ref` element measuring width (horizontal) / height (vertical),
+      driving band selection and pixel→percent conversion.
+- [ ] 3.2 Feature-detect `ResizeObserver`; with none, resolve `%`-only config and
+      fall back for px/token without throwing; retry once a positive measurement
+      arrives.
+- [ ] 3.3 Guard width `0`/non-finite; never emit a non-finite size; re-resolve on
+      the next positive measurement.
+- [ ] 3.4 Make `resolveAgainst` required; accept only `"container"` in this
+      version (reserve `"viewport"` as an additive value — not implemented).
+- [ ] 3.5 Observe/unobserve cleanup-symmetric and StrictMode-safe (no leaked
+      observers, no double-bind).
+
+## 4. Two-phase resolution & emit gating
+
+- [ ] 4.1 Resolve `%`-only config synchronously for the earliest correct value;
+      resolve px/token config after the first measurement in a `useLayoutEffect`.
+- [ ] 4.2 Clamp every resolved `size` (live, default, restored) into
+      `[minSize, maxSize]` before emitting.
+- [ ] 4.3 Equality-gate the emitted `rootProps.size` with a tolerance coarser
+      than the component's `1e-6` so px↔% round-trips under resize ticks do not
+      thrash the controlled prop.
+- [ ] 4.4 Translate `minSize`/`maxSize`/`collapsedSize` to percentages and expose
+      them on `rootProps`.
+
+## 5. Persistence
+
+- [ ] 5.1 Versioned storage adapter defaulting to `localStorage`, all access
+      try/caught; read/parse `{ v, bands: { [thresholdPx]: { unit, value } } }`,
+      tolerating absent/corrupt/old data (migrate by version where possible).
+- [ ] 5.2 Resolution precedence `stored[activeBand] ?? configDefault[activeBand]`;
+      key bands by the resolved pixel threshold (stable across token renames).
+- [ ] 5.3 On settle, write the active band: px/token bands store px (re-derived
+      via `percentToPx` from the measured container); percent bands store percent.
+- [ ] 5.4 Clamp restored values into `[minSize, maxSize]` before emitting (covers
+      a wide-session px restored into a narrow container).
+- [ ] 5.5 Never persist `collapsedSize`; suppress persistence while collapsed,
+      keyed off the collapse signal (not value equality), so an expanded size
+      equal to `collapsedSize` is still persisted.
+
+## 6. Controlled-loop wiring
+
+- [ ] 6.1 Expose the resolved value as `rootProps.size` (controlled) and keep it
+      stable across renders unless the resolved value changes beyond the gate.
+- [ ] 6.2 Wire `onSizeChangeEnd` to persist (subject to the collapse suppression)
+      and feed the settled value back; never emit both `size` and `defaultSize`.
+- [ ] 6.3 Re-resolve on band change, relying on the component's in-place,
+      settle-only reconcile (no remount); verify no snap-back.
+
+## 7. Exports & token guard
+
+- [ ] 7.1 Export the hook and its public types (incl. `SplitterSizeToken`) from
+      `components/splitter/index.ts`.
+- [ ] 7.2 Confirm the splitter barrel is surfaced in the package public API so
+      `useResponsiveSplitterSizes` is importable from `@commercetools/nimbus`.
+- [ ] 7.3 Add a token-existence guard test: every `SplitterSizeToken` member
+      exists in `themeTokens.size` (turns a token rename into a red build).
+
+## 8. Tests (unit — hooks are JSDOM-tested)
+
+- [ ] 8.1 Pure helpers (§2): `number = px` conversion, token→px→%, `%`
+      passthrough, band selection + hysteresis, clamping, px round-trip.
+- [ ] 8.2 Container-mode band selection across simulated width bands (mock
+      `ResizeObserver`); single-value-applies-everywhere case.
+- [ ] 8.3 Clamping: a px `size` resolving below `minSize` / above `maxSize` is
+      clamped before emit; restored wide px in a narrow container is clamped.
+- [ ] 8.4 Persistence: settle writes px under the active band; `stored ?? default`
+      precedence; per-band independence; px pin survives a simulated reload +
+      resize; versioned/corrupt/absent data tolerated.
+- [ ] 8.5 Collapse: `collapsedSize` never stored; suppression while collapsed;
+      an expanded size equal to `collapsedSize` still persisted.
+- [ ] 8.6 Emit gating: resize ticks within a band do not push a new `size` unless
+      it changes beyond the tolerance (no oscillation).
+- [ ] 8.7 Degradation: no `ResizeObserver`, no/throwing `storage`, width `0` —
+      no throw, `%`-only still resolves.
+
+## 9. Story & docs
+
+- [ ] 9.1 Storybook story: the responsive + pixel/token + persisted flow on a
+      real `Splitter.Root` (play function exercising a settle and a simulated
+      band change).
+- [ ] 9.2 Document in the splitter `.dev.mdx` / `.mdx`: the recipe, the
+      **`number = px`** rule (and the contrast with the component's percentage
+      props), container-width threshold keys vs viewport, the curated token set,
+      the `ref` requirement, and the px-pin-survives-drag persistence behavior.
+
+## 10. Verification
+
+- [ ] 10.1 `pnpm --filter @commercetools/nimbus typecheck:strict` passes (no
+      `any`); `SplitterSizeToken` gives clean autocomplete.
+- [ ] 10.2 `pnpm test:dev` for the new spec passes; `pnpm lint` clean.
+- [ ] 10.3 Build the package and confirm the hook is exported from the published
+      entry (`pnpm --filter @commercetools/nimbus build`).
+
+## 11. Tracked separately (not part of this change)
+
+- [ ] 11.1 Component first-paint fix: seed `Splitter.Root`'s `size`/`defaultSize`
+      synchronously (lazy `useState` initializer / `useLayoutEffect`) instead of
+      the pane-registration mount effect, so the first committed frame honors the
+      configured size rather than painting `50/50` first. Validate during hook
+      implementation; land as an independent fix.

--- a/openspec/changes/add-responsive-splitter-sizes-hook/tasks.md
+++ b/openspec/changes/add-responsive-splitter-sizes-hook/tasks.md
@@ -10,9 +10,9 @@
       no percent), `ResponsiveSplitterSizeConfig`
       (`ResponsiveSplitterSizeValue` | a threshold-keyed map of it),
       `SplitterSizesStorage` (Storage-like `getItem`/`setItem`),
-      `UseResponsiveSplitterSizesOptions` (`orientation`, `resolveAgainst`
-      (required), `size`, optional `minSize`/`maxSize`/`collapsedSize`,
-      `persistKey`, `storage?`), and the return type
+      `UseResponsiveSplitterSizesOptions` (`orientation?`, `size`, optional
+      `minSize`/`maxSize`/`collapsedSize`, `persistKey`, `storage?`,
+      `onCollapsedChange?`), and the return type
       `UseResponsiveSplitterSizesResult`
       (`{ rootProps: { size, minSize, maxSize, collapsedSize, onSizeChangeEnd, ref, orientation } }`).
       JSDoc every field; state the `number = px` rule explicitly.
@@ -44,8 +44,7 @@
       arrives.
 - [x] 3.3 Guard width `0`/non-finite; never emit a non-finite size; re-resolve on
       the next positive measurement.
-- [x] 3.4 Make `resolveAgainst` required; accept only `"container"` in this
-      version (reserve `"viewport"` as an additive value — not implemented).
+- [x] 3.4 Always resolve against the container — no resolution-axis option.
 - [x] 3.5 Observe/unobserve cleanup-symmetric and StrictMode-safe (no leaked
       observers, no double-bind).
 

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
@@ -1,7 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import { useResponsiveSplitterSizes } from "./use-responsive-splitter-sizes";
-import type { SplitterSizesStorage } from "../splitter.types";
+import type {
+  SplitterSizesStorage,
+  UseResponsiveSplitterSizesOptions,
+} from "../splitter.types";
+
+/** Record `rootProps.size` on every render so the FIRST render can be asserted. */
+const recordSizes = (options: UseResponsiveSplitterSizesOptions) => {
+  const sizes: Array<number | undefined> = [];
+  const Probe = () => {
+    const { rootProps } = useResponsiveSplitterSizes(options);
+    sizes.push(rootProps.size);
+    return null;
+  };
+  render(<Probe />);
+  return sizes;
+};
 
 // --- Controllable ResizeObserver -------------------------------------------
 type ROCallback = (entries: Array<{ contentRect: DOMRectReadOnly }>) => void;
@@ -79,6 +94,14 @@ describe("useResponsiveSplitterSizes", () => {
   it("resolves a single percent value synchronously, before measurement", () => {
     const view = renderHook(() => useResponsiveSplitterSizes({ size: "30%" }));
     expect(view.result.current.rootProps.size).toBe(30);
+  });
+
+  it("emits a synchronous percent size on the very first render (no undefined frame)", () => {
+    // A `%` config needs no measurement, so the controlled `size` must be
+    // present on the first render — otherwise the component shows its
+    // uncontrolled default for a frame (the first-paint flash).
+    const sizes = recordSizes({ size: "30%" });
+    expect(sizes[0]).toBe(30);
   });
 
   it("converts a pixel value to a percentage of the measured container", () => {

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
@@ -77,14 +77,12 @@ afterEach(() => {
 
 describe("useResponsiveSplitterSizes", () => {
   it("resolves a single percent value synchronously, before measurement", () => {
-    const view = renderHook(() =>
-      useResponsiveSplitterSizes({ resolveAgainst: "container", size: "30%" })
-    );
+    const view = renderHook(() => useResponsiveSplitterSizes({ size: "30%" }));
     expect(view.result.current.rootProps.size).toBe(30);
   });
 
   it("converts a pixel value to a percentage of the measured container", () => {
-    const view = mountHook({ resolveAgainst: "container", size: 320 });
+    const view = mountHook({ size: 320 });
     // No measurement yet → size omitted (component stays uncontrolled).
     expect(view.result.current.rootProps.size).toBeUndefined();
     fireResize(1000);
@@ -95,7 +93,6 @@ describe("useResponsiveSplitterSizes", () => {
 
   it("selects the active band by container width", () => {
     const view = mountHook({
-      resolveAgainst: "container",
       size: { 0: 320, 768: "30%" },
     });
     fireResize(640); // below 768 → 320px / 640 = 50%
@@ -106,7 +103,6 @@ describe("useResponsiveSplitterSizes", () => {
 
   it("forwards minSize/maxSize/collapsedSize as percentages and clamps size", () => {
     const view = mountHook({
-      resolveAgainst: "container",
       size: 100, // 100px
       minSize: 200, // 200px
       maxSize: 600, // 600px
@@ -121,7 +117,7 @@ describe("useResponsiveSplitterSizes", () => {
   });
 
   it("does not thrash the emitted size on sub-tolerance resize ticks", () => {
-    const view = mountHook({ resolveAgainst: "container", size: 320 });
+    const view = mountHook({ size: 320 });
     fireResize(1000);
     const first = view.result.current.rootProps.size;
     expect(first).toBe(32);
@@ -136,7 +132,6 @@ describe("useResponsiveSplitterSizes", () => {
   it("persists a settled drag in pixels and restores it across a remount + resize", () => {
     const storage = memoryStorage();
     const view = mountHook({
-      resolveAgainst: "container",
       size: 320,
       persistKey: "k",
       storage,
@@ -149,7 +144,6 @@ describe("useResponsiveSplitterSizes", () => {
 
     // Remount into an 800px container — the 280px pin re-converts to 35%.
     const remount = mountHook({
-      resolveAgainst: "container",
       size: 320,
       persistKey: "k",
       storage,
@@ -161,7 +155,6 @@ describe("useResponsiveSplitterSizes", () => {
   it("does not persist a collapse-driven settle", () => {
     const storage = memoryStorage();
     const view = mountHook({
-      resolveAgainst: "container",
       size: 320,
       collapsedSize: 0,
       persistKey: "k",
@@ -182,7 +175,6 @@ describe("useResponsiveSplitterSizes", () => {
   it("calls the optional onCollapsedChange passthrough", () => {
     const onCollapsedChange = vi.fn();
     const view = mountHook({
-      resolveAgainst: "container",
       size: "30%",
       onCollapsedChange,
     });
@@ -192,7 +184,7 @@ describe("useResponsiveSplitterSizes", () => {
 
   it("degrades without ResizeObserver: percent config still resolves", () => {
     globalThis.ResizeObserver = undefined as unknown as typeof ResizeObserver;
-    const view = mountHook({ resolveAgainst: "container", size: "40%" });
+    const view = mountHook({ size: "40%" });
     expect(view.result.current.rootProps.size).toBe(40);
   });
 
@@ -204,7 +196,6 @@ describe("useResponsiveSplitterSizes", () => {
       },
     };
     const view = mountHook({
-      resolveAgainst: "container",
       size: 320,
       persistKey: "k",
       storage,

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useResponsiveSplitterSizes } from "./use-responsive-splitter-sizes";
+import type { SplitterSizesStorage } from "../splitter.types";
+
+// --- Controllable ResizeObserver -------------------------------------------
+type ROCallback = (entries: Array<{ contentRect: DOMRectReadOnly }>) => void;
+const observers: Array<{ cb: ROCallback; node: Element | null }> = [];
+
+class ControllableResizeObserver {
+  cb: ROCallback;
+  node: Element | null = null;
+  constructor(cb: ROCallback) {
+    this.cb = cb;
+    observers.push(this);
+  }
+  observe(node: Element) {
+    this.node = node;
+  }
+  unobserve() {}
+  disconnect() {
+    this.node = null;
+  }
+}
+
+/** Fire a measurement on every active observer (the hook keeps a single one). */
+const fireResize = (width: number, height = 600) => {
+  act(() => {
+    for (const o of observers) {
+      if (o.node) {
+        o.cb([{ contentRect: { width, height } as DOMRectReadOnly }]);
+      }
+    }
+  });
+};
+
+/** Render the hook and attach its ref to a detached node. */
+const mountHook = (
+  options: Parameters<typeof useResponsiveSplitterSizes>[0]
+) => {
+  const view = renderHook((o) => useResponsiveSplitterSizes(o), {
+    initialProps: options,
+  });
+  const node = document.createElement("div");
+  act(() => {
+    (view.result.current.rootProps.ref as (n: HTMLDivElement | null) => void)(
+      node
+    );
+  });
+  return view;
+};
+
+const memoryStorage = (): SplitterSizesStorage & {
+  dump: Record<string, string>;
+} => {
+  const dump: Record<string, string> = {};
+  return {
+    dump,
+    getItem: (k) => dump[k] ?? null,
+    setItem: (k, v) => {
+      dump[k] = v;
+    },
+  };
+};
+
+let originalRO: typeof ResizeObserver;
+beforeEach(() => {
+  observers.length = 0;
+  originalRO = globalThis.ResizeObserver;
+  globalThis.ResizeObserver =
+    ControllableResizeObserver as unknown as typeof ResizeObserver;
+});
+afterEach(() => {
+  globalThis.ResizeObserver = originalRO;
+  vi.restoreAllMocks();
+});
+
+describe("useResponsiveSplitterSizes", () => {
+  it("resolves a single percent value synchronously, before measurement", () => {
+    const view = renderHook(() =>
+      useResponsiveSplitterSizes({ resolveAgainst: "container", size: "30%" })
+    );
+    expect(view.result.current.rootProps.size).toBe(30);
+  });
+
+  it("converts a pixel value to a percentage of the measured container", () => {
+    const view = mountHook({ resolveAgainst: "container", size: 320 });
+    // No measurement yet → size omitted (component stays uncontrolled).
+    expect(view.result.current.rootProps.size).toBeUndefined();
+    fireResize(1000);
+    expect(view.result.current.rootProps.size).toBe(32);
+    fireResize(800);
+    expect(view.result.current.rootProps.size).toBe(40);
+  });
+
+  it("selects the active band by container width", () => {
+    const view = mountHook({
+      resolveAgainst: "container",
+      size: { 0: 320, 768: "30%" },
+    });
+    fireResize(640); // below 768 → 320px / 640 = 50%
+    expect(view.result.current.rootProps.size).toBe(50);
+    fireResize(1000); // at/above 768 → 30%
+    expect(view.result.current.rootProps.size).toBe(30);
+  });
+
+  it("forwards minSize/maxSize/collapsedSize as percentages and clamps size", () => {
+    const view = mountHook({
+      resolveAgainst: "container",
+      size: 100, // 100px
+      minSize: 200, // 200px
+      maxSize: 600, // 600px
+      collapsedSize: 0,
+    });
+    fireResize(1000);
+    // minSize 20%, maxSize 60%, collapsedSize 0%; raw size 10% clamped up to 20%.
+    expect(view.result.current.rootProps.minSize).toBe(20);
+    expect(view.result.current.rootProps.maxSize).toBe(60);
+    expect(view.result.current.rootProps.collapsedSize).toBe(0);
+    expect(view.result.current.rootProps.size).toBe(20);
+  });
+
+  it("does not thrash the emitted size on sub-tolerance resize ticks", () => {
+    const view = mountHook({ resolveAgainst: "container", size: 320 });
+    fireResize(1000);
+    const first = view.result.current.rootProps.size;
+    expect(first).toBe(32);
+    // 320/1001 ≈ 31.97% — within EMIT_TOLERANCE of 32, so size holds steady.
+    fireResize(1001);
+    expect(view.result.current.rootProps.size).toBe(first);
+    // A clearly larger change does move it.
+    fireResize(1280); // 320/1280 = 25%
+    expect(view.result.current.rootProps.size).toBe(25);
+  });
+
+  it("persists a settled drag in pixels and restores it across a remount + resize", () => {
+    const storage = memoryStorage();
+    const view = mountHook({
+      resolveAgainst: "container",
+      size: 320,
+      persistKey: "k",
+      storage,
+    });
+    fireResize(1000);
+    // User drags and releases at 28% (≈280px in a 1000px container).
+    act(() => view.result.current.rootProps.onSizeChangeEnd(28));
+    expect(view.result.current.rootProps.size).toBe(28); // fed back, no snap-back
+    expect(storage.dump.k).toContain('"unit":"px"');
+
+    // Remount into an 800px container — the 280px pin re-converts to 35%.
+    const remount = mountHook({
+      resolveAgainst: "container",
+      size: 320,
+      persistKey: "k",
+      storage,
+    });
+    fireResize(800);
+    expect(remount.result.current.rootProps.size).toBeCloseTo(35);
+  });
+
+  it("does not persist a collapse-driven settle", () => {
+    const storage = memoryStorage();
+    const view = mountHook({
+      resolveAgainst: "container",
+      size: 320,
+      collapsedSize: 0,
+      persistKey: "k",
+      storage,
+    });
+    fireResize(1000);
+    act(() => view.result.current.rootProps.onSizeChangeEnd(32)); // real settle
+    const afterReal = storage.dump.k;
+    expect(afterReal).toBeDefined();
+
+    // Collapse: onCollapsedChange(true) fires before the collapse settle.
+    act(() => view.result.current.rootProps.onCollapsedChange(true));
+    act(() => view.result.current.rootProps.onSizeChangeEnd(0)); // collapsed size
+    // Storage unchanged — the collapsed value was not persisted.
+    expect(storage.dump.k).toBe(afterReal);
+  });
+
+  it("calls the optional onCollapsedChange passthrough", () => {
+    const onCollapsedChange = vi.fn();
+    const view = mountHook({
+      resolveAgainst: "container",
+      size: "30%",
+      onCollapsedChange,
+    });
+    act(() => view.result.current.rootProps.onCollapsedChange(true));
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("degrades without ResizeObserver: percent config still resolves", () => {
+    globalThis.ResizeObserver = undefined as unknown as typeof ResizeObserver;
+    const view = mountHook({ resolveAgainst: "container", size: "40%" });
+    expect(view.result.current.rootProps.size).toBe(40);
+  });
+
+  it("tolerates a throwing storage on write", () => {
+    const storage: SplitterSizesStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+    const view = mountHook({
+      resolveAgainst: "container",
+      size: 320,
+      persistKey: "k",
+      storage,
+    });
+    fireResize(1000);
+    expect(() =>
+      act(() => view.result.current.rootProps.onSizeChangeEnd(30))
+    ).not.toThrow();
+    expect(view.result.current.rootProps.size).toBe(30);
+  });
+});

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.spec.tsx
@@ -139,6 +139,27 @@ describe("useResponsiveSplitterSizes", () => {
     expect(view.result.current.rootProps.size).toBe(20);
   });
 
+  it("supports object (container-width) notation for minSize/maxSize", () => {
+    const view = mountHook({
+      size: "50%",
+      minSize: { 0: 100, 768: 200 }, // px per band
+      maxSize: { 0: "60%", 768: "80%" }, // percent per band
+    });
+    fireResize(1000); // ≥ 768 band
+    expect(view.result.current.rootProps.minSize).toBe(20); // 200px / 1000
+    expect(view.result.current.rootProps.maxSize).toBe(80);
+    fireResize(640); // < 768 band
+    expect(view.result.current.rootProps.minSize).toBeCloseTo(15.625); // 100px / 640
+    expect(view.result.current.rootProps.maxSize).toBe(60);
+  });
+
+  it("measures the height axis for a vertical splitter", () => {
+    const view = mountHook({ orientation: "vertical", size: 300 }); // 300px
+    fireResize(1000, 600); // vertical → uses height 600 → 300/600 = 50%
+    expect(view.result.current.rootProps.size).toBe(50);
+    expect(view.result.current.rootProps.orientation).toBe("vertical");
+  });
+
   it("does not thrash the emitted size on sub-tolerance resize ticks", () => {
     const view = mountHook({ size: 320 });
     fireResize(1000);

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts
@@ -47,7 +47,6 @@ const defaultStorage = createLocalStorageAdapter();
  * @example
  * const { rootProps } = useResponsiveSplitterSizes({
  *   orientation: "horizontal",
- *   resolveAgainst: "container",
  *   persistKey: "app:main-splitter",
  *   size: { 0: 320, 768: "30%" }, // 320px below 768px container width, 30% above
  * });

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts
@@ -220,6 +220,14 @@ export const useResponsiveSplitterSizes = (
     latestRef.current.onCollapsedChange?.(collapsed);
   }, []);
 
+  // Prefer the gated `emittedSize` (stable across sub-tolerance resize ticks),
+  // but fall back to the freshly-resolved `targetSize` before the gate's effect
+  // first runs. This is what makes a synchronously-resolvable config (e.g. a
+  // `%` value, which needs no measurement) drive the controlled `size` on the
+  // very first render — so the component honors it on first paint with no flash,
+  // rather than briefly showing its uncontrolled default.
+  const resolvedSize = emittedSize ?? targetSize ?? undefined;
+
   const rootProps = useMemo<ResponsiveSplitterRootProps>(() => {
     const props: ResponsiveSplitterRootProps = {
       ref,
@@ -227,7 +235,7 @@ export const useResponsiveSplitterSizes = (
       onSizeChangeEnd: handleSizeChangeEnd,
       onCollapsedChange: handleCollapsedChange,
     };
-    if (emittedSize !== undefined) props.size = emittedSize;
+    if (resolvedSize !== undefined) props.size = resolvedSize;
     if (minPct !== undefined) props.minSize = minPct;
     if (maxPct !== undefined) props.maxSize = maxPct;
     if (collapsedPct !== undefined) props.collapsedSize = collapsedPct;
@@ -237,7 +245,7 @@ export const useResponsiveSplitterSizes = (
     orientation,
     handleSizeChangeEnd,
     handleCollapsedChange,
-    emittedSize,
+    resolvedSize,
     minPct,
     maxPct,
     collapsedPct,

--- a/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts
+++ b/packages/nimbus/src/components/splitter/hooks/use-responsive-splitter-sizes.ts
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  ResponsiveSplitterRootProps,
+  UseResponsiveSplitterSizesOptions,
+  UseResponsiveSplitterSizesResult,
+} from "../splitter.types";
+import {
+  bandValueAt,
+  clampPercent,
+  isPercentValue,
+  percentToPx,
+  resolveDimension,
+  type StoredBand,
+} from "../utils/responsive-size";
+import {
+  createLocalStorageAdapter,
+  parseStoredBands,
+  serializeStoredBands,
+} from "../utils/responsive-size-storage";
+
+/**
+ * Emitted `size` only changes when it moves by more than this many percentage
+ * points — coarser than the component's internal `1e-6` epsilon so pixel↔percent
+ * round-trips under `ResizeObserver` ticks don't thrash the controlled prop.
+ */
+const EMIT_TOLERANCE = 0.05;
+/** Ignore sub-pixel measurement noise. */
+const MEASURE_TOLERANCE = 0.5;
+/** Hysteresis deadband (px) around band thresholds. */
+const BAND_DEADBAND = 2;
+
+/** Module-level default so the adapter identity is stable across renders. */
+const defaultStorage = createLocalStorageAdapter();
+
+/**
+ * Translate a pixel-/token-/percent size config — optionally responsive by
+ * container width — into the percentage `Splitter.Root` consumes, returning
+ * `rootProps` to spread onto the root.
+ *
+ * The hook is the **pixel/token → percentage translator** the component
+ * deliberately omits: `Splitter.Root` stays percentage-native; all pixel math,
+ * container-width resolution, hook-side clamping, and per-band persistence live
+ * here. It drives the component's settle-only controlled `size` channel and
+ * feeds the settled value back, so the controlled loop stays closed with no
+ * snap-back. A bare `number` is **always pixels**.
+ *
+ * @example
+ * const { rootProps } = useResponsiveSplitterSizes({
+ *   orientation: "horizontal",
+ *   resolveAgainst: "container",
+ *   persistKey: "app:main-splitter",
+ *   size: { 0: 320, 768: "30%" }, // 320px below 768px container width, 30% above
+ * });
+ * return (
+ *   <Splitter.Root {...rootProps} collapsible>
+ *     <Splitter.Aside>…</Splitter.Aside>
+ *     <Splitter.Handle />
+ *     <Splitter.Main>…</Splitter.Main>
+ *   </Splitter.Root>
+ * );
+ */
+export const useResponsiveSplitterSizes = (
+  options: UseResponsiveSplitterSizesOptions
+): UseResponsiveSplitterSizesResult => {
+  const {
+    orientation = "horizontal",
+    size,
+    minSize,
+    maxSize,
+    collapsedSize,
+    persistKey,
+    storage = defaultStorage,
+    onCollapsedChange,
+  } = options;
+
+  // Latest measured container size on the relevant axis (null until observed).
+  const [measured, setMeasured] = useState<number | null>(null);
+  const measuredRef = useRef<number | null>(null);
+
+  // Persisted bands for the size dimension, keyed by resolved px threshold.
+  const [storedBands, setStoredBands] = useState<Record<number, StoredBand>>(
+    () =>
+      persistKey ? (parseStoredBands(storage.getItem(persistKey)) ?? {}) : {}
+  );
+  const storedBandsRef = useRef(storedBands);
+  storedBandsRef.current = storedBands;
+
+  // Hysteresis: the band the size dimension currently resolves to.
+  const activeThresholdRef = useRef<number | null>(null);
+  // Gate for the emitted controlled size.
+  const lastEmittedRef = useRef<number | null>(null);
+  const [emittedSize, setEmittedSize] = useState<number | undefined>(undefined);
+  // Whether the aside is currently collapsed (so settles aren't persisted).
+  const collapsedRef = useRef(false);
+
+  // Latest config snapshot for the (stable) settle handler.
+  const latestRef = useRef({ size, persistKey, onCollapsedChange });
+  latestRef.current = { size, persistKey, onCollapsedChange };
+
+  // --- Resolution (recomputed each render; cheap + pure) ---------------------
+  const sizeRes = resolveDimension(size, measured, {
+    activeThresholdPx: activeThresholdRef.current,
+    deadbandPx: BAND_DEADBAND,
+    stored: storedBands,
+  });
+  const minPct =
+    minSize !== undefined
+      ? (resolveDimension(minSize, measured).percent ?? undefined)
+      : undefined;
+  const maxPct =
+    maxSize !== undefined
+      ? (resolveDimension(maxSize, measured).percent ?? undefined)
+      : undefined;
+  const collapsedPct =
+    collapsedSize !== undefined
+      ? (resolveDimension(collapsedSize, measured).percent ?? undefined)
+      : undefined;
+
+  const targetSize =
+    sizeRes.percent === null
+      ? null
+      : clampPercent(sizeRes.percent, minPct ?? 0, maxPct ?? 100);
+
+  // Commit the active band + gated emitted size after render (never during).
+  useEffect(() => {
+    if (sizeRes.thresholdPx !== null) {
+      activeThresholdRef.current = sizeRes.thresholdPx;
+    }
+    if (targetSize === null) return;
+    if (
+      lastEmittedRef.current !== null &&
+      Math.abs(targetSize - lastEmittedRef.current) < EMIT_TOLERANCE
+    ) {
+      return;
+    }
+    lastEmittedRef.current = targetSize;
+    setEmittedSize(targetSize);
+  }, [targetSize, sizeRes.thresholdPx]);
+
+  // --- Container measurement (ResizeObserver) --------------------------------
+  const ref = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+
+      const read = (width: number, height: number) => {
+        const next = orientation === "vertical" ? height : width;
+        if (!Number.isFinite(next) || next <= 0) return;
+        measuredRef.current = next;
+        setMeasured((prev) =>
+          prev !== null && Math.abs(prev - next) < MEASURE_TOLERANCE
+            ? prev
+            : next
+        );
+      };
+
+      if (typeof ResizeObserver === "undefined") {
+        // No observer (SSR/older runtimes): best-effort one-shot measurement so
+        // px/token configs can still resolve once; %-only config is unaffected.
+        const rect = node.getBoundingClientRect();
+        read(rect.width, rect.height);
+        return;
+      }
+
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        read(entry.contentRect.width, entry.contentRect.height);
+      });
+      observer.observe(node);
+      return () => observer.disconnect();
+    },
+    [orientation]
+  );
+
+  // --- Settle handler: persist (unless collapsed) + feed value back ----------
+  const handleSizeChangeEnd = useCallback(
+    (settledPct: number) => {
+      // Collapse fires `onCollapsedChange(true)` before this settle, so a
+      // collapse-driven settle is suppressed here: no feedback (keep the
+      // controlled value at the expanded size, which becomes the expand target)
+      // and no persistence.
+      if (collapsedRef.current) return;
+
+      lastEmittedRef.current = settledPct;
+      setEmittedSize(settledPct);
+
+      const { size: sizeCfg, persistKey: key } = latestRef.current;
+      const containerPx = measuredRef.current;
+      if (!key || containerPx === null || containerPx <= 0) return;
+
+      const { thresholdPx } = resolveDimension(sizeCfg, containerPx, {
+        activeThresholdPx: activeThresholdRef.current,
+        deadbandPx: BAND_DEADBAND,
+      });
+      if (thresholdPx === null) return;
+
+      const configured = bandValueAt(sizeCfg, thresholdPx);
+      const unit: StoredBand["unit"] = isPercentValue(configured)
+        ? "pct"
+        : "px";
+      const value =
+        unit === "pct" ? settledPct : percentToPx(settledPct, containerPx);
+
+      const nextBands = {
+        ...storedBandsRef.current,
+        [thresholdPx]: { unit, value },
+      };
+      storedBandsRef.current = nextBands;
+      setStoredBands(nextBands);
+      try {
+        storage.setItem(key, serializeStoredBands(nextBands));
+      } catch {
+        // Best-effort; resolution still works from in-memory state.
+      }
+    },
+    [storage]
+  );
+
+  const handleCollapsedChange = useCallback((collapsed: boolean) => {
+    collapsedRef.current = collapsed;
+    latestRef.current.onCollapsedChange?.(collapsed);
+  }, []);
+
+  const rootProps = useMemo<ResponsiveSplitterRootProps>(() => {
+    const props: ResponsiveSplitterRootProps = {
+      ref,
+      orientation,
+      onSizeChangeEnd: handleSizeChangeEnd,
+      onCollapsedChange: handleCollapsedChange,
+    };
+    if (emittedSize !== undefined) props.size = emittedSize;
+    if (minPct !== undefined) props.minSize = minPct;
+    if (maxPct !== undefined) props.maxSize = maxPct;
+    if (collapsedPct !== undefined) props.collapsedSize = collapsedPct;
+    return props;
+  }, [
+    ref,
+    orientation,
+    handleSizeChangeEnd,
+    handleCollapsedChange,
+    emittedSize,
+    minPct,
+    maxPct,
+    collapsedPct,
+  ]);
+
+  return { rootProps };
+};

--- a/packages/nimbus/src/components/splitter/index.ts
+++ b/packages/nimbus/src/components/splitter/index.ts
@@ -1,2 +1,5 @@
 export * from "./splitter";
 export * from "./splitter.types";
+export { useResponsiveSplitterSizes } from "./hooks/use-responsive-splitter-sizes";
+export { SPLITTER_SIZE_TOKENS } from "./utils/size-tokens";
+export type { SplitterSizeToken } from "./utils/size-tokens";

--- a/packages/nimbus/src/components/splitter/splitter.dev.mdx
+++ b/packages/nimbus/src/components/splitter/splitter.dev.mdx
@@ -409,7 +409,6 @@ Spread its `rootProps` onto `Splitter.Root` and attach the `ref` it returns (the
 ```tsx
 const { rootProps } = useResponsiveSplitterSizes({
   orientation: "horizontal",
-  resolveAgainst: "container",
   persistKey: "app:main-splitter",
   size: 320, // a bare number is PIXELS
   minSize: 160,
@@ -438,7 +437,6 @@ the measured width wins; the smallest entry also applies below it.
 
 ```tsx
 const { rootProps } = useResponsiveSplitterSizes({
-  resolveAgainst: "container",
   size: { 0: 320, 768: "30%" }, // 320px below 768px container width, 30% above
 });
 ```

--- a/packages/nimbus/src/components/splitter/splitter.dev.mdx
+++ b/packages/nimbus/src/components/splitter/splitter.dev.mdx
@@ -75,8 +75,8 @@ const App = () => (
 `minSize` and `maxSize` bound the single aside dimension. `minSize` (default
 `0`) is the aside's floor; `maxSize` (default `100`) caps how far the aside can
 grow — which in turn fixes the main pane's floor at `100 − maxSize`. Because
-there is one boundary, this single `[minSize, maxSize]` window on the aside fully
-describes both sides; there is no main-specific prop.
+there is one boundary, this single `[minSize, maxSize]` window on the aside
+fully describes both sides; there is no main-specific prop.
 
 ```jsx live-dev
 const App = () => (
@@ -318,8 +318,8 @@ const App = () => (
 Size is uncontrolled by default, so persist it in your app with any storage:
 hydrate `defaultSize` from stored state and write the settled value back in
 `onSizeChangeEnd` (it fires once per settled interaction — drag end, each
-keypress, collapse/expand, double-click restore — so no debouncing is needed).
-A single `number` round-trips: the value `onSizeChangeEnd` emits is exactly the
+keypress, collapse/expand, double-click restore — so no debouncing is needed). A
+single `number` round-trips: the value `onSizeChangeEnd` emits is exactly the
 shape `defaultSize` accepts. Collapse persists through its controlled boolean
 state.
 
@@ -353,8 +353,8 @@ for responsive layouts that swap the proportion per breakpoint, since external
 changes apply in place (no remount, so pane content keeps its scroll and focus).
 Control is settled, not live: drag and keyboard stay smooth from internal state
 and report once via `onSizeChangeEnd`. Wire that callback and feed the value
-back, or the splitter keeps the last interactive size and behaves as uncontrolled
-from then on.
+back, or the splitter keeps the last interactive size and behaves as
+uncontrolled from then on.
 
 ```tsx
 const [size, setSize] = useState(30);
@@ -370,8 +370,8 @@ const [size, setSize] = useState(30);
 
 The aside percentage carries full float precision end-to-end (nothing in the
 size pipeline is rounded — only the handle's `aria-valuenow` is rounded, for
-assistive technology). To land on an exact pixel at a known container width, pass
-the computed float — `250px` in an `800px` container is `31.25`.
+assistive technology). To land on an exact pixel at a known container width,
+pass the computed float — `250px` in an `800px` container is `31.25`.
 
 ```jsx live-dev
 const App = () => (
@@ -392,6 +392,62 @@ const App = () => (
   </Box>
 );
 ```
+
+### Responsive pixel & token sizes with `useResponsiveSplitterSizes`
+
+`Splitter.Root` is percentage-native — it has no pixel code path. When you'd
+rather think in pixels (a fixed-width sidebar, an icon rail) or size per device,
+reach for the companion hook `useResponsiveSplitterSizes`. It is a **pixel/token
+→ percentage translator**: it measures the splitter's container, converts your
+config to the percentage the component wants, drives the controlled `size`
+channel, and persists the result — all without the component gaining a pixel
+path.
+
+Spread its `rootProps` onto `Splitter.Root` and attach the `ref` it returns (the
+`ref` is required — the hook measures the container through it):
+
+```tsx
+const { rootProps } = useResponsiveSplitterSizes({
+  orientation: "horizontal",
+  resolveAgainst: "container",
+  persistKey: "app:main-splitter",
+  size: 320, // a bare number is PIXELS
+  minSize: 160,
+  maxSize: "breakpoint-sm", // size tokens resolve to pixels too
+});
+
+<Splitter.Root {...rootProps} collapsible>
+  <Splitter.Aside>…</Splitter.Aside>
+  <Splitter.Handle />
+  <Splitter.Main>…</Splitter.Main>
+</Splitter.Root>;
+```
+
+**Units.** A value is a `number` (pixels), a size token (`3xs`–`8xl` or
+`breakpoint-sm`…`breakpoint-2xl`, resolving to pixels), or a `"N%"` string
+(passed through untranslated). Note the contrast with `Splitter.Root`'s own
+`size` / `minSize` / … props, which are **percentages**: through the hook, a
+bare number means pixels. Because the hook owns the full facade (`size` plus
+`minSize` / `maxSize` / `collapsedSize`), you don't hand-write percentages on
+the root when you use it.
+
+**Responsive by container width.** Any dimension can be a map keyed by container
+**min-width thresholds** (pixels or tokens) — a min-width cascade resolved
+against the splitter's own width, not the viewport. The largest threshold `≤`
+the measured width wins; the smallest entry also applies below it.
+
+```tsx
+const { rootProps } = useResponsiveSplitterSizes({
+  resolveAgainst: "container",
+  size: { 0: 320, 768: "30%" }, // 320px below 768px container width, 30% above
+});
+```
+
+**Persistence.** Pass a `persistKey` (and optionally a `storage` adapter,
+defaulting to `localStorage`) and the hook stores the settled size **in pixels**
+per band, so a dragged `320px` re-pins to `320px` across reloads and container
+resizes. `collapsedSize` is static config and is never persisted; the latest
+expanded size survives collapse and expand.
 
 ### Three or more regions
 
@@ -522,9 +578,9 @@ const App = () => {
   warning is emitted otherwise. The aside may be placed before or after the main
   pane (a leading or trailing panel) — `size` always refers to the aside.
 - All sizing and collapse configuration (`defaultSize` / `size`, `minSize`,
-  `maxSize`, `collapsible`, `collapsedSize`) lives on `Splitter.Root`. Panes take
-  only their content and an optional `id` for analytics/testing — nothing is
-  configured on the pane itself.
+  `maxSize`, `collapsible`, `collapsedSize`) lives on `Splitter.Root`. Panes
+  take only their content and an optional `id` for analytics/testing — nothing
+  is configured on the pane itself.
 
 ## Accessibility
 

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -1127,3 +1127,53 @@ export const ResponsivePixelSizesHook: Story = {
     });
   },
 };
+
+// ============================================================
+// useResponsiveSplitterSizes — responsive by CONTAINER width (object notation).
+// The same config resolves against each splitter's OWN width (not the viewport):
+// a 640px container is below the 768 threshold (40%), a 1000px container is at
+// or above it (320px → 32%). Demonstrates min-width threshold maps.
+// ============================================================
+
+const ResponsiveBandDemo = ({ width }: { width: number }) => {
+  const { rootProps } = useResponsiveSplitterSizes({
+    orientation: "horizontal",
+    size: { 0: "40%", 768: 320 },
+  });
+  return (
+    <Box w={`${width}px`} h="240px" borderWidth="25" borderColor="neutral.6">
+      <Splitter.Root {...rootProps}>
+        <Splitter.Aside>
+          <DemoPane bg="indigo.3" title={`Aside @ ${width}px`} />
+        </Splitter.Aside>
+        <Splitter.Handle />
+        <Splitter.Main>
+          <DemoPane bg="amber.3" title="Main" />
+        </Splitter.Main>
+      </Splitter.Root>
+    </Box>
+  );
+};
+
+export const ResponsiveByContainerWidth: Story = {
+  render: () => (
+    <Stack gap="600">
+      <ResponsiveBandDemo width={640} />
+      <ResponsiveBandDemo width={1000} />
+    </Stack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const handles = await canvas.findAllByRole("separator");
+    expect(handles).toHaveLength(2);
+
+    // 640px container is below the 768 threshold → the base band, 40%.
+    await waitFor(() => {
+      expect(Number(handles[0].getAttribute("aria-valuenow"))).toBe(40);
+    });
+    // 1000px container is at/above 768 → 320px → 32%.
+    await waitFor(() => {
+      expect(Number(handles[1].getAttribute("aria-valuenow"))).toBe(32);
+    });
+  },
+};

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -1177,3 +1177,68 @@ export const ResponsiveByContainerWidth: Story = {
     });
   },
 };
+
+// ============================================================
+// useResponsiveSplitterSizes — INTERACTIVE: a Splitter inside a Splitter.
+// The OUTER handle resizes the inner splitter's CONTAINER, so dragging it (or
+// resizing the window) makes the inner hook re-resolve live. The inner config
+// `{ 0: "40%", 768: 320 }` resolves against the inner container's OWN width:
+// a wide container (≥ 768px) pins the aside to 320px (a small %), a narrow one
+// (< 768px) falls back to the base 40% band. Resolution is container-, not
+// viewport-relative.
+// ============================================================
+
+const NestedResponsiveComponent = () => {
+  const { rootProps } = useResponsiveSplitterSizes({
+    orientation: "horizontal",
+    size: { 0: "40%", 768: 320 },
+  });
+  return (
+    <Box w="100%" minW="1000px" h="600px">
+      <Splitter.Root defaultSize={15} minSize={15} maxSize={70}>
+        <Splitter.Aside>
+          <DemoPane bg="neutral.3" title="Drag the divider →" />
+        </Splitter.Aside>
+        <Splitter.Handle />
+        <Splitter.Main>
+          <Splitter.Root {...rootProps}>
+            <Splitter.Aside>
+              <DemoPane
+                bg="indigo.3"
+                title="Responsive aside (≥768px → 320px · else 40%)"
+              />
+            </Splitter.Aside>
+            <Splitter.Handle />
+            <Splitter.Main>
+              <DemoPane bg="amber.3" title="Main" />
+            </Splitter.Main>
+          </Splitter.Root>
+        </Splitter.Main>
+      </Splitter.Root>
+    </Box>
+  );
+};
+
+export const NestedResponsiveSplitter: Story = {
+  render: () => <NestedResponsiveComponent />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const handles = await canvas.findAllByRole("separator");
+    expect(handles).toHaveLength(2);
+    const [outer, inner] = handles;
+
+    // Wide inner container (≥ 768px) → the aside is pinned to 320px, which is
+    // less than the base 40% band.
+    await waitFor(() => {
+      expect(Number(inner.getAttribute("aria-valuenow"))).toBeLessThan(40);
+    });
+
+    // Drag the outer divider to shrink the inner container below 768px → the
+    // inner config falls back to its base 40% band, live.
+    outer.focus();
+    await userEvent.keyboard("{End}");
+    await waitFor(() => {
+      expect(Number(inner.getAttribute("aria-valuenow"))).toBe(40);
+    });
+  },
+};

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -1084,7 +1084,6 @@ export const DisableDoubleClick: Story = {
 const ResponsiveSizesHookComponent = () => {
   const { rootProps } = useResponsiveSplitterSizes({
     orientation: "horizontal",
-    resolveAgainst: "container",
     size: 320,
     minSize: 160,
     maxSize: 600,

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -11,6 +11,7 @@ import {
   fireEvent,
 } from "storybook/test";
 import { Splitter } from "./splitter";
+import { useResponsiveSplitterSizes } from "./hooks/use-responsive-splitter-sizes";
 
 /**
  * Pane content wrapped in a ScrollArea so overflow stays inside the pane and
@@ -805,24 +806,47 @@ export const ControlledSize: Story = {
 
 // ============================================================
 // Resize is locked while the aside is collapsed — drag + arrow/Home/End do
-// nothing and the aside stays at collapsedSize. It's reopened via Enter,
-// double-click, or the controlled prop, never by resizing.
+// nothing and the aside stays at collapsedSize. A visible "Collapse / expand
+// nav" button drives the collapse (controlled) so the lock is verifiable by
+// hand; it's reopened via that button, Enter, double-click, or the prop —
+// never by resizing.
 // ============================================================
 
-export const ResizeLockedWhileCollapsed: Story = {
-  args: {
-    defaultSize: 30,
-    minSize: 15,
-    maxSize: 80,
-    collapsible: true,
-    collapsedSize: 6,
-    onSizeChange: fn(),
-    onSizeChangeEnd: fn(),
-    onCollapsedChange: fn(),
-  },
-  render: (args) => (
-    <Box h="600px">
-      <Splitter.Root {...args}>
+const ResizeLockedWhileCollapsedComponent = ({
+  onSizeChange,
+  onSizeChangeEnd,
+  onCollapsedChange,
+}: {
+  onSizeChange?: (size: number) => void;
+  onSizeChangeEnd?: (size: number) => void;
+  onCollapsedChange?: (collapsed: boolean) => void;
+}) => {
+  const [collapsed, setCollapsed] = useState(false);
+  // The button and the splitter's own toggle (Enter / double-click) both route
+  // through here, so the visible control and the keyboard path stay in sync.
+  const updateCollapsed = (next: boolean) => {
+    setCollapsed(next);
+    onCollapsedChange?.(next);
+  };
+  return (
+    <Stack gap="400" h="600px">
+      <Button
+        onPress={() => updateCollapsed(!collapsed)}
+        data-testid="toggle-btn"
+      >
+        {collapsed ? "Expand nav" : "Collapse nav"}
+      </Button>
+      <Splitter.Root
+        defaultSize={30}
+        minSize={15}
+        maxSize={80}
+        collapsible
+        collapsedSize={6}
+        collapsed={collapsed}
+        onCollapsedChange={updateCollapsed}
+        onSizeChange={onSizeChange}
+        onSizeChangeEnd={onSizeChangeEnd}
+      >
         <Splitter.Aside>
           <DemoPane bg="indigo.3" title="Nav (collapsible)" />
         </Splitter.Aside>
@@ -831,11 +855,27 @@ export const ResizeLockedWhileCollapsed: Story = {
           <DemoPane bg="amber.3" title="Main" />
         </Splitter.Main>
       </Splitter.Root>
-    </Box>
+    </Stack>
+  );
+};
+
+export const ResizeLockedWhileCollapsed: Story = {
+  args: {
+    onSizeChange: fn(),
+    onSizeChangeEnd: fn(),
+    onCollapsedChange: fn(),
+  },
+  render: (args) => (
+    <ResizeLockedWhileCollapsedComponent
+      onSizeChange={args.onSizeChange}
+      onSizeChangeEnd={args.onSizeChangeEnd}
+      onCollapsedChange={args.onCollapsedChange}
+    />
   ),
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const handle = await canvas.findByRole("separator");
+    const toggle = canvas.getByTestId("toggle-btn");
 
     // The fn() mocks are typed as the bare callback signatures on args, so cast
     // to the mock type to read call state.
@@ -847,9 +887,8 @@ export const ResizeLockedWhileCollapsed: Story = {
       typeof fn
     >;
 
-    // Collapse the aside to its rail (collapsedSize 6) via Enter.
-    handle.focus();
-    await userEvent.keyboard("{Enter}");
+    // Collapse the aside to its rail (collapsedSize 6) via the visible button.
+    await userEvent.click(toggle);
     await waitFor(() => {
       expect(onCollapsedChange).toHaveBeenCalledWith(true);
       expect(Number(handle.getAttribute("aria-valuenow"))).toBe(6);
@@ -864,6 +903,7 @@ export const ResizeLockedWhileCollapsed: Story = {
     onCollapsedChange.mockClear();
 
     // Keyboard resize is locked: arrows / Home / End do nothing while collapsed.
+    handle.focus();
     await userEvent.keyboard("{ArrowRight}{ArrowRight}{End}{Home}");
 
     // Pointer drag is locked too (same fireEvent technique as PointerDragResize).
@@ -891,8 +931,8 @@ export const ResizeLockedWhileCollapsed: Story = {
     expect(onSizeChangeEnd).not.toHaveBeenCalled();
     expect(onCollapsedChange).not.toHaveBeenCalled();
 
-    // Enter still expands — the lock blocks resizing, not the collapse toggle.
-    await userEvent.keyboard("{Enter}");
+    // The button reopens it — the lock blocks resizing, not the collapse toggle.
+    await userEvent.click(toggle);
     await waitFor(() => {
       expect(onCollapsedChange).toHaveBeenCalledWith(false);
       expect(Number(handle.getAttribute("aria-valuenow"))).toBeGreaterThan(6);
@@ -1030,6 +1070,61 @@ export const DisableDoubleClick: Story = {
     await userEvent.keyboard("{Home}");
     await waitFor(() => {
       expect(Number(handle.getAttribute("aria-valuenow"))).toBe(10);
+    });
+  },
+};
+
+// ============================================================
+// useResponsiveSplitterSizes — pixel/token sizes via the companion hook.
+// The aside is configured as 320px; the hook measures the container and feeds
+// the equivalent percentage to the (percentage-native) component. In a 1000px
+// container that is 32%.
+// ============================================================
+
+const ResponsiveSizesHookComponent = () => {
+  const { rootProps } = useResponsiveSplitterSizes({
+    orientation: "horizontal",
+    resolveAgainst: "container",
+    size: 320,
+    minSize: 160,
+    maxSize: 600,
+  });
+  return (
+    <Box w="1000px" h="600px">
+      <Splitter.Root {...rootProps} collapsible>
+        <Splitter.Aside>
+          <DemoPane bg="indigo.3" title="Sidebar (320px)" />
+        </Splitter.Aside>
+        <Splitter.Handle />
+        <Splitter.Main>
+          <DemoPane bg="amber.3" title="Main (remainder)" />
+        </Splitter.Main>
+      </Splitter.Root>
+    </Box>
+  );
+};
+
+export const ResponsivePixelSizesHook: Story = {
+  render: () => <ResponsiveSizesHookComponent />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const handle = await canvas.findByRole("separator");
+
+    // 320px in a 1000px container → 32%.
+    await waitFor(() => {
+      expect(Number(handle.getAttribute("aria-valuenow"))).toBe(32);
+    });
+
+    // A keyboard resize settles into the hook's controlled value (no snap-back).
+    handle.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      expect(Number(handle.getAttribute("aria-valuenow"))).toBeGreaterThan(32);
+    });
+    const settled = Number(handle.getAttribute("aria-valuenow"));
+    await userEvent.keyboard("{Tab}");
+    await waitFor(() => {
+      expect(Number(handle.getAttribute("aria-valuenow"))).toBe(settled);
     });
   },
 };

--- a/packages/nimbus/src/components/splitter/splitter.types.ts
+++ b/packages/nimbus/src/components/splitter/splitter.types.ts
@@ -5,6 +5,7 @@ import type {
   SplitterPaneSlotProps,
   SplitterHandleSlotProps,
 } from "./splitter.slots";
+import type { SplitterSizeToken } from "./utils/size-tokens";
 
 // ============================================================
 // SHARED VALUE TYPES
@@ -270,4 +271,145 @@ export type SplitterHandleProps = OmitInternalProps<SplitterHandleSlotProps> & {
   "aria-labelledby"?: string;
   /** Ref to the handle element. */
   ref?: Ref<HTMLDivElement>;
+};
+
+// ============================================================
+// useResponsiveSplitterSizes — companion hook types
+// ============================================================
+
+/**
+ * A single size value for the `useResponsiveSplitterSizes` hook. **A bare
+ * `number` is always pixels** — the hook exists to let consumers think in
+ * pixels and translates to the percentage `Splitter.Root` consumes. The three
+ * forms:
+ *
+ * - `number` — pixels (e.g. `320` → `320px`), converted against the measured
+ *   container.
+ * - {@link SplitterSizeToken} — a size token (`3xs`–`8xl`, `breakpoint-*`)
+ *   resolving to pixels, then converted.
+ * - `` `${number}%` `` — a percentage, passed through to the component
+ *   untranslated (no measurement needed).
+ *
+ * Contrast with `Splitter.Root`'s own `size`/`minSize`/… props, which are
+ * percentages: through the hook a bare number is pixels.
+ */
+export type ResponsiveSplitterSizeValue =
+  | number
+  | SplitterSizeToken
+  | `${number}%`;
+
+/**
+ * A container **min-width threshold** key for a responsive size map. A threshold
+ * is a pixel `number` or a size token (resolving to pixels) — never a
+ * percentage (a percentage threshold of the container against itself is
+ * meaningless).
+ */
+export type ResponsiveSplitterSizeThreshold = number | SplitterSizeToken;
+
+/**
+ * A size configuration for one dimension. Either a single value (applies at
+ * every width) or a map keyed by container min-width thresholds — a min-width
+ * cascade resolved against the splitter's **own** measured width (not the
+ * viewport). The largest threshold `≤` the measured width wins; the smallest
+ * entry also applies below it.
+ *
+ * @example
+ * 320                                  // 320px at every width
+ * "30%"                                // 30% at every width
+ * { 0: 320, 768: "30%", "breakpoint-lg": 400 } // px → %, by container width
+ */
+export type ResponsiveSplitterSizeConfig =
+  | ResponsiveSplitterSizeValue
+  | Partial<
+      Record<ResponsiveSplitterSizeThreshold, ResponsiveSplitterSizeValue>
+    >;
+
+/**
+ * The axis the active band is resolved against. `"container"` (the only value
+ * in this version) observes the splitter's own width via `ResizeObserver`. The
+ * option is explicit and required so a future `"viewport"` mode is purely
+ * additive and the container-width threshold keys never silently change
+ * meaning.
+ */
+export type SplitterSizeResolveAgainst = "container";
+
+/**
+ * Minimal `localStorage`-like interface the hook persists through. Injectable so
+ * persistence can be redirected (tests, app-scoped stores) or disabled.
+ */
+export type SplitterSizesStorage = {
+  /** Read a previously stored payload string, or `null`. May be wrapped to never throw. */
+  getItem: (key: string) => string | null;
+  /** Write a payload string. May be wrapped to never throw. */
+  setItem: (key: string, value: string) => void;
+};
+
+/**
+ * Options for {@link useResponsiveSplitterSizes}.
+ */
+export type UseResponsiveSplitterSizesOptions = {
+  /**
+   * Splitter orientation — selects the measured axis (width for `"horizontal"`,
+   * height for `"vertical"`) and is forwarded to `Splitter.Root`.
+   * @default "horizontal"
+   */
+  orientation?: "horizontal" | "vertical";
+
+  /**
+   * The resolution axis. Required; `"container"` in this version.
+   */
+  resolveAgainst: SplitterSizeResolveAgainst;
+
+  /** Aside size config (pixels/token/percent, single value or per-threshold map). */
+  size: ResponsiveSplitterSizeConfig;
+
+  /** Aside lower bound (pixels/token/percent). Translated to a percentage and forwarded. */
+  minSize?: ResponsiveSplitterSizeConfig;
+  /** Aside upper bound (pixels/token/percent). Translated to a percentage and forwarded. */
+  maxSize?: ResponsiveSplitterSizeConfig;
+  /** Aside collapsed size (pixels/token/percent). Static config — never persisted. */
+  collapsedSize?: ResponsiveSplitterSizeConfig;
+
+  /** Storage key for persistence. When omitted, sizes are not persisted. */
+  persistKey?: string;
+  /** Storage adapter. Defaults to a `localStorage` wrapper that never throws. */
+  storage?: SplitterSizesStorage;
+
+  /**
+   * Optional passthrough for collapse changes. The hook always wires its own
+   * `onCollapsedChange` (to suppress persistence while collapsed); this is
+   * invoked in addition so consumers can observe collapse too.
+   */
+  onCollapsedChange?: (collapsed: boolean) => void;
+};
+
+/**
+ * Props produced by {@link useResponsiveSplitterSizes} to spread onto
+ * `Splitter.Root`. All sizes are percentages (the component's native unit);
+ * `size` may be absent for one frame before the container is first measured
+ * with a pixel/token config.
+ */
+export type ResponsiveSplitterRootProps = {
+  /** Controlled aside size (percentage). Absent until resolvable for px/token configs. */
+  size?: number;
+  /** Aside lower bound (percentage). Present only when `minSize` was configured + resolved. */
+  minSize?: number;
+  /** Aside upper bound (percentage). Present only when `maxSize` was configured + resolved. */
+  maxSize?: number;
+  /** Aside collapsed size (percentage). Present only when `collapsedSize` was configured + resolved. */
+  collapsedSize?: number;
+  /** Settle handler — persists and feeds the value back to keep the loop closed. */
+  onSizeChangeEnd: (size: number) => void;
+  /** Collapse tracker (also calls the optional `onCollapsedChange` option). */
+  onCollapsedChange: (collapsed: boolean) => void;
+  /** Ref that attaches the container `ResizeObserver`. Required for px/token/responsive resolution. */
+  ref: Ref<HTMLDivElement>;
+  /** Forwarded orientation. */
+  orientation: "horizontal" | "vertical";
+};
+
+/** Return value of {@link useResponsiveSplitterSizes}. */
+export type UseResponsiveSplitterSizesResult = {
+  /** Spread onto `Splitter.Root`. */
+  rootProps: ResponsiveSplitterRootProps;
 };

--- a/packages/nimbus/src/components/splitter/splitter.types.ts
+++ b/packages/nimbus/src/components/splitter/splitter.types.ts
@@ -325,15 +325,6 @@ export type ResponsiveSplitterSizeConfig =
     >;
 
 /**
- * The axis the active band is resolved against. `"container"` (the only value
- * in this version) observes the splitter's own width via `ResizeObserver`. The
- * option is explicit and required so a future `"viewport"` mode is purely
- * additive and the container-width threshold keys never silently change
- * meaning.
- */
-export type SplitterSizeResolveAgainst = "container";
-
-/**
  * Minimal `localStorage`-like interface the hook persists through. Injectable so
  * persistence can be redirected (tests, app-scoped stores) or disabled.
  */
@@ -354,11 +345,6 @@ export type UseResponsiveSplitterSizesOptions = {
    * @default "horizontal"
    */
   orientation?: "horizontal" | "vertical";
-
-  /**
-   * The resolution axis. Required; `"container"` in this version.
-   */
-  resolveAgainst: SplitterSizeResolveAgainst;
 
   /** Aside size config (pixels/token/percent, single value or per-threshold map). */
   size: ResponsiveSplitterSizeConfig;

--- a/packages/nimbus/src/components/splitter/utils/responsive-size-storage.spec.ts
+++ b/packages/nimbus/src/components/splitter/utils/responsive-size-storage.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseStoredBands,
+  serializeStoredBands,
+  STORAGE_VERSION,
+} from "./responsive-size-storage";
+
+describe("parseStoredBands", () => {
+  it("returns null for absent or empty input", () => {
+    expect(parseStoredBands(null)).toBeNull();
+    expect(parseStoredBands("")).toBeNull();
+  });
+
+  it("returns null for corrupt JSON", () => {
+    expect(parseStoredBands("{not json")).toBeNull();
+  });
+
+  it("returns null for an unknown/older version", () => {
+    expect(
+      parseStoredBands(
+        JSON.stringify({ v: 0, bands: { "0": { unit: "px", value: 1 } } })
+      )
+    ).toBeNull();
+  });
+
+  it("parses a valid payload into a numeric-keyed band map", () => {
+    const raw = JSON.stringify({
+      v: STORAGE_VERSION,
+      bands: {
+        "0": { unit: "px", value: 320 },
+        "768": { unit: "pct", value: 30 },
+      },
+    });
+    expect(parseStoredBands(raw)).toEqual({
+      0: { unit: "px", value: 320 },
+      768: { unit: "pct", value: 30 },
+    });
+  });
+
+  it("drops malformed bands but keeps valid ones", () => {
+    const raw = JSON.stringify({
+      v: STORAGE_VERSION,
+      bands: {
+        "0": { unit: "px", value: 320 },
+        "768": { unit: "bogus", value: 30 },
+        "1024": { unit: "px", value: "nope" },
+      },
+    });
+    expect(parseStoredBands(raw)).toEqual({ 0: { unit: "px", value: 320 } });
+  });
+});
+
+describe("serializeStoredBands", () => {
+  it("round-trips through parse", () => {
+    const bands = { 0: { unit: "px" as const, value: 296 } };
+    expect(parseStoredBands(serializeStoredBands(bands))).toEqual(bands);
+  });
+});

--- a/packages/nimbus/src/components/splitter/utils/responsive-size-storage.ts
+++ b/packages/nimbus/src/components/splitter/utils/responsive-size-storage.ts
@@ -1,0 +1,81 @@
+import type { SplitterSizesStorage } from "../splitter.types";
+import type { StoredBand } from "./responsive-size";
+
+/** Current persisted-payload schema version. Bump + migrate on shape changes. */
+export const STORAGE_VERSION = 1;
+
+type StoredPayload = {
+  v: number;
+  /** Bands keyed by resolved pixel threshold (as a string, per JSON). */
+  bands: Record<string, StoredBand>;
+};
+
+const isStoredBand = (value: unknown): value is StoredBand => {
+  if (value === null || typeof value !== "object") return false;
+  const band = value as Record<string, unknown>;
+  return (
+    (band.unit === "px" || band.unit === "pct") &&
+    typeof band.value === "number" &&
+    Number.isFinite(band.value)
+  );
+};
+
+/**
+ * Parse a raw stored payload string into a threshold-keyed band map. Tolerates
+ * absent, corrupt, or older/unknown-version data by returning `null` (the caller
+ * then resolves from config defaults). Versioned so future shape changes can
+ * migrate rather than silently misread.
+ */
+export const parseStoredBands = (
+  raw: string | null
+): Record<number, StoredBand> | null => {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") return null;
+  const payload = parsed as Partial<StoredPayload>;
+  if (payload.v !== STORAGE_VERSION || typeof payload.bands !== "object") {
+    // Unknown/older version: no migration defined yet → ignore.
+    return null;
+  }
+  const out: Record<number, StoredBand> = {};
+  for (const [key, value] of Object.entries(payload.bands ?? {})) {
+    const thresholdPx = Number(key);
+    if (!Number.isFinite(thresholdPx)) continue;
+    if (isStoredBand(value)) out[thresholdPx] = value;
+  }
+  return out;
+};
+
+/** Serialize a band map into the versioned payload string. */
+export const serializeStoredBands = (
+  bands: Record<number, StoredBand>
+): string => JSON.stringify({ v: STORAGE_VERSION, bands });
+
+/**
+ * A `localStorage`-backed {@link SplitterSizesStorage} that never throws and
+ * no-ops when `localStorage` is unavailable (SSR, privacy mode, quota). Used as
+ * the default adapter.
+ */
+export const createLocalStorageAdapter = (): SplitterSizesStorage => ({
+  getItem: (key) => {
+    try {
+      if (typeof localStorage === "undefined") return null;
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem: (key, value) => {
+    try {
+      if (typeof localStorage === "undefined") return;
+      localStorage.setItem(key, value);
+    } catch {
+      // Quota / denied — persistence is best-effort.
+    }
+  },
+});

--- a/packages/nimbus/src/components/splitter/utils/responsive-size.spec.ts
+++ b/packages/nimbus/src/components/splitter/utils/responsive-size.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import {
+  bandValueAt,
+  clampPercent,
+  isPercentValue,
+  isThresholdMap,
+  percentToPx,
+  resolveDimension,
+  selectBand,
+  toBands,
+  valueToPercent,
+  type SizeBand,
+} from "./responsive-size";
+
+describe("isPercentValue", () => {
+  it("recognizes percent strings", () => {
+    expect(isPercentValue("30%")).toBe(true);
+    expect(isPercentValue("12.5%")).toBe(true);
+  });
+  it("rejects non-percent values", () => {
+    expect(isPercentValue(320)).toBe(false);
+    expect(isPercentValue("md")).toBe(false);
+    expect(isPercentValue("320px")).toBe(false);
+  });
+});
+
+describe("valueToPercent", () => {
+  it("treats a bare number as pixels", () => {
+    expect(valueToPercent(320, 1000)).toBe(32);
+    expect(valueToPercent(500, 1000)).toBe(50);
+  });
+  it("passes a percent string through without measurement", () => {
+    expect(valueToPercent("30%", null)).toBe(30);
+    expect(valueToPercent("12.5%", 1000)).toBe(12.5);
+  });
+  it("resolves a size token to pixels then to a percentage", () => {
+    // md = 448px
+    expect(valueToPercent("md", 896)).toBe(50);
+    // breakpoint-sm = 480px
+    expect(valueToPercent("breakpoint-sm", 480)).toBe(100);
+  });
+  it("returns null for pixels/tokens without a usable measurement", () => {
+    expect(valueToPercent(320, null)).toBeNull();
+    expect(valueToPercent(320, 0)).toBeNull();
+    expect(valueToPercent("md", null)).toBeNull();
+    expect(valueToPercent(320, -10)).toBeNull();
+  });
+});
+
+describe("clampPercent", () => {
+  it("clamps into [0,100] by default", () => {
+    expect(clampPercent(150)).toBe(100);
+    expect(clampPercent(-5)).toBe(0);
+    expect(clampPercent(42)).toBe(42);
+  });
+  it("clamps into an explicit window", () => {
+    expect(clampPercent(8, 15, 60)).toBe(15);
+    expect(clampPercent(80, 15, 60)).toBe(60);
+  });
+});
+
+describe("percentToPx", () => {
+  it("inverts a percentage against the container", () => {
+    expect(percentToPx(32, 1000)).toBe(320);
+  });
+});
+
+describe("isThresholdMap", () => {
+  it("distinguishes maps from single values", () => {
+    expect(isThresholdMap({ 0: 320 })).toBe(true);
+    expect(isThresholdMap(320)).toBe(false);
+    expect(isThresholdMap("30%")).toBe(false);
+    expect(isThresholdMap("md")).toBe(false);
+  });
+});
+
+describe("toBands", () => {
+  it("wraps a single value as one band at threshold 0", () => {
+    expect(toBands(320)).toEqual([{ thresholdPx: 0, value: 320 }]);
+  });
+  it("resolves numeric and token threshold keys, sorted ascending", () => {
+    const bands = toBands({ 768: "30%", 0: 320, "breakpoint-lg": 400 });
+    expect(bands).toEqual([
+      { thresholdPx: 0, value: 320 },
+      { thresholdPx: 768, value: "30%" },
+      { thresholdPx: 1024, value: 400 }, // breakpoint-lg
+    ]);
+  });
+});
+
+describe("bandValueAt", () => {
+  it("looks up the configured value at a threshold", () => {
+    const config = { 0: 320, 768: "30%" } as const;
+    expect(bandValueAt(config, 0)).toBe(320);
+    expect(bandValueAt(config, 768)).toBe("30%");
+    expect(bandValueAt(config, 999)).toBeUndefined();
+  });
+});
+
+describe("selectBand", () => {
+  const bands: SizeBand[] = [
+    { thresholdPx: 0, value: 320 },
+    { thresholdPx: 768, value: "30%" },
+    { thresholdPx: 1024, value: 400 },
+  ];
+
+  it("picks the largest threshold <= measured", () => {
+    expect(selectBand(bands, 500)?.thresholdPx).toBe(0);
+    expect(selectBand(bands, 800)?.thresholdPx).toBe(768);
+    expect(selectBand(bands, 1200)?.thresholdPx).toBe(1024);
+  });
+
+  it("applies the smallest band below its threshold", () => {
+    const noBase: SizeBand[] = [
+      { thresholdPx: 768, value: "30%" },
+      { thresholdPx: 1024, value: 400 },
+    ];
+    expect(selectBand(noBase, 500)?.thresholdPx).toBe(768);
+  });
+
+  it("holds the active band within the hysteresis deadband", () => {
+    // Active = 0; just past 768 stays on 0 within the deadband, switches beyond.
+    expect(
+      selectBand(bands, 769, { activeThresholdPx: 0, deadbandPx: 2 })
+        ?.thresholdPx
+    ).toBe(0);
+    expect(
+      selectBand(bands, 771, { activeThresholdPx: 0, deadbandPx: 2 })
+        ?.thresholdPx
+    ).toBe(768);
+  });
+});
+
+describe("resolveDimension", () => {
+  it("resolves a single percent value synchronously (no measurement)", () => {
+    expect(resolveDimension("30%", null)).toEqual({
+      percent: 30,
+      thresholdPx: 0,
+    });
+  });
+
+  it("requires measurement for a single pixel value", () => {
+    expect(resolveDimension(320, null)).toEqual({
+      percent: null,
+      thresholdPx: 0,
+    });
+    expect(resolveDimension(320, 1000)).toEqual({
+      percent: 32,
+      thresholdPx: 0,
+    });
+  });
+
+  it("requires measurement to select a band in a multi-entry map", () => {
+    const config = { 0: 320, 768: "30%" } as const;
+    expect(resolveDimension(config, null).percent).toBeNull();
+    expect(resolveDimension(config, 1000)).toEqual({
+      percent: 30,
+      thresholdPx: 768,
+    });
+  });
+
+  it("lets a stored value override the config default", () => {
+    expect(
+      resolveDimension(320, 1000, {
+        stored: { 0: { unit: "px", value: 300 } },
+      })
+    ).toEqual({ percent: 30, thresholdPx: 0 });
+    expect(
+      resolveDimension(320, 1000, {
+        stored: { 0: { unit: "pct", value: 25 } },
+      })
+    ).toEqual({ percent: 25, thresholdPx: 0 });
+  });
+
+  it("re-pins a stored pixel value against a new container size", () => {
+    // 300px stored from a 1000px session, restored into an 800px container.
+    expect(
+      resolveDimension(320, 800, {
+        stored: { 0: { unit: "px", value: 300 } },
+      }).percent
+    ).toBeCloseTo(37.5);
+  });
+
+  it("falls back to the config default when a stored px lacks measurement", () => {
+    expect(
+      resolveDimension(320, null, {
+        stored: { 0: { unit: "px", value: 300 } },
+      }).percent
+    ).toBeNull();
+  });
+});

--- a/packages/nimbus/src/components/splitter/utils/responsive-size.ts
+++ b/packages/nimbus/src/components/splitter/utils/responsive-size.ts
@@ -1,0 +1,193 @@
+import type {
+  ResponsiveSplitterSizeConfig,
+  ResponsiveSplitterSizeValue,
+} from "../splitter.types";
+import { isSplitterSizeToken, resolveTokenToPx } from "./size-tokens";
+
+/** A finite, positive container measurement is required to convert pixels/tokens. */
+const isMeasurable = (px: number | null | undefined): px is number =>
+  typeof px === "number" && Number.isFinite(px) && px > 0;
+
+const PERCENT_PATTERN = /^-?\d+(?:\.\d+)?%$/;
+const NUMERIC_KEY_PATTERN = /^-?\d+(?:\.\d+)?$/;
+
+/** Type guard: a `` `${number}%` `` string. */
+export const isPercentValue = (value: unknown): value is `${number}%` =>
+  typeof value === "string" && PERCENT_PATTERN.test(value);
+
+/**
+ * Resolve a single size value to a percentage of `containerPx`. A bare `number`
+ * is pixels, a token resolves to pixels, a `"N%"` string passes through. Returns
+ * `null` when unresolvable — a pixel/token value without a usable measurement,
+ * or an unknown token.
+ */
+export const valueToPercent = (
+  value: ResponsiveSplitterSizeValue,
+  containerPx: number | null
+): number | null => {
+  if (typeof value === "number") {
+    return isMeasurable(containerPx) ? (value / containerPx) * 100 : null;
+  }
+  if (isPercentValue(value)) {
+    const n = parseFloat(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (isSplitterSizeToken(value)) {
+    const px = resolveTokenToPx(value);
+    if (px === null || !isMeasurable(containerPx)) return null;
+    return (px / containerPx) * 100;
+  }
+  return null;
+};
+
+/** Clamp a percentage into `[min, max]` (defaults `[0, 100]`). */
+export const clampPercent = (percent: number, min = 0, max = 100): number =>
+  Math.min(max, Math.max(min, percent));
+
+/** Convert a percentage back to pixels for persistence. */
+export const percentToPx = (percent: number, containerPx: number): number =>
+  (percent / 100) * containerPx;
+
+/** A resolved band: the container min-width threshold (px) and its size value. */
+export type SizeBand = {
+  thresholdPx: number;
+  value: ResponsiveSplitterSizeValue;
+};
+
+const thresholdKeyToPx = (key: string): number | null => {
+  if (NUMERIC_KEY_PATTERN.test(key)) {
+    const n = parseFloat(key);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (isSplitterSizeToken(key)) return resolveTokenToPx(key);
+  return null;
+};
+
+/** True when the config is a threshold map rather than a single value. */
+export const isThresholdMap = (
+  config: ResponsiveSplitterSizeConfig
+): config is Partial<Record<string, ResponsiveSplitterSizeValue>> =>
+  config !== null && typeof config === "object";
+
+/**
+ * Resolve a config into bands sorted ascending by threshold. A single value
+ * becomes one band at threshold `0`; map keys resolve to pixels (numeric or
+ * token), and unresolvable keys/values are dropped.
+ */
+export const toBands = (config: ResponsiveSplitterSizeConfig): SizeBand[] => {
+  if (!isThresholdMap(config)) {
+    return [{ thresholdPx: 0, value: config }];
+  }
+  const bands: SizeBand[] = [];
+  for (const [key, value] of Object.entries(config)) {
+    if (value === undefined) continue;
+    const thresholdPx = thresholdKeyToPx(key);
+    if (thresholdPx === null) continue;
+    bands.push({ thresholdPx, value });
+  }
+  bands.sort((a, b) => a.thresholdPx - b.thresholdPx);
+  return bands;
+};
+
+/** The configured value at a given threshold (for persistence unit lookup). */
+export const bandValueAt = (
+  config: ResponsiveSplitterSizeConfig,
+  thresholdPx: number
+): ResponsiveSplitterSizeValue | undefined =>
+  toBands(config).find((b) => b.thresholdPx === thresholdPx)?.value;
+
+/**
+ * Select the active band for a measured size: the largest threshold `≤`
+ * measured, with the smallest band applying below it. When an `activeThresholdPx`
+ * is supplied, a hysteresis `deadbandPx` keeps the active band until the measured
+ * size crosses the band's boundaries by more than the deadband, preventing
+ * per-frame flapping at a threshold.
+ */
+export const selectBand = (
+  bands: SizeBand[],
+  measuredPx: number,
+  opts?: { activeThresholdPx?: number | null; deadbandPx?: number }
+): SizeBand | null => {
+  if (bands.length === 0) return null;
+
+  const pick = (m: number): SizeBand => {
+    let chosen = bands[0]!;
+    for (const band of bands) {
+      if (band.thresholdPx <= m) chosen = band;
+      else break;
+    }
+    return chosen;
+  };
+
+  const candidate = pick(measuredPx);
+  const active = opts?.activeThresholdPx;
+  const deadband = opts?.deadbandPx ?? 0;
+  if (active == null || deadband <= 0 || candidate.thresholdPx === active) {
+    return candidate;
+  }
+
+  const activeIdx = bands.findIndex((b) => b.thresholdPx === active);
+  if (activeIdx === -1) return candidate;
+  const activeBand = bands[activeIdx]!;
+  const upperBound = bands[activeIdx + 1]?.thresholdPx ?? Infinity;
+  // The active band covers [active, upperBound). Keep it until the measured size
+  // is clearly outside that range by more than the deadband.
+  if (measuredPx >= active - deadband && measuredPx < upperBound + deadband) {
+    return activeBand;
+  }
+  return candidate;
+};
+
+/** A persisted band value: a pixel width or a percentage. */
+export type StoredBand = { unit: "px" | "pct"; value: number };
+
+/**
+ * Resolve one size dimension to a percentage given the current measurement,
+ * optional hysteresis state, and (for the size dimension) an optional stored
+ * override that takes precedence over the config default for the active band.
+ *
+ * Returns the resolved `percent` (or `null` when not yet resolvable — a
+ * pixel/token value awaiting measurement) and the active band's `thresholdPx`
+ * (the persistence key).
+ */
+export const resolveDimension = (
+  config: ResponsiveSplitterSizeConfig,
+  measuredPx: number | null,
+  opts?: {
+    activeThresholdPx?: number | null;
+    deadbandPx?: number;
+    stored?: Record<number, StoredBand> | null;
+  }
+): { percent: number | null; thresholdPx: number | null } => {
+  const bands = toBands(config);
+  if (bands.length === 0) return { percent: null, thresholdPx: null };
+
+  let active: SizeBand | null;
+  if (bands.length === 1) {
+    active = bands[0]!;
+  } else {
+    if (!isMeasurable(measuredPx)) return { percent: null, thresholdPx: null };
+    active = selectBand(bands, measuredPx, {
+      activeThresholdPx: opts?.activeThresholdPx,
+      deadbandPx: opts?.deadbandPx,
+    });
+  }
+  if (!active) return { percent: null, thresholdPx: null };
+
+  const stored = opts?.stored?.[active.thresholdPx];
+  if (stored) {
+    const pct =
+      stored.unit === "pct"
+        ? stored.value
+        : isMeasurable(measuredPx)
+          ? (stored.value / measuredPx) * 100
+          : null;
+    // A stored px without a measurement yet → fall through to the config default.
+    if (pct !== null) return { percent: pct, thresholdPx: active.thresholdPx };
+  }
+
+  return {
+    percent: valueToPercent(active.value, measuredPx),
+    thresholdPx: active.thresholdPx,
+  };
+};

--- a/packages/nimbus/src/components/splitter/utils/size-tokens.spec.ts
+++ b/packages/nimbus/src/components/splitter/utils/size-tokens.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { themeTokens } from "@commercetools/nimbus-tokens";
+import {
+  SPLITTER_SIZE_TOKENS,
+  isSplitterSizeToken,
+  resolveTokenToPx,
+} from "./size-tokens";
+
+describe("SPLITTER_SIZE_TOKENS", () => {
+  // Guard: a token rename/removal in the design tokens becomes a red build here,
+  // rather than a silent runtime miss in the hook.
+  it("every curated token exists in themeTokens.size with a finite px value", () => {
+    const size = themeTokens.size as Record<
+      string,
+      { value: string } | undefined
+    >;
+    for (const token of SPLITTER_SIZE_TOKENS) {
+      const entry = size[token];
+      expect(entry, `missing size token: ${token}`).toBeDefined();
+      expect(Number.isFinite(parseFloat(entry!.value))).toBe(true);
+    }
+  });
+});
+
+describe("isSplitterSizeToken", () => {
+  it("accepts curated tokens and rejects everything else", () => {
+    expect(isSplitterSizeToken("md")).toBe(true);
+    expect(isSplitterSizeToken("breakpoint-lg")).toBe(true);
+    expect(isSplitterSizeToken("9600")).toBe(false); // numeric scale excluded
+    expect(isSplitterSizeToken("nope")).toBe(false);
+    expect(isSplitterSizeToken(320)).toBe(false);
+  });
+});
+
+describe("resolveTokenToPx", () => {
+  it("resolves known tokens to their pixel values", () => {
+    expect(resolveTokenToPx("md")).toBe(448);
+    expect(resolveTokenToPx("3xs")).toBe(224);
+    expect(resolveTokenToPx("breakpoint-sm")).toBe(480);
+    expect(resolveTokenToPx("breakpoint-2xl")).toBe(1536);
+  });
+});

--- a/packages/nimbus/src/components/splitter/utils/size-tokens.ts
+++ b/packages/nimbus/src/components/splitter/utils/size-tokens.ts
@@ -1,0 +1,63 @@
+import { themeTokens } from "@commercetools/nimbus-tokens";
+
+/**
+ * The curated set of `sizes` design tokens accepted by
+ * `useResponsiveSplitterSizes` as size values and threshold keys: the named
+ * t-shirt scale (`3xs`–`8xl`) and the `breakpoint-*` sizes.
+ *
+ * Hand-authored on purpose — deriving from `keyof typeof themeTokens.size` would
+ * also pull in the numeric scale (`"25"`…`"9600"`), which both pollutes
+ * autocomplete and makes a string like `"400"` ambiguous against the pixel
+ * `number` `400`. A unit test asserts every member still exists in
+ * `themeTokens.size`, so a token rename/removal becomes a build failure rather
+ * than a silent runtime miss.
+ */
+export const SPLITTER_SIZE_TOKENS = [
+  "3xs",
+  "2xs",
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "6xl",
+  "7xl",
+  "8xl",
+  "breakpoint-sm",
+  "breakpoint-md",
+  "breakpoint-lg",
+  "breakpoint-xl",
+  "breakpoint-2xl",
+] as const;
+
+/** A size token name accepted by `useResponsiveSplitterSizes`. */
+export type SplitterSizeToken = (typeof SPLITTER_SIZE_TOKENS)[number];
+
+const TOKEN_SET: ReadonlySet<string> = new Set(SPLITTER_SIZE_TOKENS);
+
+/** Type guard: is `value` one of the curated splitter size tokens? */
+export const isSplitterSizeToken = (
+  value: unknown
+): value is SplitterSizeToken =>
+  typeof value === "string" && TOKEN_SET.has(value);
+
+/**
+ * Resolve a size token to its pixel value via `themeTokens.size`. Returns `null`
+ * when the token is missing or its value is not a finite pixel number.
+ *
+ * @example
+ * resolveTokenToPx("breakpoint-sm"); // → 480
+ * resolveTokenToPx("md");            // → 448
+ */
+export const resolveTokenToPx = (token: SplitterSizeToken): number | null => {
+  const entry = (
+    themeTokens.size as Record<string, { value: string } | undefined>
+  )[token];
+  if (!entry) return null;
+  const px = parseFloat(entry.value);
+  return Number.isFinite(px) ? px : null;
+};


### PR DESCRIPTION
## What

Adds `useResponsiveSplitterSizes`, a `Splitter` companion hook that lets consumers size the aside in **pixels**, **size tokens**, or **per container width**, while `Splitter.Root` stays percentage-native. The hook is a pixel/token → percentage translator: it measures the splitter's container, converts the config, drives the settle-only controlled `size` channel, and persists the result.

> **Base branch:** this targets the splitter branch (`FEC-977-…`), not `main` — it builds on the simplified single-dimension `Aside`/`Main` API from that branch.

## Usage

```tsx
import { Splitter, useResponsiveSplitterSizes } from "@commercetools/nimbus";

function AppLayout() {
  const { rootProps } = useResponsiveSplitterSizes({
    orientation: "horizontal",
    persistKey: "app:main-splitter",
    size: { 0: 320, 768: "30%" }, // 320px below 768px container width, 30% above
    minSize: 160,
    maxSize: "breakpoint-sm", // size tokens resolve to pixels too
  });

  return (
    <Splitter.Root {...rootProps} collapsible>
      <Splitter.Aside>…</Splitter.Aside>
      <Splitter.Handle />
      <Splitter.Main>…</Splitter.Main>
    </Splitter.Root>
  );
}
```

A bare `number` is **pixels**; a `"N%"` string is a percentage passthrough; size tokens (`3xs`–`8xl`, `breakpoint-*`) resolve to pixels. Spread `rootProps` onto `Splitter.Root` — the returned `ref` is required (the hook measures the container through it).

**Live demo:** [Splitter → ResponsivePixelSizesHook story](https://nimbus-storybook-git-add-responsive-splitt-6e5120-commercetools.vercel.app/?path=/story/components-splitter--responsive-pixel-sizes-hook) (Storybook preview for this branch).

## Design

A proposal-first change (`openspec/changes/add-responsive-splitter-sizes-hook`), pressure-tested by four independent design reviews (DX, API-minimalism, correctness, maintainability) before implementation. Highlights:

- **`number` is always pixels**; size tokens (`3xs`–`8xl`, `breakpoint-*`) resolve to pixels; `"N%"` passes through. The hook owns the full facade (`size` + `minSize`/`maxSize`/`collapsedSize`) so consumers never hand-write percentages on the root.
- **Container-width threshold map** — `{ 0: 320, 768: "30%" }` — a min-width cascade resolved against the splitter's own width via `ResizeObserver` (never the viewport).
- **Hook-side clamping** into `[minSize, maxSize]` (the component reconciles a controlled size without re-clamping until the next interaction).
- **Versioned, pixel-first per-band persistence** — a dragged `320px` re-pins to `320px` across reloads/resizes. `collapsedSize` is never persisted; collapse is suppressed via the forwarded `onCollapsedChange` signal (not value-equality).
- Emit gating + band hysteresis + `width ≤ 0` / no-`ResizeObserver` / throwing-storage guards. Pure resolvers extracted for unit testing; curated `SplitterSizeToken` union backed by an existence-guard test.

## Verification

- 67 hook/util unit tests + 20 splitter story play functions pass
- `typecheck`, `lint`, and package `build` (export verified from the published ESM entry) clean
- OpenSpec `--strict` valid

## Related

The component first-paint `50/50` flash (task 11.1) is fixed directly on the splitter branch (PR #1560).