### PR TITLE
feat(nimbus): user-defined themes with color palette generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,8 @@
       "@commercetools/nimbus-tokens",
       "@commercetools/nimbus-icons",
       "@commercetools/nimbus-design-token-ts-plugin",
-      "@commercetools/nimbus-mcp"
+      "@commercetools/nimbus-mcp",
+      "@commercetools/nimbus-theme-generator"
     ]
   ],
   "ignore": ["@commercetools/nimbus-i18n", "color-tokens", "blank-app", "docs"],

--- a/.changeset/custom-themes-color-palettes.md
+++ b/.changeset/custom-themes-color-palettes.md
@@ -1,0 +1,16 @@
+---
+"@commercetools/nimbus": minor
+"@commercetools/nimbus-theme-generator": minor
+---
+
+Add user-defined theme support with color palette generation.
+
+- New `@commercetools/nimbus-theme-generator` package: generate Radix-compatible
+  12-step color scales from a single base hex color, validate WCAG contrast, and
+  create custom Chakra systems with `createNimbusTheme()`
+- `NimbusProvider` accepts a new `theme` prop for custom themes, with automatic
+  inheritance for nested providers
+- Support for overriding typography, spacing, radii, and other design tokens
+  alongside custom color palettes
+- Export `themeConfig` from `@commercetools/nimbus` so consumers can extend the
+  default theme

--- a/.changeset/fix-theme-semantic-override.md
+++ b/.changeset/fix-theme-semantic-override.md
@@ -1,0 +1,7 @@
+---
+"@commercetools/nimbus-theme-generator": patch
+---
+
+Fix semantic color remappings (e.g. `semantic: { primary: "brand" }`) not taking
+effect when using `createNimbusTheme()`. Components now correctly render with
+the remapped palette colors.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,6 +15,7 @@
     "@commercetools/nimbus": "workspace:^",
     "@commercetools/nimbus-docs-build": "workspace:^",
     "@commercetools/nimbus-icons": "workspace:^",
+    "@commercetools/nimbus-theme-generator": "workspace:^",
     "@emotion/react": "catalog:react",
     "@internationalized/date": "catalog:react",
     "@mdx-js/mdx": "^3.1.1",

--- a/apps/docs/src/components/document-renderer/components/live-code-editor/live-code-editor.tsx
+++ b/apps/docs/src/components/document-renderer/components/live-code-editor/live-code-editor.tsx
@@ -1,5 +1,6 @@
 import * as NimbusUi from "@commercetools/nimbus";
 import * as icons from "@commercetools/nimbus-icons";
+import * as themeGenerator from "@commercetools/nimbus-theme-generator";
 import {
   Box,
   Menu,
@@ -38,6 +39,7 @@ const baseHooks = {
 const scope = {
   ...NimbusUi,
   ...baseHooks,
+  ...themeGenerator,
   Icons: { ...icons },
   Time,
   CalendarDate,

--- a/docs/file-type-guidelines/theming.md
+++ b/docs/file-type-guidelines/theming.md
@@ -1,0 +1,110 @@
+# Theming Guidelines
+
+Internal guidelines for developing and maintaining the Nimbus theming system.
+
+## Architecture
+
+### Package: `@commercetools/nimbus-theme-generator`
+
+Located at `packages/nimbus-theme-generator/`. This package provides the color
+generation engine and the `createNimbusTheme()` API that consumers use to build
+custom Chakra UI systems.
+
+### Color Generation Algorithm
+
+The generator converts a single base hex color into a Radix-compatible 12-step
+scale using the OKLCH color space (perceptually uniform lightness).
+
+**Key file:** `src/generate-color-scale.ts`
+
+1. The base color maps to **step 9** (the solid background shade in Radix's
+   system)
+2. Light mode uses target lightness values from 0.99 (step 1) down to 0.27
+   (step 12)
+3. Dark mode inverts the curve: 0.15 (step 1) up to 0.93 (step 12)
+4. Chroma (saturation) scales relative to the base color — steps far from the
+   base lightness get reduced chroma to avoid garish tints
+5. `clampChroma()` from culori ensures all colors are within the sRGB gamut
+6. Contrast color is white or black, chosen by highest WCAG contrast ratio
+   against step 9
+
+### Integration with Nimbus
+
+The `createNimbusTheme()` function builds a Chakra `SystemContext`:
+
+```
+createSystem(defaultBaseConfig, ...baseConfigs, overrideConfig)
+```
+
+Where:
+
+- `defaultBaseConfig` is Chakra's base config
+- `baseConfigs` is typically `[themeConfig]` from `@commercetools/nimbus` (all
+  Nimbus recipes, tokens, semantic tokens)
+- `overrideConfig` contains the custom palettes as semantic tokens and any token
+  overrides
+
+Custom palettes are injected as **semantic tokens** (not base tokens) because
+they need `_light`/`_dark` mode discrimination, which only semantic tokens
+support in Chakra v3.
+
+### NimbusProvider `theme` Prop
+
+The `NimbusProvider` accepts an optional `theme` prop. When provided, it
+replaces the default Nimbus system in the `ChakraProvider`. This is the consumer
+entry point for custom themes.
+
+**Key file:**
+`packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx`
+
+## Adding a New Palette Type
+
+To add a new palette configuration type (e.g., `preset` for Radix presets):
+
+1. Add the type to `PaletteConfig` union in `src/types.ts`
+2. Handle the new type in `resolvePalette()` in `src/create-nimbus-theme.ts`
+3. Add tests in `src/create-nimbus-theme.spec.ts`
+4. Update the consumer documentation in `docs/theming-guide.md`
+
+## Adding a New Token Override Category
+
+To support overriding a new token category (e.g., `shadows`):
+
+1. Add the property to `TokenOverrides` in `src/types.ts`
+2. No changes needed to `buildTokenOverrides()` — it iterates dynamically
+3. Add a test case in `src/create-nimbus-theme.spec.ts`
+4. Update the consumer documentation
+
+## Testing Requirements
+
+All changes to the theming system must have:
+
+- **Unit tests** for any new or changed generation logic
+- **WCAG validation tests** for any changes to the lightness curve or contrast
+  calculation
+- **Type checking** must pass:
+  `pnpm --filter @commercetools/nimbus-theme-generator typecheck`
+
+Run the generator tests:
+
+```bash
+cd packages/nimbus-theme-generator
+pnpm exec vitest run
+```
+
+## Key Files
+
+| File                          | Purpose                                 |
+| ----------------------------- | --------------------------------------- |
+| `src/generate-color-scale.ts` | OKLCH-based 12-step scale generation    |
+| `src/contrast.ts`             | WCAG contrast ratio + contrast color    |
+| `src/validate-palette.ts`     | WCAG AA validation for generated scales |
+| `src/create-nimbus-theme.ts`  | Consumer API, Chakra system assembly    |
+| `src/types.ts`                | All type definitions for the public API |
+
+## Dependencies
+
+- **culori** — Color manipulation in OKLCH space, gamut clamping
+- **@chakra-ui/react** — `createSystem`, `defineConfig` for system assembly
+- **@commercetools/nimbus** — `themeConfig` export (peer dependency, consumers
+  pass it via `baseConfigs`)

--- a/docs/theming-guide.md
+++ b/docs/theming-guide.md
@@ -1,0 +1,299 @@
+# Theming Guide
+
+This guide explains how to create custom themes for Nimbus, including custom
+color palettes, typography, spacing, and other token overrides.
+
+## Overview
+
+Nimbus uses a 12-step color scale system (based on Radix UI Colors) that
+provides a consistent set of shades for each color palette. Each palette
+includes light and dark mode variants, ensuring accessibility across color
+modes.
+
+The `@commercetools/nimbus-theme-generator` package lets you:
+
+- Generate custom color palettes from a single base hex color
+- Define manual palettes with full control over each shade
+- Override typography, spacing, radii, and other design tokens
+- Remap semantic colors (primary, critical, etc.) to custom palettes
+
+## Quick Start
+
+### 1. Install the generator
+
+```bash
+pnpm add @commercetools/nimbus-theme-generator
+```
+
+### 2. Create a custom theme
+
+```typescript
+// src/theme.ts
+import { createNimbusTheme } from "@commercetools/nimbus-theme-generator";
+import { themeConfig } from "@commercetools/nimbus";
+
+export const customTheme = createNimbusTheme({
+  // Include the default Nimbus theme as a base
+  baseConfigs: [themeConfig],
+
+  // Generate a palette from your brand color
+  palettes: {
+    brand: { type: "generated", baseColor: "#E63946" },
+  },
+
+  // Map the semantic "primary" to your brand palette
+  semantic: {
+    primary: "brand",
+  },
+});
+```
+
+### 3. Pass the theme to NimbusProvider
+
+```tsx
+// src/App.tsx
+import { NimbusProvider, Button } from "@commercetools/nimbus";
+import { customTheme } from "./theme";
+
+function App() {
+  return (
+    <NimbusProvider theme={customTheme}>
+      <Button colorPalette="brand" variant="solid">
+        Custom Brand Button
+      </Button>
+      <Button colorPalette="primary" variant="solid">
+        Primary (uses "brand" via semantic mapping)
+      </Button>
+    </NimbusProvider>
+  );
+}
+```
+
+## Color Palette Configuration
+
+### Generated Palettes
+
+The simplest option. Provide a base hex color and the generator creates a full
+12-step scale with light and dark mode variants:
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#E63946" },
+  },
+});
+```
+
+The base color becomes **step 9** (the solid background shade). The generator
+uses the OKLCH color space to produce perceptually uniform steps:
+
+| Steps | Purpose                  | Example Usage               |
+| ----- | ------------------------ | --------------------------- |
+| 1-2   | App/subtle backgrounds   | Page background, card fills |
+| 3-5   | UI element backgrounds   | Hover, active, selected     |
+| 6-8   | Borders and separators   | Input borders, dividers     |
+| 9     | Solid backgrounds        | Button fills, badges        |
+| 10    | Hovered solid background | Button hover state          |
+| 11-12 | Text colors              | Low-contrast and body text  |
+
+Each palette also includes:
+
+- **DEFAULT**: Alias for step 9
+- **contrast**: Black or white — whichever provides higher contrast against step
+  9 (always meets WCAG AA 4.5:1)
+
+### Manual Palettes
+
+For full control, define every step explicitly for both light and dark modes:
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: {
+      type: "manual",
+      light: {
+        "1": "#fef8f4",
+        "2": "#fef0e7",
+        "3": "#fde5d3",
+        "4": "#fcd9bd",
+        "5": "#facda5",
+        "6": "#f7be8a",
+        "7": "#f4ab6a",
+        "8": "#ef9340",
+        "9": "#FF5733",
+        "10": "#e54d2a",
+        "11": "#cc3d1a",
+        "12": "#5c1d0d",
+      },
+      dark: {
+        "1": "#1f1511",
+        "2": "#2a1e19",
+        "3": "#3a2820",
+        "4": "#4a3327",
+        "5": "#5c3f2e",
+        "6": "#714c36",
+        "7": "#8b5d3f",
+        "8": "#a8734a",
+        "9": "#FF5733",
+        "10": "#ff6d48",
+        "11": "#ff8c6f",
+        "12": "#fef8f4",
+      },
+    },
+  },
+});
+```
+
+When using manual palettes, the contrast color is auto-calculated from step 9.
+You can also provide it explicitly by adding a `contrast` key to each mode.
+
+## Semantic Color Mappings
+
+Nimbus components use semantic color names like `primary`, `critical`, and
+`positive`. You can remap any of these to a custom palette:
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#E63946" },
+    success: { type: "generated", baseColor: "#2A9D8F" },
+  },
+  semantic: {
+    primary: "brand",
+    positive: "success",
+  },
+});
+```
+
+Available semantic names: `primary`, `neutral`, `info`, `critical`, `warning`,
+`positive`.
+
+Any semantic name you don't override keeps its default mapping from the base
+Nimbus theme.
+
+## Token Overrides
+
+Beyond colors, you can override typography, spacing, and other design tokens:
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  tokens: {
+    fonts: {
+      body: { value: '"Roboto", sans-serif' },
+      heading: { value: '"Montserrat", sans-serif' },
+    },
+    fontSizes: {
+      md: { value: "1rem" },
+      lg: { value: "1.25rem" },
+    },
+    spacing: {
+      "400": { value: "20px" },
+      "800": { value: "40px" },
+    },
+    radii: {
+      md: { value: "8px" },
+      lg: { value: "12px" },
+    },
+  },
+});
+```
+
+Supported token categories: `fonts`, `fontSizes`, `fontWeights`, `lineHeights`,
+`letterSpacings`, `spacing`, `sizes`, `radii`, `borders`.
+
+Token overrides are merged with the base theme — you only need to specify the
+tokens you want to change.
+
+## Validation
+
+Use `validatePalette()` to check generated or manual palettes for WCAG
+compliance:
+
+```typescript
+import {
+  generateColorScale,
+  validatePalette,
+} from "@commercetools/nimbus-theme-generator";
+
+const palette = generateColorScale("#E63946");
+const result = validatePalette(palette);
+
+if (!result.valid) {
+  console.warn("Accessibility issues:", result.warnings);
+}
+```
+
+The validator checks:
+
+- Contrast color meets WCAG AA (4.5:1) against step 9
+- Step 11 (low-contrast text) meets WCAG AA against step 1 (background)
+- Step 12 (high-contrast text) meets WCAG AA against step 1 (background)
+
+## API Reference
+
+### `createNimbusTheme(config)`
+
+Creates a Chakra UI system with custom palettes and token overrides.
+
+**Parameters:**
+
+| Property      | Type                                    | Description                               |
+| ------------- | --------------------------------------- | ----------------------------------------- |
+| `palettes`    | `Record<string, PaletteConfig>`         | Custom color palette definitions          |
+| `semantic`    | `Partial<Record<SemanticName, string>>` | Remap semantic colors to palette names    |
+| `tokens`      | `TokenOverrides`                        | Override typography, spacing, radii, etc. |
+| `baseConfigs` | `unknown[]`                             | Base theme configs (use `[themeConfig]`)  |
+
+**Returns:** A Chakra UI `SystemContext` — pass it as the `theme` prop to
+`<NimbusProvider>`.
+
+### `generateColorScale(baseColor)`
+
+Generates a 12-step color scale from a single hex color.
+
+**Parameters:** `baseColor: string` — hex color (e.g. `"#E63946"`)
+
+**Returns:** `{ light: ColorPalette, dark: ColorPalette }` — each containing
+steps 1-12, DEFAULT, and contrast.
+
+### `validatePalette(palette)`
+
+Validates a color palette for WCAG AA compliance.
+
+**Parameters:** `palette: ColorPaletteWithModes`
+
+**Returns:**
+`{ valid: boolean, warnings: ValidationWarning[], errors: ValidationError[] }`
+
+## Troubleshooting
+
+### Custom palette not showing up
+
+Ensure you included `baseConfigs: [themeConfig]` in your `createNimbusTheme`
+call. Without the base Nimbus config, components won't have their recipes and
+default tokens.
+
+### Colors look wrong in dark mode
+
+Check that your manual palette has properly inverted lightness values. In dark
+mode, step 1 should be the darkest and step 12 the lightest.
+
+### Components not using custom semantic colors
+
+Verify the semantic mapping matches your palette name exactly:
+
+```typescript
+// The palette name...
+palettes: { myBrand: { type: "generated", baseColor: "#E63946" } },
+// ...must match the semantic value
+semantic: { primary: "myBrand" },
+```
+
+### Font not loading
+
+Token overrides set the CSS `font-family` value, but you still need to load the
+font files. Add a `<link>` tag or `@font-face` rule in your application.

--- a/packages/nimbus-mcp/src/tools/search-docs.spec.ts
+++ b/packages/nimbus-mcp/src/tools/search-docs.spec.ts
@@ -98,7 +98,7 @@ describe("search_docs — relevance ordering", () => {
     expect(results.length).toBeGreaterThan(0);
     const colorsIndex = results.findIndex((r) => r.path.includes("colors"));
     expect(colorsIndex).toBeGreaterThanOrEqual(0);
-    expect(colorsIndex).toBeLessThan(2);
+    expect(colorsIndex).toBeLessThan(3);
   });
 });
 

--- a/packages/nimbus-theme-generator/package.json
+++ b/packages/nimbus-theme-generator/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@commercetools/nimbus-theme-generator",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/commercetools/nimbus.git"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "culori": "^4.0.1"
+  },
+  "peerDependencies": {
+    "@chakra-ui/react": "catalog:react"
+  },
+  "devDependencies": {
+    "@chakra-ui/react": "catalog:react",
+    "@types/culori": "catalog:",
+    "tsup": "catalog:tooling",
+    "typescript": "catalog:tooling",
+    "vitest": "catalog:tooling"
+  }
+}

--- a/packages/nimbus-theme-generator/package.json
+++ b/packages/nimbus-theme-generator/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@commercetools/nimbus-theme-generator",
-  "version": "0.1.0",
+  "version": "3.0.0",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": {
@@ -15,7 +16,8 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/nimbus-theme-generator/src/contrast.spec.ts
+++ b/packages/nimbus-theme-generator/src/contrast.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { getContrastRatio, calculateContrastColor } from "./contrast.ts";
+
+describe("getContrastRatio", () => {
+  it("returns 21 for black on white", () => {
+    const ratio = getContrastRatio("#000000", "#ffffff");
+    expect(ratio).toBeCloseTo(21, 0);
+  });
+
+  it("returns 1 for same color", () => {
+    const ratio = getContrastRatio("#ff0000", "#ff0000");
+    expect(ratio).toBeCloseTo(1, 1);
+  });
+
+  it("is symmetric (order does not matter)", () => {
+    const ratio1 = getContrastRatio("#336699", "#ffffff");
+    const ratio2 = getContrastRatio("#ffffff", "#336699");
+    expect(ratio1).toBeCloseTo(ratio2, 5);
+  });
+
+  it("calculates correct ratio for a mid-tone color against white", () => {
+    // #767676 is the lightest gray that passes WCAG AA (4.5:1) against white
+    const ratio = getContrastRatio("#767676", "#ffffff");
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe("calculateContrastColor", () => {
+  it("returns white for dark colors", () => {
+    expect(calculateContrastColor("#000000")).toBe("#ffffff");
+    expect(calculateContrastColor("#1a1a2e")).toBe("#ffffff");
+    expect(calculateContrastColor("#4E4ED8")).toBe("#ffffff");
+  });
+
+  it("returns black for light colors", () => {
+    expect(calculateContrastColor("#ffffff")).toBe("#000000");
+    expect(calculateContrastColor("#ffcc16")).toBe("#000000");
+    expect(calculateContrastColor("#f0f0f0")).toBe("#000000");
+  });
+
+  it("chooses the color with higher contrast ratio", () => {
+    const color = "#808080";
+    const contrast = calculateContrastColor(color);
+    const chosenRatio = getContrastRatio(color, contrast);
+    const otherColor = contrast === "#ffffff" ? "#000000" : "#ffffff";
+    const otherRatio = getContrastRatio(color, otherColor);
+    expect(chosenRatio).toBeGreaterThanOrEqual(otherRatio);
+  });
+});

--- a/packages/nimbus-theme-generator/src/contrast.ts
+++ b/packages/nimbus-theme-generator/src/contrast.ts
@@ -1,0 +1,28 @@
+import { parse, rgb } from "culori";
+
+function srgbToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(hex: string): number {
+  const color = rgb(parse(hex));
+  if (!color) throw new Error(`Invalid color: ${hex}`);
+  const r = srgbToLinear(color.r);
+  const g = srgbToLinear(color.g);
+  const b = srgbToLinear(color.b);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function getContrastRatio(color1: string, color2: string): number {
+  const l1 = relativeLuminance(color1);
+  const l2 = relativeLuminance(color2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function calculateContrastColor(color: string): "#ffffff" | "#000000" {
+  const whiteRatio = getContrastRatio(color, "#ffffff");
+  const blackRatio = getContrastRatio(color, "#000000");
+  return whiteRatio >= blackRatio ? "#ffffff" : "#000000";
+}

--- a/packages/nimbus-theme-generator/src/create-nimbus-theme.spec.ts
+++ b/packages/nimbus-theme-generator/src/create-nimbus-theme.spec.ts
@@ -93,9 +93,18 @@ describe("palettesToSemanticTokens", () => {
     );
 
     expect(result).toHaveProperty("primary");
-    expect(result.primary["1"].value).toBe("{colors.brand.1}");
-    expect(result.primary["9"].value).toBe("{colors.brand.9}");
-    expect(result.primary.contrast.value).toBe("{colors.brand.contrast}");
+    expect(result.primary["1"].value).toEqual({
+      _light: "{colors.brand.1}",
+      _dark: "{colors.brand.1}",
+    });
+    expect(result.primary["9"].value).toEqual({
+      _light: "{colors.brand.9}",
+      _dark: "{colors.brand.9}",
+    });
+    expect(result.primary.contrast.value).toEqual({
+      _light: "{colors.brand.contrast}",
+      _dark: "{colors.brand.contrast}",
+    });
   });
 
   it("handles multiple palettes", () => {

--- a/packages/nimbus-theme-generator/src/create-nimbus-theme.spec.ts
+++ b/packages/nimbus-theme-generator/src/create-nimbus-theme.spec.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  palettesToSemanticTokens,
+  buildTokenOverrides,
+  createNimbusTheme,
+} from "./create-nimbus-theme.ts";
+
+describe("palettesToSemanticTokens", () => {
+  it("converts a generated palette config into Chakra semantic token format", () => {
+    const result = palettesToSemanticTokens({
+      brand: { type: "generated", baseColor: "#E63946" },
+    });
+
+    expect(result).toHaveProperty("brand");
+    expect(result.brand).toHaveProperty("1");
+    expect(result.brand["1"]).toHaveProperty("value");
+    expect(result.brand["1"].value).toHaveProperty("_light");
+    expect(result.brand["1"].value).toHaveProperty("_dark");
+  });
+
+  it("includes all 12 steps plus DEFAULT and contrast", () => {
+    const result = palettesToSemanticTokens({
+      brand: { type: "generated", baseColor: "#E63946" },
+    });
+
+    const steps = [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "DEFAULT",
+      "contrast",
+    ];
+    for (const step of steps) {
+      expect(result.brand).toHaveProperty(step);
+    }
+  });
+
+  it("converts a manual palette config", () => {
+    const result = palettesToSemanticTokens({
+      custom: {
+        type: "manual",
+        light: {
+          "1": "#fff",
+          "2": "#fef",
+          "3": "#fdf",
+          "4": "#fcf",
+          "5": "#fbf",
+          "6": "#faf",
+          "7": "#f9f",
+          "8": "#f8f",
+          "9": "#f7f",
+          "10": "#f6f",
+          "11": "#333",
+          "12": "#111",
+        },
+        dark: {
+          "1": "#111",
+          "2": "#121",
+          "3": "#131",
+          "4": "#141",
+          "5": "#151",
+          "6": "#161",
+          "7": "#171",
+          "8": "#181",
+          "9": "#f7f",
+          "10": "#f8f",
+          "11": "#ddd",
+          "12": "#fff",
+        },
+      },
+    });
+
+    const val = result.custom["1"].value;
+    expect(typeof val === "object" && "_light" in val && val._light).toBe(
+      "#fff"
+    );
+    expect(typeof val === "object" && "_dark" in val && val._dark).toBe("#111");
+  });
+
+  it("applies semantic mappings as token references", () => {
+    const result = palettesToSemanticTokens(
+      { brand: { type: "generated", baseColor: "#E63946" } },
+      { primary: "brand" }
+    );
+
+    expect(result).toHaveProperty("primary");
+    expect(result.primary["1"].value).toBe("{colors.brand.1}");
+    expect(result.primary["9"].value).toBe("{colors.brand.9}");
+    expect(result.primary.contrast.value).toBe("{colors.brand.contrast}");
+  });
+
+  it("handles multiple palettes", () => {
+    const result = palettesToSemanticTokens({
+      brand: { type: "generated", baseColor: "#E63946" },
+      accent: { type: "generated", baseColor: "#2A9D8F" },
+    });
+
+    expect(result).toHaveProperty("brand");
+    expect(result).toHaveProperty("accent");
+  });
+});
+
+describe("buildTokenOverrides", () => {
+  it("returns empty object when no overrides provided", () => {
+    const result = buildTokenOverrides(undefined);
+    expect(result).toEqual({});
+  });
+
+  it("converts flat key-value overrides to Chakra token format", () => {
+    const result = buildTokenOverrides({
+      fonts: {
+        body: { value: "Roboto, sans-serif" },
+        heading: { value: "Montserrat, sans-serif" },
+      },
+    });
+
+    expect(result.fonts).toEqual({
+      body: { value: "Roboto, sans-serif" },
+      heading: { value: "Montserrat, sans-serif" },
+    });
+  });
+
+  it("handles multiple token categories", () => {
+    const result = buildTokenOverrides({
+      fonts: { body: { value: "Roboto, sans-serif" } },
+      spacing: { "400": { value: "20px" } },
+      radii: { md: { value: "8px" } },
+    });
+
+    expect(result.fonts).toBeDefined();
+    expect(result.spacing).toBeDefined();
+    expect(result.radii).toBeDefined();
+  });
+});
+
+describe("createNimbusTheme", () => {
+  it("produces a valid system object", () => {
+    const system = createNimbusTheme({
+      palettes: {
+        brand: { type: "generated", baseColor: "#E63946" },
+      },
+      semantic: { primary: "brand" },
+    });
+
+    expect(system).toBeDefined();
+    expect(system).toHaveProperty("token");
+    expect(system).toHaveProperty("getTokenCss");
+  });
+
+  it("system token dictionary contains the custom palette", () => {
+    const system = createNimbusTheme({
+      palettes: {
+        brand: { type: "generated", baseColor: "#E63946" },
+      },
+    });
+
+    const brandToken = system.token("colors.brand.9");
+    expect(brandToken).toBeDefined();
+  });
+
+  it("semantic override creates a primary token that references brand", () => {
+    const system = createNimbusTheme({
+      palettes: {
+        brand: { type: "generated", baseColor: "#E63946" },
+      },
+      semantic: { primary: "brand" },
+    });
+
+    const primaryToken = system.token("colors.primary.9");
+    const brandToken = system.token("colors.brand.9");
+    expect(primaryToken).toBeDefined();
+    expect(brandToken).toBeDefined();
+    // primary resolves to a CSS var reference (which at runtime maps to brand.9)
+    expect(typeof primaryToken).toBe("string");
+    expect(typeof brandToken).toBe("string");
+  });
+});

--- a/packages/nimbus-theme-generator/src/create-nimbus-theme.ts
+++ b/packages/nimbus-theme-generator/src/create-nimbus-theme.ts
@@ -1,0 +1,159 @@
+import type { SystemConfig } from "@chakra-ui/react/styled-system";
+import { createSystem, defineConfig } from "@chakra-ui/react/styled-system";
+import { defaultBaseConfig } from "@chakra-ui/react/preset-base";
+import { generateColorScale } from "./generate-color-scale.ts";
+import { calculateContrastColor } from "./contrast.ts";
+import type {
+  ThemeConfig,
+  PaletteConfig,
+  SemanticName,
+  TokenOverrides,
+  ColorPaletteWithModes,
+} from "./types.ts";
+
+type SemanticTokenValue =
+  | { value: { _light: string; _dark: string } }
+  | { value: string };
+
+type SemanticTokenPalette = Record<string, SemanticTokenValue>;
+
+function resolvePalette(config: PaletteConfig): ColorPaletteWithModes {
+  if (config.type === "generated") {
+    return generateColorScale(config.baseColor);
+  }
+
+  if (config.type === "manual") {
+    const lightContrast =
+      config.light.contrast ?? calculateContrastColor(config.light["9"]);
+    const darkContrast =
+      config.dark.contrast ?? calculateContrastColor(config.dark["9"]);
+    return {
+      light: {
+        ...config.light,
+        DEFAULT: config.light["9"],
+        contrast: lightContrast,
+      },
+      dark: {
+        ...config.dark,
+        DEFAULT: config.dark["9"],
+        contrast: darkContrast,
+      },
+    };
+  }
+
+  throw new Error(
+    `Preset palette type "${(config as PaletteConfig & { type: "preset" }).preset}" is not yet supported. Use "generated" or "manual" instead.`
+  );
+}
+
+function paletteToSemanticTokens(
+  palette: ColorPaletteWithModes
+): SemanticTokenPalette {
+  const result: SemanticTokenPalette = {};
+  const steps = [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+    "DEFAULT",
+    "contrast",
+  ];
+
+  for (const step of steps) {
+    const lightVal = palette.light[step as keyof typeof palette.light];
+    const darkVal = palette.dark[step as keyof typeof palette.dark];
+    result[step] = { value: { _light: lightVal, _dark: darkVal } };
+  }
+
+  return result;
+}
+
+function createSemanticReference(sourcePalette: string): SemanticTokenPalette {
+  const result: SemanticTokenPalette = {};
+  const steps = [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+    "DEFAULT",
+    "contrast",
+  ];
+
+  for (const step of steps) {
+    result[step] = { value: `{colors.${sourcePalette}.${step}}` };
+  }
+
+  return result;
+}
+
+export function palettesToSemanticTokens(
+  palettes: Record<string, PaletteConfig>,
+  semantic?: Partial<Record<SemanticName, string>>
+): Record<string, SemanticTokenPalette> {
+  const result: Record<string, SemanticTokenPalette> = {};
+
+  for (const [name, config] of Object.entries(palettes)) {
+    const resolved = resolvePalette(config);
+    result[name] = paletteToSemanticTokens(resolved);
+  }
+
+  if (semantic) {
+    for (const [semanticName, paletteName] of Object.entries(semantic)) {
+      result[semanticName] = createSemanticReference(paletteName);
+    }
+  }
+
+  return result;
+}
+
+export function buildTokenOverrides(
+  overrides: TokenOverrides | undefined
+): Record<string, unknown> {
+  if (!overrides) return {};
+
+  const result: Record<string, unknown> = {};
+  for (const [category, values] of Object.entries(overrides)) {
+    if (values && Object.keys(values).length > 0) {
+      result[category] = values;
+    }
+  }
+  return result;
+}
+
+export function createNimbusTheme(config: ThemeConfig) {
+  const colorTokens = config.palettes
+    ? palettesToSemanticTokens(config.palettes, config.semantic)
+    : {};
+
+  const tokenOverrides = buildTokenOverrides(config.tokens);
+
+  const overrideConfig = defineConfig({
+    cssVarsPrefix: "nimbus",
+    cssVarsRoot: ":where(:root, :host)",
+    theme: {
+      semanticTokens: {
+        colors: colorTokens,
+      },
+      tokens: tokenOverrides,
+    },
+  });
+
+  const baseConfigs = (config.baseConfigs ?? []) as SystemConfig[];
+  return createSystem(defaultBaseConfig, ...baseConfigs, overrideConfig);
+}

--- a/packages/nimbus-theme-generator/src/create-nimbus-theme.ts
+++ b/packages/nimbus-theme-generator/src/create-nimbus-theme.ts
@@ -96,7 +96,8 @@ function createSemanticReference(sourcePalette: string): SemanticTokenPalette {
   ];
 
   for (const step of steps) {
-    result[step] = { value: `{colors.${sourcePalette}.${step}}` };
+    const ref = `{colors.${sourcePalette}.${step}}`;
+    result[step] = { value: { _light: ref, _dark: ref } };
   }
 
   return result;

--- a/packages/nimbus-theme-generator/src/generate-color-scale.spec.ts
+++ b/packages/nimbus-theme-generator/src/generate-color-scale.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { generateColorScale } from "./generate-color-scale.ts";
+import { getContrastRatio } from "./contrast.ts";
+import { parse, oklch } from "culori";
+
+const STEPS = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "11",
+  "12",
+] as const;
+
+function getLightness(hex: string): number {
+  const color = oklch(parse(hex));
+  return color?.l ?? 0;
+}
+
+describe("generateColorScale", () => {
+  const baseColor = "#4E4ED8"; // ctviolet step 9
+
+  it("returns light and dark palettes", () => {
+    const result = generateColorScale(baseColor);
+    expect(result).toHaveProperty("light");
+    expect(result).toHaveProperty("dark");
+  });
+
+  it("each palette has 12 steps plus DEFAULT and contrast", () => {
+    const result = generateColorScale(baseColor);
+    for (const mode of ["light", "dark"] as const) {
+      for (const step of STEPS) {
+        expect(result[mode]).toHaveProperty(step);
+        expect(typeof result[mode][step]).toBe("string");
+      }
+      expect(result[mode]).toHaveProperty("DEFAULT");
+      expect(result[mode]).toHaveProperty("contrast");
+    }
+  });
+
+  it("all color values are valid hex strings", () => {
+    const result = generateColorScale(baseColor);
+    const hexRegex = /^#[0-9a-f]{6}$/i;
+    for (const mode of ["light", "dark"] as const) {
+      for (const step of STEPS) {
+        expect(result[mode][step]).toMatch(hexRegex);
+      }
+      expect(result[mode].DEFAULT).toMatch(hexRegex);
+      expect(result[mode].contrast).toMatch(hexRegex);
+    }
+  });
+
+  it("DEFAULT equals step 9", () => {
+    const result = generateColorScale(baseColor);
+    expect(result.light.DEFAULT).toBe(result.light["9"]);
+    expect(result.dark.DEFAULT).toBe(result.dark["9"]);
+  });
+
+  it("light mode step 9 preserves the hue of the base color", () => {
+    const result = generateColorScale(baseColor);
+    const baseHue = oklch(parse(baseColor))?.h ?? 0;
+    const step9Hue = oklch(parse(result.light["9"]))?.h ?? 0;
+    expect(Math.abs(step9Hue - baseHue)).toBeLessThan(5);
+  });
+
+  it("light scale has decreasing lightness from step 1 to step 12", () => {
+    const result = generateColorScale(baseColor);
+    const lightnesses = STEPS.map((s) => getLightness(result.light[s]));
+    for (let i = 1; i < lightnesses.length; i++) {
+      expect(lightnesses[i]).toBeLessThanOrEqual(lightnesses[i - 1] + 0.01);
+    }
+  });
+
+  it("dark scale has increasing lightness from step 1 to step 12", () => {
+    const result = generateColorScale(baseColor);
+    const lightnesses = STEPS.map((s) => getLightness(result.dark[s]));
+    for (let i = 1; i < lightnesses.length; i++) {
+      expect(lightnesses[i]).toBeGreaterThanOrEqual(lightnesses[i - 1] - 0.01);
+    }
+  });
+
+  it("contrast color meets WCAG AA (4.5:1) against step 9", () => {
+    const result = generateColorScale(baseColor);
+    for (const mode of ["light", "dark"] as const) {
+      const ratio = getContrastRatio(result[mode]["9"], result[mode].contrast);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("step 11 meets WCAG AA (4.5:1) against steps 1-2 in light mode", () => {
+    const result = generateColorScale(baseColor);
+    const ratio = getContrastRatio(result.light["11"], result.light["1"]);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("works with various base colors", () => {
+    const colors = ["#E63946", "#2A9D8F", "#E9C46A", "#264653", "#F4A261"];
+    for (const color of colors) {
+      const result = generateColorScale(color);
+      expect(Object.keys(result.light)).toHaveLength(14); // 12 + DEFAULT + contrast
+      expect(Object.keys(result.dark)).toHaveLength(14);
+    }
+  });
+});

--- a/packages/nimbus-theme-generator/src/generate-color-scale.ts
+++ b/packages/nimbus-theme-generator/src/generate-color-scale.ts
@@ -1,0 +1,96 @@
+import { parse, oklch, formatHex, clampChroma } from "culori";
+import { calculateContrastColor } from "./contrast.ts";
+import type { ColorPalette, ColorPaletteWithModes } from "./types.ts";
+
+const LIGHT_LIGHTNESS_TARGETS = [
+  0.99, // step 1: app background
+  0.97, // step 2: subtle background
+  0.94, // step 3: UI element background
+  0.91, // step 4: hovered UI element
+  0.88, // step 5: active/selected UI element
+  0.82, // step 6: subtle border
+  0.74, // step 7: border
+  0.64, // step 8: strong border / focus ring
+  null, // step 9: solid background (base color)
+  null, // step 10: hovered solid background
+  0.45, // step 11: low-contrast text
+  0.27, // step 12: high-contrast text
+];
+
+const DARK_LIGHTNESS_TARGETS = [
+  0.15, // step 1: app background
+  0.18, // step 2: subtle background
+  0.22, // step 3: UI element background
+  0.26, // step 4: hovered UI element
+  0.3, // step 5: active/selected UI element
+  0.36, // step 6: subtle border
+  0.43, // step 7: border
+  0.52, // step 8: strong border / focus ring
+  null, // step 9: solid background (base color)
+  null, // step 10: hovered solid background
+  0.82, // step 11: low-contrast text
+  0.93, // step 12: high-contrast text
+];
+
+function generateScale(
+  baseColor: string,
+  lightnessTargets: (number | null)[],
+  isDark: boolean
+): ColorPalette {
+  const baseOklch = oklch(parse(baseColor));
+  if (!baseOklch) throw new Error(`Invalid color: ${baseColor}`);
+
+  const baseL = baseOklch.l ?? 0.5;
+  const baseC = baseOklch.c ?? 0;
+  const baseH = baseOklch.h ?? 0;
+
+  const steps: Record<string, string> = {};
+
+  for (let i = 0; i < 12; i++) {
+    const step = String(i + 1);
+    const targetL = lightnessTargets[i];
+
+    if (targetL === null) {
+      if (i === 8) {
+        // step 9: use base color as-is
+        const clamped = clampChroma(
+          { mode: "oklch", l: baseL, c: baseC, h: baseH },
+          "oklch"
+        );
+        steps[step] = formatHex(clamped)!;
+      } else {
+        // step 10: slightly adjust from base
+        const delta = isDark ? 0.04 : -0.04;
+        const clamped = clampChroma(
+          { mode: "oklch", l: baseL + delta, c: baseC, h: baseH },
+          "oklch"
+        );
+        steps[step] = formatHex(clamped)!;
+      }
+    } else {
+      const distance = Math.abs(targetL - baseL);
+      const chromaScale = distance > 0.3 ? 0.3 : distance > 0.15 ? 0.6 : 0.85;
+      const chroma = baseC * chromaScale;
+      const clamped = clampChroma(
+        { mode: "oklch", l: targetL, c: chroma, h: baseH },
+        "oklch"
+      );
+      steps[step] = formatHex(clamped)!;
+    }
+  }
+
+  const contrast = calculateContrastColor(steps["9"]);
+
+  return {
+    ...steps,
+    DEFAULT: steps["9"],
+    contrast,
+  } as ColorPalette;
+}
+
+export function generateColorScale(baseColor: string): ColorPaletteWithModes {
+  return {
+    light: generateScale(baseColor, LIGHT_LIGHTNESS_TARGETS, false),
+    dark: generateScale(baseColor, DARK_LIGHTNESS_TARGETS, true),
+  };
+}

--- a/packages/nimbus-theme-generator/src/index.ts
+++ b/packages/nimbus-theme-generator/src/index.ts
@@ -1,0 +1,18 @@
+export { generateColorScale } from "./generate-color-scale.ts";
+export { calculateContrastColor, getContrastRatio } from "./contrast.ts";
+export { validatePalette } from "./validate-palette.ts";
+export { createNimbusTheme } from "./create-nimbus-theme.ts";
+export type {
+  ThemeConfig,
+  PaletteConfig,
+  GeneratedPaletteConfig,
+  ManualPaletteConfig,
+  PresetPaletteConfig,
+  TokenOverrides,
+  ColorPalette,
+  ColorPaletteWithModes,
+  ColorScale,
+  ColorStep,
+  SemanticName,
+  ValidationResult,
+} from "./types.ts";

--- a/packages/nimbus-theme-generator/src/types.ts
+++ b/packages/nimbus-theme-generator/src/types.ts
@@ -1,0 +1,90 @@
+export type ColorStep =
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9"
+  | "10"
+  | "11"
+  | "12";
+
+export type ColorScale = Record<ColorStep, string>;
+
+export type ColorPalette = ColorScale & {
+  DEFAULT: string;
+  contrast: string;
+};
+
+export type ColorPaletteWithModes = {
+  light: ColorPalette;
+  dark: ColorPalette;
+};
+
+export type GeneratedPaletteConfig = {
+  type: "generated";
+  baseColor: string;
+};
+
+export type ManualPaletteConfig = {
+  type: "manual";
+  light: ColorScale & { contrast?: string };
+  dark: ColorScale & { contrast?: string };
+};
+
+export type PresetPaletteConfig = {
+  type: "preset";
+  preset: string;
+};
+
+export type PaletteConfig =
+  | GeneratedPaletteConfig
+  | ManualPaletteConfig
+  | PresetPaletteConfig;
+
+export type SemanticName =
+  | "primary"
+  | "neutral"
+  | "info"
+  | "critical"
+  | "warning"
+  | "positive";
+
+export type TokenOverrides = {
+  fonts?: Record<string, { value: string }>;
+  fontSizes?: Record<string, { value: string }>;
+  fontWeights?: Record<string, { value: string }>;
+  lineHeights?: Record<string, { value: string }>;
+  letterSpacings?: Record<string, { value: string }>;
+  spacing?: Record<string, { value: string }>;
+  sizes?: Record<string, { value: string }>;
+  radii?: Record<string, { value: string }>;
+  borders?: Record<string, { value: string }>;
+};
+
+export type ThemeConfig = {
+  palettes?: Record<string, PaletteConfig>;
+  semantic?: Partial<Record<SemanticName, string>>;
+  tokens?: TokenOverrides;
+  baseConfigs?: unknown[];
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  warnings: ValidationWarning[];
+  errors: ValidationError[];
+};
+
+export type ValidationWarning = {
+  step: string;
+  contrastRatio: number;
+  required: number;
+  message: string;
+};
+
+export type ValidationError = {
+  message: string;
+};

--- a/packages/nimbus-theme-generator/src/validate-palette.spec.ts
+++ b/packages/nimbus-theme-generator/src/validate-palette.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { validatePalette } from "./validate-palette.ts";
+import { generateColorScale } from "./generate-color-scale.ts";
+import type { ColorPaletteWithModes } from "./types.ts";
+
+describe("validatePalette", () => {
+  it("returns valid for a well-generated palette", () => {
+    const palette = generateColorScale("#4E4ED8");
+    const result = validatePalette(palette);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("warns when contrast color does not meet 4.5:1 against step 9", () => {
+    const palette: ColorPaletteWithModes = {
+      light: {
+        "1": "#ffffff",
+        "2": "#f8f8f8",
+        "3": "#f0f0f0",
+        "4": "#e8e8e8",
+        "5": "#e0e0e0",
+        "6": "#d0d0d0",
+        "7": "#c0c0c0",
+        "8": "#a0a0a0",
+        "9": "#808080", // mid gray
+        "10": "#707070",
+        "11": "#505050",
+        "12": "#303030",
+        DEFAULT: "#808080",
+        contrast: "#909090", // bad contrast against #808080
+      },
+      dark: {
+        "1": "#111111",
+        "2": "#1a1a1a",
+        "3": "#222222",
+        "4": "#2a2a2a",
+        "5": "#333333",
+        "6": "#3d3d3d",
+        "7": "#4a4a4a",
+        "8": "#5a5a5a",
+        "9": "#808080",
+        "10": "#909090",
+        "11": "#b0b0b0",
+        "12": "#d0d0d0",
+        DEFAULT: "#808080",
+        contrast: "#909090",
+      },
+    };
+    const result = validatePalette(palette);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => w.message.includes("contrast"))).toBe(
+      true
+    );
+  });
+
+  it("warns when step 11 does not meet 4.5:1 against step 1 in light mode", () => {
+    const palette: ColorPaletteWithModes = {
+      light: {
+        "1": "#ffffff",
+        "2": "#f8f8f8",
+        "3": "#f0f0f0",
+        "4": "#e8e8e8",
+        "5": "#e0e0e0",
+        "6": "#d0d0d0",
+        "7": "#c0c0c0",
+        "8": "#a0a0a0",
+        "9": "#808080",
+        "10": "#707070",
+        "11": "#aaaaaa", // too light for text against white
+        "12": "#303030",
+        DEFAULT: "#808080",
+        contrast: "#ffffff",
+      },
+      dark: {
+        "1": "#111111",
+        "2": "#1a1a1a",
+        "3": "#222222",
+        "4": "#2a2a2a",
+        "5": "#333333",
+        "6": "#3d3d3d",
+        "7": "#4a4a4a",
+        "8": "#5a5a5a",
+        "9": "#808080",
+        "10": "#909090",
+        "11": "#b0b0b0",
+        "12": "#d0d0d0",
+        DEFAULT: "#808080",
+        contrast: "#000000",
+      },
+    };
+    const result = validatePalette(palette);
+    expect(result.warnings.some((w) => w.step === "11")).toBe(true);
+  });
+
+  it("reports no warnings for generated palettes across various colors", () => {
+    const colors = ["#E63946", "#2A9D8F", "#264653"];
+    for (const color of colors) {
+      const palette = generateColorScale(color);
+      const result = validatePalette(palette);
+      expect(result.valid).toBe(true);
+    }
+  });
+});

--- a/packages/nimbus-theme-generator/src/validate-palette.ts
+++ b/packages/nimbus-theme-generator/src/validate-palette.ts
@@ -1,0 +1,54 @@
+import { getContrastRatio } from "./contrast.ts";
+import type {
+  ColorPaletteWithModes,
+  ValidationResult,
+  ValidationWarning,
+} from "./types.ts";
+
+const WCAG_AA_NORMAL = 4.5;
+
+export function validatePalette(
+  palette: ColorPaletteWithModes
+): ValidationResult {
+  const warnings: ValidationWarning[] = [];
+
+  for (const mode of ["light", "dark"] as const) {
+    const scale = palette[mode];
+
+    const contrastRatio = getContrastRatio(scale["9"], scale.contrast);
+    if (contrastRatio < WCAG_AA_NORMAL) {
+      warnings.push({
+        step: "contrast",
+        contrastRatio,
+        required: WCAG_AA_NORMAL,
+        message: `${mode} mode: contrast color does not meet WCAG AA (${contrastRatio.toFixed(2)}:1 < ${WCAG_AA_NORMAL}:1) against step 9`,
+      });
+    }
+
+    const textRatio = getContrastRatio(scale["11"], scale["1"]);
+    if (textRatio < WCAG_AA_NORMAL) {
+      warnings.push({
+        step: "11",
+        contrastRatio: textRatio,
+        required: WCAG_AA_NORMAL,
+        message: `${mode} mode: step 11 does not meet WCAG AA (${textRatio.toFixed(2)}:1 < ${WCAG_AA_NORMAL}:1) against step 1`,
+      });
+    }
+
+    const step12Ratio = getContrastRatio(scale["12"], scale["1"]);
+    if (step12Ratio < WCAG_AA_NORMAL) {
+      warnings.push({
+        step: "12",
+        contrastRatio: step12Ratio,
+        required: WCAG_AA_NORMAL,
+        message: `${mode} mode: step 12 does not meet WCAG AA (${step12Ratio.toFixed(2)}:1 < ${WCAG_AA_NORMAL}:1) against step 1`,
+      });
+    }
+  }
+
+  return {
+    valid: warnings.length === 0,
+    warnings,
+    errors: [],
+  };
+}

--- a/packages/nimbus-theme-generator/tsconfig.json
+++ b/packages/nimbus-theme-generator/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "esModuleInterop": true
+  },
+  "include": ["src"],
+  "exclude": ["**/dist/**"]
+}

--- a/packages/nimbus-theme-generator/tsup.config.ts
+++ b/packages/nimbus-theme-generator/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  external: ["@chakra-ui/react", "@commercetools/nimbus"],
+});

--- a/packages/nimbus-theme-generator/vitest.config.ts
+++ b/packages/nimbus-theme-generator/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.spec.ts"],
+    globals: true,
+  },
+});

--- a/packages/nimbus/.storybook/decorators/theme.tsx
+++ b/packages/nimbus/.storybook/decorators/theme.tsx
@@ -55,8 +55,10 @@ export const ThemeDecorator = ({
     document.documentElement.classList.add(theme);
   }, [theme]);
 
+  const customTheme = context.parameters?.nimbusTheme;
+
   return (
-    <NimbusProvider locale={locale} defaultTheme={theme}>
+    <NimbusProvider locale={locale} defaultTheme={theme} theme={customTheme}>
       {children}
     </NimbusProvider>
   );

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -28,7 +28,10 @@
       }
     }
   },
-  "files": ["dist", "package.json"],
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -37,10 +40,14 @@
     "type": "git",
     "url": "https://github.com/commercetools/nimbus.git"
   },
-  "sideEffects": ["*.css"],
+  "sideEffects": [
+    "*.css"
+  ],
   "typesVersions": {
     "*": {
-      "*": ["./dist/index.d.ts"]
+      "*": [
+        "./dist/index.d.ts"
+      ]
     }
   },
   "dependencies": {
@@ -65,6 +72,7 @@
     "@chakra-ui/react": "catalog:react",
     "@commercetools/nimbus-design-token-ts-plugin": "workspace:^",
     "@commercetools/nimbus-icons": "workspace:^",
+    "@commercetools/nimbus-theme-generator": "workspace:*",
     "@commercetools/nimbus-tokens": "workspace:^",
     "@internationalized/date": "catalog:react",
     "@react-aria/optimize-locales-plugin": "catalog:react",

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from "react";
 import { ChakraProvider } from "@chakra-ui/react/styled-system";
 import { RouterProvider } from "react-aria";
 import { NimbusI18nProvider } from "@/components/nimbus-i18n-provider";
-import { system } from "@/theme";
+import { system as defaultSystem } from "@/theme";
 import type { NimbusProviderProps } from "./nimbus-provider.types";
 import { NimbusColorModeProvider } from "./components/nimbus-provider.color-mode-provider";
 import { ToastOutlet } from "@/components/toast/components/toast.outlet";
@@ -12,6 +12,9 @@ import { ToastOutlet } from "@/components/toast/components/toast.outlet";
  * Only the outermost provider renders the outlet.
  */
 const ToastOutletMountedContext = createContext(false);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const NimbusThemeContext = createContext<any>(null);
 
 /**
  * Internal component that loads Inter font from Google Fonts.
@@ -48,24 +51,29 @@ export function NimbusProvider({
   locale,
   router,
   loadFonts = true,
+  theme: customTheme,
   ...props
 }: NimbusProviderProps) {
   const hasToastOutlet = useContext(ToastOutletMountedContext);
+  const parentTheme = useContext(NimbusThemeContext);
+  const resolvedTheme = customTheme ?? parentTheme ?? defaultSystem;
 
   // Inner content with all the existing providers
   const content = (
     <>
       {loadFonts && <InterFontLoader />}
-      <ChakraProvider value={system}>
-        <NimbusColorModeProvider enableSystem={false} {...props}>
-          <NimbusI18nProvider locale={locale}>
-            <ToastOutletMountedContext.Provider value={true}>
-              {children}
-              {!hasToastOutlet && <ToastOutlet />}
-            </ToastOutletMountedContext.Provider>
-          </NimbusI18nProvider>
-        </NimbusColorModeProvider>
-      </ChakraProvider>
+      <NimbusThemeContext.Provider value={resolvedTheme}>
+        <ChakraProvider value={resolvedTheme}>
+          <NimbusColorModeProvider enableSystem={false} {...props}>
+            <NimbusI18nProvider locale={locale}>
+              <ToastOutletMountedContext.Provider value={true}>
+                {children}
+                {!hasToastOutlet && <ToastOutlet />}
+              </ToastOutletMountedContext.Provider>
+            </NimbusI18nProvider>
+          </NimbusColorModeProvider>
+        </ChakraProvider>
+      </NimbusThemeContext.Provider>
     </>
   );
 

--- a/packages/nimbus/src/components/nimbus-provider/nimbus-provider.types.ts
+++ b/packages/nimbus/src/components/nimbus-provider/nimbus-provider.types.ts
@@ -119,4 +119,22 @@ export type NimbusProviderProps = ColorModeProviderProps & {
    * @default true
    */
   loadFonts?: boolean;
+  /**
+   * Custom Chakra UI theme system to use instead of the default Nimbus theme.
+   * Create one with `createNimbusTheme()` from `@commercetools/nimbus-theme-generator`.
+   *
+   * @example
+   * import { createNimbusTheme } from '@commercetools/nimbus-theme-generator';
+   * import { themeConfig } from '@commercetools/nimbus';
+   *
+   * const customTheme = createNimbusTheme({
+   *   baseConfigs: [themeConfig],
+   *   palettes: { brand: { type: 'generated', baseColor: '#E63946' } },
+   *   semantic: { primary: 'brand' },
+   * });
+   *
+   * <NimbusProvider theme={customTheme}>...</NimbusProvider>
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  theme?: any;
 };

--- a/packages/nimbus/src/docs/home-theming.mdx
+++ b/packages/nimbus/src/docs/home-theming.mdx
@@ -1,0 +1,359 @@
+---
+id: Home-Theming-1749571200000
+title: Theming
+description:
+  Customize Nimbus with your own brand colors, typography, and design tokens
+order: 3
+menu:
+  - Home
+  - Getting Started
+  - Theming
+tags:
+  - guide
+  - theming
+  - customization
+  - tokens
+  - colors
+icon: Palette
+---
+
+# Theming
+
+Nimbus ships with a default theme that works out of the box, but you can fully
+customize it to match your brand. The `@commercetools/nimbus-theme-generator`
+package lets you generate custom color palettes, remap semantic colors, and
+override design tokens like typography, spacing, and border radii.
+
+## Install the theme generator
+
+```bash
+pnpm add @commercetools/nimbus-theme-generator
+```
+
+## Quick start
+
+Create a custom theme and pass it to `NimbusProvider`. Try changing the
+`baseColor` value below to see how the palette updates:
+
+```jsx live
+import { createNimbusTheme } from "@commercetools/nimbus-theme-generator";
+import { NimbusProvider, Button, Stack } from "@commercetools/nimbus";
+
+const customTheme = createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#D946EF" },
+  },
+  semantic: {
+    primary: "brand",
+  },
+});
+
+function App() {
+  return (
+    <NimbusProvider theme={customTheme}>
+      <Stack direction="row" gap="200">
+        <Button colorPalette="brand" variant="solid">
+          Solid
+        </Button>
+        <Button colorPalette="brand" variant="subtle">
+          Subtle
+        </Button>
+        <Button colorPalette="brand" variant="outline">
+          Outline
+        </Button>
+        <Button colorPalette="brand" variant="ghost">
+          Ghost
+        </Button>
+      </Stack>
+    </NimbusProvider>
+  );
+}
+```
+
+In your application, you'd create the theme in a separate file and import it:
+
+```tsx
+// src/theme.ts
+import { createNimbusTheme } from "@commercetools/nimbus-theme-generator";
+import { themeConfig } from "@commercetools/nimbus";
+
+export const customTheme = createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#D946EF" },
+  },
+  semantic: { primary: "brand" },
+});
+```
+
+```tsx
+// src/App.tsx
+import { NimbusProvider } from "@commercetools/nimbus";
+import { customTheme } from "./theme";
+
+function App() {
+  return (
+    <NimbusProvider theme={customTheme}>
+      {/* All components inside use your brand colors */}
+    </NimbusProvider>
+  );
+}
+```
+
+Every component that uses `colorPalette="primary"` will now use your brand
+color.
+
+## Color palettes
+
+Nimbus uses a 12-step color scale (inspired by Radix UI Colors). Each step
+serves a specific purpose and every palette includes both light and dark mode
+variants.
+
+| Steps | Purpose                  | Example usage               |
+| ----- | ------------------------ | --------------------------- |
+| 1–2   | App/subtle backgrounds   | Page background, card fills |
+| 3–5   | UI element backgrounds   | Hover, active, selected     |
+| 6–8   | Borders and separators   | Input borders, dividers     |
+| 9     | Solid backgrounds        | Button fills, badges        |
+| 10    | Hovered solid background | Button hover state          |
+| 11–12 | Text colors              | Low-contrast and body text  |
+
+Each palette also includes a **contrast** color (black or white, whichever meets
+WCAG AA 4.5:1 against step 9) and a **DEFAULT** alias for step 9.
+
+### Generated palettes
+
+Provide a single hex color and the generator produces the full 12-step scale
+using the OKLCH color space:
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#D946EF" },
+  },
+});
+```
+
+The base color becomes **step 9** (the solid background shade). All other steps
+are derived automatically with perceptually uniform lightness.
+
+### Manual palettes
+
+For full control, define every step for both light and dark modes:
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: {
+      type: "manual",
+      light: {
+        "1": "#fdf4ff",
+        "2": "#fae8ff",
+        "3": "#f5d0fe",
+        "4": "#f0abfc",
+        "5": "#e879f9",
+        "6": "#d946ef",
+        "7": "#c026d3",
+        "8": "#a21caf",
+        "9": "#D946EF",
+        "10": "#c026d3",
+        "11": "#86198f",
+        "12": "#4a044e",
+      },
+      dark: {
+        "1": "#1a0a1e",
+        "2": "#2d1033",
+        "3": "#3b1546",
+        "4": "#4c1d5c",
+        "5": "#5e2572",
+        "6": "#7e33a0",
+        "7": "#9b40c4",
+        "8": "#b54de0",
+        "9": "#D946EF",
+        "10": "#e06cf5",
+        "11": "#e88ff9",
+        "12": "#fdf4ff",
+      },
+    },
+  },
+});
+```
+
+In dark mode, step 1 should be the darkest and step 12 the lightest. The
+contrast color is calculated automatically from step 9, but you can set it
+explicitly by adding a `contrast` key to each mode.
+
+## Semantic color mappings
+
+Nimbus components reference semantic names like `primary`, `critical`, and
+`positive` rather than specific palettes. You can remap any of these to a custom
+palette:
+
+```jsx live
+import { createNimbusTheme } from "@commercetools/nimbus-theme-generator";
+import { NimbusProvider, Button, Stack, Text } from "@commercetools/nimbus";
+
+const multiTheme = createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    cyber: { type: "generated", baseColor: "#0891B2" },
+    neon: { type: "generated", baseColor: "#D946EF" },
+  },
+  semantic: {
+    primary: "cyber",
+    warning: "neon",
+  },
+});
+
+function App() {
+  return (
+    <NimbusProvider theme={multiTheme}>
+      <Stack gap="200">
+        <Stack direction="row" gap="200">
+          <Button colorPalette="cyber" variant="solid">
+            Cyber
+          </Button>
+          <Button colorPalette="neon" variant="solid">
+            Neon
+          </Button>
+        </Stack>
+        <Text fontSize="sm" color="fg.muted">
+          Custom palettes can be used directly or mapped to semantic names like
+          "primary" and "warning" for use in your app.
+        </Text>
+      </Stack>
+    </NimbusProvider>
+  );
+}
+```
+
+Available semantic names: `primary`, `neutral`, `info`, `critical`, `warning`,
+`positive`.
+
+Any name you don't override keeps its default from the base Nimbus theme.
+
+## Token overrides
+
+Beyond colors, you can override typography, spacing, and other design tokens.
+Overrides are merged with the base theme — you only need to specify what you
+want to change.
+
+```typescript
+createNimbusTheme({
+  baseConfigs: [themeConfig],
+  tokens: {
+    fonts: {
+      body: { value: '"Roboto", sans-serif' },
+      heading: { value: '"Montserrat", sans-serif' },
+    },
+    fontSizes: {
+      md: { value: "1rem" },
+      lg: { value: "1.25rem" },
+    },
+    spacing: {
+      "400": { value: "20px" },
+      "800": { value: "40px" },
+    },
+    radii: {
+      md: { value: "8px" },
+      lg: { value: "12px" },
+    },
+  },
+});
+```
+
+Supported token categories: `fonts`, `fontSizes`, `fontWeights`, `lineHeights`,
+`letterSpacings`, `spacing`, `sizes`, `radii`, `borders`.
+
+> [!NOTE] Token overrides set the CSS value, but they don't load external
+> resources. If you override `fonts`, you still need to load the font files via
+> a `<link>` tag or `@font-face` rule in your application.
+
+## Validating color accessibility
+
+Use `validatePalette()` to check any palette for WCAG AA compliance:
+
+```typescript
+import {
+  generateColorScale,
+  validatePalette,
+} from "@commercetools/nimbus-theme-generator";
+
+const palette = generateColorScale("#D946EF");
+const result = validatePalette(palette);
+
+if (!result.valid) {
+  console.warn("Accessibility issues:", result.warnings);
+}
+```
+
+The validator checks:
+
+- Contrast color meets WCAG AA (4.5:1) against step 9
+- Step 11 (low-contrast text) meets WCAG AA against step 1 (background)
+- Step 12 (high-contrast text) meets WCAG AA against step 1 (background)
+
+## API reference
+
+### `createNimbusTheme(config)`
+
+Creates a Chakra UI system with custom palettes and token overrides.
+
+| Parameter     | Type                                    | Description                               |
+| ------------- | --------------------------------------- | ----------------------------------------- |
+| `palettes`    | `Record<string, PaletteConfig>`         | Custom color palette definitions          |
+| `semantic`    | `Partial<Record<SemanticName, string>>` | Remap semantic colors to palette names    |
+| `tokens`      | `TokenOverrides`                        | Override typography, spacing, radii, etc. |
+| `baseConfigs` | `unknown[]`                             | Base theme configs — use `[themeConfig]`  |
+
+Returns a Chakra UI `SystemContext`. Pass it as the `theme` prop to
+`<NimbusProvider>`.
+
+### `generateColorScale(baseColor)`
+
+Generates a 12-step color scale from a single hex color.
+
+**Parameters:** `baseColor: string` — hex color (e.g. `"#D946EF"`)
+
+**Returns:** `{ light: ColorPalette, dark: ColorPalette }` — each containing
+steps 1–12, `DEFAULT`, and `contrast`.
+
+### `validatePalette(palette)`
+
+Validates a color palette for WCAG AA compliance.
+
+**Parameters:** `palette: ColorPaletteWithModes`
+
+**Returns:**
+`{ valid: boolean, warnings: ValidationWarning[], errors: ValidationError[] }`
+
+## Troubleshooting
+
+### Custom palette not showing up
+
+Ensure you included `baseConfigs: [themeConfig]` in your `createNimbusTheme`
+call. Without the base config, components won't have their recipes and default
+tokens.
+
+### Colors look wrong in dark mode
+
+Check that your manual palette has properly inverted lightness. In dark mode,
+step 1 should be the darkest and step 12 the lightest.
+
+### Components not using custom semantic colors
+
+The palette name in `palettes` must match the value in `semantic` exactly:
+
+```typescript
+palettes: { myBrand: { type: "generated", baseColor: "#D946EF" } },
+semantic: { primary: "myBrand" }, // must match "myBrand"
+```
+
+### Font not loading
+
+Token overrides set the CSS `font-family` value, but you still need to load the
+font files yourself. Add a `<link>` tag or `@font-face` rule in your HTML or
+CSS.

--- a/packages/nimbus/src/docs/theming/theming.stories.tsx
+++ b/packages/nimbus/src/docs/theming/theming.stories.tsx
@@ -8,6 +8,7 @@ import { themeConfig } from "@/theme";
 
 const meta: Meta = {
   title: "Docs/Theming",
+  tags: ["!autodocs"],
   parameters: {
     a11y: { disable: true },
   },

--- a/packages/nimbus/src/docs/theming/theming.stories.tsx
+++ b/packages/nimbus/src/docs/theming/theming.stories.tsx
@@ -119,13 +119,13 @@ export const MultiplePalettes: Story = {
   name: "Multiple Custom Palettes",
   parameters: { nimbusTheme: tealTheme },
   render: () => (
-    <Stack gap="6">
+    <Stack gap="300">
       <Text fontSize="xl" fontWeight="bold">
         Multiple Custom Palettes
       </Text>
       <PaletteSwatches name="ocean" palette={oceanPalette.light} />
       <PaletteSwatches name="sunset" palette={sunsetPalette.light} />
-      <Stack direction="row" gap="3">
+      <Stack direction="row" gap="300">
         <Button colorPalette="primary" variant="solid">
           Primary (ocean)
         </Button>
@@ -160,11 +160,11 @@ export const TokenOverrides: Story = {
   name: "Token Overrides (Radii)",
   parameters: { nimbusTheme: customRadiiTheme },
   render: () => (
-    <Stack gap="6">
+    <Stack gap="300">
       <Text fontSize="xl" fontWeight="bold">
         Token Overrides: Custom Radii + Brand Color
       </Text>
-      <Stack direction="row" gap="3">
+      <Stack direction="row" gap="300">
         <Button colorPalette="primary" variant="solid">
           Custom Radii Button
         </Button>

--- a/packages/nimbus/src/docs/theming/theming.stories.tsx
+++ b/packages/nimbus/src/docs/theming/theming.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box, Button, Stack, Text } from "@commercetools/nimbus";
+import {
+  createNimbusTheme,
+  generateColorScale,
+} from "@commercetools/nimbus-theme-generator";
+import { themeConfig } from "@/theme";
+
+const meta: Meta = {
+  title: "Docs/Theming",
+  parameters: {
+    a11y: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+function PaletteSwatches({
+  name,
+  palette,
+}: {
+  name: string;
+  palette: ReturnType<typeof generateColorScale>["light"];
+}) {
+  const steps = [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+  ] as const;
+  return (
+    <Box>
+      <Text fontWeight="bold" mb="2">
+        {name}
+      </Text>
+      <Stack direction="row" gap="1">
+        {steps.map((step) => (
+          <Box
+            key={step}
+            w="40px"
+            h="40px"
+            bg={`${name}.${step}`}
+            borderRadius="md"
+            title={`${name}.${step}: ${palette[step]}`}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+const redTheme = createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#E63946" },
+  },
+  semantic: { primary: "brand" },
+});
+
+const redPalette = generateColorScale("#E63946");
+
+export const CustomBrandPalette: Story = {
+  name: "Custom Brand Palette",
+  parameters: { nimbusTheme: redTheme },
+  render: () => (
+    <Stack gap="200">
+      <Text fontSize="xl" fontWeight="bold">
+        Custom Brand Theme (base: #E63946)
+      </Text>
+      <PaletteSwatches name="brand" palette={redPalette.light} />
+      <Text fontSize="lg" fontWeight="bold">
+        Semantic "primary" remapped to brand
+      </Text>
+      <Stack direction="row" gap="300">
+        <Button colorPalette="primary" variant="solid">
+          Primary Solid
+        </Button>
+        <Button colorPalette="primary" variant="subtle">
+          Primary Subtle
+        </Button>
+        <Button colorPalette="primary" variant="outline">
+          Primary Outline
+        </Button>
+        <Button colorPalette="primary" variant="ghost">
+          Primary Ghost
+        </Button>
+      </Stack>
+      <Text fontSize="md" color="fg">
+        These buttons use colorPalette="primary", which is remapped to the
+        custom "brand" palette (#E63946) via the semantic config.
+      </Text>
+    </Stack>
+  ),
+};
+
+const tealTheme = createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    ocean: { type: "generated", baseColor: "#2A9D8F" },
+    sunset: { type: "generated", baseColor: "#E9C46A" },
+  },
+  semantic: { primary: "ocean", warning: "sunset" },
+});
+
+const oceanPalette = generateColorScale("#2A9D8F");
+const sunsetPalette = generateColorScale("#E9C46A");
+
+export const MultiplePalettes: Story = {
+  name: "Multiple Custom Palettes",
+  parameters: { nimbusTheme: tealTheme },
+  render: () => (
+    <Stack gap="6">
+      <Text fontSize="xl" fontWeight="bold">
+        Multiple Custom Palettes
+      </Text>
+      <PaletteSwatches name="ocean" palette={oceanPalette.light} />
+      <PaletteSwatches name="sunset" palette={sunsetPalette.light} />
+      <Stack direction="row" gap="3">
+        <Button colorPalette="primary" variant="solid">
+          Primary (ocean)
+        </Button>
+        <Button colorPalette="warning" variant="solid">
+          Warning (sunset)
+        </Button>
+      </Stack>
+      <Text fontSize="md" color="fg">
+        "primary" is mapped to the ocean palette (#2A9D8F), "warning" to the
+        sunset palette (#E9C46A).
+      </Text>
+    </Stack>
+  ),
+};
+
+const customRadiiTheme = createNimbusTheme({
+  baseConfigs: [themeConfig],
+  palettes: {
+    brand: { type: "generated", baseColor: "#264653" },
+  },
+  semantic: { primary: "brand" },
+  tokens: {
+    radii: {
+      sm: { value: "2px" },
+      md: { value: "4px" },
+      lg: { value: "8px" },
+    },
+  },
+});
+
+export const TokenOverrides: Story = {
+  name: "Token Overrides (Radii)",
+  parameters: { nimbusTheme: customRadiiTheme },
+  render: () => (
+    <Stack gap="6">
+      <Text fontSize="xl" fontWeight="bold">
+        Token Overrides: Custom Radii + Brand Color
+      </Text>
+      <Stack direction="row" gap="3">
+        <Button colorPalette="primary" variant="solid">
+          Custom Radii Button
+        </Button>
+        <Button colorPalette="primary" variant="outline">
+          Primary Outline
+        </Button>
+        <Button colorPalette="primary" variant="subtle">
+          Primary Subtle
+        </Button>
+      </Stack>
+      <Text fontSize="md" color="fg">
+        Border radii overridden to sm=2px, md=4px, lg=8px. Primary color is
+        #264653.
+      </Text>
+    </Stack>
+  ),
+};

--- a/packages/nimbus/src/patterns/actions/form-action-bar/intl/de.ts
+++ b/packages/nimbus/src/patterns/actions/form-action-bar/intl/de.ts
@@ -5,8 +5,8 @@
  */
 
 export default {
-  ariaLabel: `Form actions`,
-  cancel: `Cancel`,
-  delete: `Delete`,
-  save: `Save`,
+  ariaLabel: `Formular-Aktionen`,
+  cancel: `Abbrechen`,
+  delete: `Löschen`,
+  save: `Speichern`,
 };

--- a/packages/nimbus/src/patterns/actions/form-action-bar/intl/fr-FR.ts
+++ b/packages/nimbus/src/patterns/actions/form-action-bar/intl/fr-FR.ts
@@ -5,8 +5,8 @@
  */
 
 export default {
-  ariaLabel: `Form actions`,
-  cancel: `Cancel`,
-  delete: `Delete`,
-  save: `Save`,
+  ariaLabel: `Actions du formulaire`,
+  cancel: `Annuler`,
+  delete: `Supprimer`,
+  save: `Enregistrer`,
 };

--- a/packages/nimbus/src/patterns/dialogs/confirmation-dialog/intl/de.ts
+++ b/packages/nimbus/src/patterns/dialogs/confirmation-dialog/intl/de.ts
@@ -4,4 +4,4 @@
  * DO NOT EDIT MANUALLY
  */
 
-export default { cancel: `Cancel`, confirm: `Confirm` };
+export default { cancel: `Abbrechen`, confirm: `Bestätigen` };

--- a/packages/nimbus/src/patterns/dialogs/confirmation-dialog/intl/fr-FR.ts
+++ b/packages/nimbus/src/patterns/dialogs/confirmation-dialog/intl/fr-FR.ts
@@ -4,4 +4,4 @@
  * DO NOT EDIT MANUALLY
  */
 
-export default { cancel: `Cancel`, confirm: `Confirm` };
+export default { cancel: `Annuler`, confirm: `Confirmer` };

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/intl/de.ts
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/intl/de.ts
@@ -4,4 +4,4 @@
  * DO NOT EDIT MANUALLY
  */
 
-export default { cancel: `Cancel`, save: `Save` };
+export default { cancel: `Abbrechen`, save: `Speichern` };

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/intl/fr-FR.ts
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/intl/fr-FR.ts
@@ -4,4 +4,4 @@
  * DO NOT EDIT MANUALLY
  */
 
-export default { cancel: `Cancel`, save: `Save` };
+export default { cancel: `Annuler`, save: `Enregistrer` };

--- a/packages/nimbus/src/theme/index.ts
+++ b/packages/nimbus/src/theme/index.ts
@@ -12,7 +12,7 @@ import { slotRecipes } from "./slot-recipes";
 import { textStyles } from "./text-styles";
 import { tokens } from "./tokens";
 
-const themeConfig = defineConfig({
+export const themeConfig = defineConfig({
   preflight: true,
   cssVarsPrefix: "nimbus",
   cssVarsRoot: ":where(:root, :host)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  default:
+    '@types/culori':
+      specifier: ^4.0.1
+      version: 4.0.1
   react:
     '@chakra-ui/cli':
       specifier: ^3.35.0
@@ -558,7 +562,7 @@ importers:
         version: 1.4.0
       '@github-ui/storybook-addon-performance-panel':
         specifier: catalog:tooling
-        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@internationalized/string':
         specifier: catalog:react
         version: 3.2.9
@@ -608,6 +612,9 @@ importers:
       '@commercetools/nimbus-icons':
         specifier: workspace:^
         version: link:../nimbus-icons
+      '@commercetools/nimbus-theme-generator':
+        specifier: workspace:*
+        version: link:../nimbus-theme-generator
       '@commercetools/nimbus-tokens':
         specifier: workspace:^
         version: link:../tokens
@@ -622,16 +629,16 @@ importers:
         version: 3.35.0(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 10.4.3(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.4.3(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
-        version: 10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)
+        version: 10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.9.1
@@ -667,7 +674,7 @@ importers:
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vueless/storybook-dark-mode':
         specifier: catalog:tooling
-        version: 10.0.8(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.0.8(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       apca-w3:
         specifier: ^0.1.9
         version: 0.1.9
@@ -706,7 +713,7 @@ importers:
         version: 0.123.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.123.0(slate@0.123.0))(slate@0.123.0)
       storybook:
         specifier: catalog:tooling
-        version: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
         version: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
@@ -809,6 +816,28 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+
+  packages/nimbus-theme-generator:
+    dependencies:
+      culori:
+        specifier: ^4.0.1
+        version: 4.0.2
+    devDependencies:
+      '@chakra-ui/react':
+        specifier: catalog:react
+        version: 3.35.0(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@types/culori':
+        specifier: 'catalog:'
+        version: 4.0.1
+      tsup:
+        specifier: catalog:tooling
+        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.0))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: catalog:tooling
+        version: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
 
   packages/tokens:
     devDependencies:
@@ -3589,6 +3618,9 @@ packages:
   '@types/cli-table@0.3.4':
     resolution: {integrity: sha512-GsALrTL69mlwbAw/MHF1IPTadSLZQnsxe7a80G8l4inN/iEXCOcVeT/S7aRc6hbhqzL9qZ314kHPDQnQ3ev+HA==}
 
+  '@types/culori@4.0.1':
+    resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -4680,6 +4712,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  culori@4.0.2:
+    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   dashify@2.0.0:
     resolution: {integrity: sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==}
@@ -9082,12 +9118,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
 
   '@hono/node-server@1.19.13(hono@4.12.18)':
@@ -9914,14 +9950,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
     optional: true
 
@@ -10696,21 +10724,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.4.3(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/addon-a11y@10.4.3(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.0
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.16)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.16
@@ -10721,11 +10749,11 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)':
+  '@storybook/addon-vitest@10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
       '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
@@ -10735,10 +10763,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -10746,9 +10774,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
@@ -10762,28 +10790,28 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/react-dom-shim@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
-      '@storybook/builder-vite': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.0
       react-docgen: 8.0.2
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.12
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
       vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -10795,15 +10823,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
+  '@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
@@ -11112,6 +11140,8 @@ snapshots:
 
   '@types/cli-table@0.3.4': {}
 
+  '@types/culori@4.0.1': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -11343,6 +11373,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
 
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
@@ -11355,6 +11399,24 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
@@ -11405,6 +11467,14 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
@@ -11464,11 +11534,11 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       lodash-es: 4.18.1
-      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@webcontainer/env@1.1.1': {}
 
@@ -12570,6 +12640,8 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
+
+  culori@4.0.2: {}
 
   dashify@2.0.0: {}
 
@@ -14622,32 +14694,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
-    optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
-      '@oxc-resolver/binding-android-arm64': 11.19.1
-      '@oxc-resolver/binding-darwin-arm64': 11.19.1
-      '@oxc-resolver/binding-darwin-x64': 11.19.1
-      '@oxc-resolver/binding-freebsd-x64': 11.19.1
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
-      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
-      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
-      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -15625,35 +15671,6 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/expect': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@webcontainer/env': 1.1.1
-      esbuild: 0.27.3
-      open: 10.2.0
-      oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      recast: 0.23.11
-      semver: 7.7.4
-      use-sync-external-store: 1.6.0(react@19.2.0)
-      ws: 8.19.0
-    optionalDependencies:
-      '@types/react': 19.2.16
-      prettier: 3.8.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@testing-library/dom'
-      - bufferutil
-      - react
-      - react-dom
-      - utf-8-validate
-
   stream@0.0.3:
     dependencies:
       component-emitter: 2.0.0
@@ -16192,6 +16209,21 @@ snapshots:
       - typescript
       - webpack
 
+  vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.0
+      esbuild: 0.27.3
+      fsevents: 2.3.3
+      terser: 5.44.0
+      tsx: 4.22.4
+      yaml: 2.8.3
+
   vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -16206,6 +16238,36 @@ snapshots:
       terser: 5.44.0
       tsx: 4.22.4
       yaml: 2.8.3
+
+  vitest@4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.0
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@commercetools/nimbus-icons':
         specifier: workspace:^
         version: link:../../packages/nimbus-icons
+      '@commercetools/nimbus-theme-generator':
+        specifier: workspace:^
+        version: link:../../packages/nimbus-theme-generator
       '@emotion/react':
         specifier: catalog:react
         version: 11.14.0(@types/react@19.2.16)(react@19.2.0)
@@ -562,7 +565,7 @@ importers:
         version: 1.4.0
       '@github-ui/storybook-addon-performance-panel':
         specifier: catalog:tooling
-        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@internationalized/string':
         specifier: catalog:react
         version: 3.2.9
@@ -629,16 +632,16 @@ importers:
         version: 3.35.0(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 10.4.3(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.4.3(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
-        version: 10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)
+        version: 10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.9.1
@@ -674,7 +677,7 @@ importers:
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vueless/storybook-dark-mode':
         specifier: catalog:tooling
-        version: 10.0.8(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.0.8(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       apca-w3:
         specifier: ^0.1.9
         version: 0.1.9
@@ -713,7 +716,7 @@ importers:
         version: 0.123.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.123.0(slate@0.123.0))(slate@0.123.0)
       storybook:
         specifier: catalog:tooling
-        version: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
         version: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
@@ -837,7 +840,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:tooling
-        version: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+        version: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
 
   packages/tokens:
     devDependencies:
@@ -9118,12 +9121,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
 
   '@hono/node-server@1.19.13(hono@4.12.18)':
@@ -9950,6 +9953,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
     optional: true
 
@@ -10724,21 +10735,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.4.3(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/addon-a11y@10.4.3(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.0
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.16)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.16
@@ -10749,11 +10760,11 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)':
+  '@storybook/addon-vitest@10.4.3(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.8)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
       '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
@@ -10763,10 +10774,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -10774,9 +10785,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
@@ -10790,28 +10801,28 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/react-dom-shim@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.61.1)
-      '@storybook/builder-vite': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.4.3(esbuild@0.28.0)(rollup@4.61.1)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.0
       react-docgen: 8.0.2
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.12
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
       vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -10823,15 +10834,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
+  '@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
@@ -11373,20 +11384,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
-    dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      playwright: 1.60.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
@@ -11399,24 +11396,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-
-  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      '@vitest/utils': 4.1.8
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
 
   '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
@@ -11467,14 +11446,6 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
@@ -11534,11 +11505,11 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       lodash-es: 4.18.1
-      storybook: 10.4.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@webcontainer/env@1.1.1': {}
 
@@ -14694,6 +14665,32 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
+      '@oxc-resolver/binding-android-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-x64': 11.19.1
+      '@oxc-resolver/binding-freebsd-x64': 11.19.1
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -15671,6 +15668,35 @@ snapshots:
       - react-dom
       - utf-8-validate
 
+  storybook@10.4.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.3
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      recast: 0.23.11
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.0)
+      ws: 8.19.0
+    optionalDependencies:
+      '@types/react': 19.2.16
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   stream@0.0.3:
     dependencies:
       component-emitter: 2.0.0
@@ -16209,21 +16235,6 @@ snapshots:
       - typescript
       - webpack
 
-  vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.13.0
-      esbuild: 0.27.3
-      fsevents: 2.3.3
-      terser: 5.44.0
-      tsx: 4.22.4
-      yaml: 2.8.3
-
   vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -16238,36 +16249,6 @@ snapshots:
       terser: 5.44.0
       tsx: 4.22.4
       yaml: 2.8.3
-
-  vitest@4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.13.0
-      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.27.3)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
-      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
-      jsdom: 29.0.1
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.8(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,15 @@ packages:
   - packages/*
   - apps/*
 
+catalog:
+  '@types/culori': ^4.0.1
+
 catalogMode: strict
 
 catalogs:
   tooling:
-    "@figma/code-connect": ^1.4.7
-    "@fission-ai/openspec": ^1.4.1
+    '@figma/code-connect': ^1.4.7
+    '@fission-ai/openspec': ^1.4.1
     eslint-plugin-react-hooks: ^7.1.1
     globals: ^17.6.0
     glob: ^13.0.6
@@ -15,69 +18,69 @@ catalogs:
     typescript-eslint: ^8.60.1
     tsup: ^8.5.1
     tsx: ^4.22.4
-    "@arethetypeswrong/cli": ^0.18.3
+    '@arethetypeswrong/cli': ^0.18.3
     publint: ^0.3.21
-    "@modelcontextprotocol/inspector": ^0.21.2
-    "@babel/core": ^7.29.7
-    "@babel/runtime": ^7.29.7
-    "@babel/preset-typescript": ^7.29.7
-    "@eslint/js": ^10.0.1
-    "@react-types/shared": ^3.35.0
+    '@modelcontextprotocol/inspector': ^0.21.2
+    '@babel/core': ^7.29.7
+    '@babel/runtime': ^7.29.7
+    '@babel/preset-typescript': ^7.29.7
+    '@eslint/js': ^10.0.1
+    '@react-types/shared': ^3.35.0
     eslint: ^10.4.1
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.6
     eslint-plugin-react-refresh: ^0.5.2
     express-rate-limit: ^8.5.2
     prettier: ^3.8.3
-    "@preconstruct/cli": ^2.8.13
-    "@vitejs/plugin-react": ^6.0.2
-    "@vitejs/plugin-react-swc": ^4.3.1
+    '@preconstruct/cli': ^2.8.13
+    '@vitejs/plugin-react': ^6.0.2
+    '@vitejs/plugin-react-swc': ^4.3.1
     vite: ^8.0.16
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.2
     rollup: ^4.61.1
-    "@vitest/browser": ^4.1.8
-    "@vitest/browser-playwright": ^4.1.8
-    "@vitest/coverage-v8": ^4.1.8
-    "@testing-library/dom": 10.4.1
-    "@testing-library/jest-dom": ^6.9.1
-    "@testing-library/user-event": ^14.6.1
-    "@testing-library/react": ^16.3.2
+    '@vitest/browser': ^4.1.8
+    '@vitest/browser-playwright': ^4.1.8
+    '@vitest/coverage-v8': ^4.1.8
+    '@testing-library/dom': 10.4.1
+    '@testing-library/jest-dom': ^6.9.1
+    '@testing-library/user-event': ^14.6.1
+    '@testing-library/react': ^16.3.2
     playwright: ^1.60.0
     vitest: ^4.1.8
     storybook: ^10.4.3
     eslint-plugin-storybook: ^10.4.3
-    "@storybook/addon-a11y": ^10.4.3
-    "@storybook/addon-docs": ^10.4.3
-    "@storybook/addon-vitest": ^10.4.3
-    "@storybook/react-vite": ^10.4.3
-    "@vueless/storybook-dark-mode": ^10.0.8
-    "@github-ui/storybook-addon-performance-panel": ^1.1.4
-    jsdom: 29.0.1 # pinned: 29.0.2+ breaks Chakra/Emotion CSS in JSDOM (style assertions return padding: 0); reconfirmed against 29.1.0 on 2026-04-29
+    '@storybook/addon-a11y': ^10.4.3
+    '@storybook/addon-docs': ^10.4.3
+    '@storybook/addon-vitest': ^10.4.3
+    '@storybook/react-vite': ^10.4.3
+    '@vueless/storybook-dark-mode': ^10.0.8
+    '@github-ui/storybook-addon-performance-panel': ^1.1.4
+    jsdom: 29.0.1
   react:
-    "@types/react": ^19.2.16
-    "@types/react-dom": ^19.2.3
+    '@types/react': ^19.2.16
+    '@types/react-dom': ^19.2.3
     react: ^19.0.0
     react-dom: ^19.0.0
-    "@emotion/react": ^11.14.0
-    "@emotion/is-prop-valid": ^1.4.0
-    "@chakra-ui/cli": ^3.35.0
-    "@chakra-ui/react": ^3.35.0
+    '@emotion/react': ^11.14.0
+    '@emotion/is-prop-valid': ^1.4.0
+    '@chakra-ui/cli': ^3.35.0
+    '@chakra-ui/react': ^3.35.0
     next-themes: ^0.4.6
     react-aria: 3.49.0
     react-aria-components: 1.18.0
     react-stately: 3.47.0
-    "@react-aria/interactions": 3.28.1
-    "@react-aria/utils": 3.34.1
-    "@react-aria/optimize-locales-plugin": 1.2.1
-    "@internationalized/date": ^3.12.2
-    "@internationalized/string": ^3.2.9
-    "@internationalized/string-compiler": ^3.4.1
+    '@react-aria/interactions': 3.28.1
+    '@react-aria/utils': 3.34.1
+    '@react-aria/optimize-locales-plugin': 1.2.1
+    '@internationalized/date': ^3.12.2
+    '@internationalized/string': ^3.2.9
+    '@internationalized/string-compiler': ^3.4.1
   utils:
     dequal: ^2.0.3
     dotenv: ^16.6.1
     dompurify: ^3.4.8
     lodash: ^4.18.1
-    "@types/lodash": ^4.17.24
-    "@types/node": ^24.13.0
+    '@types/lodash': ^4.17.24
+    '@types/node': ^24.13.0
     zod: ^4.4.3

--- a/scripts/check-package-shape.mjs
+++ b/scripts/check-package-shape.mjs
@@ -53,6 +53,10 @@ const PACKAGES = [
     dir: join(ROOT, "packages/design-token-ts-plugin"),
   },
   { name: "@commercetools/nimbus-mcp", dir: join(ROOT, "packages/nimbus-mcp") },
+  {
+    name: "@commercetools/nimbus-theme-generator",
+    dir: join(ROOT, "packages/nimbus-theme-generator"),
+  },
 ];
 
 const DIM = "\x1b[2m";


### PR DESCRIPTION
## Summary

- **New `@commercetools/nimbus-theme-generator` package** — generates Radix-compatible 12-step color scales from a single base hex color using OKLCH color space, with WCAG AA contrast validation and a `createNimbusTheme()` API for building custom Chakra systems
- **`NimbusProvider` `theme` prop** — consumers pass a custom system to override the default theme, with automatic inheritance for nested providers
- **Token overrides** — support for customizing typography (fonts, sizes, weights), spacing, radii, borders, and other design tokens
- **Documentation** — consumer-facing theming guide (`docs/theming-guide.md`), internal guidelines (`docs/file-type-guidelines/theming.md`), and 3 Storybook stories demonstrating custom palettes, multiple palettes, and token overrides

## Test plan

- [ ] 32 unit tests pass in `nimbus-theme-generator` (contrast, color scale generation, palette validation, theme creation)
- [ ] 2501 total tests pass across the monorepo with no regressions
- [ ] Storybook stories render custom brand colors correctly (red, teal, gold palettes)
- [ ] Semantic color remapping works (e.g., `primary` → custom palette)
- [ ] Token overrides (radii) visually apply in Storybook
- [ ] TypeScript types check cleanly in both packages