### PR TITLE
perf(stories): type Story from the component, not the meta object

### DIFF
--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -84,7 +84,7 @@ const meta: Meta<typeof ComponentName> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ComponentName>;
 
 // Stories follow below...
 ```
@@ -552,7 +552,8 @@ You MUST validate against these requirements:
 - [ ] Imports from `@storybook/react-vite` and `storybook/test`
 - [ ] Meta configuration with title, component, tags
 - [ ] Default export of meta
-- [ ] Story type from `StoryObj<typeof meta>`
+- [ ] Story type from `StoryObj<typeof ComponentName>` (the component, not
+      `typeof meta` — see note in `docs/file-type-guidelines/stories.md`)
 
 #### Required Stories
 

--- a/docs/component-templates/compound-component.stories.md
+++ b/docs/component-templates/compound-component.stories.md
@@ -48,7 +48,7 @@ const meta: Meta<typeof ComponentName.Root> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ComponentName.Root>;
 
 /**
  * Default story - simplest usage

--- a/docs/component-templates/single-component.stories.md
+++ b/docs/component-templates/single-component.stories.md
@@ -43,7 +43,7 @@ const meta: Meta<typeof ComponentName> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ComponentName>;
 
 /**
  * Default story - simplest usage

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -195,10 +195,25 @@ const meta: Meta<typeof ComponentName> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ComponentName>;
 
 // Stories follow...
 ```
+
+> **Use `StoryObj<typeof ComponentName>`, not `StoryObj<typeof meta>`.** Both
+> typecheck, but `StoryObj<typeof meta>` routes TypeScript through the expensive
+> branch of `StoryObj` (`Simplify<ComponentProps<C> & ArgsFromMeta<…>>` plus
+> `AddMocks`/`SetOptional`), which fully flattens the component's prop object
+> and is re-instantiated for every `Story` reference in the file. For components
+> with large prop types (Chakra style-prop spreads via `HTMLChakraProps`,
+> polymorphic `as`, big recipe-variant unions) this is dramatic: in practice
+> these files took **2–5 seconds each** to typecheck versus **10–150ms** with
+> `StoryObj<typeof ComponentName>` — a ~5× reduction in total `tsc` time across
+> the package. The cost tracks the component's prop complexity, not the number
+> of stories. Use the component (or `ComponentName.Root` for compound
+> components). The only exception is a story file with no `component` (e.g. a
+> `const meta: Meta = {…}` hosting render-only examples), where `typeof meta`
+> resolves to a loose `Args` type and is already cheap.
 
 ## Story Organization
 

--- a/packages/nimbus/src/components/collapsible-motion/collapsible-motion.stories.tsx
+++ b/packages/nimbus/src/components/collapsible-motion/collapsible-motion.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof CollapsibleMotion.Root> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof CollapsibleMotion.Root>;
 
 /**
  * Basic uncontrolled example with compound component pattern

--- a/packages/nimbus/src/components/dialog/dialog.stories.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta<typeof Dialog.Root> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Dialog.Root>;
 
 /**
  * The default dialog configuration with medium size and center placement.

--- a/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
+++ b/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof DraggableList.Root> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof DraggableList.Root>;
 
 export const Base: Story = {
   render: () => {

--- a/packages/nimbus/src/components/drawer/drawer.stories.tsx
+++ b/packages/nimbus/src/components/drawer/drawer.stories.tsx
@@ -56,7 +56,7 @@ const meta: Meta<typeof Drawer.Root> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Drawer.Root>;
 
 /**
  * The default drawer configuration with medium size and center placement.

--- a/packages/nimbus/src/components/inline-svg/inline-svg.stories.tsx
+++ b/packages/nimbus/src/components/inline-svg/inline-svg.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof InlineSvg> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof InlineSvg>;
 
 // Simple SVG data for testing
 const simpleSvg = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/packages/nimbus/src/components/menu/menu.stories.tsx
+++ b/packages/nimbus/src/components/menu/menu.stories.tsx
@@ -62,7 +62,7 @@ const meta: Meta<typeof Menu.Root> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Menu.Root>;
 
 export const Basic: Story = {
   render: (args) => (

--- a/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
+++ b/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof ModalPage.Root> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ModalPage.Root>;
 
 /**
  * Basic info page — tests open/close lifecycle via trigger and back button.

--- a/packages/nimbus/src/components/nimbus-i18n-provider/nimbus-i18n-provider.stories.tsx
+++ b/packages/nimbus/src/components/nimbus-i18n-provider/nimbus-i18n-provider.stories.tsx
@@ -55,7 +55,7 @@ const meta: Meta<typeof NimbusI18nProvider> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof NimbusI18nProvider>;
 
 /**
  * Default NimbusI18nProvider with US English locale.

--- a/packages/nimbus/src/components/rich-text-input/rich-text-input.stories.tsx
+++ b/packages/nimbus/src/components/rich-text-input/rich-text-input.stories.tsx
@@ -65,7 +65,7 @@ const meta = {
 } satisfies Meta<typeof RichTextInput>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof RichTextInput>;
 
 // =============================================================================
 // Basic States

--- a/packages/nimbus/src/components/scoped-search-input/scoped-search-input.stories.tsx
+++ b/packages/nimbus/src/components/scoped-search-input/scoped-search-input.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof ScopedSearchInput> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ScopedSearchInput>;
 
 const defaultOptions = [
   { label: "All Fields", value: "all" },

--- a/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/nimbus/src/components/scroll-area/scroll-area.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof ScrollArea> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ScrollArea>;
 
 const OverflowingContent = () =>
   Array.from({ length: 30 }, (_, i) => (

--- a/packages/nimbus/src/components/spacer/spacer.stories.tsx
+++ b/packages/nimbus/src/components/spacer/spacer.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Spacer> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Spacer>;
 
 /**
  * Basic usage of Spacer to push elements apart in a horizontal layout.

--- a/packages/nimbus/src/components/split-button/split-button.stories.tsx
+++ b/packages/nimbus/src/components/split-button/split-button.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof SplitButton> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof SplitButton>;
 
 export const Basic: Story = {
   render: () => (

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -33,7 +33,7 @@ export default meta;
  * Story type for TypeScript support
  * StoryObj provides type checking for our story configurations
  */
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof TabNav.Root>;
 
 /**
  * The default TabNav usage with three navigation items.

--- a/packages/nimbus/src/components/tree/tree.stories.tsx
+++ b/packages/nimbus/src/components/tree/tree.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Tree.Root> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Tree.Root>;
 
 /** Recursive render function for a dynamic collection of `TreeNode`s. */
 const renderNode = (node: TreeNode) => (

--- a/packages/nimbus/src/hooks/use-drag-and-drop/use-drag-and-drop.stories.tsx
+++ b/packages/nimbus/src/hooks/use-drag-and-drop/use-drag-and-drop.stories.tsx
@@ -128,7 +128,7 @@ const meta: Meta<typeof DraggableList.Root<Item>> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof DraggableList.Root>;
 
 export const Reorder: Story = {
   render: () => <ReorderDemo />,

--- a/packages/nimbus/src/patterns/dialogs/confirmation-dialog/confirmation-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/confirmation-dialog/confirmation-dialog.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof ConfirmationDialog> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof ConfirmationDialog>;
 
 /**
  * Basic controlled usage with the default intent. Cancel and Confirm

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof FormDialog> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof FormDialog>;
 
 /**
  * Basic controlled usage with a string title and a single form field.

--- a/packages/nimbus/src/patterns/dialogs/info-dialog/info-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/info-dialog/info-dialog.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof InfoDialog> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof InfoDialog>;
 
 /**
  * Basic controlled usage with a string title. The pattern has no trigger


### PR DESCRIPTION
## Summary
Typecheck of `@commercetools/nimbus` went from **54.8s → 10.2s (~5.4× faster)** by
changing how 18 Storybook story files declare their `Story` type — from
`StoryObj<typeof meta>` to `StoryObj<typeof Component>`. No runtime or API change.

## Benchmark
`tsc --noEmit --extendedDiagnostics` in `packages/nimbus`, same freshly-built
workspace, with vs. without the change:

| | Check time | Instantiations |
|---|---|---|
| Before (`typeof meta`) | 54.82s | 3,820,092 |
| After (`typeof Component`) | 10.18s | 2,787,100 |

Per-file (from `tsc --generateTrace`): 11 prop-heavy story files dominated the
check. Examples:

| File | Before | After |
|---|---|---|
| `scoped-search-input.stories.tsx` | 5133ms | 13ms |
| `spacer.stories.tsx` | 4376ms | 11ms |
| `menu.stories.tsx` | 4640ms | 146ms |
| `dialog.stories.tsx` | 4464ms | 113ms |

Combined, these files dropped from **48,436ms → 620ms**.

**The slowness did not correlate with the number of stories** (Pearson r ≈ −0.02):
`use-drag-and-drop` has 4 stories but took 4.7s; `combobox` has 112 stories and
took 0.2s. It tracks **component prop complexity**, not story volume.

## Approach
`StoryObj<typeof meta>` routes TypeScript through the expensive branch of the
`StoryObj` conditional type — `Simplify<ComponentProps<C> & ArgsFromMeta<…>>`
plus `AddMocks`/`SetOptional` — which fully flattens the component's prop object
and re-instantiates it for every `Story` reference in the file. For components
that spread Chakra `HTMLChakraProps` (hundreds of style-prop members) or are
polymorphic/compound, that flattening is enormous. `StoryObj<typeof Component>`
hits the cheap branch (`StoryAnnotations<ReactRenderer, ComponentProps<Component>>`)
instead. This also aligns these 18 outliers with the 63 story files already using
the component form.

`toast.stories.tsx` is intentionally left on `typeof meta`: its meta has no
`component`, so it resolves to a loose `Args` type and was already cheap.

Docs, the `writing-stories` skill, and the story templates are updated to teach
`StoryObj<typeof ComponentName>` so new components don't reintroduce the slow
pattern.

## Trade-offs
`StoryObj<typeof meta>` is meta-aware: args that `meta.args` already supplies are
made optional per story, and `argTypes`-derived args fold in. `StoryObj<typeof
Component>` only knows the component's own props, so it loses that meta-derived
inference. In practice it's a non-issue here — these are render-based
compound/portal components — and typecheck confirms zero new errors in any story
file.

## Test plan
- [x] `tsc --noEmit` — zero new errors in story files (pre-existing `rating/`
      errors are from a separate WIP component, untouched here)
- [x] Benchmark reproduces locally (numbers above)
- [ ] CI green

<!-- No ticket found on branch/commits. Internal dev-experience change; no
consumer-facing changeset needed per docs/changeset-conventions.md. -->
