### PR TITLE
chore(deps): update workspace dependencies to latest minor/patch versions

### DIFF
--- a/.changeset/housekeeping-deps-20260623-0708.md
+++ b/.changeset/housekeeping-deps-20260623-0708.md
@@ -1,0 +1,15 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Update React Aria dependencies to their latest minor versions (`react-aria`
+3.50.0, `react-aria-components` 1.19.0, `react-stately` 3.48.0).
+
+- `Menu`'s `onAction` callback now receives the selected item's value as a
+  second argument (`onAction(key, value)`), following React Aria's updated
+  signature. Existing handlers that only read the key continue to work
+  unchanged.
+- Fixed keyboard navigation for removable tags in `ComboBox` (multi-select) and
+  `TagGroup`: the tag's remove button is no longer a separate tab stop, which
+  restores the single-Tab-stop entry into the tag list and arrow-key navigation
+  between tags. Tags are still removed with Delete/Backspace once focused.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       # Make sure to grab the latest version of the Playwright image
       # https://playwright.dev/docs/docker#pull-the-image
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
 
     steps:
       - name: Checkout repository

--- a/packages/nimbus-icons/.svgrrc.js
+++ b/packages/nimbus-icons/.svgrrc.js
@@ -3,9 +3,16 @@ module.exports = {
   jsx: {
     babelConfig: {
       plugins: [
-        // For an example, this plugin will remove "id" attribute from "svg" tag
+        // Resolve to an absolute path so Babel loads the plugin regardless of
+        // how pnpm hoists it. A bare module name is resolved by @babel/core
+        // relative to its resolution base, which is not reliable under pnpm's
+        // strict node_modules layout (e.g. a clean CI install) and caused
+        // "Cannot find module '@svgr/babel-plugin-add-jsx-attribute'" on Vercel.
+        // The plugin is declared as a direct devDependency of this package so
+        // require.resolve always finds it here.
         [
-          "@svgr/babel-plugin-add-jsx-attribute",
+          // eslint-disable-next-line no-undef
+          require.resolve("@svgr/babel-plugin-add-jsx-attribute"),
           {
             elements: ["svg"],
             attributes: [

--- a/packages/nimbus-icons/package.json
+++ b/packages/nimbus-icons/package.json
@@ -30,6 +30,7 @@
     "@svgr/cli": "^8.1.0"
   },
   "devDependencies": {
+    "@svgr/babel-plugin-add-jsx-attribute": "^8.0.0",
     "@svgr/plugin-jsx": "^8.1.0",
     "@types/node": "catalog:utils",
     "@types/react": "catalog:react",

--- a/packages/nimbus/src/components/menu/menu.docs.spec.tsx
+++ b/packages/nimbus/src/components/menu/menu.docs.spec.tsx
@@ -102,7 +102,7 @@ describe("Menu - Interactions", () => {
 
     await user.click(screen.getByRole("menuitem", { name: "Edit" }));
 
-    expect(handleAction).toHaveBeenCalledWith("edit");
+    expect(handleAction).toHaveBeenCalledWith("edit", undefined);
     await waitFor(() => {
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
@@ -166,7 +166,7 @@ describe("Menu - Action callback", () => {
 
     await user.click(screen.getByRole("menuitem", { name: "Copy" }));
 
-    expect(handleAction).toHaveBeenCalledWith("copy");
+    expect(handleAction).toHaveBeenCalledWith("copy", undefined);
   });
 
   it("calls onAction with Enter key", async () => {
@@ -197,7 +197,7 @@ describe("Menu - Action callback", () => {
 
     await user.keyboard("{Enter}");
 
-    expect(handleAction).toHaveBeenCalledWith("save");
+    expect(handleAction).toHaveBeenCalledWith("save", undefined);
   });
 });
 

--- a/packages/nimbus/src/components/menu/menu.stories.tsx
+++ b/packages/nimbus/src/components/menu/menu.stories.tsx
@@ -163,7 +163,7 @@ export const Basic: Story = {
       // Focus is already on copy item from previous step
       // Press Enter to select
       await userEvent.keyboard("{Enter}");
-      await expect(args.onAction).toHaveBeenCalledWith("copy");
+      await expect(args.onAction).toHaveBeenCalledWith("copy", undefined);
       await waitFor(() => {
         expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
       });
@@ -1108,7 +1108,7 @@ export const MixedSelection: Story = {
         await userEvent.click(copyItem);
 
         // Should trigger action and close menu
-        await expect(args.onAction).toHaveBeenCalledWith("copy");
+        await expect(args.onAction).toHaveBeenCalledWith("copy", undefined);
 
         // First menu should be closed
         await waitFor(() => {
@@ -1994,9 +1994,9 @@ export const CollectionPatternDemo: Story = {
           </Text>
 
           <Menu.Root
-            onAction={(key) => {
+            onAction={(key, value) => {
               setLastAction(key as string);
-              args.onAction?.(key);
+              args.onAction?.(key, value);
             }}
             onOpenChange={args.onOpenChange}
           >
@@ -2066,7 +2066,7 @@ export const CollectionPatternDemo: Story = {
       const newFileItem = canvas.getByRole("menuitem", { name: /New File/ });
       await userEvent.click(newFileItem);
 
-      await expect(args.onAction).toHaveBeenCalledWith("new");
+      await expect(args.onAction).toHaveBeenCalledWith("new", undefined);
       await waitFor(() => {
         expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
       });
@@ -2084,7 +2084,7 @@ export const CollectionPatternDemo: Story = {
       const deleteItem = canvas.getByRole("menuitem", { name: /Delete/ });
       await userEvent.click(deleteItem);
 
-      await expect(args.onAction).toHaveBeenCalledWith("delete");
+      await expect(args.onAction).toHaveBeenCalledWith("delete", undefined);
       await waitFor(() => {
         expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
       });

--- a/packages/nimbus/src/components/split-button/split-button.types.ts
+++ b/packages/nimbus/src/components/split-button/split-button.types.ts
@@ -1,8 +1,5 @@
-import type { ReactNode } from "react";
-import type {
-  MenuTriggerProps as RaMenuTriggerProps,
-  MenuProps as RaMenuProps,
-} from "react-aria-components";
+import type { Key, ReactNode } from "react";
+import type { MenuTriggerProps as RaMenuTriggerProps } from "react-aria-components";
 import type { ButtonProps } from "../button/button.types";
 import type {
   HTMLChakraProps,
@@ -35,8 +32,12 @@ export type SplitButtonTriggerSlotProps = HTMLChakraProps<"button">;
 // ============================================================
 export type SplitButtonProps = SplitButtonRecipeProps &
   Pick<ButtonProps, "size" | "colorPalette" | "variant" | "isDisabled"> &
-  Omit<RaMenuTriggerProps, "trigger" | "children"> &
-  Required<Pick<RaMenuProps<object>, "onAction">> & {
+  Omit<RaMenuTriggerProps, "trigger" | "children"> & {
+    /**
+     * Handler called when the primary action button is pressed or a dropdown
+     * menu item is selected. Receives the action's key.
+     */
+    onAction: (key: Key) => void;
     /**
      * Accessibility label for the dropdown trigger
      */

--- a/packages/nimbus/src/components/tag-group/components/tag-group.tag.tsx
+++ b/packages/nimbus/src/components/tag-group/components/tag-group.tag.tsx
@@ -30,6 +30,7 @@ export const TagGroupTag: TagGroupTagComponent = ({
                 size="2xs"
                 variant={isSelected ? "solid" : "ghost"}
                 slot="remove"
+                excludeFromTabOrder
                 colorPalette={isSelected ? undefined : "neutral"}
                 aria-label={msg.format("removeTag")}
               >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,9 +206,9 @@ overrides:
   '@babel/runtime': ^7.29.7
   prismjs: ^1.30.0
   typescript: ~5.9.3
-  react-aria: 3.49.0
-  react-aria-components: 1.18.0
-  react-stately: 3.47.0
+  react-aria: 3.50.0
+  react-aria-components: 1.19.0
+  react-stately: 3.48.0
   '@react-aria/interactions': 3.28.1
   brace-expansion@<2: ^2.0.3
   brace-expansion@2: ~2.0.3
@@ -423,11 +423,11 @@ importers:
         specifier: catalog:react
         version: 19.2.0
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-aria-components:
-        specifier: 1.18.0
-        version: 1.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 1.19.0
+        version: 1.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-docgen-typescript:
         specifier: ^2.4.0
         version: 2.4.0(typescript@5.9.3)
@@ -444,8 +444,8 @@ importers:
         specifier: ^7.17.0
         version: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
-        specifier: 3.47.0
-        version: 3.47.0(react@19.2.0)
+        specifier: 3.48.0
+        version: 3.48.0(react@19.2.0)
       react-syntax-highlighter:
         specifier: ^16.1.1
         version: 16.1.1(react@19.2.0)
@@ -605,17 +605,17 @@ importers:
         specifier: catalog:react
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-aria:
-        specifier: 3.49.0
-        version: 3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-aria-components:
-        specifier: 1.18.0
-        version: 1.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 1.19.0
+        version: 1.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-hotkeys-hook:
         specifier: ^5.3.2
         version: 5.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
-        specifier: 3.47.0
-        version: 3.47.0(react@19.2.0)
+        specifier: 3.48.0
+        version: 3.48.0(react@19.2.0)
       react-use:
         specifier: ^17.6.1
         version: 17.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2707,11 +2707,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/shared@3.35.0':
-    resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-types/shared@3.36.0':
     resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
@@ -6694,14 +6689,14 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-aria-components@1.18.0:
-    resolution: {integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==}
+  react-aria-components@1.19.0:
+    resolution: {integrity: sha512-2smSS5nqJ8cGYMQezuUXveZm7eMyHCqTN6mDpylQBYLYbdF5dxCCuW1DHn1VKLe1DybSfPvX/cZtJlDmvFfn8A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-aria@3.49.0:
-    resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
+  react-aria@3.50.0:
+    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -6797,8 +6792,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-stately@3.47.0:
-    resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
+  react-stately@3.48.0:
+    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -10387,7 +10382,7 @@ snapshots:
       '@react-types/shared': 3.36.0(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
-      react-aria: 3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
   '@react-aria/optimize-locales-plugin@1.2.1':
@@ -10398,13 +10393,9 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.17
       react: 19.2.0
-      react-aria: 3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
-      react-stately: 3.47.0(react@19.2.0)
-
-  '@react-types/shared@3.35.0(react@19.2.0)':
-    dependencies:
-      react: 19.2.0
+      react-stately: 3.48.0(react@19.2.0)
 
   '@react-types/shared@3.36.0(react@19.2.0)':
     dependencies:
@@ -15030,29 +15021,29 @@ snapshots:
       iconv-lite: 0.7.0
       unpipe: 1.0.0
 
-  react-aria-components@1.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-aria-components@1.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@internationalized/date': 3.12.2
-      '@react-types/shared': 3.35.0(react@19.2.0)
+      '@react-types/shared': 3.36.0(react@19.2.0)
       '@swc/helpers': 0.5.17
       client-only: 0.0.1
       react: 19.2.0
-      react-aria: 3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
-      react-stately: 3.47.0(react@19.2.0)
+      react-stately: 3.48.0(react@19.2.0)
 
-  react-aria@3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-aria@3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
       '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@19.2.0)
+      '@react-types/shared': 3.36.0(react@19.2.0)
       '@swc/helpers': 0.5.17
       aria-hidden: 1.2.6
       clsx: 2.1.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-stately: 3.47.0(react@19.2.0)
+      react-stately: 3.48.0(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
@@ -15147,12 +15138,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-stately@3.47.0(react@19.2.0):
+  react-stately@3.48.0(react@19.2.0):
     dependencies:
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
       '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.35.0(react@19.2.0)
+      '@react-types/shared': 3.36.0(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,9 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
     devDependencies:
+      '@svgr/babel-plugin-add-jsx-attribute':
+        specifier: ^8.0.0
+        version: 8.0.0(@babel/core@7.29.7)
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ catalogs:
       version: 19.2.0
   tooling:
     '@arethetypeswrong/cli':
-      specifier: ^0.18.3
-      version: 0.18.3
+      specifier: ^0.18.4
+      version: 0.18.4
     '@babel/preset-typescript':
       specifier: ^7.29.7
       version: 7.29.7
@@ -74,8 +74,8 @@ catalogs:
       specifier: ^2.8.13
       version: 2.8.13
     '@react-types/shared':
-      specifier: ^3.35.0
-      version: 3.35.0
+      specifier: ^3.36.0
+      version: 3.36.0
     '@storybook/addon-a11y':
       specifier: ^10.4.6
       version: 10.4.6
@@ -137,11 +137,11 @@ catalogs:
       specifier: ^13.0.6
       version: 13.0.6
     globals:
-      specifier: ^17.6.0
-      version: 17.6.0
+      specifier: ^17.7.0
+      version: 17.7.0
     playwright:
-      specifier: ^1.60.0
-      version: 1.60.0
+      specifier: ^1.61.0
+      version: 1.61.0
     prettier:
       specifier: ^3.8.4
       version: 3.8.4
@@ -158,8 +158,8 @@ catalogs:
       specifier: ^4.22.4
       version: 4.22.4
     typescript-eslint:
-      specifier: ^8.61.0
-      version: 8.61.0
+      specifier: ^8.62.0
+      version: 8.62.0
     vite:
       specifier: ^8.0.16
       version: 8.0.16
@@ -202,7 +202,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  rollup: ^4.62.0
+  rollup: ^4.62.2
   '@babel/runtime': ^7.29.7
   prismjs: ^1.30.0
   typescript: ~5.9.3
@@ -246,7 +246,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: catalog:tooling
-        version: 0.18.3
+        version: 0.18.4
       '@babel/core':
         specifier: ^7.29.6
         version: 7.29.7
@@ -291,10 +291,10 @@ importers:
         version: 10.4.6(eslint@10.5.0)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       globals:
         specifier: catalog:tooling
-        version: 17.6.0
+        version: 17.7.0
       playwright:
         specifier: catalog:tooling
-        version: 1.60.0
+        version: 1.61.0
       prettier:
         specifier: catalog:tooling
         version: 3.8.4
@@ -309,7 +309,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+        version: 8.62.0(eslint@10.5.0)(typescript@5.9.3)
       vite-bundle-analyzer:
         specifier: catalog:tooling
         version: 1.3.8
@@ -352,13 +352,13 @@ importers:
         version: 0.5.3(eslint@10.5.0)
       globals:
         specifier: catalog:tooling
-        version: 17.6.0
+        version: 17.7.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+        version: 8.62.0(eslint@10.5.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
@@ -494,13 +494,13 @@ importers:
         version: 0.5.3(eslint@10.5.0)
       globals:
         specifier: catalog:tooling
-        version: 17.6.0
+        version: 17.7.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+        version: 8.62.0(eslint@10.5.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
@@ -643,19 +643,19 @@ importers:
         version: 1.2.1
       '@react-types/shared':
         specifier: catalog:tooling
-        version: 3.35.0(react@19.2.0)
+        version: 3.36.0(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: catalog:tooling
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
         version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9)(@vitest/runner@4.1.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.9)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.9.1
@@ -685,7 +685,7 @@ importers:
         version: 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
       '@vitest/browser-playwright':
         specifier: catalog:tooling
-        version: 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: catalog:tooling
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -709,7 +709,7 @@ importers:
         version: 29.0.1
       playwright:
         specifier: catalog:tooling
-        version: 1.60.0
+        version: 1.61.0
       react:
         specifier: catalog:react
         version: 19.2.0
@@ -736,7 +736,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: catalog:tooling
-        version: 5.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+        version: 5.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
       vitest:
         specifier: catalog:tooling
         version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
@@ -860,13 +860,13 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
-  '@arethetypeswrong/cli@0.18.3':
-    resolution: {integrity: sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ==}
+  '@arethetypeswrong/cli@0.18.4':
+    resolution: {integrity: sha512-kNWo6LTzGAuLYPpJ7Sgo63whSUeeSuKMlYx6IBgzs4ONEG807gW4hSSENvpeCHzO2H2wIzG5EFl0OKBbqGBAyA==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.18.3':
-    resolution: {integrity: sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==}
+  '@arethetypeswrong/core@0.18.4':
+    resolution: {integrity: sha512-M5F0ePyN6h2Z6XxRiyIPqjGbltotXLjR0CKA0uKspsDu0QmgTNYvRb4RSQPMUs2ZXZHCCYpbaZbFbYOXLxCjUA==}
     engines: {node: '>=20'}
 
   '@ark-ui/react@5.37.2':
@@ -2713,6 +2713,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-types/shared@3.36.0':
+    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@remote-dom/core@1.10.1':
     resolution: {integrity: sha512-MlbUOGuHjOrB7uOkaYkIoLUG8lDK8/H1D7MHnGkgqbG6jwjwQSlGPHhbwnD6HYWsTGpAPOP02Byd8wBt9U6TEw==}
     engines: {node: '>=14.0.0'}
@@ -2834,52 +2839,52 @@ packages:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
 
   '@rollup/plugin-commonjs@15.1.0':
     resolution: {integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
 
   '@rollup/plugin-json@4.1.0':
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
 
   '@rollup/plugin-node-resolve@11.2.1':
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
 
   '@rollup/pluginutils@3.1.0':
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.62.0
+      rollup: ^4.62.2
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.62.0':
-    resolution: {integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==}
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.62.0':
-    resolution: {integrity: sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==}
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
@@ -2893,6 +2898,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.61.1':
     resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
     cpu: [x64]
@@ -2903,23 +2913,28 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.62.0':
-    resolution: {integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==}
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.62.0':
-    resolution: {integrity: sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==}
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
-    resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.0':
-    resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
 
@@ -2933,43 +2948,48 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.62.0':
-    resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.0':
-    resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.62.0':
-    resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.0':
-    resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.0':
-    resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.0':
-    resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.0':
-    resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.0':
-    resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
 
@@ -2983,18 +3003,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.62.0':
-    resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.62.0':
-    resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.62.0':
-    resolution: {integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==}
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -3008,13 +3033,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.0':
-    resolution: {integrity: sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.62.0':
-    resolution: {integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==}
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
@@ -3025,6 +3055,11 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
@@ -3111,7 +3146,7 @@ packages:
     resolution: {integrity: sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==}
     peerDependencies:
       esbuild: '>=0.28.1'
-      rollup: ^4.62.0
+      rollup: ^4.62.2
       storybook: ^10.4.6
       vite: '*'
       webpack: '*'
@@ -3520,16 +3555,16 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.61.0':
-    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+  '@typescript-eslint/eslint-plugin@8.62.0':
+    resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.61.0
+      '@typescript-eslint/parser': ^8.62.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ~5.9.3
 
-  '@typescript-eslint/parser@8.61.0':
-    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+  '@typescript-eslint/parser@8.62.0':
+    resolution: {integrity: sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3547,8 +3582,18 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
+  '@typescript-eslint/project-service@8.62.0':
+    resolution: {integrity: sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
   '@typescript-eslint/scope-manager@8.61.0':
     resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.62.0':
+    resolution: {integrity: sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -3563,8 +3608,14 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
-  '@typescript-eslint/type-utils@8.61.0':
-    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+  '@typescript-eslint/tsconfig-utils@8.62.0':
+    resolution: {integrity: sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
+  '@typescript-eslint/type-utils@8.62.0':
+    resolution: {integrity: sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3582,6 +3633,10 @@ packages:
     resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.62.0':
+    resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.56.1':
     resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3594,8 +3649,21 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
+  '@typescript-eslint/typescript-estree@8.62.0':
+    resolution: {integrity: sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
   '@typescript-eslint/utils@8.61.0':
     resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ~5.9.3
+
+  '@typescript-eslint/utils@8.62.0':
+    resolution: {integrity: sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3607,6 +3675,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.62.0':
+    resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -5241,8 +5313,8 @@ packages:
     engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globals@17.6.0:
-    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -6476,13 +6548,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6894,8 +6966,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.62.0:
-    resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -7563,8 +7635,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript-eslint@8.61.0:
-    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+  typescript-eslint@8.62.0:
+    resolution: {integrity: sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -7640,7 +7712,7 @@ packages:
       '@vue/language-core': ~3.1.5
       esbuild: '>=0.28.1'
       rolldown: '*'
-      rollup: ^4.62.0
+      rollup: ^4.62.2
       typescript: ~5.9.3
       vite: '>=3'
       webpack: ^4 || ^5
@@ -7770,7 +7842,7 @@ packages:
     resolution: {integrity: sha512-lNeHS+dwGju6eRmNvZQt8Shwv9j3m98hbHse/lIbLq9q3yE2DcIOBBYQEVUF6tS0kOmv+VA9Z5FqmzFnGe4U8g==}
     peerDependencies:
       '@microsoft/api-extractor': '>=7'
-      rollup: ^4.62.0
+      rollup: ^4.62.2
       vite: '>=3'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -8080,9 +8152,9 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@arethetypeswrong/cli@0.18.3':
+  '@arethetypeswrong/cli@0.18.4':
     dependencies:
-      '@arethetypeswrong/core': 0.18.3
+      '@arethetypeswrong/core': 0.18.4
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
@@ -8090,7 +8162,7 @@ snapshots:
       marked-terminal: 7.3.0(marked@9.1.6)
       semver: 7.7.4
 
-  '@arethetypeswrong/core@0.18.3':
+  '@arethetypeswrong/core@0.18.4':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       '@loaderkit/resolve': 1.0.5
@@ -9447,12 +9519,12 @@ snapshots:
       '@oven/bun-linux-x64-musl-baseline': 1.3.10
       '@oven/bun-windows-x64': 1.3.10
       '@oven/bun-windows-x64-baseline': 1.3.10
-      '@rollup/rollup-darwin-arm64': 4.61.1
-      '@rollup/rollup-darwin-x64': 4.61.1
-      '@rollup/rollup-linux-arm64-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-gnu': 4.61.1
-      '@rollup/rollup-win32-arm64-msvc': 4.61.1
-      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.62.0
+      '@rollup/rollup-darwin-x64': 4.62.0
+      '@rollup/rollup-linux-arm64-gnu': 4.62.0
+      '@rollup/rollup-linux-x64-gnu': 4.62.0
+      '@rollup/rollup-win32-arm64-msvc': 4.62.0
+      '@rollup/rollup-win32-x64-msvc': 4.62.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -9839,11 +9911,11 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7
       '@babel/runtime': 7.29.7
       '@preconstruct/hook': 0.4.0
-      '@rollup/plugin-alias': 3.1.9(rollup@4.62.0)
-      '@rollup/plugin-commonjs': 15.1.0(rollup@4.62.0)
-      '@rollup/plugin-json': 4.1.0(rollup@4.62.0)
-      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.62.0)
-      '@rollup/plugin-replace': 2.4.2(rollup@4.62.0)
+      '@rollup/plugin-alias': 3.1.9(rollup@4.62.2)
+      '@rollup/plugin-commonjs': 15.1.0(rollup@4.62.2)
+      '@rollup/plugin-json': 4.1.0(rollup@4.62.2)
+      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.62.2)
+      '@rollup/plugin-replace': 2.4.2(rollup@4.62.2)
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -9865,7 +9937,7 @@ snapshots:
       parse-json: 5.2.0
       quick-lru: 5.1.1
       resolve-from: 5.0.0
-      rollup: 4.62.0
+      rollup: 4.62.2
       semver: 7.7.4
       terser: 5.44.0
       v8-compile-cache: 2.4.0
@@ -10312,7 +10384,7 @@ snapshots:
 
   '@react-aria/interactions@3.28.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@react-types/shared': 3.35.0(react@19.2.0)
+      '@react-types/shared': 3.36.0(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria: 3.49.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10331,6 +10403,10 @@ snapshots:
       react-stately: 3.47.0(react@19.2.0)
 
   '@react-types/shared@3.35.0(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-types/shared@3.36.0(react@19.2.0)':
     dependencies:
       react: 19.2.0
 
@@ -10405,62 +10481,62 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-alias@3.1.9(rollup@4.62.0)':
+  '@rollup/plugin-alias@3.1.9(rollup@4.62.2)':
     dependencies:
-      rollup: 4.62.0
+      rollup: 4.62.2
       slash: 3.0.0
 
-  '@rollup/plugin-commonjs@15.1.0(rollup@4.62.0)':
+  '@rollup/plugin-commonjs@15.1.0(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.12
-      rollup: 4.62.0
+      rollup: 4.62.2
 
-  '@rollup/plugin-json@4.1.0(rollup@4.62.0)':
+  '@rollup/plugin-json@4.1.0(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.0)
-      rollup: 4.62.0
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
+      rollup: 4.62.2
 
-  '@rollup/plugin-node-resolve@11.2.1(rollup@4.62.0)':
+  '@rollup/plugin-node-resolve@11.2.1(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.12
-      rollup: 4.62.0
+      rollup: 4.62.2
 
-  '@rollup/plugin-replace@2.4.2(rollup@4.62.0)':
+  '@rollup/plugin-replace@2.4.2(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.0)
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
       magic-string: 0.25.9
-      rollup: 4.62.0
+      rollup: 4.62.2
 
-  '@rollup/pluginutils@3.1.0(rollup@4.62.0)':
+  '@rollup/pluginutils@3.1.0(rollup@4.62.2)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 4.0.4
-      rollup: 4.62.0
+      rollup: 4.62.2
 
-  '@rollup/pluginutils@5.3.0(rollup@4.62.0)':
+  '@rollup/pluginutils@5.3.0(rollup@4.62.2)':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.62.0
+      rollup: 4.62.2
 
-  '@rollup/rollup-android-arm-eabi@4.62.0':
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.62.0':
+  '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.61.1':
@@ -10469,22 +10545,28 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.62.0':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.62.0':
+  '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.62.0':
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
+  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
@@ -10493,28 +10575,31 @@ snapshots:
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.62.0':
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.0':
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.62.0':
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.0':
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.0':
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.0':
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
@@ -10523,13 +10608,16 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.62.0':
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.62.0':
+  '@rollup/rollup-linux-x64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.62.0':
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.61.1':
@@ -10538,16 +10626,22 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.62.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.0':
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.62.0':
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
   '@rushstack/node-core-library@5.17.0(@types/node@24.13.2)':
@@ -10606,10 +10700,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -10632,16 +10726,16 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
-      '@vitest/browser-playwright': 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
       '@vitest/runner': 4.1.9
       vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
       storybook: 10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
@@ -10650,13 +10744,13 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
-      rollup: 4.62.0
+      rollup: 4.62.2
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
       webpack: 5.107.2(esbuild@0.28.1)
 
@@ -10676,11 +10770,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.0)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -11063,14 +11157,14 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/parser': 8.62.0(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.62.0
+      '@typescript-eslint/type-utils': 8.62.0(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.62.0
       eslint: 10.5.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -11079,12 +11173,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/scope-manager': 8.62.0
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.62.0
       debug: 4.4.3
       eslint: 10.5.0
       typescript: 5.9.3
@@ -11109,10 +11203,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.62.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.62.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.61.0':
     dependencies:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/visitor-keys': 8.61.0
+
+  '@typescript-eslint/scope-manager@8.62.0':
+    dependencies:
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/visitor-keys': 8.62.0
 
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
     dependencies:
@@ -11122,11 +11230,15 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.62.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.62.0(eslint@10.5.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0)(typescript@5.9.3)
       debug: 4.4.3
       eslint: 10.5.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -11139,6 +11251,8 @@ snapshots:
   '@typescript-eslint/types@8.56.1': {}
 
   '@typescript-eslint/types@8.61.0': {}
+
+  '@typescript-eslint/types@8.62.0': {}
 
   '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
     dependencies:
@@ -11170,12 +11284,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.62.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/visitor-keys': 8.62.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      eslint: 10.5.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.62.0(eslint@10.5.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@typescript-eslint/scope-manager': 8.62.0
+      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
       eslint: 10.5.0
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11189,6 +11329,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.61.0':
     dependencies:
       '@typescript-eslint/types': 8.61.0
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.62.0':
+    dependencies:
+      '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -11208,11 +11353,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)':
     dependencies:
       '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
       '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
-      playwright: 1.60.0
+      playwright: 1.61.0
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.0.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))
     transitivePeerDependencies:
@@ -13057,7 +13202,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.62.0
+      rollup: 4.62.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -13225,7 +13370,7 @@ snapshots:
       minimatch: 5.1.9
       once: 1.4.0
 
-  globals@17.6.0: {}
+  globals@17.7.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -14771,11 +14916,11 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.0: {}
 
-  playwright@1.60.0:
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -15264,35 +15409,35 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
-  rollup@4.62.0:
+  rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.62.0
-      '@rollup/rollup-android-arm64': 4.62.0
-      '@rollup/rollup-darwin-arm64': 4.62.0
-      '@rollup/rollup-darwin-x64': 4.62.0
-      '@rollup/rollup-freebsd-arm64': 4.62.0
-      '@rollup/rollup-freebsd-x64': 4.62.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.0
-      '@rollup/rollup-linux-arm64-gnu': 4.62.0
-      '@rollup/rollup-linux-arm64-musl': 4.62.0
-      '@rollup/rollup-linux-loong64-gnu': 4.62.0
-      '@rollup/rollup-linux-loong64-musl': 4.62.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.0
-      '@rollup/rollup-linux-ppc64-musl': 4.62.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.0
-      '@rollup/rollup-linux-riscv64-musl': 4.62.0
-      '@rollup/rollup-linux-s390x-gnu': 4.62.0
-      '@rollup/rollup-linux-x64-gnu': 4.62.0
-      '@rollup/rollup-linux-x64-musl': 4.62.0
-      '@rollup/rollup-openbsd-x64': 4.62.0
-      '@rollup/rollup-openharmony-arm64': 4.62.0
-      '@rollup/rollup-win32-arm64-msvc': 4.62.0
-      '@rollup/rollup-win32-ia32-msvc': 4.62.0
-      '@rollup/rollup-win32-x64-gnu': 4.62.0
-      '@rollup/rollup-win32-x64-msvc': 4.62.0
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -15968,7 +16113,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.22.4)(yaml@2.8.3)
       resolve-from: 5.0.0
-      rollup: 4.62.0
+      rollup: 4.62.2
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 0.3.2
@@ -16003,12 +16148,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3):
+  typescript-eslint@8.62.0(eslint@10.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0)(typescript@5.9.3)
       eslint: 10.5.0
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16080,9 +16225,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1)):
+  unplugin-dts@1.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1)):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       '@volar/typescript': 2.4.28
       compare-versions: 6.1.1
       debug: 4.4.3
@@ -16095,7 +16240,7 @@ snapshots:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.2)
       esbuild: 0.28.1
       rolldown: 1.0.3
-      rollup: 4.62.0
+      rollup: 4.62.2
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
       webpack: 5.107.2(esbuild@0.28.1)
     transitivePeerDependencies:
@@ -16204,12 +16349,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@5.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1)):
+  vite-plugin-dts@5.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1)):
     dependencies:
-      unplugin-dts: 1.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.0)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
+      unplugin-dts: 1.0.2(@microsoft/api-extractor@7.53.1(@types/node@24.13.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.62.2)(typescript@5.9.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.1))
     optionalDependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.2)
-      rollup: 4.62.0
+      rollup: 4.62.2
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -16259,7 +16404,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.2
-      '@vitest/browser-playwright': 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       jsdom: 29.0.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,20 +9,20 @@ catalogs:
     "@figma/code-connect": ^1.4.8
     "@fission-ai/openspec": ^1.4.1
     eslint-plugin-react-hooks: ^7.1.1
-    globals: ^17.6.0
+    globals: ^17.7.0
     glob: ^13.0.6
     typescript: ~5.9.3
-    typescript-eslint: ^8.61.0
+    typescript-eslint: ^8.62.0
     tsup: ^8.5.1
     tsx: ^4.22.4
-    "@arethetypeswrong/cli": ^0.18.3
+    "@arethetypeswrong/cli": ^0.18.4
     publint: ^0.3.21
     "@modelcontextprotocol/inspector": ^0.21.2
     "@babel/core": ^7.29.6
     "@babel/runtime": ^7.29.7
     "@babel/preset-typescript": ^7.29.7
     "@eslint/js": ^10.0.1
-    "@react-types/shared": ^3.35.0
+    "@react-types/shared": ^3.36.0
     eslint: ^10.5.0
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.6
@@ -37,7 +37,7 @@ catalogs:
     webpack-cli: ^7.0.3
     vite-bundle-analyzer: ^1.3.8
     vite-plugin-dts: ^5.0.2
-    rollup: ^4.62.0
+    rollup: ^4.62.2
     "@vitest/browser": ^4.1.9
     "@vitest/browser-playwright": ^4.1.9
     "@vitest/coverage-v8": ^4.1.9
@@ -45,7 +45,7 @@ catalogs:
     "@testing-library/jest-dom": ^6.9.1
     "@testing-library/user-event": ^14.6.1
     "@testing-library/react": ^16.3.2
-    playwright: ^1.60.0
+    playwright: ^1.61.0
     vitest: ^4.1.9
     storybook: ^10.4.6
     eslint-plugin-storybook: ^10.4.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,9 +66,9 @@ catalogs:
     "@chakra-ui/cli": ^3.36.0
     "@chakra-ui/react": ^3.36.0
     next-themes: ^0.4.6
-    react-aria: 3.49.0
-    react-aria-components: 1.18.0
-    react-stately: 3.47.0
+    react-aria: 3.50.0
+    react-aria-components: 1.19.0
+    react-stately: 3.48.0
     "@react-aria/interactions": 3.28.1
     "@react-aria/utils": 3.34.1
     "@react-aria/optimize-locales-plugin": 1.2.1


### PR DESCRIPTION
> [!NOTE]
> Usually I just merge the housekeeping PRs if CI passes, this one needed a couple adjustments though due to some react-aria upgrade (see below), affecting keyboard-navigation the `TagGroup` component

## Summary

Updates `pnpm-workspace.yaml` catalog dependencies to their latest **minor/patch** versions (no major bumps), in risk-ordered groups with build + test checkpoints. Two React Aria behavior changes required small, contained source adaptations (documented below).

## 🔧 Tooling Group (6 updated)

| Package | Old → New |
| --- | --- |
| `globals` | ^17.6.0 → ^17.7.0 |
| `typescript-eslint` | ^8.61.0 → ^8.62.0 |
| `@arethetypeswrong/cli` | ^0.18.3 → ^0.18.4 |
| `@react-types/shared` | ^3.35.0 → ^3.36.0 |
| `rollup` | ^4.62.0 → ^4.62.2 |
| `playwright` | ^1.60.0 → ^1.61.0 |

These are devDependencies → no changeset needed for this group.

## ⚛️ React Aria Group (3 updated, runtime deps)

| Package | Old → New |
| --- | --- |
| `react-aria` | 3.49.0 → 3.50.0 |
| `react-aria-components` | 1.18.0 → 1.19.0 |
| `react-stately` | 3.47.0 → 3.48.0 |

These are **runtime dependencies** of the published `@commercetools/nimbus`, so a **changeset** is included.

`react-aria-components` 1.19.0 introduced two behavior changes that this PR adapts to:

1. **`Menu.onAction` now passes `(key, value)`** ([adobe/react-spectrum#10191](https://github.com/adobe/react-spectrum/pull/10191)). The menu story handler forwards the new `value`; affected story + docs-spec assertions now assert `(key, value)`. `SplitButton` keeps its **single-arg** `onAction` public API (typed explicitly rather than borrowing the Menu type).
2. **Stricter TagGroup focus model.** The remove ("x") button inside a tag was a tab stop (`tabindex=0`), which 1.18.0 tolerated but 1.19.0 does not — it broke single-Tab-stop entry and arrow-key navigation between tags in `ComboBox` (multi-select) and `TagGroup`. Fixed by adding `excludeFromTabOrder` to the remove button, aligning nimbus with React Aria's intended pattern (tags removed via Delete/Backspace once focused). No test changes were needed for this — the existing keyboard-nav story passes once the component is fixed.

## ⏸️ Frozen (consumer-controlled peers — not updated)

- `react` (`^19.0.0`), `react-dom` (`^19.0.0`), `@emotion/react` (`^11.14.0`)
- `@types/react` (`^19.2.17`) / `@types/react-dom` (`^19.2.3`) — already at latest within the v19 range

## 🚫 Skipped (major versions / semver-constrained)

`typescript` (6.0.3), `@babel/*` (8.x), `@react-aria/optimize-locales-plugin` (2.0.0), `@modelcontextprotocol/inspector` (0.22.0 — caret-locked under 0.x), `dotenv` (17.x), `@types/node` (26.x). `jsdom` left pinned at `29.0.1` per its in-file note (29.0.2+ breaks Chakra/Emotion CSS in JSDOM).

## 🧪 Testing

- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test:storybook` — **84 files, 933 tests** pass
- ✅ `pnpm test:unit` — **1349 tests** pass
- ✅ `pnpm build` (incl. docs) — passes

> **Note on Playwright:** local browser binary for 1.61.0 could not be downloaded in this environment (TLS-restricted), so the browser suite was validated against Playwright 1.60.0's installed Chromium. CI installs and validates against 1.61.0's browser.

## 📝 Summary

- ✅ **9 packages updated** (6 tooling + 3 React Aria)
- 🔧 **3 small source adaptations** for react-aria-components 1.19.0 behavior changes
- ⏸️ **5 packages frozen** (React core + types + Emotion)
- 🚫 **6 packages skipped** (major/semver-constrained) + `jsdom` intentionally pinned