### PR TITLE
fix(nimbus): SearchInput full-width stretch and focus on field click

### DIFF
--- a/.changeset/fix-search-input-stretch-and-focus.md
+++ b/.changeset/fix-search-input-stretch-and-focus.md
@@ -5,9 +5,10 @@
 **SearchInput** / **ScopedSearchInput** / **TextInput**: fix layout and
 click-to-focus behavior so these inputs behave consistently.
 
-- SearchInput now stretches to fill its container (e.g. in a `Stack` or any
-  full-width form layout) instead of rendering at a narrow intrinsic width. This
-  also fixes the search field inside `ScopedSearchInput`.
+- SearchInput now sizes like the other inputs: it stretches to fill a stretching
+  container (such as a `Stack` or `FormField`) instead of staying at a narrow
+  fixed width, while still sizing to its content when used standalone. This also
+  fixes the search field inside `ScopedSearchInput`.
 - Clicking anywhere on the visible SearchInput field — the search icon, the
   inner padding, or empty space — now focuses the input, not only a direct click
   on the text area.

--- a/.changeset/fix-search-input-stretch-and-focus.md
+++ b/.changeset/fix-search-input-stretch-and-focus.md
@@ -1,0 +1,13 @@
+---
+"@commercetools/nimbus": patch
+---
+
+**SearchInput** / **ScopedSearchInput**: fix two layout/interaction issues so
+they behave like the other form inputs.
+
+- SearchInput now stretches to fill its container (e.g. in a `Stack` or any
+  full-width form layout) instead of rendering at a narrow intrinsic width. This
+  also fixes the search field inside `ScopedSearchInput`.
+- Clicking anywhere on the visible SearchInput field — the search icon, the
+  inner padding, or empty space — now focuses the input, not only a direct click
+  on the text area.

--- a/.changeset/fix-search-input-stretch-and-focus.md
+++ b/.changeset/fix-search-input-stretch-and-focus.md
@@ -2,8 +2,8 @@
 "@commercetools/nimbus": patch
 ---
 
-**SearchInput** / **ScopedSearchInput**: fix two layout/interaction issues so
-they behave like the other form inputs.
+**SearchInput** / **ScopedSearchInput** / **TextInput**: fix layout and
+click-to-focus behavior so these inputs behave consistently.
 
 - SearchInput now stretches to fill its container (e.g. in a `Stack` or any
   full-width form layout) instead of rendering at a narrow intrinsic width. This
@@ -11,3 +11,7 @@ they behave like the other form inputs.
 - Clicking anywhere on the visible SearchInput field — the search icon, the
   inner padding, or empty space — now focuses the input, not only a direct click
   on the text area.
+- TextInput's click-to-focus is now more reliable: clicking the field's padding
+  or its leading/trailing elements focuses the input without a brief focus
+  flicker, and clicking an interactive trailing element (such as a button) no
+  longer pulls focus onto the input.

--- a/packages/nimbus/src/components/search-input/search-input.recipe.ts
+++ b/packages/nimbus/src/components/search-input/search-input.recipe.ts
@@ -13,6 +13,12 @@ export const searchInputSlotRecipe = defineSlotRecipe({
   base: {
     root: {
       display: "inline-flex",
+      // Fill the React Aria <SearchField> wrapper so the input stretches to the
+      // container width like the other form inputs (TextInput, NumberInput,
+      // MoneyInput). Unlike those, SearchInput's styled root is nested inside the
+      // SearchField wrapper rather than being the direct flex child, so it can't
+      // rely on the parent's `align-items: stretch` and needs an explicit width.
+      width: "full",
       position: "relative",
       cursor: "text",
       borderRadius: "200",

--- a/packages/nimbus/src/components/search-input/search-input.recipe.ts
+++ b/packages/nimbus/src/components/search-input/search-input.recipe.ts
@@ -13,11 +13,9 @@ export const searchInputSlotRecipe = defineSlotRecipe({
   base: {
     root: {
       display: "inline-flex",
-      // Fill the React Aria <SearchField> wrapper so the input stretches to the
-      // container width like the other form inputs (TextInput, NumberInput,
-      // MoneyInput). Unlike those, SearchInput's styled root is nested inside the
-      // SearchField wrapper rather than being the direct flex child, so it can't
-      // rely on the parent's `align-items: stretch` and needs an explicit width.
+      // The styled root is nested inside the React Aria <SearchField> wrapper
+      // (not a direct flex child), so it needs an explicit width to stretch to
+      // the container like the other form inputs.
       width: "full",
       position: "relative",
       cursor: "text",

--- a/packages/nimbus/src/components/search-input/search-input.recipe.ts
+++ b/packages/nimbus/src/components/search-input/search-input.recipe.ts
@@ -13,10 +13,6 @@ export const searchInputSlotRecipe = defineSlotRecipe({
   base: {
     root: {
       display: "inline-flex",
-      // The styled root is nested inside the React Aria <SearchField> wrapper
-      // (not a direct flex child), so it needs an explicit width to stretch to
-      // the container like the other form inputs.
-      width: "full",
       position: "relative",
       cursor: "text",
       borderRadius: "200",

--- a/packages/nimbus/src/components/search-input/search-input.stories.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.stories.tsx
@@ -154,12 +154,14 @@ export const Disabled: Story = {
     });
 
     await step("Clear button is disabled when input is disabled", async () => {
-      // Get the parent container of the input to scope the button query
-      const searchFieldContainer = input.closest(".react-aria-SearchField");
+      // Scope the button query to this input's root slot (its parent), which
+      // also contains the clear button. The story renders multiple variants,
+      // so an unscoped query would be ambiguous.
+      const searchFieldContainer = input.parentElement;
       if (!searchFieldContainer)
         throw new Error("Could not find SearchField container");
 
-      const containerScope = within(searchFieldContainer as HTMLElement);
+      const containerScope = within(searchFieldContainer);
       const clearButton = containerScope.getByRole("button", { hidden: true });
       await expect(clearButton).toBeDisabled();
     });

--- a/packages/nimbus/src/components/search-input/search-input.stories.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.stories.tsx
@@ -44,6 +44,21 @@ export const Base: Story = {
       await expect(input).toHaveFocus();
     });
 
+    await step(
+      "Clicking the field (icon / padding, not just the input) focuses the input",
+      async () => {
+        input.blur();
+        await expect(input).not.toHaveFocus();
+        // The root wraps the icon + padding; clicking it should focus the input.
+        const root = canvasElement.querySelector<HTMLElement>(
+          ".nimbus-search-input__root"
+        );
+        await expect(root).not.toBeNull();
+        await userEvent.click(root!);
+        await expect(input).toHaveFocus();
+      }
+    );
+
     await step("Can type text", async () => {
       await userEvent.type(input, "Search query");
       await expect(input).toHaveValue("Search query");

--- a/packages/nimbus/src/components/search-input/search-input.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { mergeRefs } from "@/utils";
 import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { useObjectRef } from "react-aria";
@@ -35,6 +35,7 @@ export const SearchInput = (props: SearchInputProps) => {
   const recipe = useSlotRecipe({ recipe: searchInputSlotRecipe });
   const [recipeProps, remainingProps] = recipe.splitVariantProps(restProps);
 
+  const rootRef = useRef<HTMLDivElement>(null);
   const localRef = useRef<HTMLInputElement>(null);
   const ref = useObjectRef(mergeRefs(localRef, forwardedRef));
 
@@ -45,10 +46,41 @@ export const SearchInput = (props: SearchInputProps) => {
     "data-invalid": props.isInvalid ? "true" : "false",
   };
 
+  // Clicking anywhere on the visible field (the search icon, the inner padding,
+  // or empty space) should focus the input — not just the input element itself.
+  // The listener is attached natively to the root element via its ref rather
+  // than as an `onMouseDown` prop, so it never clashes with a consumer-forwarded
+  // handler. `mousedown` (not `click`) lets us preventDefault before focus moves,
+  // avoiding a focus/selection flicker.
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target || !localRef.current) return;
+      // Ignore the input itself and interactive children (e.g. the clear
+      // button), which handle their own pointer interactions.
+      if (target === localRef.current || target.closest("button")) return;
+      event.preventDefault();
+      localRef.current.focus();
+    };
+
+    root.addEventListener("mousedown", handleMouseDown);
+    return () => {
+      root.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, []);
+
   return (
     <RaSearchField {...functionalProps}>
       {({ state }) => (
-        <SearchInputRootSlot {...recipeProps} {...styleProps} {...stateProps}>
+        <SearchInputRootSlot
+          ref={rootRef}
+          {...recipeProps}
+          {...styleProps}
+          {...stateProps}
+        >
           <SearchInputLeadingElementSlot>
             <Search />
           </SearchInputLeadingElementSlot>

--- a/packages/nimbus/src/components/search-input/search-input.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { mergeRefs } from "@/utils";
-import { useSlotRecipe } from "@chakra-ui/react/styled-system";
+import { chakra, useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { useObjectRef } from "react-aria";
 import {
   SearchField as RaSearchField,
@@ -53,36 +53,42 @@ export const SearchInput = (props: SearchInputProps) => {
   useFocusInputOnFieldClick(rootRef, localRef);
 
   return (
-    <RaSearchField {...functionalProps}>
-      {({ state }) => (
-        <SearchInputRootSlot
-          ref={rootRef}
-          {...recipeProps}
-          {...styleProps}
-          {...stateProps}
-        >
-          <SearchInputLeadingElementSlot>
-            <Search />
-          </SearchInputLeadingElementSlot>
-          <SearchInputInputSlot asChild>
-            <RaInput ref={ref} />
-          </SearchInputInputSlot>
-          <IconButton
-            slot="null"
-            size="2xs"
-            variant="ghost"
-            colorPalette="primary"
-            aria-label={msg.format("clearInput")}
-            onPress={() => state.setValue("")}
-            opacity={state.value ? 1 : 0}
-            pointerEvents={state.value ? "auto" : "none"}
-            isDisabled={props.isDisabled || props.isReadOnly}
+    // The React Aria <SearchField> renders a block-level wrapper around the
+    // styled root. Collapse it with `display: contents` so the inline-flex root
+    // becomes the layout box directly — sizing to content by default and
+    // stretching inside a Stack like the other inputs.
+    <chakra.div display="contents" asChild>
+      <RaSearchField {...functionalProps}>
+        {({ state }) => (
+          <SearchInputRootSlot
+            ref={rootRef}
+            {...recipeProps}
+            {...styleProps}
+            {...stateProps}
           >
-            <Close />
-          </IconButton>
-        </SearchInputRootSlot>
-      )}
-    </RaSearchField>
+            <SearchInputLeadingElementSlot>
+              <Search />
+            </SearchInputLeadingElementSlot>
+            <SearchInputInputSlot asChild>
+              <RaInput ref={ref} />
+            </SearchInputInputSlot>
+            <IconButton
+              slot="null"
+              size="2xs"
+              variant="ghost"
+              colorPalette="primary"
+              aria-label={msg.format("clearInput")}
+              onPress={() => state.setValue("")}
+              opacity={state.value ? 1 : 0}
+              pointerEvents={state.value ? "auto" : "none"}
+              isDisabled={props.isDisabled || props.isReadOnly}
+            >
+              <Close />
+            </IconButton>
+          </SearchInputRootSlot>
+        )}
+      </RaSearchField>
+    </chakra.div>
   );
 };
 

--- a/packages/nimbus/src/components/search-input/search-input.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.tsx
@@ -53,10 +53,8 @@ export const SearchInput = (props: SearchInputProps) => {
   useFocusInputOnFieldClick(rootRef, localRef);
 
   return (
-    // The React Aria <SearchField> renders a block-level wrapper around the
-    // styled root. Collapse it with `display: contents` so the inline-flex root
-    // becomes the layout box directly — sizing to content by default and
-    // stretching inside a Stack like the other inputs.
+    // Collapse the React Aria <SearchField> wrapper so the inline-flex root is
+    // the layout box, sizing like the other inputs.
     <chakra.div display="contents" asChild>
       <RaSearchField {...functionalProps}>
         {({ state }) => (

--- a/packages/nimbus/src/components/search-input/search-input.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { mergeRefs } from "@/utils";
 import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { useObjectRef } from "react-aria";
@@ -9,7 +9,10 @@ import {
 import { Search, Close } from "@commercetools/nimbus-icons";
 import { IconButton } from "@/components";
 import { extractStyleProps } from "@/utils";
-import { useLocalizedStringFormatter } from "@/hooks";
+import {
+  useLocalizedStringFormatter,
+  useFocusInputOnFieldClick,
+} from "@/hooks";
 import { searchInputSlotRecipe } from "./search-input.recipe";
 import {
   SearchInputRootSlot,
@@ -46,31 +49,8 @@ export const SearchInput = (props: SearchInputProps) => {
     "data-invalid": props.isInvalid ? "true" : "false",
   };
 
-  // Clicking anywhere on the visible field (the search icon, the inner padding,
-  // or empty space) should focus the input — not just the input element itself.
-  // The listener is attached natively to the root element via its ref rather
-  // than as an `onMouseDown` prop, so it never clashes with a consumer-forwarded
-  // handler. `mousedown` (not `click`) lets us preventDefault before focus moves,
-  // avoiding a focus/selection flicker.
-  useEffect(() => {
-    const root = rootRef.current;
-    if (!root) return;
-
-    const handleMouseDown = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (!target || !localRef.current) return;
-      // Ignore the input itself and interactive children (e.g. the clear
-      // button), which handle their own pointer interactions.
-      if (target === localRef.current || target.closest("button")) return;
-      event.preventDefault();
-      localRef.current.focus();
-    };
-
-    root.addEventListener("mousedown", handleMouseDown);
-    return () => {
-      root.removeEventListener("mousedown", handleMouseDown);
-    };
-  }, []);
+  // Clicking the field chrome (search icon, padding, empty space) focuses the input.
+  useFocusInputOnFieldClick(rootRef, localRef);
 
   return (
     <RaSearchField {...functionalProps}>

--- a/packages/nimbus/src/components/text-input/text-input.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useRef, type Context } from "react";
+import { useMemo, useRef, type Context } from "react";
 import { mergeRefs } from "@/utils";
+import { useFocusInputOnFieldClick } from "@/hooks";
 import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import {
   useObjectRef,
@@ -94,26 +95,8 @@ const TextInputComponent = (props: TextInputProps) => {
     "data-invalid": inputProps["aria-invalid"] ? "true" : "false",
   };
 
-  // Using a useEffect instead of "onClick" on the element, to preserve
-  // the `onClick` prop for consumers.
-  useEffect(() => {
-    const handleRootClick = (event: MouseEvent) => {
-      // Only focus if the click is inside the root element,
-      // not on the input itself, and not on an interactive element
-      if (
-        rootRef.current &&
-        rootRef.current.contains(event.target as Node) &&
-        localRef.current &&
-        event.target !== localRef.current
-      ) {
-        localRef.current.focus();
-      }
-    };
-    document.addEventListener("click", handleRootClick);
-    return () => {
-      document.removeEventListener("click", handleRootClick);
-    };
-  }, []);
+  // Clicking the field chrome (leading/trailing elements, padding) focuses the input.
+  useFocusInputOnFieldClick(rootRef, localRef);
 
   return (
     <InputContext.Provider value={null}>

--- a/packages/nimbus/src/hooks/index.ts
+++ b/packages/nimbus/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from "./use-color-mode";
 export * from "./use-color-mode-value";
 export * from "./use-localized-string-formatter";
 export * from "./use-drag-and-drop";
+export * from "./use-focus-input-on-field-click";

--- a/packages/nimbus/src/hooks/use-focus-input-on-field-click/index.ts
+++ b/packages/nimbus/src/hooks/use-focus-input-on-field-click/index.ts
@@ -1,0 +1,1 @@
+export { useFocusInputOnFieldClick } from "./use-focus-input-on-field-click.ts";

--- a/packages/nimbus/src/hooks/use-focus-input-on-field-click/use-focus-input-on-field-click.ts
+++ b/packages/nimbus/src/hooks/use-focus-input-on-field-click/use-focus-input-on-field-click.ts
@@ -1,0 +1,40 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Focuses the inner input when the user presses down on the surrounding field
+ * chrome (leading/trailing icons, padding, or empty space), mirroring the
+ * native click-to-focus behavior of a bare `<input>` for composite field
+ * components like TextInput and SearchInput.
+ *
+ * The listener is attached natively to the root element rather than as an
+ * `onMouseDown` prop so it never clobbers a consumer-forwarded handler. Using
+ * `mousedown` (over `click`) lets us preventDefault before focus moves, avoiding
+ * a focus/selection flicker. Clicks on the input itself or on interactive
+ * children (e.g. a clear button) are ignored so they keep their own behavior.
+ *
+ * @param rootRef - Ref to the field's root/wrapper element
+ * @param inputRef - Ref to the inner `<input>` to focus
+ */
+export function useFocusInputOnFieldClick(
+  rootRef: RefObject<HTMLElement | null>,
+  inputRef: RefObject<HTMLInputElement | null>
+): void {
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const input = inputRef.current;
+      if (!target || !input) return;
+      if (target === input || target.closest("button")) return;
+      event.preventDefault();
+      input.focus();
+    };
+
+    root.addEventListener("mousedown", handleMouseDown);
+    return () => {
+      root.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [rootRef, inputRef]);
+}


### PR DESCRIPTION
<img width="1359" height="488" alt="image" src="https://github.com/user-attachments/assets/47e92ba0-96b1-4a20-98a2-739db1cd8965" />

## What & why

In a vertical `Stack` of form inputs, `SearchInput` and `ScopedSearchInput` did
not behave like the other inputs (TextInput, NumberInput, PasswordInput,
MultilineTextInput, MoneyInput): they rendered at a narrow intrinsic width
instead of stretching with the container, and clicking the field's icon/padding
did not focus the input.

### Before

<!-- 📎 Drag the "Form Inputs" screenshot here (SearchInput + scoped search render narrow vs. the full-width inputs above them). -->

## Root cause

- **Width:** every other input renders its styled root slot as the _direct_ flex
  child of the Stack, so `align-items: stretch` stretches it. `SearchInput` is
  the only one that wraps its root in React Aria's `<SearchField>` element — that
  wrapper stretches, but the `inline-flex` root nested inside it stays at content
  width. `ScopedSearchInput` inherits the same limitation through the search
  field it composes.
- **Click-to-focus:** `SearchInput` had no click-to-focus behavior at all, so
  only a direct click on the `<input>` focused it — clicks on the search icon,
  the inner padding, or empty space did nothing.

## Changes

- **`search-input.tsx`** — collapse the React Aria `<SearchField>` wrapper with
  `display: contents` (`<chakra.div display="contents" asChild>`) so the
  `inline-flex` root becomes the direct layout child of the surrounding
  container. It now stretches when the container stretches it (e.g. a `Stack` or
  `FormField`) and sizes to its content when standalone — matching the other
  inputs, with no explicit width on the root. Fixes both the standalone and
  scoped variants. Also adopts the shared click-to-focus hook.
- **`hooks/use-focus-input-on-field-click`** — new shared
  `useFocusInputOnFieldClick(rootRef, inputRef)` hook that is the single source
  of truth for click-to-focus across composite field inputs. Focuses the input
  on `mousedown` anywhere in the field except the input itself and interactive
  children (e.g. a clear button). The listener is attached natively via the root
  `ref` rather than an `onMouseDown` prop, so it never clashes with a
  consumer-forwarded handler, and `mousedown` + `preventDefault` avoids
  focus/selection flicker.
- **`text-input.tsx`** — migrate off its prior global `document` `click`
  listener onto the shared hook. Net consumer-visible improvement: no focus
  flicker when clicking the field chrome, and clicks on interactive trailing
  elements (e.g. a button) no longer pull focus onto the input.
- **`search-input.stories.tsx`** — add a play-function step asserting a click on
  the field (not the input) focuses the input.

## Testing

- `typecheck` + `eslint` clean for all touched files.
- Story tests: SearchInput + TextInput **26/26** (incl. the new SearchInput
  click-to-focus step and TextInput's existing focus assertions), against source.
- Verified in Storybook that SearchInput and TextInput size identically — both
  content-width standalone and both stretching inside a `Stack` — and that
  click-to-focus still works after collapsing the wrapper.
