### PR TITLE
fix(splitter): collapse/expand no longer fire the size callbacks

### DIFF
--- a/.changeset/splitter-collapse-no-size-settle.md
+++ b/.changeset/splitter-collapse-no-size-settle.md
@@ -1,0 +1,13 @@
+---
+"@commercetools/nimbus": patch
+---
+
+**Splitter**: collapsing or expanding the aside no longer fires `onSizeChangeEnd`.
+
+`onSizeChangeEnd` is the resize-settle channel (drag end, keyboard, double-click
+restore) — the seam consumers wire persistence to. Collapse/expand are signalled
+by `onCollapsedChange`, so they no longer also emit `onSizeChangeEnd`. This fixes
+controlled-size consumers that feed the settled value back into `size`: a
+programmatic collapse previously fed the collapsed size back, so the aside
+reopened at the collapsed width (e.g. 0) instead of its real width. `onSizeChange`
+(the live, per-tick channel) still reports collapse/expand.

--- a/.changeset/splitter-collapse-no-size-settle.md
+++ b/.changeset/splitter-collapse-no-size-settle.md
@@ -1,14 +1,16 @@
 ---
-"@commercetools/nimbus": patch
+"@commercetools/nimbus": minor
 ---
 
-**Splitter**: collapsing or expanding the aside no longer fires `onSizeChange` or
-`onSizeChangeEnd`.
+`Splitter`: collapsing or expanding the aside is no longer reported on the size
+callbacks (`onSizeChange` / `onSizeChangeEnd`) — only on `onCollapsedChange`.
 
-Collapse/expand change only the aside's layout (main takes the remainder) and are
-signalled by `onCollapsedChange` — they are not size *changes* a consumer should
-react to on the size channels. The size channels stay resize-only (drag,
-keyboard, double-click restore). This fixes controlled-size consumers that feed
-the settled value back into `size`: a programmatic collapse previously fed the
-collapsed size back, so the aside reopened at the collapsed width (e.g. 0) instead
-of its real width.
+- Fixed: a controlled splitter (you drive `size` and feed `onSizeChangeEnd` back)
+  no longer breaks on a programmatic collapse. Previously, collapsing fed the
+  collapsed size back into `size`, so expanding reopened the aside at the
+  collapsed width (e.g. `0`) instead of its previous width. Collapse/expand now
+  preserve the size to restore, with no special wiring on your part.
+- Behavior change: `onSizeChange` and `onSizeChangeEnd` now fire only for genuine
+  resizes (drag, keyboard, double-click restore). They no longer fire on
+  collapse/expand. If you need to react to the aside collapsing or expanding, use
+  `onCollapsedChange`.

--- a/.changeset/splitter-collapse-no-size-settle.md
+++ b/.changeset/splitter-collapse-no-size-settle.md
@@ -2,12 +2,13 @@
 "@commercetools/nimbus": patch
 ---
 
-**Splitter**: collapsing or expanding the aside no longer fires `onSizeChangeEnd`.
+**Splitter**: collapsing or expanding the aside no longer fires `onSizeChange` or
+`onSizeChangeEnd`.
 
-`onSizeChangeEnd` is the resize-settle channel (drag end, keyboard, double-click
-restore) — the seam consumers wire persistence to. Collapse/expand are signalled
-by `onCollapsedChange`, so they no longer also emit `onSizeChangeEnd`. This fixes
-controlled-size consumers that feed the settled value back into `size`: a
-programmatic collapse previously fed the collapsed size back, so the aside
-reopened at the collapsed width (e.g. 0) instead of its real width. `onSizeChange`
-(the live, per-tick channel) still reports collapse/expand.
+Collapse/expand change only the aside's layout (main takes the remainder) and are
+signalled by `onCollapsedChange` — they are not size *changes* a consumer should
+react to on the size channels. The size channels stay resize-only (drag,
+keyboard, double-click restore). This fixes controlled-size consumers that feed
+the settled value back into `size`: a programmatic collapse previously fed the
+collapsed size back, so the aside reopened at the collapsed width (e.g. 0) instead
+of its real width.

--- a/openspec/changes/add-splitter-component/specs/nimbus-splitter/spec.md
+++ b/openspec/changes/add-splitter-component/specs/nimbus-splitter/spec.md
@@ -98,10 +98,10 @@ counterpart, see "Optional controlled `size` prop".
 - **WHEN** `defaultSize` is omitted or non-finite
 - **THEN** SHALL fall back to a 50/50 split
 
-#### Scenario: `onSizeChange` fires on every size update
+#### Scenario: `onSizeChange` fires on every resize update
 
 - **WHEN** the user drags the handle (each tick), presses an arrow key on a
-  focused handle, collapses/expands, or double-clicks to restore
+  focused handle, or double-clicks to restore
 - **THEN** SHALL call `onSizeChange(size)` with the post-change aside size
   (`0–100`)
 
@@ -112,14 +112,14 @@ counterpart, see "Optional controlled `size` prop".
 - **THEN** SHALL call `onSizeChangeEnd(size)` exactly once for that interaction
   (the seam consumers wire persistence to — no debounce required)
 
-#### Scenario: collapse/expand do not fire `onSizeChangeEnd`
+#### Scenario: collapse/expand do not fire `onSizeChange` or `onSizeChangeEnd`
 
 - **WHEN** the aside collapses or expands (via Enter on the focused handle or the
   controlled `collapsed` prop)
-- **THEN** SHALL NOT call `onSizeChangeEnd` — collapse/expand are signalled by
-  `onCollapsedChange`, not the resize-settle channel, so a consumer feeding the
-  settled value back into a controlled `size` never persists or restores the
-  collapsed size
+- **THEN** SHALL NOT call `onSizeChange` or `onSizeChangeEnd` — collapse/expand
+  change only the aside's layout and are signalled by `onCollapsedChange`, so a
+  consumer feeding the settled value back into a controlled `size` never persists
+  or restores the collapsed size
 
 #### Scenario: Size preserves float precision
 
@@ -381,10 +381,12 @@ for writing back; collapse persists via its controlled `collapsed` boolean.
 
 #### Scenario: Persist on settled change
 
-- **WHEN** an interaction settles (drag end, keypress, collapse/expand, restore)
+- **WHEN** a resize interaction settles (drag end, keypress, double-click
+  restore)
 - **THEN** SHALL call `onSizeChangeEnd(size)` once, which the consumer wires to
   its storage `set` — no debouncing required since it fires per interaction, not
-  per drag tick
+  per drag tick (collapse/expand do not fire it; collapse state is persisted via
+  `onCollapsedChange`)
 
 #### Scenario: No imperative API
 

--- a/openspec/changes/add-splitter-component/specs/nimbus-splitter/spec.md
+++ b/openspec/changes/add-splitter-component/specs/nimbus-splitter/spec.md
@@ -105,12 +105,21 @@ counterpart, see "Optional controlled `size` prop".
 - **THEN** SHALL call `onSizeChange(size)` with the post-change aside size
   (`0–100`)
 
-#### Scenario: `onSizeChangeEnd` fires once per settled interaction
+#### Scenario: `onSizeChangeEnd` fires once per settled resize
 
-- **WHEN** a drag ends, an arrow/Home/End key is pressed, the aside collapses or
-  expands, or double-click restores defaults
+- **WHEN** a drag ends, an arrow/Home/End key is pressed, or double-click
+  restores defaults
 - **THEN** SHALL call `onSizeChangeEnd(size)` exactly once for that interaction
   (the seam consumers wire persistence to — no debounce required)
+
+#### Scenario: collapse/expand do not fire `onSizeChangeEnd`
+
+- **WHEN** the aside collapses or expands (via Enter on the focused handle or the
+  controlled `collapsed` prop)
+- **THEN** SHALL NOT call `onSizeChangeEnd` — collapse/expand are signalled by
+  `onCollapsedChange`, not the resize-settle channel, so a consumer feeding the
+  settled value back into a controlled `size` never persists or restores the
+  collapsed size
 
 #### Scenario: Size preserves float precision
 

--- a/packages/nimbus/src/components/splitter/hooks/use-splitter-state.ts
+++ b/packages/nimbus/src/components/splitter/hooks/use-splitter-state.ts
@@ -194,19 +194,23 @@ export const useSplitterState = (
     if (cur && !asideConfig.collapsible) return;
     appliedCollapseRef.current = cur;
 
-    // Collapse/expand only changes the aside's layout and is signalled via
-    // `onCollapsedChange` — it is not a resize settle. Use `setSize` (fires
-    // `onSizeChange` but NOT `onSizeChangeEnd`) so a controlled-size consumer
-    // feeding `onSizeChangeEnd` back doesn't persist/restore the collapsed size.
-    // `onSizeChangeEnd` stays the user-resize seam (drag, keyboard, double-click,
+    // Collapse/expand only change the aside's layout and are signalled via
+    // `onCollapsedChange` — they are not size changes a consumer should react to.
+    // Write the size silently (no `onSizeChange`, no `onSizeChangeEnd`), the same
+    // way the controlled-`size` reconcile below writes the consumer's own value,
+    // so a controlled-size consumer never sees the collapsed size on either
+    // channel. Both stay the resize channels (drag, keyboard, double-click,
     // drag-to-expand).
     if (cur) {
       if (!prev) preCollapseSizeRef.current = sizeRef.current;
-      setSize(asideConfig.collapsedSize);
+      sizeRef.current = asideConfig.collapsedSize;
+      setSizeState(asideConfig.collapsedSize);
     } else {
       const restore = preCollapseSizeRef.current;
       preCollapseSizeRef.current = null;
-      setSize(restore ?? initialSizeRef.current);
+      const next = restore ?? initialSizeRef.current;
+      sizeRef.current = next;
+      setSizeState(next);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapsed, paneOrder]);

--- a/packages/nimbus/src/components/splitter/hooks/use-splitter-state.ts
+++ b/packages/nimbus/src/components/splitter/hooks/use-splitter-state.ts
@@ -194,13 +194,19 @@ export const useSplitterState = (
     if (cur && !asideConfig.collapsible) return;
     appliedCollapseRef.current = cur;
 
+    // Collapse/expand only changes the aside's layout and is signalled via
+    // `onCollapsedChange` — it is not a resize settle. Use `setSize` (fires
+    // `onSizeChange` but NOT `onSizeChangeEnd`) so a controlled-size consumer
+    // feeding `onSizeChangeEnd` back doesn't persist/restore the collapsed size.
+    // `onSizeChangeEnd` stays the user-resize seam (drag, keyboard, double-click,
+    // drag-to-expand).
     if (cur) {
       if (!prev) preCollapseSizeRef.current = sizeRef.current;
-      commitSize(asideConfig.collapsedSize);
+      setSize(asideConfig.collapsedSize);
     } else {
       const restore = preCollapseSizeRef.current;
       preCollapseSizeRef.current = null;
-      commitSize(restore ?? initialSizeRef.current);
+      setSize(restore ?? initialSizeRef.current);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collapsed, paneOrder]);

--- a/packages/nimbus/src/components/splitter/splitter.dev.mdx
+++ b/packages/nimbus/src/components/splitter/splitter.dev.mdx
@@ -317,8 +317,9 @@ const App = () => (
 
 Size is uncontrolled by default, so persist it in your app with any storage:
 hydrate `defaultSize` from stored state and write the settled value back in
-`onSizeChangeEnd` (it fires once per settled interaction — drag end, each
-keypress, collapse/expand, double-click restore — so no debouncing is needed). A
+`onSizeChangeEnd` (it fires once per settled **resize** — drag end, each
+keypress, double-click restore — so no debouncing is needed; collapse/expand are
+signalled by `onCollapsedChange`, not here). A
 single `number` round-trips: the value `onSizeChangeEnd` emits is exactly the
 shape `defaultSize` accepts. Collapse persists through its controlled boolean
 state.

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -815,6 +815,70 @@ export const ControlledSize: Story = {
 };
 
 // ============================================================
+// Controlled size + controlled collapse (NO hook) — regression for collapse
+// emitting a resize settle. The consumer follows the contract (feed
+// onSizeChangeEnd back into `size`). A programmatic collapse must NOT feed the
+// collapsed size back, so expanding restores the real width (30), not 0.
+// Collapse/expand are silent on onSizeChangeEnd; they are signalled by
+// onCollapsedChange only.
+// ============================================================
+
+const ControlledSizeCollapseReproComponent = () => {
+  const [size, setSize] = useState(30);
+  const [open, setOpen] = useState(true);
+  return (
+    <Stack gap="400" h="lg">
+      <Button onPress={() => setOpen((o) => !o)} data-testid="toggle-btn">
+        {open ? "Collapse aside" : "Expand aside"}
+      </Button>
+      <Splitter.Root
+        size={size}
+        minSize={10}
+        maxSize={80}
+        onSizeChangeEnd={setSize}
+        collapsible
+        collapsedSize={0}
+        collapsed={!open}
+        onCollapsedChange={(c) => setOpen(!c)}
+      >
+        <Splitter.Aside>
+          <DemoPane bg="indigo.3" title="Aside" />
+        </Splitter.Aside>
+        <Splitter.Handle />
+        <Splitter.Main>
+          <DemoPane bg="amber.3" title="Main" />
+        </Splitter.Main>
+      </Splitter.Root>
+    </Stack>
+  );
+};
+
+export const ControlledSizeCollapseRepro: Story = {
+  render: () => <ControlledSizeCollapseReproComponent />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const handle = await canvas.findByRole("separator");
+    const button = canvas.getByTestId("toggle-btn");
+
+    await waitFor(() => {
+      expect(Number(handle.getAttribute("aria-valuenow"))).toBe(30);
+    });
+
+    await userEvent.click(button); // programmatic collapse
+    await waitFor(() => {
+      expect(Number(handle.getAttribute("aria-valuenow"))).toBe(0);
+    });
+
+    await userEvent.click(button); // expand
+    await canvas.findByRole("button", { name: "Collapse aside" });
+
+    // The collapse did not feed 0 back into the controlled size, so expand
+    // restores the real width — not the collapsed 0.
+    expect(Number(handle.getAttribute("aria-valuenow"))).toBe(30);
+  },
+};
+
+// ============================================================
 // Resize is locked while the aside is collapsed — drag + arrow/Home/End do
 // nothing and the aside stays at collapsedSize. A visible "Collapse / expand
 // nav" button drives the collapse (controlled) so the lock is verifiable by

--- a/packages/nimbus/src/components/splitter/splitter.types.ts
+++ b/packages/nimbus/src/components/splitter/splitter.types.ts
@@ -160,9 +160,10 @@ export type SplitterRootProps = OmitInternalProps<SplitterRootSlotProps> & {
   collapsedSize?: number;
 
   /**
-   * Notification callback fired on every size change, including each drag tick
-   * (~60Hz). Receives the aside size (0–100). For persistence, prefer
-   * `onSizeChangeEnd`.
+   * Notification callback fired on every **resize** update, including each drag
+   * tick (~60Hz). Receives the aside size (0–100). For persistence, prefer
+   * `onSizeChangeEnd`. Collapse and expand do **not** fire this — they only
+   * change the aside's layout and are signalled by `onCollapsedChange`.
    */
   onSizeChange?: (size: number) => void;
 

--- a/packages/nimbus/src/components/splitter/splitter.types.ts
+++ b/packages/nimbus/src/components/splitter/splitter.types.ts
@@ -167,9 +167,12 @@ export type SplitterRootProps = OmitInternalProps<SplitterRootSlotProps> & {
   onSizeChange?: (size: number) => void;
 
   /**
-   * Notification callback fired once when a size interaction settles (drag end,
-   * each keypress, collapse/expand, double-click restore). Receives the aside
-   * size (0–100). This is the seam to wire persistence to — no debouncing.
+   * Notification callback fired once when a **resize** interaction settles (drag
+   * end, each keypress, double-click restore). Receives the aside size (0–100).
+   * This is the seam to wire persistence to — no debouncing. Collapse and expand
+   * do **not** fire this (they are signalled by `onCollapsedChange`); only a
+   * genuine resize does, so feeding the value back into a controlled `size`
+   * never restores the collapsed size.
    */
   onSizeChangeEnd?: (size: number) => void;
 


### PR DESCRIPTION
## Summary

A controlled `Splitter` (you drive `size` and feed `onSizeChangeEnd` back) broke on a programmatic collapse: the aside reopened at the **collapsed width** (e.g. `0`) instead of its previous size. Collapse and expand now change only the aside's layout and are reported solely via `onCollapsedChange` — the size callbacks (`onSizeChange`, `onSizeChangeEnd`) no longer fire on them, so there's nothing for a controlled consumer to feed back and corrupt.

## Root cause

`onSizeChangeEnd` is the seam consumers wire persistence/controlled-`size` to, and the contract says to feed the settled value back into `size`. But collapse committed the size through the normal channel, firing `onSizeChange`/`onSizeChangeEnd` with `collapsedSize`. A consumer following the contract fed that `0` back into `size`; on expand the component restored the (now-`0`) value. It reproduces with **no hook involved** — any controlled-size + controlled-collapse consumer hits it:

```tsx
const [size, setSize] = useState(30);
const [collapsed, setCollapsed] = useState(false);
<Splitter.Root size={size} onSizeChangeEnd={setSize}
  collapsible collapsed={collapsed} onCollapsedChange={setCollapsed} />
// programmatic collapse → onSizeChangeEnd(0) → setSize(0) → expand restores to 0
```

So the defect is in the component, not in `useResponsiveSplitterSizes` (which was simply the first consumer to surface it).

## Fix

The collapse/expand reconcile in `use-splitter-state.ts` now writes the size **silently** — it updates the rendered layout but emits neither `onSizeChange` nor `onSizeChangeEnd` (the same silent-write the controlled-`size` reconcile already uses). Collapse state reaches consumers through `onCollapsedChange`; the size callbacks stay resize-only (drag, keyboard, double-click restore, drag-to-expand). `preCollapseSizeRef` expand-restore and the controlled-`size` loop are unchanged. Fixed at the source, so it holds for every consumer and every wiring — no hook collapse-awareness needed.

## Behavior change / compatibility

This changes the public contract of the size callbacks (hence the `minor` changeset): `onSizeChange` / `onSizeChangeEnd` no longer fire on collapse/expand. A consumer that relied on either firing during collapse should read collapse from `onCollapsedChange` instead. Persistence/controlled-size consumers need no change — the previously-broken case now just works.

## Regression test

`ControlledSizeCollapseRepro` (`splitter.stories.tsx`) — a plain controlled-size + controlled-collapse story with **no hook**: collapse → expand must restore the real width. It fails `expected 30, received 0` against the unfixed component and passes with the fix. `ResizeLockedWhileCollapsed` continues to guard that resize stays locked while collapsed.

## Test plan

- [x] `pnpm test:storybook:dev .../splitter.stories.tsx` — 24/24 stories green (incl. the new repro)
- [x] `pnpm exec vitest --run .../use-splitter-state.spec.tsx .../use-responsive-splitter-sizes.spec.tsx` — 19/19
- [x] `openspec validate add-splitter-component --strict` passes (size-channel scenarios updated + a negative scenario added)
- [x] no splitter typecheck errors

## Risk

Medium — a public behavior change to the size callbacks on collapse, but narrowly scoped to the splitter and covered by stories + unit tests. No migration, infra, or dependency impact.

## Docs / spec

- `splitter.types.ts` + `splitter.dev.mdx`: `onSizeChange`/`onSizeChangeEnd` docs no longer list collapse/expand.
- `add-splitter-component` OpenSpec spec: size-channel scenarios corrected + a negative scenario for collapse/expand.