### PR TITLE
fix(nimbus-icons): resolve @svgr/babel-plugin-add-jsx-attribute reliably (Vercel build fix)

### DIFF
--- a/packages/nimbus-icons/.svgrrc.js
+++ b/packages/nimbus-icons/.svgrrc.js
@@ -3,9 +3,16 @@ module.exports = {
   jsx: {
     babelConfig: {
       plugins: [
-        // For an example, this plugin will remove "id" attribute from "svg" tag
+        // Resolve to an absolute path so Babel loads the plugin regardless of
+        // how pnpm hoists it. A bare module name is resolved by @babel/core
+        // relative to its resolution base, which is not reliable under pnpm's
+        // strict node_modules layout (e.g. a clean CI install) and caused
+        // "Cannot find module '@svgr/babel-plugin-add-jsx-attribute'" on Vercel.
+        // The plugin is declared as a direct devDependency of this package so
+        // require.resolve always finds it here.
         [
-          "@svgr/babel-plugin-add-jsx-attribute",
+          // eslint-disable-next-line no-undef
+          require.resolve("@svgr/babel-plugin-add-jsx-attribute"),
           {
             elements: ["svg"],
             attributes: [

--- a/packages/nimbus-icons/package.json
+++ b/packages/nimbus-icons/package.json
@@ -30,6 +30,7 @@
     "@svgr/cli": "^8.1.0"
   },
   "devDependencies": {
+    "@svgr/babel-plugin-add-jsx-attribute": "^8.0.0",
     "@svgr/plugin-jsx": "^8.1.0",
     "@types/node": "catalog:utils",
     "@types/react": "catalog:react",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,9 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
     devDependencies:
+      '@svgr/babel-plugin-add-jsx-attribute':
+        specifier: ^8.0.0
+        version: 8.0.0(@babel/core@7.29.7)
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))


### PR DESCRIPTION
## Problem

Vercel deployments fail in the `nimbus-icons` build step:

```
packages/nimbus-icons build: Error: Cannot find module '@svgr/babel-plugin-add-jsx-attribute'
    at jsxPlugin (.../@svgr/plugin-jsx/dist/index.js:77:23) { code: 'MODULE_NOT_FOUND' }
```

Adding `--frozen-lockfile` to the install command (done previously) did **not** help, because the lockfile was never the problem.

## Root cause

`packages/nimbus-icons/.svgrrc.js` references the babel plugin **by bare name**:

```js
plugins: [["@svgr/babel-plugin-add-jsx-attribute", { ... }]]
```

`@svgr/plugin-jsx` passes that config to `@babel/core`, which resolves the bare module name relative to its resolution base. The plugin is only a **transitive** dependency (`@svgr/cli`/`@svgr/plugin-jsx` → `@svgr/babel-preset` → `@svgr/babel-plugin-add-jsx-attribute`) and is declared by **no package in the chain** that references it.

Under pnpm's strict `node_modules` layout this is non-deterministic: it happens to resolve locally (the plugin is hoisted into a reachable spot) but **not** on Vercel's clean `pnpm install --frozen-lockfile`, where it isn't hoisted there. Same lockfile, different hoisting → the bare-name resolution fails.

## Fix

1. **Declare** `@svgr/babel-plugin-add-jsx-attribute` as a direct `devDependency` of `nimbus-icons` (the package that references it — matching the repo's "declare what you reference" convention, alongside the existing `@svgr/plugin-jsx` devDep).
2. **Reference it via `require.resolve(...)`** in `.svgrrc.js`, so Babel receives an **absolute path** and performs no name resolution — independent of pnpm hoisting or install mode.

## Verification

- `@svgr/babel-plugin-add-jsx-attribute` now symlinks into `packages/nimbus-icons/node_modules/@svgr/` and resolves directly from the package.
- `pnpm --filter @commercetools/nimbus-icons run build:icons` succeeds (previously failed).
- **Generated icon output is byte-identical** — `git status` shows zero changes under `src/material-icons/`. This fix only changes resolution, not output.

No changeset: devDependency + build-config only; the published package's runtime deps and built artifacts are unchanged.