### PR TITLE
feat(nimbus): add SSR/RSC support with tests, CI checks, and docs

### DIFF
--- a/.changeset/add-ssr-rsc-support.md
+++ b/.changeset/add-ssr-rsc-support.md
@@ -1,0 +1,10 @@
+---
+"@commercetools/nimbus": minor
+---
+
+All component entry points now include `"use client"` directives, enabling
+Nimbus to work in React Server Component environments such as Next.js App
+Router. Components can be imported directly in server component files without
+triggering RSC compilation errors.
+
+`ToastOutlet` no longer crashes during server-side rendering.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check package shape
         run: pnpm check:package-shape
 
+      - name: Check "use client" directives
+        run: pnpm check:use-client
+
       - name: Clean temp before tests
         run: rm -rf /tmp/* || true
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,13 +431,14 @@ capabilities.
 
 ### Testing Strategy
 
-The testing system uses Vitest with three distinct test categories:
+The testing system uses Vitest with four distinct test categories:
 
-| Category                          | File Pattern      | Purpose                                  | Audience     |
-| --------------------------------- | ----------------- | ---------------------------------------- | ------------ |
-| **Story Tests**                   | `*.stories.tsx`   | Internal component behavior testing      | Internal     |
-| **Internal Unit Tests**           | `*.spec.tsx`      | Internal utility and hook testing        | Internal     |
-| **Consumer Implementation Tests** | `*.docs.spec.tsx` | Documentation examples for consumer apps | **External** |
+| Category                          | File Pattern       | Purpose                                  | Audience     |
+| --------------------------------- | ------------------ | ---------------------------------------- | ------------ |
+| **Story Tests**                   | `*.stories.tsx`    | Internal component behavior testing      | Internal     |
+| **Internal Unit Tests**           | `*.spec.tsx`       | Internal utility and hook testing        | Internal     |
+| **Consumer Implementation Tests** | `*.docs.spec.tsx`  | Documentation examples for consumer apps | **External** |
+| **SSR Smoke Tests**               | `ssr.ssr.spec.tsx` | Server-side rendering validation         | Internal     |
 
 - **Story Tests**: Test component behavior with play functions in headless
   Chromium via Playwright. ALL component states, interactions, and a11y tested

--- a/apps/ssr-test/app/layout.tsx
+++ b/apps/ssr-test/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Providers } from "./providers";
+
+export const metadata: Metadata = {
+  title: "Nimbus SSR Test",
+  description:
+    "Validates Nimbus components render correctly via SSR in Next.js App Router",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/apps/ssr-test/app/page.tsx
+++ b/apps/ssr-test/app/page.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import {
+  Accordion,
+  Alert,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Calendar,
+  Card,
+  Checkbox,
+  Code,
+  CollapsibleMotion,
+  ComboBox,
+  DataTable,
+  DateInput,
+  DatePicker,
+  DateRangePicker,
+  DefaultPage,
+  Dialog,
+  Drawer,
+  FieldErrors,
+  Flex,
+  FormField,
+  Grid,
+  Group,
+  Heading,
+  Icon,
+  IconButton,
+  IconToggleButton,
+  Image,
+  Kbd,
+  Link,
+  List,
+  LoadingSpinner,
+  Menu,
+  ModalPage,
+  MultilineTextInput,
+  NumberInput,
+  PageContent,
+  Pagination,
+  PasswordInput,
+  ProgressBar,
+  RadioInput,
+  RangeCalendar,
+  ScrollArea,
+  SearchInput,
+  Select,
+  Separator,
+  SimpleGrid,
+  Spacer,
+  Stack,
+  Steps,
+  Switch,
+  TabNav,
+  Tabs,
+  TagGroup,
+  Text,
+  TextInput,
+  TimeInput,
+  ToastOutlet,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+  Tooltip,
+  VisuallyHidden,
+} from "@commercetools/nimbus";
+import { Star } from "@commercetools/nimbus-icons";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Stack gap="400" paddingY="400">
+      <Heading as="h2">{title}</Heading>
+      <Box
+        borderWidth="1px"
+        borderColor="neutral.6"
+        borderRadius="200"
+        padding="400"
+      >
+        {children}
+      </Box>
+    </Stack>
+  );
+}
+
+export default function Page() {
+  return (
+    <Box padding="600" maxWidth="960px" marginX="auto">
+      <Heading as="h1">Nimbus SSR Test</Heading>
+      <Text>
+        Every component below was server-rendered by Next.js App Router. If you
+        can see this page without errors, SSR is working.
+      </Text>
+
+      <Separator marginY="400" />
+
+      <Section title="Layout Primitives">
+        <Stack gap="200">
+          <Box>Box</Box>
+          <Flex>Flex</Flex>
+          <Grid>Grid</Grid>
+          <Stack>Stack</Stack>
+          <Group>Group</Group>
+          <SimpleGrid>SimpleGrid</SimpleGrid>
+          <Spacer />
+          <Separator />
+          <PageContent.Root>
+            <PageContent.Column>PageContent</PageContent.Column>
+          </PageContent.Root>
+          <ScrollArea maxHeight="100px">ScrollArea content</ScrollArea>
+        </Stack>
+      </Section>
+
+      <Section title="Typography and Display">
+        <Stack gap="200">
+          <Text>Text</Text>
+          <Heading as="h3">Heading</Heading>
+          <Code>Code</Code>
+          <Kbd>K</Kbd>
+          <Badge>Badge</Badge>
+          <Icon>
+            <Star />
+          </Icon>
+          <Image
+            src="https://placehold.co/50x50"
+            alt="placeholder"
+            width="50px"
+            height="50px"
+          />
+          <Avatar firstName="Test" lastName="User" />
+          <VisuallyHidden>Hidden text</VisuallyHidden>
+        </Stack>
+      </Section>
+
+      <Section title="Feedback">
+        <Stack gap="200">
+          <Alert.Root variant="flat">
+            <Alert.Description>Alert message</Alert.Description>
+          </Alert.Root>
+          <LoadingSpinner />
+          <ProgressBar value={50} aria-label="progress" />
+          <ToastOutlet />
+        </Stack>
+      </Section>
+
+      <Section title="Buttons">
+        <Group gap="200">
+          <Button>Button</Button>
+          <IconButton aria-label="action" />
+          <ToggleButton>Toggle</ToggleButton>
+          <IconToggleButton aria-label="toggle" />
+          <ToggleButtonGroup.Root selectionMode="single">
+            <ToggleButtonGroup.Button id="a">A</ToggleButtonGroup.Button>
+            <ToggleButtonGroup.Button id="b">B</ToggleButtonGroup.Button>
+          </ToggleButtonGroup.Root>
+        </Group>
+      </Section>
+
+      <Section title="Form Inputs">
+        <Stack gap="200">
+          <TextInput aria-label="text" />
+          <NumberInput aria-label="number" />
+          <PasswordInput aria-label="password" />
+          <MultilineTextInput aria-label="multiline" />
+          <SearchInput aria-label="search" />
+          <Checkbox>Checkbox</Checkbox>
+          <Switch>Switch</Switch>
+          <RadioInput.Root aria-label="radio">
+            <RadioInput.Option value="a">A</RadioInput.Option>
+            <RadioInput.Option value="b">B</RadioInput.Option>
+          </RadioInput.Root>
+          <DateInput aria-label="date" />
+          <TimeInput aria-label="time" />
+          <Select.Root aria-label="select">
+            <Select.Options>
+              <Select.Option id="1">One</Select.Option>
+              <Select.Option id="2">Two</Select.Option>
+              <Select.Option id="3">Three</Select.Option>
+              <Select.Option id="4">Four</Select.Option>
+            </Select.Options>
+          </Select.Root>
+        </Stack>
+      </Section>
+
+      <Section title="Compound and Overlay Components">
+        <Stack gap="400">
+          <Accordion.Root>
+            <Accordion.Item value="a">
+              <Accordion.Header>Accordion Header</Accordion.Header>
+              <Accordion.Content>Accordion Content</Accordion.Content>
+            </Accordion.Item>
+          </Accordion.Root>
+
+          <Card.Root>
+            <Card.Header>Card Header</Card.Header>
+            <Card.Body>Card Body</Card.Body>
+          </Card.Root>
+
+          <CollapsibleMotion.Root>
+            <CollapsibleMotion.Trigger>
+              Collapsible Trigger
+            </CollapsibleMotion.Trigger>
+            <CollapsibleMotion.Content>
+              Collapsible Content
+            </CollapsibleMotion.Content>
+          </CollapsibleMotion.Root>
+
+          <Tabs.Root>
+            <Tabs.List>
+              <Tabs.Tab id="t1">Overview</Tabs.Tab>
+              <Tabs.Tab id="t2">Details</Tabs.Tab>
+              <Tabs.Tab id="t3">Settings</Tabs.Tab>
+            </Tabs.List>
+            <Tabs.Panels>
+              <Tabs.Panel id="t1">Overview panel content</Tabs.Panel>
+              <Tabs.Panel id="t2">Details panel content</Tabs.Panel>
+              <Tabs.Panel id="t3">Settings panel content</Tabs.Panel>
+            </Tabs.Panels>
+          </Tabs.Root>
+
+          <Dialog.Root>
+            <Dialog.Trigger asChild>
+              <Button>Open Dialog</Button>
+            </Dialog.Trigger>
+            <Dialog.Content>
+              <Dialog.Title>Dialog Title</Dialog.Title>
+              <Dialog.Body>Dialog Body</Dialog.Body>
+            </Dialog.Content>
+          </Dialog.Root>
+
+          <Drawer.Root>
+            <Drawer.Trigger asChild>
+              <Button>Open Drawer</Button>
+            </Drawer.Trigger>
+            <Drawer.Content>
+              <Drawer.Header>
+                <Drawer.Title>Drawer Title</Drawer.Title>
+              </Drawer.Header>
+              <Drawer.Body>Drawer Body</Drawer.Body>
+            </Drawer.Content>
+          </Drawer.Root>
+
+          <Box width="fit-content">
+            <Menu.Root>
+              <Menu.Trigger>
+                <Button>Open Menu</Button>
+              </Menu.Trigger>
+              <Menu.Content>
+                <Menu.Item id="a">Menu Item</Menu.Item>
+              </Menu.Content>
+            </Menu.Root>
+          </Box>
+
+          <Tooltip.Root>
+            <Button>Hover for Tooltip</Button>
+            <Tooltip.Content>Tooltip content</Tooltip.Content>
+          </Tooltip.Root>
+
+          <Steps.Root count={4} defaultStep={1}>
+            <Steps.List>
+              <Steps.Item index={0}>
+                <Steps.Trigger>
+                  <Steps.Indicator />
+                  Account
+                </Steps.Trigger>
+              </Steps.Item>
+              <Steps.Item index={1}>
+                <Steps.Trigger>
+                  <Steps.Indicator />
+                  Profile
+                </Steps.Trigger>
+              </Steps.Item>
+              <Steps.Item index={2}>
+                <Steps.Trigger>
+                  <Steps.Indicator />
+                  Review
+                </Steps.Trigger>
+              </Steps.Item>
+              <Steps.Item index={3}>
+                <Steps.Trigger>
+                  <Steps.Indicator />
+                  Complete
+                </Steps.Trigger>
+              </Steps.Item>
+            </Steps.List>
+            <Steps.Content index={0}>Create your account</Steps.Content>
+            <Steps.Content index={1}>Fill in your profile</Steps.Content>
+            <Steps.Content index={2}>Review your information</Steps.Content>
+            <Steps.Content index={3}>All done!</Steps.Content>
+          </Steps.Root>
+
+          <ModalPage.Root isOpen={false} onClose={() => {}}>
+            <ModalPage.TopBar
+              previousPathLabel="Back"
+              currentPathLabel="Details"
+            />
+            <ModalPage.Header>
+              <ModalPage.Title>Modal Page</ModalPage.Title>
+            </ModalPage.Header>
+            <ModalPage.Content>Modal content</ModalPage.Content>
+          </ModalPage.Root>
+        </Stack>
+      </Section>
+
+      <Section title="Navigation">
+        <Stack gap="200">
+          <Link href="#">Link</Link>
+          <TabNav.Root aria-label="nav">
+            <TabNav.Item href="/home">Home</TabNav.Item>
+          </TabNav.Root>
+          <Pagination totalItems={100} />
+        </Stack>
+      </Section>
+
+      <Section title="Data Display">
+        <Stack gap="400">
+          <DataTable.Root
+            aria-label="data table"
+            columns={[
+              { id: "name", header: "Name", accessor: (row) => row.name },
+              { id: "role", header: "Role", accessor: (row) => row.role },
+              { id: "status", header: "Status", accessor: (row) => row.status },
+            ]}
+            rows={[
+              { id: "1", name: "Alice", role: "Engineer", status: "Active" },
+              { id: "2", name: "Bob", role: "Designer", status: "Active" },
+              { id: "3", name: "Carol", role: "PM", status: "Away" },
+            ]}
+          >
+            <DataTable.Table />
+          </DataTable.Root>
+
+          <TagGroup.Root aria-label="tags">
+            <TagGroup.TagList>
+              <TagGroup.Tag id="a">Tag A</TagGroup.Tag>
+            </TagGroup.TagList>
+          </TagGroup.Root>
+
+          <List.Root>
+            <List.Item>List Item</List.Item>
+          </List.Root>
+        </Stack>
+      </Section>
+
+      <Section title="Form Structure">
+        <Stack gap="200">
+          <FormField.Root>
+            <FormField.Label>Label</FormField.Label>
+            <FormField.Input>
+              <TextInput aria-label="field" />
+            </FormField.Input>
+          </FormField.Root>
+          <FieldErrors errors={{ required: true }} />
+        </Stack>
+      </Section>
+
+      <Section title="Date Components">
+        <Stack gap="200">
+          <Calendar aria-label="calendar" />
+          <RangeCalendar aria-label="range calendar" />
+          <DatePicker aria-label="date picker" />
+          <DateRangePicker aria-label="date range picker" />
+        </Stack>
+      </Section>
+
+      <Section title="Miscellaneous">
+        <Stack gap="200">
+          <Toolbar aria-label="toolbar">
+            <Button>Tool</Button>
+          </Toolbar>
+
+          <ComboBox.Root aria-label="combo">
+            <ComboBox.Trigger />
+            <ComboBox.Popover>
+              <ComboBox.ListBox>
+                <ComboBox.Option id="a">Apple</ComboBox.Option>
+                <ComboBox.Option id="b">Banana</ComboBox.Option>
+                <ComboBox.Option id="c">Cherry</ComboBox.Option>
+                <ComboBox.Option id="d">Date</ComboBox.Option>
+              </ComboBox.ListBox>
+            </ComboBox.Popover>
+          </ComboBox.Root>
+
+          <DefaultPage.Root>
+            <DefaultPage.Header>
+              <DefaultPage.Title>Default Page</DefaultPage.Title>
+            </DefaultPage.Header>
+            <DefaultPage.Content>Default page content</DefaultPage.Content>
+          </DefaultPage.Root>
+        </Stack>
+      </Section>
+    </Box>
+  );
+}

--- a/apps/ssr-test/app/page.tsx
+++ b/apps/ssr-test/app/page.tsx
@@ -19,6 +19,7 @@ import {
   DateRangePicker,
   DefaultPage,
   Dialog,
+  DraggableList,
   Drawer,
   FieldErrors,
   Flex,
@@ -30,12 +31,15 @@ import {
   IconButton,
   IconToggleButton,
   Image,
+  InlineSvg,
   Kbd,
   Link,
   List,
   LoadingSpinner,
+  LocalizedField,
   Menu,
   ModalPage,
+  MoneyInput,
   MultilineTextInput,
   NumberInput,
   PageContent,
@@ -45,11 +49,13 @@ import {
   RadioInput,
   RangeCalendar,
   ScrollArea,
+  ScopedSearchInput,
   SearchInput,
   Select,
   Separator,
   SimpleGrid,
   Spacer,
+  SplitButton,
   Stack,
   Steps,
   Switch,
@@ -134,6 +140,7 @@ export default function Page() {
             width="50px"
             height="50px"
           />
+          <InlineSvg data='<svg><path d="M0 0" /></svg>' />
           <Avatar firstName="Test" lastName="User" />
           <VisuallyHidden>Hidden text</VisuallyHidden>
         </Stack>
@@ -156,6 +163,9 @@ export default function Page() {
           <IconButton aria-label="action" />
           <ToggleButton>Toggle</ToggleButton>
           <IconToggleButton aria-label="toggle" />
+          <SplitButton onAction={() => {}} aria-label="more actions">
+            <Menu.Item id="action">Action</Menu.Item>
+          </SplitButton>
           <ToggleButtonGroup.Root selectionMode="single">
             <ToggleButtonGroup.Button id="a">A</ToggleButtonGroup.Button>
             <ToggleButtonGroup.Button id="b">B</ToggleButtonGroup.Button>
@@ -170,6 +180,17 @@ export default function Page() {
           <PasswordInput aria-label="password" />
           <MultilineTextInput aria-label="multiline" />
           <SearchInput aria-label="search" />
+          <ScopedSearchInput
+            aria-label="scoped search"
+            options={[{ value: "all", label: "All" }]}
+            value={{ option: "all", text: "" }}
+            onSubmit={() => {}}
+          />
+          <MoneyInput
+            aria-label="money"
+            currencies={["EUR", "USD"]}
+            value={{ amount: "", currencyCode: "EUR" }}
+          />
           <Checkbox>Checkbox</Checkbox>
           <Switch>Switch</Switch>
           <RadioInput.Root aria-label="radio">
@@ -321,7 +342,7 @@ export default function Page() {
 
       <Section title="Data Display">
         <Stack gap="400">
-          <DataTable.Root
+          <DataTable
             aria-label="data table"
             columns={[
               { id: "name", header: "Name", accessor: (row) => row.name },
@@ -333,9 +354,7 @@ export default function Page() {
               { id: "2", name: "Bob", role: "Designer", status: "Active" },
               { id: "3", name: "Carol", role: "PM", status: "Away" },
             ]}
-          >
-            <DataTable.Table />
-          </DataTable.Root>
+          />
 
           <TagGroup.Root aria-label="tags">
             <TagGroup.TagList>
@@ -346,6 +365,15 @@ export default function Page() {
           <List.Root>
             <List.Item>List Item</List.Item>
           </List.Root>
+
+          <DraggableList.Root
+            aria-label="draggable"
+            items={[
+              { id: "1", key: "1", label: "Item 1" },
+              { id: "2", key: "2", label: "Item 2" },
+              { id: "3", key: "3", label: "Item 3" },
+            ]}
+          />
         </Stack>
       </Section>
 
@@ -358,6 +386,12 @@ export default function Page() {
             </FormField.Input>
           </FormField.Root>
           <FieldErrors errors={{ required: true }} />
+          <LocalizedField
+            aria-label="localized"
+            defaultLocaleOrCurrency="en"
+            valuesByLocaleOrCurrency={{ en: "hello" }}
+            onChange={() => {}}
+          />
         </Stack>
       </Section>
 

--- a/apps/ssr-test/app/providers.tsx
+++ b/apps/ssr-test/app/providers.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { NimbusProvider } from "@commercetools/nimbus";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <NimbusProvider locale="en-US" loadFonts={false}>
+      {children}
+    </NimbusProvider>
+  );
+}

--- a/apps/ssr-test/next-env.d.ts
+++ b/apps/ssr-test/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/ssr-test/next.config.ts
+++ b/apps/ssr-test/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  transpilePackages: ["@commercetools/nimbus", "@commercetools/nimbus-icons"],
+};
+
+export default nextConfig;

--- a/apps/ssr-test/package.json
+++ b/apps/ssr-test/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ssr-test",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@commercetools/nimbus": "workspace:*",
+    "@commercetools/nimbus-icons": "workspace:*",
+    "@emotion/react": "catalog:react",
+    "@chakra-ui/react": "catalog:react",
+    "next": "^15.3.4",
+    "react": "catalog:react",
+    "react-dom": "catalog:react"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:react",
+    "@types/react-dom": "catalog:react",
+    "typescript": "catalog:tooling"
+  }
+}

--- a/apps/ssr-test/tsconfig.json
+++ b/apps/ssr-test/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/component-guidelines.md
+++ b/docs/component-guidelines.md
@@ -106,10 +106,14 @@ These documents provide standards that apply across all component types:
 9. **[Add Documentation Tests](../engineering-docs-validation.md)** - Create
    `.docs.spec.tsx` with consumer test examples (optional but recommended)
 10. **[Export](./file-type-guidelines/barrel-exports.md)** - Set up public API
+11. **[SSR Smoke Test](./file-type-guidelines/testing-strategy.md#ssr-smoke-tests-srctestssrssrspectsx)** -
+    Add a test case to `src/test/ssr.ssr.spec.tsx` and render the component in
+    `apps/ssr-test/app/page.tsx`
 
 **Note**: All component behavior is tested in Storybook stories with play
 functions. Documentation tests (`.docs.spec.tsx`) provide consumer-facing
-examples.
+examples. SSR smoke tests ensure the component renders without crashing on the
+server.
 
 ### 🎨 Adding Styling to Components
 

--- a/docs/file-type-guidelines/testing-strategy.md
+++ b/docs/file-type-guidelines/testing-strategy.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Nimbus uses 3 test categories, each serving a distinct purpose and audience.
+Nimbus uses 4 test categories, each serving a distinct purpose and audience.
 
 ## The 4 Test Categories
 

--- a/docs/file-type-guidelines/testing-strategy.md
+++ b/docs/file-type-guidelines/testing-strategy.md
@@ -10,13 +10,14 @@
 
 Nimbus uses 3 test categories, each serving a distinct purpose and audience.
 
-## The 3 Test Categories
+## The 4 Test Categories
 
-| Category                          | File Pattern      | Purpose                                  | Audience     |
-| --------------------------------- | ----------------- | ---------------------------------------- | ------------ |
-| **Story Tests**                   | `*.stories.tsx`   | Internal component behavior testing      | Internal     |
-| **Internal Unit Tests**           | `*.spec.tsx`      | Internal utility and hook testing        | Internal     |
-| **Consumer Implementation Tests** | `*.docs.spec.tsx` | Documentation examples for consumer apps | **External** |
+| Category                          | File Pattern       | Purpose                                  | Audience     |
+| --------------------------------- | ------------------ | ---------------------------------------- | ------------ |
+| **Story Tests**                   | `*.stories.tsx`    | Internal component behavior testing      | Internal     |
+| **Internal Unit Tests**           | `*.spec.tsx`       | Internal utility and hook testing        | Internal     |
+| **Consumer Implementation Tests** | `*.docs.spec.tsx`  | Documentation examples for consumer apps | **External** |
+| **SSR Smoke Tests**               | `ssr.ssr.spec.tsx` | Server-side rendering validation         | Internal     |
 
 ---
 
@@ -155,6 +156,61 @@ Internal component behavior tests belong in Stories, not here:
 
 ---
 
+## SSR Smoke Tests (`src/test/ssr.ssr.spec.tsx`)
+
+### Purpose
+
+SSR smoke tests verify that every Nimbus component can render on the server
+without crashing. They run `renderToString` in a pure Node.js environment (no
+JSDOM, no `window`/`document`) to catch browser-only global access during
+render.
+
+### What Belongs Here
+
+- A single `renderToString` call per component with minimal required props
+- Assertions that the render produces truthy output (does not throw)
+- Where possible, `toContain()` checks for expected text content
+
+### When to Add
+
+**Every new component or pattern must have an SSR smoke test.** When creating a
+new component, add a test case to `packages/nimbus/src/test/ssr.ssr.spec.tsx`
+and render the component in the Next.js SSR test app at `apps/ssr-test/`.
+
+### How to Add
+
+1. Import the component in `packages/nimbus/src/test/ssr.ssr.spec.tsx`
+2. Add an `it()` block that renders the component inside the `renderSSR()`
+   helper
+3. Use the minimum required props to make the component render
+4. Add the component to the appropriate section in `apps/ssr-test/app/page.tsx`
+5. Run `pnpm vitest run --project=ssr` to verify the test passes
+6. Rebuild the SSR test app (`cd apps/ssr-test && pnpm exec next build`) to
+   verify it works in a real Next.js environment
+
+### Example
+
+```typescript
+// In src/test/ssr.ssr.spec.tsx
+it("MyComponent", () => {
+  expect(
+    renderSSR(<MyComponent aria-label="test">content</MyComponent>)
+  ).toContain("content");
+});
+```
+
+### Common Pitfalls
+
+- Components using `useSyncExternalStore` must provide a `getServerSnapshot`
+  (third argument) or they throw during SSR
+- Components that access `window`/`document`/`navigator` during render (not in
+  effects) will fail — guard these with `typeof window !== "undefined"` checks
+  or move them into `useEffect`
+- `useEffect` does not run during SSR — components that set state via effects
+  (like `FormField.Label`) will render without that state on the server
+
+---
+
 ## Decision Flowchart
 
 ```mermaid
@@ -165,30 +221,38 @@ flowchart TD
     Q1 -->|No| Q2{Documentation example<br/>for consumers?}
 
     Q2 -->|Yes| Consumer[Consumer Implementation Test<br/>.docs.spec.tsx]
-    Q2 -->|No| Story[Story Test<br/>.stories.tsx]
+    Q2 -->|No| Q3{New component<br/>or pattern?}
+
+    Q3 -->|Yes| SSR[SSR Smoke Test<br/>ssr.ssr.spec.tsx<br/>+ SSR test app]
+    Q3 -->|No| Story[Story Test<br/>.stories.tsx]
+    Q3 -->|Yes| Story
 
     Consumer --> C1[Form integration<br/>Async data loading<br/>State management<br/>Multi-component workflows]
 
     Story --> S1[ARIA attributes<br/>Keyboard navigation<br/>Visual states<br/>Component behavior]
 
     Unit --> U1[Utilities<br/>Hooks<br/>Pure functions]
+
+    SSR --> SSR1[renderToString smoke test<br/>Next.js App Router page]
 ```
 
 ---
 
 ## Quick Reference
 
-| What You're Testing              | Category                     | File Pattern      |
-| -------------------------------- | ---------------------------- | ----------------- |
-| Component states and behavior    | Story Test                   | `*.stories.tsx`   |
-| ARIA attributes                  | Story Test                   | `*.stories.tsx`   |
-| Keyboard navigation              | Story Test                   | `*.stories.tsx`   |
-| Visual variants                  | Story Test                   | `*.stories.tsx`   |
-| Form library integration example | Consumer Implementation Test | `*.docs.spec.tsx` |
-| Async data loading example       | Consumer Implementation Test | `*.docs.spec.tsx` |
-| State management example         | Consumer Implementation Test | `*.docs.spec.tsx` |
-| Utility function                 | Internal Unit Test           | `*.spec.tsx`      |
-| Custom hook                      | Internal Unit Test           | `*.spec.tsx`      |
+| What You're Testing              | Category                     | File Pattern       |
+| -------------------------------- | ---------------------------- | ------------------ |
+| Component states and behavior    | Story Test                   | `*.stories.tsx`    |
+| ARIA attributes                  | Story Test                   | `*.stories.tsx`    |
+| Keyboard navigation              | Story Test                   | `*.stories.tsx`    |
+| Visual variants                  | Story Test                   | `*.stories.tsx`    |
+| Form library integration example | Consumer Implementation Test | `*.docs.spec.tsx`  |
+| Async data loading example       | Consumer Implementation Test | `*.docs.spec.tsx`  |
+| State management example         | Consumer Implementation Test | `*.docs.spec.tsx`  |
+| Utility function                 | Internal Unit Test           | `*.spec.tsx`       |
+| Custom hook                      | Internal Unit Test           | `*.spec.tsx`       |
+| New component renders on server  | SSR Smoke Test               | `ssr.ssr.spec.tsx` |
+| New component works in Next.js   | SSR Test App                 | `apps/ssr-test/`   |
 
 ---
 
@@ -199,6 +263,8 @@ flowchart TD
 - [Stories](./stories.md) - Storybook stories with play functions
 - [Engineering Docs Validation](../engineering-docs-validation.md) - Test file
   integration with documentation
+- [SSR Documentation](/home/getting-started/server-side-rendering) - Consumer
+  guide for using Nimbus in SSR/RSC environments
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,12 @@ export default tseslint.config(
    * Global ignores for common build and dependency directories
    */
   {
-    ignores: ["**/node_modules/**", "**/dist/**", "**/storybook-static/**"],
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/storybook-static/**",
+      "**/next-env.d.ts",
+    ],
   },
   /**
    * Base ESLint recommended rules

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:storybook:dev": "pnpm vitest run --config vitest.dev.config.ts --project=storybook-dev",
     "check:bundle-size": "node .github/actions/bundle-size/check-bundle-size.mjs",
     "check:package-shape": "node scripts/check-package-shape.mjs",
+    "check:use-client": "node scripts/check-use-client.mjs",
     "bundle-sizes:trend": "node scripts/bundle-sizes-trend.mjs"
   },
   "packageManager": "pnpm@10.12.3+sha512.467df2c586056165580ad6dfb54ceaad94c5a30f80893ebdec5a44c5aa73c205ae4a5bb9d5ed6bb84ea7c249ece786642bbb49d06a307df218d03da41c317417",

--- a/packages/nimbus/src/components/toast/components/toast.outlet.tsx
+++ b/packages/nimbus/src/components/toast/components/toast.outlet.tsx
@@ -65,7 +65,11 @@ function subscribeToActivation(onStoreChange: () => void) {
  * @internal
  */
 export function ToastOutlet() {
-  const active = useSyncExternalStore(subscribeToActivation, isToastersActive);
+  const active = useSyncExternalStore(
+    subscribeToActivation,
+    isToastersActive,
+    () => false
+  );
 
   // Supplement zag-js hotkeys with numpad support.
   // Zag only matches `Digit*` codes; this listener handles `Numpad*` equivalents.

--- a/packages/nimbus/src/docs/home-ssr.mdx
+++ b/packages/nimbus/src/docs/home-ssr.mdx
@@ -1,0 +1,222 @@
+---
+id: Home-SSR
+title: Server-Side Rendering
+description:
+  How to use Nimbus in SSR and React Server Component environments like Next.js
+  App Router and Remix.
+order: 3
+menu:
+  - Home
+  - Getting Started
+  - Server-Side Rendering
+tags:
+  - guide
+  - ssr
+  - rsc
+  - nextjs
+  - remix
+icon: Cloud
+---
+
+# Server-Side Rendering
+
+Nimbus is compatible with server-side rendering (SSR) and React Server
+Components (RSC). All published entry points include a `"use client"` directive,
+so bundlers like Next.js App Router automatically treat Nimbus imports as client
+boundaries.
+
+## How it works
+
+Every Nimbus component is a client component — it uses React hooks, event
+handlers, and browser APIs that require a client environment. The `"use client"`
+directive is prepended to every entry-point file at build time, so you do not
+need to add it yourself.
+
+Nimbus components rely on the Chakra UI context provided by `NimbusProvider`. In
+Next.js App Router, the recommended pattern is to use Nimbus components inside
+Client Components (files with `"use client"`). The `"use client"` directive on
+Nimbus entry points ensures the bundler treats them correctly — they are still
+server-rendered as HTML during the initial request, but they hydrate on the
+client and require the provider context.
+
+```tsx
+// app/dashboard/page.tsx
+"use client";
+
+import { Button, Text } from "@commercetools/nimbus";
+
+export default function Dashboard() {
+  return (
+    <main>
+      <Text>This text is server-rendered, then hydrates on the client.</Text>
+      <Button onPress={() => alert("Hello!")}>Click me</Button>
+    </main>
+  );
+}
+```
+
+> [!NOTE] Even though the file has `"use client"`, Next.js still server-renders
+> the component as HTML on the initial request — the directive controls where
+> hydration happens, not whether SSR occurs.
+
+## Setup with Next.js App Router
+
+### 1. Install Nimbus
+
+Follow the standard [Installation](/home/getting-started/installation) guide.
+
+### 2. Create a client provider
+
+`NimbusProvider` uses React context and must run on the client. Create a
+dedicated provider component:
+
+```tsx
+// app/providers.tsx
+"use client";
+
+import { NimbusProvider } from "@commercetools/nimbus";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <NimbusProvider loadFonts={false}>{children}</NimbusProvider>;
+}
+```
+
+> [!NOTE] Set `loadFonts={false}` if you load Inter via `next/font` or another
+> mechanism. See the [Installation guide](/home/getting-started/installation)
+> for details.
+
+### 3. Wrap your root layout
+
+```tsx
+// app/layout.tsx
+import { Providers } from "./providers";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}
+```
+
+### 4. Use components in any page
+
+Mark pages that use Nimbus components with `"use client"`. The components are
+still server-rendered as HTML — the directive tells Next.js to hydrate them on
+the client, which is required for interactivity and Chakra context.
+
+```tsx
+// app/dashboard/page.tsx
+"use client";
+
+import { Card, Heading, Text } from "@commercetools/nimbus";
+
+export default function Dashboard() {
+  return (
+    <Card.Root>
+      <Card.Header>
+        <Heading as="h2">Dashboard</Heading>
+      </Card.Header>
+      <Card.Body>
+        <Text>Welcome back.</Text>
+      </Card.Body>
+    </Card.Root>
+  );
+}
+```
+
+## Setup with Remix
+
+Remix renders components on the server by default. Nimbus works out of the box
+because the `"use client"` directive is only meaningful to RSC-aware bundlers —
+Remix ignores it.
+
+```tsx
+// app/root.tsx
+import { NimbusProvider } from "@commercetools/nimbus";
+
+export default function App() {
+  return (
+    <html lang="en">
+      <body>
+        <NimbusProvider>
+          <Outlet />
+        </NimbusProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+## What renders on the server
+
+During SSR, React calls `renderToString` (or its streaming equivalents) to
+produce HTML. Components render their markup, but:
+
+- **`useEffect` does not run** — effects are skipped during server rendering and
+  only fire after hydration on the client.
+- **Overlay components render their triggers only** — components like `Dialog`,
+  `Drawer`, `Menu`, and `Tooltip` render the trigger button on the server. The
+  overlay content appears after hydration when the user interacts with the
+  trigger.
+- **`ToastOutlet` renders nothing** — the toast system activates on the client
+  when a toast is triggered.
+
+This is standard React SSR behavior. After hydration completes, all components
+become fully interactive.
+
+## Caveats
+
+### Emotion style injection
+
+Nimbus uses Emotion for CSS-in-JS. During SSR, Emotion inlines `<style>` tags
+into the HTML stream. If you see a flash of unstyled content (FOUC), ensure
+Emotion's SSR setup is configured. For Next.js App Router, this is handled
+automatically. For custom SSR setups, see the
+[Emotion SSR documentation](https://emotion.sh/docs/ssr).
+
+### FormField labels during SSR
+
+`FormField.Label` stores its text via `useEffect` and renders `null` during the
+server pass. The label text appears after hydration. If your application
+requires the label to be present in the initial server-rendered HTML (e.g., for
+accessibility scanners that evaluate the raw SSR output), add a `VisuallyHidden`
+label with the appropriate `aria-label` on the input:
+
+```tsx
+<FormField.Root>
+  <FormField.Label>Email</FormField.Label>
+  <FormField.Input>
+    <TextInput aria-label="Email" />
+  </FormField.Input>
+</FormField.Root>
+```
+
+The `aria-label` ensures the input is accessible before hydration, and
+`FormField.Label` takes over after effects run on the client.
+
+### Hydration mismatches
+
+Nimbus components are designed to produce consistent output between server and
+client renders. If you encounter a hydration mismatch warning, check that:
+
+- You are not conditionally rendering Nimbus components based on
+  `typeof window !== "undefined"` or similar browser-only checks.
+- Your `NimbusProvider` locale prop matches between server and client.
+
+## Verifying SSR compatibility
+
+The Nimbus test suite includes dedicated SSR tests that render every component
+with `renderToString` in a pure Node.js environment (no JSDOM). These tests run
+in CI to prevent regressions.
+
+If you are contributing a new component, add an SSR smoke test to
+`packages/nimbus/src/test/ssr.ssr.spec.tsx` to ensure it renders without
+crashing on the server.

--- a/packages/nimbus/src/test/ssr.ssr.spec.tsx
+++ b/packages/nimbus/src/test/ssr.ssr.spec.tsx
@@ -83,6 +83,7 @@ import {
   ToggleButtonGroup,
   Toolbar,
   Tooltip,
+  RichTextInput,
   VisuallyHidden,
 } from "@/components";
 
@@ -98,6 +99,7 @@ import {
   SearchInputField,
   MultilineTextInputField,
   DateRangePickerField,
+  MoneyInputField,
 } from "@/patterns";
 
 function renderSSR(ui: React.ReactElement): string {
@@ -247,7 +249,7 @@ describe("SSR: typography and display", () => {
   });
 
   it("Avatar", () => {
-    expect(renderSSR(<Avatar name="Test User" />)).toBeTruthy();
+    expect(renderSSR(<Avatar firstName="Test" lastName="User" />)).toBeTruthy();
   });
 
   it("VisuallyHidden", () => {
@@ -265,7 +267,7 @@ describe("SSR: feedback components", () => {
   it("Alert", () => {
     expect(
       renderSSR(
-        <Alert.Root variant="info">
+        <Alert.Root variant="flat">
           <Alert.Description>message</Alert.Description>
         </Alert.Root>
       )
@@ -311,12 +313,8 @@ describe("SSR: buttons", () => {
   it("SplitButton", () => {
     expect(
       renderSSR(
-        <SplitButton>
-          <SplitButton.Action>action</SplitButton.Action>
-          <SplitButton.MenuTrigger aria-label="more" />
-          <SplitButton.Menu>
-            <SplitButton.MenuItem>item</SplitButton.MenuItem>
-          </SplitButton.Menu>
+        <SplitButton onAction={() => {}} aria-label="more actions">
+          <Menu.Item id="action">action</Menu.Item>
         </SplitButton>
       )
     ).toContain("action");
@@ -366,8 +364,9 @@ describe("SSR: form inputs", () => {
       renderSSR(
         <ScopedSearchInput
           aria-label="scoped search"
-          options={[{ id: "all", label: "All" }]}
+          options={[{ value: "all", label: "All" }]}
           value={{ option: "all", text: "" }}
+          onSubmit={() => {}}
         />
       )
     ).toBeTruthy();
@@ -378,10 +377,8 @@ describe("SSR: form inputs", () => {
       renderSSR(
         <MoneyInput
           aria-label="money"
-          currencies={[{ code: "EUR", label: "EUR" }]}
-          selectedCurrency="EUR"
-          onCurrencyChange={() => {}}
-          value={{ amount: "", currency: "EUR" }}
+          currencies={["EUR", "USD"]}
+          value={{ amount: "", currencyCode: "EUR" }}
         />
       )
     ).toBeTruthy();
@@ -562,7 +559,7 @@ describe("SSR: compound and overlay components", () => {
         <ModalPage.Header>
           <ModalPage.Title>Title</ModalPage.Title>
         </ModalPage.Header>
-        <ModalPage.Body>body</ModalPage.Body>
+        <ModalPage.Content>body</ModalPage.Content>
       </ModalPage.Root>
     );
     expect(html).toBeTruthy();
@@ -591,12 +588,7 @@ describe("SSR: navigation", () => {
   it("Pagination", () => {
     expect(
       renderSSR(
-        <Pagination
-          totalItems={100}
-          page={1}
-          onPageChange={() => {}}
-          onPerPageChange={() => {}}
-        />
+        <Pagination totalItems={100} currentPage={1} onPageChange={() => {}} />
       )
     ).toBeTruthy();
   });
@@ -627,26 +619,13 @@ describe("SSR: data display", () => {
   it("DataTable", () => {
     expect(
       renderSSR(
-        <DataTable.Root
+        <DataTable
           aria-label="data table"
-          columns={[{ id: "name", name: "Name", accessor: (row) => row.name }]}
+          columns={[
+            { id: "name", header: "Name", accessor: (row) => row.name },
+          ]}
           rows={[{ id: "1", name: "Alice" }]}
-        >
-          <DataTable.Table>
-            <DataTable.Header>
-              {(column) => (
-                <DataTable.ColumnHeader>{column.name}</DataTable.ColumnHeader>
-              )}
-            </DataTable.Header>
-            <DataTable.Body>
-              {(row) => (
-                <DataTable.Row>
-                  <DataTable.Cell>{row.name}</DataTable.Cell>
-                </DataTable.Row>
-              )}
-            </DataTable.Body>
-          </DataTable.Table>
-        </DataTable.Root>
+        />
       )
     ).toContain("Alice");
   });
@@ -714,6 +693,7 @@ describe("SSR: form structure", () => {
           aria-label="localized"
           defaultLocaleOrCurrency="en"
           valuesByLocaleOrCurrency={{ en: "hello" }}
+          onChange={() => {}}
         />
       )
     ).toBeTruthy();
@@ -797,6 +777,8 @@ describe("SSR: pattern components", () => {
         title="Confirm?"
         isOpen={false}
         onOpenChange={() => {}}
+        onConfirm={() => {}}
+        onCancel={() => {}}
       >
         <Text>Are you sure?</Text>
       </ConfirmationDialog>
@@ -819,7 +801,8 @@ describe("SSR: pattern components", () => {
         title="Edit"
         isOpen={false}
         onOpenChange={() => {}}
-        onSubmit={() => {}}
+        onSave={() => {}}
+        onCancel={() => {}}
       >
         <TextInput aria-label="name" />
       </FormDialog>
@@ -879,5 +862,28 @@ describe("SSR: pattern components", () => {
         <DateRangePickerField label="Date range" aria-label="date range" />
       )
     ).toBeTruthy();
+  });
+
+  it("MoneyInputField", () => {
+    expect(
+      renderSSR(
+        <MoneyInputField
+          label="Price"
+          aria-label="price"
+          currencies={["EUR", "USD"]}
+          value={{ amount: "", currencyCode: "EUR" }}
+        />
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rich text
+// ---------------------------------------------------------------------------
+
+describe("SSR: rich text", () => {
+  it("RichTextInput", () => {
+    expect(renderSSR(<RichTextInput aria-label="rich text" />)).toBeTruthy();
   });
 });

--- a/packages/nimbus/src/test/ssr.ssr.spec.tsx
+++ b/packages/nimbus/src/test/ssr.ssr.spec.tsx
@@ -1,0 +1,883 @@
+/**
+ * SSR (Server-Side Rendering) validation tests.
+ *
+ * These tests run in a pure Node.js environment (no JSDOM, no window/document)
+ * and use `renderToString` from `react-dom/server` to verify every Nimbus
+ * component can render without crashing on the server.
+ *
+ * Failures here mean a component accesses browser-only globals during render,
+ * which would break SSR in Next.js, Remix, or any server-rendering framework.
+ */
+import { renderToString } from "react-dom/server";
+
+import {
+  Accordion,
+  Alert,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Calendar,
+  Card,
+  Checkbox,
+  Code,
+  CollapsibleMotion,
+  ComboBox,
+  DataTable,
+  DateInput,
+  DatePicker,
+  DateRangePicker,
+  DefaultPage,
+  Dialog,
+  DraggableList,
+  Drawer,
+  FieldErrors,
+  Flex,
+  FormField,
+  Grid,
+  Group,
+  Heading,
+  Icon,
+  IconButton,
+  IconToggleButton,
+  Image,
+  InlineSvg,
+  Kbd,
+  Link,
+  List,
+  LoadingSpinner,
+  LocalizedField,
+  Menu,
+  ModalPage,
+  MoneyInput,
+  MultilineTextInput,
+  NimbusI18nProvider,
+  NimbusProvider,
+  NumberInput,
+  PageContent,
+  Pagination,
+  PasswordInput,
+  ProgressBar,
+  RadioInput,
+  RangeCalendar,
+  ScrollArea,
+  ScopedSearchInput,
+  SearchInput,
+  Select,
+  Separator,
+  SimpleGrid,
+  Spacer,
+  SplitButton,
+  Stack,
+  Steps,
+  Switch,
+  TabNav,
+  Table,
+  Tabs,
+  TagGroup,
+  Text,
+  TextInput,
+  TimeInput,
+  ToastOutlet,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+  Tooltip,
+  VisuallyHidden,
+} from "@/components";
+
+import {
+  ConfirmationDialog,
+  FormActionBar,
+  FormDialog,
+  InfoDialog,
+  PublicPageLayout,
+  TextInputField,
+  NumberInputField,
+  PasswordInputField,
+  SearchInputField,
+  MultilineTextInputField,
+  DateRangePickerField,
+} from "@/patterns";
+
+function renderSSR(ui: React.ReactElement): string {
+  return renderToString(
+    <NimbusProvider locale="en-US" loadFonts={false}>
+      {ui}
+    </NimbusProvider>
+  );
+}
+
+function renderSSRRaw(ui: React.ReactElement): string {
+  return renderToString(ui);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+describe("SSR: NimbusProvider", () => {
+  it("renders without crashing", () => {
+    const html = renderSSRRaw(
+      <NimbusProvider locale="en-US" loadFonts={false}>
+        <div>app</div>
+      </NimbusProvider>
+    );
+    expect(html).toContain("app");
+  });
+
+  it("renders with font loading enabled", () => {
+    const html = renderSSRRaw(
+      <NimbusProvider locale="en-US" loadFonts={true}>
+        <div>app</div>
+      </NimbusProvider>
+    );
+    expect(html).toContain("app");
+  });
+});
+
+describe("SSR: NimbusI18nProvider", () => {
+  it("renders without crashing", () => {
+    const html = renderSSRRaw(
+      <NimbusI18nProvider locale="en-US">
+        <div>i18n</div>
+      </NimbusI18nProvider>
+    );
+    expect(html).toContain("i18n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layout primitives
+// ---------------------------------------------------------------------------
+
+describe("SSR: layout primitives", () => {
+  it("Box", () => {
+    expect(renderSSR(<Box>content</Box>)).toContain("content");
+  });
+
+  it("Flex", () => {
+    expect(renderSSR(<Flex>flex</Flex>)).toContain("flex");
+  });
+
+  it("Grid", () => {
+    expect(renderSSR(<Grid>grid</Grid>)).toContain("grid");
+  });
+
+  it("Stack", () => {
+    expect(renderSSR(<Stack>stack</Stack>)).toContain("stack");
+  });
+
+  it("Group", () => {
+    expect(renderSSR(<Group>group</Group>)).toContain("group");
+  });
+
+  it("SimpleGrid", () => {
+    expect(renderSSR(<SimpleGrid>simple</SimpleGrid>)).toContain("simple");
+  });
+
+  it("Spacer", () => {
+    expect(renderSSR(<Spacer />)).toBeTruthy();
+  });
+
+  it("Separator", () => {
+    expect(renderSSR(<Separator />)).toBeTruthy();
+  });
+
+  it("PageContent", () => {
+    expect(
+      renderSSR(
+        <PageContent.Root>
+          <PageContent.Column>col</PageContent.Column>
+        </PageContent.Root>
+      )
+    ).toContain("col");
+  });
+
+  it("ScrollArea", () => {
+    expect(renderSSR(<ScrollArea>scroll</ScrollArea>)).toContain("scroll");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Typography & display
+// ---------------------------------------------------------------------------
+
+describe("SSR: typography and display", () => {
+  it("Text", () => {
+    expect(renderSSR(<Text>hello</Text>)).toContain("hello");
+  });
+
+  it("Heading", () => {
+    expect(renderSSR(<Heading as="h1">title</Heading>)).toContain("title");
+  });
+
+  it("Code", () => {
+    expect(renderSSR(<Code>code</Code>)).toContain("code");
+  });
+
+  it("Kbd", () => {
+    expect(renderSSR(<Kbd>K</Kbd>)).toContain("K");
+  });
+
+  it("Badge", () => {
+    expect(renderSSR(<Badge>new</Badge>)).toContain("new");
+  });
+
+  it("Icon", () => {
+    expect(
+      renderSSR(
+        <Icon>
+          <svg>
+            <path d="M0 0" />
+          </svg>
+        </Icon>
+      )
+    ).toBeTruthy();
+  });
+
+  it("InlineSvg", () => {
+    expect(
+      renderSSR(<InlineSvg data='<svg><path d="M0 0" /></svg>' />)
+    ).toBeTruthy();
+  });
+
+  it("Image", () => {
+    expect(renderSSR(<Image src="test.png" alt="test" />)).toContain("test");
+  });
+
+  it("Avatar", () => {
+    expect(renderSSR(<Avatar name="Test User" />)).toBeTruthy();
+  });
+
+  it("VisuallyHidden", () => {
+    expect(renderSSR(<VisuallyHidden>hidden</VisuallyHidden>)).toContain(
+      "hidden"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feedback
+// ---------------------------------------------------------------------------
+
+describe("SSR: feedback components", () => {
+  it("Alert", () => {
+    expect(
+      renderSSR(
+        <Alert.Root variant="info">
+          <Alert.Description>message</Alert.Description>
+        </Alert.Root>
+      )
+    ).toContain("message");
+  });
+
+  it("LoadingSpinner", () => {
+    expect(renderSSR(<LoadingSpinner />)).toBeTruthy();
+  });
+
+  it("ProgressBar", () => {
+    expect(
+      renderSSR(<ProgressBar value={50} aria-label="progress" />)
+    ).toBeTruthy();
+  });
+
+  it("ToastOutlet", () => {
+    expect(renderSSR(<ToastOutlet />)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Buttons
+// ---------------------------------------------------------------------------
+
+describe("SSR: buttons", () => {
+  it("Button", () => {
+    expect(renderSSR(<Button>click</Button>)).toContain("click");
+  });
+
+  it("IconButton", () => {
+    expect(renderSSR(<IconButton aria-label="action" />)).toBeTruthy();
+  });
+
+  it("ToggleButton", () => {
+    expect(renderSSR(<ToggleButton>toggle</ToggleButton>)).toContain("toggle");
+  });
+
+  it("IconToggleButton", () => {
+    expect(renderSSR(<IconToggleButton aria-label="toggle" />)).toBeTruthy();
+  });
+
+  it("SplitButton", () => {
+    expect(
+      renderSSR(
+        <SplitButton>
+          <SplitButton.Action>action</SplitButton.Action>
+          <SplitButton.MenuTrigger aria-label="more" />
+          <SplitButton.Menu>
+            <SplitButton.MenuItem>item</SplitButton.MenuItem>
+          </SplitButton.Menu>
+        </SplitButton>
+      )
+    ).toContain("action");
+  });
+
+  it("ToggleButtonGroup", () => {
+    expect(
+      renderSSR(
+        <ToggleButtonGroup.Root selectionMode="single">
+          <ToggleButtonGroup.Button id="a">A</ToggleButtonGroup.Button>
+          <ToggleButtonGroup.Button id="b">B</ToggleButtonGroup.Button>
+        </ToggleButtonGroup.Root>
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Form inputs
+// ---------------------------------------------------------------------------
+
+describe("SSR: form inputs", () => {
+  it("TextInput", () => {
+    expect(renderSSR(<TextInput aria-label="text" />)).toBeTruthy();
+  });
+
+  it("NumberInput", () => {
+    expect(renderSSR(<NumberInput aria-label="number" />)).toBeTruthy();
+  });
+
+  it("PasswordInput", () => {
+    expect(renderSSR(<PasswordInput aria-label="password" />)).toBeTruthy();
+  });
+
+  it("MultilineTextInput", () => {
+    expect(
+      renderSSR(<MultilineTextInput aria-label="multiline" />)
+    ).toBeTruthy();
+  });
+
+  it("SearchInput", () => {
+    expect(renderSSR(<SearchInput aria-label="search" />)).toBeTruthy();
+  });
+
+  it("ScopedSearchInput", () => {
+    expect(
+      renderSSR(
+        <ScopedSearchInput
+          aria-label="scoped search"
+          options={[{ id: "all", label: "All" }]}
+          value={{ option: "all", text: "" }}
+        />
+      )
+    ).toBeTruthy();
+  });
+
+  it("MoneyInput", () => {
+    expect(
+      renderSSR(
+        <MoneyInput
+          aria-label="money"
+          currencies={[{ code: "EUR", label: "EUR" }]}
+          selectedCurrency="EUR"
+          onCurrencyChange={() => {}}
+          value={{ amount: "", currency: "EUR" }}
+        />
+      )
+    ).toBeTruthy();
+  });
+
+  it("Checkbox", () => {
+    expect(renderSSR(<Checkbox>agree</Checkbox>)).toContain("agree");
+  });
+
+  it("Switch", () => {
+    expect(renderSSR(<Switch>toggle</Switch>)).toContain("toggle");
+  });
+
+  it("RadioInput", () => {
+    expect(
+      renderSSR(
+        <RadioInput.Root aria-label="radio">
+          <RadioInput.Option value="a">A</RadioInput.Option>
+          <RadioInput.Option value="b">B</RadioInput.Option>
+        </RadioInput.Root>
+      )
+    ).toBeTruthy();
+  });
+
+  it("DateInput", () => {
+    expect(renderSSR(<DateInput aria-label="date" />)).toBeTruthy();
+  });
+
+  it("TimeInput", () => {
+    expect(renderSSR(<TimeInput aria-label="time" />)).toBeTruthy();
+  });
+
+  it("Select", () => {
+    expect(
+      renderSSR(
+        <Select.Root aria-label="select">
+          <Select.Options>
+            <Select.Option id="1">One</Select.Option>
+          </Select.Options>
+        </Select.Root>
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound/overlay components
+// ---------------------------------------------------------------------------
+
+describe("SSR: compound and overlay components", () => {
+  it("Accordion", () => {
+    expect(
+      renderSSR(
+        <Accordion.Root>
+          <Accordion.Item value="a">
+            <Accordion.Header>Header</Accordion.Header>
+            <Accordion.Content>Content</Accordion.Content>
+          </Accordion.Item>
+        </Accordion.Root>
+      )
+    ).toContain("Header");
+  });
+
+  it("Card", () => {
+    expect(
+      renderSSR(
+        <Card.Root>
+          <Card.Header>header</Card.Header>
+          <Card.Body>body</Card.Body>
+        </Card.Root>
+      )
+    ).toContain("header");
+  });
+
+  it("CollapsibleMotion", () => {
+    expect(
+      renderSSR(
+        <CollapsibleMotion.Root>
+          <CollapsibleMotion.Trigger>trigger</CollapsibleMotion.Trigger>
+          <CollapsibleMotion.Content>content</CollapsibleMotion.Content>
+        </CollapsibleMotion.Root>
+      )
+    ).toContain("trigger");
+  });
+
+  it("Tabs", () => {
+    expect(
+      renderSSR(
+        <Tabs.Root>
+          <Tabs.List>
+            <Tabs.Tab id="t1">Tab 1</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panels>
+            <Tabs.Panel id="t1">Panel 1</Tabs.Panel>
+          </Tabs.Panels>
+        </Tabs.Root>
+      )
+    ).toContain("Tab 1");
+  });
+
+  it("Dialog", () => {
+    const html = renderSSR(
+      <Dialog.Root>
+        <Dialog.Trigger>
+          <Button>open</Button>
+        </Dialog.Trigger>
+        <Dialog.Content>
+          <Dialog.Title>Title</Dialog.Title>
+          <Dialog.Body>Body</Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+    );
+    expect(html).toContain("open");
+  });
+
+  it("Drawer", () => {
+    const html = renderSSR(
+      <Drawer.Root>
+        <Drawer.Trigger>
+          <Button>open</Button>
+        </Drawer.Trigger>
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Title</Drawer.Title>
+          </Drawer.Header>
+          <Drawer.Body>Body</Drawer.Body>
+        </Drawer.Content>
+      </Drawer.Root>
+    );
+    expect(html).toContain("open");
+  });
+
+  it("Menu", () => {
+    const html = renderSSR(
+      <Menu.Root>
+        <Menu.Trigger>
+          <Button>menu</Button>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Item id="a">Item A</Menu.Item>
+        </Menu.Content>
+      </Menu.Root>
+    );
+    expect(html).toContain("menu");
+  });
+
+  it("Tooltip", () => {
+    const html = renderSSR(
+      <Tooltip.Root>
+        <Button>hover</Button>
+        <Tooltip.Content>tip</Tooltip.Content>
+      </Tooltip.Root>
+    );
+    expect(html).toContain("hover");
+  });
+
+  it("Steps", () => {
+    expect(
+      renderSSR(
+        <Steps.Root count={3}>
+          <Steps.List>
+            <Steps.Item index={0}>
+              <Steps.Trigger>
+                <Steps.Indicator />
+              </Steps.Trigger>
+            </Steps.Item>
+          </Steps.List>
+          <Steps.Content index={0}>Step 1</Steps.Content>
+        </Steps.Root>
+      )
+    ).toContain("Step 1");
+  });
+
+  it("ModalPage", () => {
+    const html = renderSSR(
+      <ModalPage.Root isOpen={false} onClose={() => {}}>
+        <ModalPage.TopBar previousPathLabel="Back" currentPathLabel="Details" />
+        <ModalPage.Header>
+          <ModalPage.Title>Title</ModalPage.Title>
+        </ModalPage.Header>
+        <ModalPage.Body>body</ModalPage.Body>
+      </ModalPage.Root>
+    );
+    expect(html).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+describe("SSR: navigation", () => {
+  it("Link", () => {
+    expect(renderSSR(<Link href="#">link</Link>)).toContain("link");
+  });
+
+  it("TabNav", () => {
+    expect(
+      renderSSR(
+        <TabNav.Root aria-label="nav">
+          <TabNav.Item href="#">Home</TabNav.Item>
+        </TabNav.Root>
+      )
+    ).toContain("Home");
+  });
+
+  it("Pagination", () => {
+    expect(
+      renderSSR(
+        <Pagination
+          totalItems={100}
+          page={1}
+          onPageChange={() => {}}
+          onPerPageChange={() => {}}
+        />
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data display
+// ---------------------------------------------------------------------------
+
+describe("SSR: data display", () => {
+  it("Table", () => {
+    expect(
+      renderSSR(
+        <Table.Root aria-label="table">
+          <Table.Header>
+            <Table.ColumnHeader>Name</Table.ColumnHeader>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Alice</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Root>
+      )
+    ).toContain("Alice");
+  });
+
+  it("DataTable", () => {
+    expect(
+      renderSSR(
+        <DataTable.Root
+          aria-label="data table"
+          columns={[{ id: "name", name: "Name", accessor: (row) => row.name }]}
+          rows={[{ id: "1", name: "Alice" }]}
+        >
+          <DataTable.Table>
+            <DataTable.Header>
+              {(column) => (
+                <DataTable.ColumnHeader>{column.name}</DataTable.ColumnHeader>
+              )}
+            </DataTable.Header>
+            <DataTable.Body>
+              {(row) => (
+                <DataTable.Row>
+                  <DataTable.Cell>{row.name}</DataTable.Cell>
+                </DataTable.Row>
+              )}
+            </DataTable.Body>
+          </DataTable.Table>
+        </DataTable.Root>
+      )
+    ).toContain("Alice");
+  });
+
+  it("TagGroup", () => {
+    expect(
+      renderSSR(
+        <TagGroup.Root aria-label="tags">
+          <TagGroup.TagList>
+            <TagGroup.Tag id="a">Tag A</TagGroup.Tag>
+          </TagGroup.TagList>
+        </TagGroup.Root>
+      )
+    ).toContain("Tag A");
+  });
+
+  it("List", () => {
+    expect(
+      renderSSR(
+        <List.Root>
+          <List.Item>item</List.Item>
+        </List.Root>
+      )
+    ).toContain("item");
+  });
+
+  it("DraggableList", () => {
+    expect(
+      renderSSR(
+        <DraggableList.Root
+          aria-label="draggable"
+          items={[{ id: "1", key: "1", label: "Item 1" }]}
+        />
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Form structure
+// ---------------------------------------------------------------------------
+
+describe("SSR: form structure", () => {
+  it("FormField", () => {
+    expect(
+      renderSSR(
+        <FormField.Root>
+          <FormField.Label>Label</FormField.Label>
+          <FormField.Input>
+            <TextInput aria-label="field" />
+          </FormField.Input>
+        </FormField.Root>
+      )
+    ).toBeTruthy();
+  });
+
+  it("FieldErrors", () => {
+    expect(renderSSR(<FieldErrors errors={{ required: true }} />)).toBeTruthy();
+  });
+
+  it("LocalizedField", () => {
+    expect(
+      renderSSR(
+        <LocalizedField
+          aria-label="localized"
+          defaultLocaleOrCurrency="en"
+          valuesByLocaleOrCurrency={{ en: "hello" }}
+        />
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date components
+// ---------------------------------------------------------------------------
+
+describe("SSR: date components", () => {
+  it("Calendar", () => {
+    expect(renderSSR(<Calendar aria-label="calendar" />)).toBeTruthy();
+  });
+
+  it("RangeCalendar", () => {
+    expect(renderSSR(<RangeCalendar aria-label="range" />)).toBeTruthy();
+  });
+
+  it("DatePicker", () => {
+    expect(renderSSR(<DatePicker aria-label="pick date" />)).toBeTruthy();
+  });
+
+  it("DateRangePicker", () => {
+    expect(renderSSR(<DateRangePicker aria-label="date range" />)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+describe("SSR: miscellaneous", () => {
+  it("Toolbar", () => {
+    expect(
+      renderSSR(
+        <Toolbar aria-label="toolbar">
+          <Button>tool</Button>
+        </Toolbar>
+      )
+    ).toContain("tool");
+  });
+
+  it("ComboBox", () => {
+    expect(
+      renderSSR(
+        <ComboBox.Root aria-label="combo">
+          <ComboBox.Trigger />
+          <ComboBox.Popover>
+            <ComboBox.ListBox>
+              <ComboBox.Option id="a">A</ComboBox.Option>
+            </ComboBox.ListBox>
+          </ComboBox.Popover>
+        </ComboBox.Root>
+      )
+    ).toBeTruthy();
+  });
+
+  it("DefaultPage", () => {
+    expect(
+      renderSSR(
+        <DefaultPage.Root>
+          <DefaultPage.Header>
+            <DefaultPage.Title>Page</DefaultPage.Title>
+          </DefaultPage.Header>
+          <DefaultPage.Content>content</DefaultPage.Content>
+        </DefaultPage.Root>
+      )
+    ).toContain("Page");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
+
+describe("SSR: pattern components", () => {
+  it("ConfirmationDialog", () => {
+    const html = renderSSR(
+      <ConfirmationDialog
+        title="Confirm?"
+        isOpen={false}
+        onOpenChange={() => {}}
+      >
+        <Text>Are you sure?</Text>
+      </ConfirmationDialog>
+    );
+    expect(html).toBeTruthy();
+  });
+
+  it("InfoDialog", () => {
+    const html = renderSSR(
+      <InfoDialog title="Info" isOpen={false} onOpenChange={() => {}}>
+        <Text>Information</Text>
+      </InfoDialog>
+    );
+    expect(html).toBeTruthy();
+  });
+
+  it("FormDialog", () => {
+    const html = renderSSR(
+      <FormDialog
+        title="Edit"
+        isOpen={false}
+        onOpenChange={() => {}}
+        onSubmit={() => {}}
+      >
+        <TextInput aria-label="name" />
+      </FormDialog>
+    );
+    expect(html).toBeTruthy();
+  });
+
+  it("FormActionBar", () => {
+    expect(
+      renderSSR(<FormActionBar onCancel={() => {}} onSave={() => {}} />)
+    ).toBeTruthy();
+  });
+
+  it("PublicPageLayout", () => {
+    expect(
+      renderSSR(
+        <PublicPageLayout>
+          <Text>Welcome</Text>
+        </PublicPageLayout>
+      )
+    ).toContain("Welcome");
+  });
+
+  it("TextInputField", () => {
+    expect(
+      renderSSR(<TextInputField label="Name" aria-label="name" />)
+    ).toBeTruthy();
+  });
+
+  it("NumberInputField", () => {
+    expect(
+      renderSSR(<NumberInputField label="Age" aria-label="age" />)
+    ).toBeTruthy();
+  });
+
+  it("PasswordInputField", () => {
+    expect(
+      renderSSR(<PasswordInputField label="Password" aria-label="password" />)
+    ).toBeTruthy();
+  });
+
+  it("SearchInputField", () => {
+    expect(
+      renderSSR(<SearchInputField label="Search" aria-label="search" />)
+    ).toBeTruthy();
+  });
+
+  it("MultilineTextInputField", () => {
+    expect(
+      renderSSR(<MultilineTextInputField label="Notes" aria-label="notes" />)
+    ).toBeTruthy();
+  });
+
+  it("DateRangePickerField", () => {
+    expect(
+      renderSSR(
+        <DateRangePickerField label="Date range" aria-label="date range" />
+      )
+    ).toBeTruthy();
+  });
+});

--- a/packages/nimbus/src/test/ssr.ssr.spec.tsx
+++ b/packages/nimbus/src/test/ssr.ssr.spec.tsx
@@ -8,6 +8,7 @@
  * Failures here mean a component accesses browser-only globals during render,
  * which would break SSR in Next.js, Remix, or any server-rendering framework.
  */
+import { describe, it, expect } from "vitest";
 import { renderToString } from "react-dom/server";
 
 import {

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -2,11 +2,32 @@ import { fileURLToPath } from "node:url";
 import { glob } from "glob";
 import optimizeLocales from "@react-aria/optimize-locales-plugin";
 import { defineConfig, esmExternalRequirePlugin } from "vite";
-import type { LibraryFormats, PluginOption, Rollup } from "vite";
+import type { LibraryFormats, Plugin, PluginOption, Rollup } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
 import { analyzer } from "vite-bundle-analyzer";
 import { LOCALE_BCP47_CODES } from "../i18n/scripts/locales";
+
+/**
+ * Rollup plugin that prepends `"use client"` to every entry-point chunk.
+ *
+ * This makes all published components compatible with React Server Components
+ * (RSC) — bundlers like Next.js App Router see the directive and treat the
+ * import as a client boundary. Non-entry chunks (shared helpers) are skipped
+ * because the directive on the entry is sufficient, and `setup-jsdom-polyfills`
+ * is skipped because it is a test utility, not a React component.
+ */
+function useClientDirectivePlugin(): Plugin {
+  return {
+    name: "nimbus:use-client-directive",
+    renderChunk(code, chunk) {
+      if (chunk.isEntry && chunk.name !== "setup-jsdom-polyfills") {
+        return { code: `"use client";\n${code}`, map: { mappings: "" } };
+      }
+      return null;
+    },
+  };
+}
 
 /**
  * Builds the entry map for the library build.
@@ -161,6 +182,7 @@ export default defineConfig(async () => {
          */
         plugins: [
           esmExternalRequirePlugin({ external: requireRewriteExternals }),
+          useClientDirectivePlugin(),
         ],
         external,
         output: {

--- a/packages/nimbus/vitest.ssr.config.ts
+++ b/packages/nimbus/vitest.ssr.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import createBaseConfig from "./vite.config";
+
+export default defineConfig(async () => {
+  const baseConfig = await createBaseConfig({
+    command: "build",
+    mode: "production",
+  });
+
+  return mergeConfig(
+    baseConfig,
+    defineConfig({
+      test: {
+        name: "ssr",
+        environment: "node",
+        include: ["src/**/*.ssr.spec.{ts,tsx}"],
+        globals: true,
+      },
+    })
+  );
+});

--- a/packages/nimbus/vitest.unit.config.ts
+++ b/packages/nimbus/vitest.unit.config.ts
@@ -18,6 +18,8 @@ export default defineConfig(async () => {
         include: ["src/**/*.spec.{ts,tsx}"],
         exclude: [
           "src/**/*.stories.{ts,tsx}",
+          // SSR tests run in their own project (environment: node, not jsdom)
+          "src/**/*.ssr.spec.{ts,tsx}",
           // Files using vi.mock() must run isolated to avoid polluting
           // the shared module cache (see vitest.unit-isolated.config.ts)
           "src/components/toast/toast.spec.tsx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,40 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
 
+  apps/ssr-test:
+    dependencies:
+      '@chakra-ui/react':
+        specifier: catalog:react
+        version: 3.35.0(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools/nimbus':
+        specifier: workspace:*
+        version: link:../../packages/nimbus
+      '@commercetools/nimbus-icons':
+        specifier: workspace:*
+        version: link:../../packages/nimbus-icons
+      '@emotion/react':
+        specifier: catalog:react
+        version: 11.14.0(@types/react@19.2.16)(react@19.2.0)
+      next:
+        specifier: ^15.3.4
+        version: 15.5.19(@babel/core@7.29.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react:
+        specifier: catalog:react
+        version: 19.2.0
+      react-dom:
+        specifier: catalog:react
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@types/react':
+        specifier: catalog:react
+        version: 19.2.16
+      '@types/react-dom':
+        specifier: catalog:react
+        version: 19.2.3(@types/react@19.2.16)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   packages/color-tokens:
     dependencies:
       '@radix-ui/colors':
@@ -1723,6 +1757,143 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
@@ -2135,6 +2306,57 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@next/env@15.5.19':
+    resolution: {integrity: sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==}
+
+  '@next/swc-darwin-arm64@15.5.19':
+    resolution: {integrity: sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.19':
+    resolution: {integrity: sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    resolution: {integrity: sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.5.19':
+    resolution: {integrity: sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.19':
+    resolution: {integrity: sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.5.19':
+    resolution: {integrity: sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    resolution: {integrity: sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.19':
+    resolution: {integrity: sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3499,6 +3721,9 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
@@ -6245,6 +6470,27 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
+  next@15.5.19:
+    resolution: {integrity: sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
@@ -7021,6 +7267,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -7268,6 +7518,19 @@ packages:
 
   style-to-object@1.0.11:
     resolution: {integrity: sha512-5A560JmXr7wDyGLK12Nq/EYS38VkGlglVzkis1JEdbGWSnbQIEhZzTJhzURXN5/8WwwFCs/f/VVcmkTppbXLow==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -9105,6 +9368,103 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@inquirer/ansi@1.0.2': {}
 
   '@inquirer/checkbox@4.3.2(@types/node@24.13.0)':
@@ -9743,6 +10103,32 @@ snapshots:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@next/env@15.5.19': {}
+
+  '@next/swc-darwin-arm64@15.5.19':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.19':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.19':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.19':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.19':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.19':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -11004,6 +11390,10 @@ snapshots:
       '@swc/helpers': 0.5.17
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@swc/helpers@0.5.17':
     dependencies:
@@ -14446,6 +14836,29 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
+  next@15.5.19(@babel/core@7.29.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 15.5.19
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001751
+      postcss: 8.5.14
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.19
+      '@next/swc-darwin-x64': 15.5.19
+      '@next/swc-linux-arm64-gnu': 15.5.19
+      '@next/swc-linux-arm64-musl': 15.5.19
+      '@next/swc-linux-x64-gnu': 15.5.19
+      '@next/swc-linux-x64-musl': 15.5.19
+      '@next/swc-win32-arm64-msvc': 15.5.19
+      '@next/swc-win32-x64-msvc': 15.5.19
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -15426,6 +15839,38 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -15734,6 +16179,13 @@ snapshots:
   style-to-object@1.0.11:
     dependencies:
       inline-style-parser: 0.2.4
+
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.0
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   stylis@4.2.0: {}
 

--- a/scripts/check-use-client.mjs
+++ b/scripts/check-use-client.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that every entry-point file in the Nimbus dist has a `"use client"`
+ * directive at the top. This ensures components work when imported from React
+ * Server Components (Next.js App Router, etc.).
+ *
+ * The directive is injected by the `useClientDirectivePlugin` in vite.config.ts.
+ * This script catches regressions — run it after `pnpm build`.
+ *
+ * Usage:
+ *   node scripts/check-use-client.mjs
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const DIST = join(__dirname, "..", "packages", "nimbus", "dist");
+
+const SKIP = ["setup-jsdom-polyfills"];
+
+if (!existsSync(DIST)) {
+  console.error(
+    `FAIL  dist directory not found at ${DIST}\n` +
+      `       Run "pnpm --filter @commercetools/nimbus build" first.`
+  );
+  process.exit(1);
+}
+
+function checkFile(filePath) {
+  if (!existsSync(filePath)) {
+    console.error(`FAIL  ${filePath} does not exist`);
+    return false;
+  }
+  const content = readFileSync(filePath, "utf-8");
+  return content.startsWith('"use client"');
+}
+
+let failures = 0;
+let checked = 0;
+
+// Check main entry points
+for (const ext of ["es.js", "cjs"]) {
+  const file = join(DIST, `index.${ext}`);
+  checked++;
+  if (!checkFile(file)) {
+    console.error(`FAIL  index.${ext} missing "use client"`);
+    failures++;
+  }
+}
+
+// Check component entry points.
+// Pattern entries (actions, dialogs, fields, pages) are also routed to
+// dist/components/ by lib.fileName — they are covered by this scan.
+const componentsDir = join(DIST, "components");
+for (const file of readdirSync(componentsDir)) {
+  if (!file.endsWith(".es.js") && !file.endsWith(".cjs")) continue;
+  const fullPath = join(componentsDir, file);
+
+  checked++;
+  if (!checkFile(fullPath)) {
+    console.error(`FAIL  components/${file} missing "use client"`);
+    failures++;
+  }
+}
+
+// Verify excluded files do NOT have the directive
+for (const name of SKIP) {
+  for (const ext of ["es.js", "cjs"]) {
+    const file = join(DIST, `${name}.${ext}`);
+    if (!existsSync(file)) continue;
+    const content = readFileSync(file, "utf-8");
+    if (content.startsWith('"use client"')) {
+      console.error(
+        `FAIL  ${name}.${ext} has "use client" but should not (test utility)`
+      );
+      failures++;
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} file(s) failed the "use client" check.`);
+  process.exit(1);
+} else {
+  console.log(`OK  ${checked} entry points have "use client" directive.`);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "./packages/nimbus/vitest.unit-isolated.config.ts",
       "./packages/design-token-ts-plugin/vitest.config.ts",
       "./packages/nimbus-mcp/vitest.config.ts",
+      "./packages/nimbus/vitest.ssr.config.ts",
       "./vitest.scripts.config.ts",
     ],
   },

--- a/vitest.dev.config.ts
+++ b/vitest.dev.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "./packages/nimbus/vitest.unit-isolated.config.ts",
       "./packages/design-token-ts-plugin/vitest.config.ts",
       "./packages/nimbus-mcp/vitest.config.ts",
+      "./packages/nimbus/vitest.ssr.config.ts",
       "./vitest.scripts.config.ts",
     ],
   },


### PR DESCRIPTION
## Summary

- Add `"use client"` directives to all component entry points via a Vite build plugin, enabling Nimbus to work in React Server Component (RSC) environments like Next.js App Router
- Add comprehensive SSR smoke tests (`renderToString` in Node.js) covering 87 components and patterns
- Add a Next.js App Router test app (`apps/ssr-test/`) that renders every Nimbus component via SSR
- Add `check-use-client.mjs` script and wire it into CI to prevent `"use client"` directive regressions
- Fix `ToastOutlet` SSR crash by adding `getServerSnapshot` to `useSyncExternalStore`
- Add SSR documentation for consumers (`home-ssr.mdx`)
- Update testing strategy docs to reflect the new 4th test category (SSR Smoke Tests)

## Test plan

- [ ] `pnpm vitest run --project=ssr` — all 87 SSR smoke tests pass
- [ ] `pnpm test:dev` — all 2,585 tests pass (no regressions)
- [ ] `pnpm check:use-client` — validates `"use client"` directives in built output
- [ ] `cd apps/ssr-test && pnpm exec next build` — Next.js SSR test app builds without errors
- [ ] CI workflow runs `check:use-client` step after `check:package-shape`