### PR TITLE
fix(checkbox): thicken indicator icon stroke for visibility

### DIFF
--- a/.changeset/fix-checkbox-indicator-stroke.md
+++ b/.changeset/fix-checkbox-indicator-stroke.md
@@ -1,0 +1,7 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Fix `Checkbox` checked and indeterminate icons being hard to see. The indicator
+icon now renders with a stroke matching the indicator's contrast color, making
+the checkmark and dash render with a bolder, more visible weight.

--- a/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
@@ -48,6 +48,8 @@ export const checkboxSlotRecipe = defineSlotRecipe({
       _icon: {
         w: "350",
         h: "350",
+        stroke: "colorPalette.contrast",
+        strokeWidth: "50",
       },
 
       "&:hover": {

--- a/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
@@ -48,6 +48,12 @@ export const checkboxSlotRecipe = defineSlotRecipe({
       _icon: {
         w: "350",
         h: "350",
+      },
+
+      // Stroke the checkmark / indeterminate-dash glyph itself (the svg path)
+      // so the indicator reads as clearly checked. `_icon` targets the <svg>
+      // wrapper, not the rendered glyph, so the path is selected directly.
+      "& :where(svg path)": {
         stroke: "colorPalette.contrast",
         strokeWidth: "50",
       },

--- a/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
@@ -48,12 +48,9 @@ export const checkboxSlotRecipe = defineSlotRecipe({
       _icon: {
         w: "350",
         h: "350",
-      },
-
-      // Stroke the checkmark / indeterminate-dash glyph itself (the svg path)
-      // so the indicator reads as clearly checked. `_icon` targets the <svg>
-      // wrapper, not the rendered glyph, so the path is selected directly.
-      "& :where(svg path)": {
+        // Stroke the indicator glyph so the checkmark / indeterminate dash
+        // reads as clearly checked. `stroke` and `stroke-width` are inherited
+        // SVG properties, so setting them on the <svg> applies to its path.
         stroke: "colorPalette.contrast",
         strokeWidth: "50",
       },

--- a/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
@@ -51,8 +51,10 @@ export const checkboxSlotRecipe = defineSlotRecipe({
         // Stroke the indicator glyph so the checkmark / indeterminate dash
         // reads as clearly checked. `stroke` and `stroke-width` are inherited
         // SVG properties, so setting them on the <svg> applies to its path.
+        // `strokeWidth` has no token scale in Chakra, so reference the token
+        // explicitly — a bare "50" would compile to a literal `50px` stroke.
         stroke: "colorPalette.contrast",
-        strokeWidth: "50",
+        strokeWidth: "{sizes.50}",
       },
 
       "&:hover": {


### PR DESCRIPTION


## Summary

The `Checkbox` checked and indeterminate icons were rendering with too thin a stroke, making it hard to tell at a glance that a checkbox was checked.

This applies a `stroke` and `strokeWidth` to the indicator's `_icon` selector in the recipe:

- **`stroke: "colorPalette.contrast"`** — the icon stroke now uses the current color scale's contrast step, matching the indicator's foreground color across selected/indeterminate (and invalid) states.
- **`strokeWidth: "50"`** — border-width token `50` (2px), giving the checkmark/dash a bolder, clearly visible weight.


<img width="714" height="805" alt="image" src="https://github.com/user-attachments/assets/fce24f1c-74c8-4e8c-ae23-a78d9df0f4f2" />

## Changes

- `checkbox.recipe.ts`: add `stroke` + `strokeWidth` to the existing `indicator._icon` selector.
- Changeset (`patch`).

## Test plan

- [ ] Verify the checkmark is clearly visible in the checked state in Storybook.
- [ ] Verify the indeterminate dash renders with the same bolder stroke.
- [ ] Verify invalid + selected state still reads correctly (contrast stroke over critical background).