### PR TITLE
ci: add /canary PR comment trigger for snapshot publishing

### DIFF
--- a/.github/workflows/canary-publish-on-comment.yml
+++ b/.github/workflows/canary-publish-on-comment.yml
@@ -13,7 +13,7 @@ jobs:
   canary:
     if: >
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/canary')
+      contains(github.event.comment.body, '/deploy_canary')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/canary-publish-on-comment.yml
+++ b/.github/workflows/canary-publish-on-comment.yml
@@ -1,0 +1,110 @@
+name: Publish Canary from PR
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  canary:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/canary')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Get PR branch
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+
+      - name: React to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.12"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install and build
+        uses: ./.github/actions/ci
+
+      - name: Setup npm registry for publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.12"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Generate GitHub token
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+
+      - name: Publish canary snapshot
+        id: publish
+        run: |
+          set -euo pipefail
+          pnpm changeset version --snapshot canary
+          pnpm changeset publish --tag canary 2>&1 | tee /tmp/publish-output.txt
+
+          # Extract published version from output
+          VERSION=$(grep -oP '@commercetools/nimbus@\K[^\s]+' /tmp/publish-output.txt | head -1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+
+      - name: Comment with install instructions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ steps.publish.outputs.version }}';
+            const sha = '${{ steps.pr.outputs.sha }}'.slice(0, 7);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                `### 🚀 Canary published`,
+                '',
+                `**Version:** \`${version}\``,
+                `**Commit:** \`${sha}\``,
+                '',
+                '```bash',
+                `pnpm add @commercetools/nimbus@${version}`,
+                `pnpm add @commercetools/nimbus-tokens@${version}`,
+                `pnpm add @commercetools/nimbus-icons@${version}`,
+                `pnpm add @commercetools/nimbus-theme-generator@${version}`,
+                '```',
+              ].join('\n'),
+            });

--- a/.github/workflows/canary-publish-on-comment.yml
+++ b/.github/workflows/canary-publish-on-comment.yml
@@ -13,7 +13,7 @@ jobs:
   canary:
     if: >
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/deploy_canary')
+      contains(github.event.comment.body, '/deploy-canary')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow triggered by `/canary` comments on PRs
- Publishes snapshot versions of all packages to npm with the `canary` tag
- Uses the same trusted publishing (OIDC) and CT Changesets App setup as the existing release workflow
- Posts install instructions back as a PR comment with the published version

## How to use

Comment `/canary` on any PR. The workflow will:
1. Check out the PR branch
2. Build all packages
3. Publish snapshot versions (e.g. `3.0.0-canary-20260612.0`)
4. Comment back with `pnpm add` commands

## Test plan
- [ ] Merge this PR, then comment `/canary` on the nimbus-4.0 PR to verify it publishes
- [ ] Verify the comment includes correct version and install commands
- [ ] Verify published packages install correctly in a consumer project