### PR TITLE
feat(button): allow Tooltips on disabled Buttons via allowFocusWhenDisabled

### DIFF
--- a/.changeset/button-allow-focus-when-disabled.md
+++ b/.changeset/button-allow-focus-when-disabled.md
@@ -1,0 +1,26 @@
+---
+"@commercetools/nimbus": minor
+---
+
+`Button`: add `allowFocusWhenDisabled` to support tooltips on disabled buttons.
+
+A disabled button normally can't host a `Tooltip` because the native `disabled`
+attribute removes it from the tab order and stops hover/focus events — exactly
+when a tooltip explaining _why_ the action is unavailable is most useful. Pass
+`allowFocusWhenDisabled` alongside `isDisabled` to keep the button focusable and
+hoverable: it is announced as disabled via `aria-disabled` (not the native
+`disabled` attribute), stays in the tab order, and its action stays fully
+suppressed (press, click, `Enter`/`Space`, form submit/reset, and link
+navigation).
+
+```tsx
+<Tooltip.Root>
+  <Button isDisabled allowFocusWhenDisabled>
+    Publish
+  </Button>
+  <Tooltip.Content>Complete all required fields to publish.</Tooltip.Content>
+</Tooltip.Root>
+```
+
+Default disabled behavior is unchanged — omit the prop and `isDisabled` works
+exactly as before.

--- a/openspec/changes/add-button-allow-focus-when-disabled/design.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/design.md
@@ -1,0 +1,134 @@
+# Design: `allowFocusWhenDisabled` on Button
+
+## Problem framing
+
+A disabled `Button` cannot host a `Tooltip`. `useButton` applies the native
+`disabled` attribute to `<button>` elements; natively-disabled elements are
+non-focusable and emit no pointer/focus events, so `TooltipTrigger` (which opens
+on hover and focus and needs a focusable trigger) has nothing to bind to.
+
+The accessibility-correct fix is the well-established **"disabled but
+focusable"** pattern: render `aria-disabled="true"` instead of the native
+`disabled` attribute, keep the element focusable, and suppress activation. WAI-
+ARIA explicitly allows `aria-disabled` elements to remain focusable so that
+their state — and any associated explanation — is reachable by all users.
+
+## Why not React Aria's `useButton({ allowFocusWhenDisabled })` directly
+
+`useButton` already accepts an (undocumented) `allowFocusWhenDisabled` option,
+but it does **not** solve our case for native buttons:
+
+```js
+// useButton.mjs — native button branch
+if (elementType === 'button') additionalProps = { type, disabled: isDisabled, ... };
+// ...
+if (allowFocusWhenDisabled) focusableProps.tabIndex = isDisabled ? -1 : tabIndex;
+```
+
+Two problems:
+
+1. For a native `<button>`, `disabled: isDisabled` is **still applied**. The
+   native `disabled` attribute overrides `tabIndex` entirely — the element
+   remains non-focusable and event-silent. So RA's option doesn't actually make
+   a native button focusable; it only helps non-native element types.
+2. Even where it helps, it sets `tabIndex = -1` — focusable programmatically but
+   **removed from the tab order**. For a tooltip whose job is to explain why an
+   action is unavailable, keyboard users must be able to **Tab to it**; `-1`
+   defeats the purpose.
+
+So we keep React Aria's term (familiarity) but implement the behavior ourselves
+as a correct superset that works for native buttons and preserves the natural
+tab order.
+
+## Approach
+
+Compute a single derived flag in `button.tsx`:
+
+```ts
+const isDisabled = contextProps.isDisabled ?? contextProps.disabled;
+const softDisabled = Boolean(isDisabled && allowFocusWhenDisabled);
+```
+
+Then branch:
+
+- **`softDisabled === false`** → today's path, untouched. Pass `isDisabled`
+  straight to `useButton`; native `disabled` attribute applied as before.
+
+- **`softDisabled === true`** → tell `useButton` the button is **enabled**
+  (`isDisabled: false`) so it does NOT emit the native `disabled` attribute and
+  the element stays focusable + hoverable. Then layer the disabled semantics and
+  activation-suppression back on ourselves:
+
+  1. **Withhold activation handlers** from `useButton` (`onPress`,
+     `onPressStart`, `onPressEnd`, `onPressUp`, `onPressChange`, `onClick`) so
+     no consumer press/click logic fires. `useButton` thinks it's enabled, but
+     there is nothing for it to invoke.
+  2. **Suppress the default action** with an `onClick` handler that calls
+     `event.preventDefault()` and `event.stopPropagation()`. Keyboard activation
+     (`Enter`/`Space`) on a native button dispatches a click, so a single click
+     guard covers mouse, touch, keyboard, **form submit/reset**
+     (`type="submit"`/`"reset"`), and **link navigation** (`as="a"` with
+     `href`).
+  3. **Set `aria-disabled="true"`** on the rendered element. The button recipe's
+     `_disabled` condition matches `[aria-disabled=true]`, so the disabled
+     styling (reduced opacity via `layerStyle: "disabled"`) applies with no
+     recipe change. `isPressed` stays `false`, so no `data-pressed`.
+
+This keeps the existing "delegate to `useButton`" architecture intact for the
+common path and confines the new behavior to one well-labeled branch.
+
+## Tab order
+
+Soft-disabled buttons keep their natural `tabIndex` (typically `0`) so keyboard
+users discover them and the tooltip opens on focus. Consumers who explicitly
+pass `excludeFromTabOrder` still get `-1` — the prop composes and is not
+overridden.
+
+## Why a boolean and not `disabledBehavior="…"`
+
+A union prop (`disabledBehavior="all" | "keepFocusable"`) was considered.
+Rejected: it collides conceptually with React Aria collections'
+`disabledBehavior="selection" | "all"` (different meaning), and a boolean that
+pairs with `isDisabled` reads clearly at the call site:
+
+```tsx
+<Tooltip>
+  <Tooltip.Trigger>
+    <Button isDisabled allowFocusWhenDisabled>
+      Publish
+    </Button>
+  </Tooltip.Trigger>
+  <Tooltip.Content>Complete all required fields to publish.</Tooltip.Content>
+</Tooltip>
+```
+
+## Why explicit opt-in, not automatic when wrapped in a Tooltip
+
+Auto-switching disabled semantics based on whether a `Tooltip` ancestor exists
+would be implicit, hard to discover, and fragile (context plumbing, surprising
+behavior when a tooltip is conditionally rendered). An explicit prop keeps the
+disabled contract predictable and self-documenting.
+
+## Accessibility notes
+
+- `aria-disabled="true"` is announced as "dimmed/disabled" by screen readers
+  while the element remains in the accessibility tree and focusable — the
+  intended outcome.
+- The tooltip content is associated via `aria-describedby` by `TooltipTrigger`
+  as usual, so the explanation is announced on focus.
+- Suppressing activation (not just visually disabling) is essential: a focusable
+  button that still fired its action would be a worse bug than the original
+  limitation.
+
+## Testing strategy
+
+- **Stories (play functions)** are the source of truth for behavior:
+  - soft-disabled button is focusable (receives focus via Tab) and exposes
+    `aria-disabled="true"` with no native `disabled` attribute;
+  - `onPress`/`onClick` do **not** fire on click or `Enter`/`Space`;
+  - a `type="submit"` soft-disabled button does **not** submit its form;
+  - paired with `Tooltip`, the tooltip opens on hover and on focus;
+  - default disabled (no `allowFocusWhenDisabled`) is unchanged: native
+    `disabled`, not focusable, tooltip does not open.
+- **Docs spec** adds a copyable consumer example of a tooltip on a disabled
+  button.

--- a/openspec/changes/add-button-allow-focus-when-disabled/design.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/design.md
@@ -102,6 +102,31 @@ pairs with `isDisabled` reads clearly at the call site:
 </Tooltip>
 ```
 
+## Why suppress activation, rather than visual-only `aria-disabled`
+
+A simpler model was considered: just let consumers set `aria-disabled` (which
+`Button` already accepts), show the disabled styling, and stop there — no
+focusability handling, no activation suppression. In fact that path **already
+works today**: `<Button aria-disabled>` renders the disabled look (the recipe's
+`_disabled` matches `[aria-disabled=true]`), stays a normal enabled button
+underneath, and so is focusable + hoverable and can host a tooltip.
+
+The reason that is not enough — and why suppression is the substance of this
+feature, not an add-on — is that `aria-disabled="true"` is a promise to
+assistive tech and keyboard users that the control is *non-operable*. Without
+suppression, the button still fires `onPress`, and a `type="submit"` button
+still **submits its form on click/Enter even with no handler wired**. That
+produces a control that is announced as disabled but still acts (and looks
+disabled but still submits) — a worse defect than the original limitation, and
+precisely the case consumers ship, because the dangerous path (form submit /
+Enter) needs no handler at all, so "just don't wire `onPress`" does not cover
+it. Doing it correctly means guarding press, click, keydown, submit, and link
+navigation together — identical for every consumer, so it belongs in the
+component. The component's job is to keep the announced disabled state and the
+actual behavior in agreement by default. The visual-only behavior remains
+available as the deprecated `aria-disabled` escape hatch for consumers who
+deliberately want to own activation themselves.
+
 ## Why explicit opt-in, not automatic when wrapped in a Tooltip
 
 Auto-switching disabled semantics based on whether a `Tooltip` ancestor exists

--- a/openspec/changes/add-button-allow-focus-when-disabled/proposal.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/proposal.md
@@ -1,0 +1,82 @@
+# Change: Allow Tooltips on disabled Buttons (`allowFocusWhenDisabled`)
+
+## Why
+
+Consumers want to attach a `Tooltip` to a disabled `Button` — almost always to
+explain **why** the action is unavailable ("Complete required fields first",
+"You don't have permission"). This is one of the highest-value places a tooltip
+can appear, and today it is impossible.
+
+The reason is mechanical. `Button` delegates disabled state to React Aria's
+`useButton`, which for a native `<button>` applies the **native `disabled`
+attribute**. A natively-disabled element:
+
+- is removed from the tab order (cannot be focused), and
+- does not fire pointer or focus events.
+
+`TooltipTrigger` (react-aria-components) shows on hover **and** focus and
+requires a **focusable** trigger. A natively-disabled button gives it neither,
+so the tooltip never opens — for mouse or keyboard users. The control that most
+needs an explanation is the one that can't carry one.
+
+Telling consumers "no" pushes them toward worse workarounds: wrapping the button
+in an extra focusable `<span>` (tooltip describes the wrong element, no
+`aria-disabled` semantics), or faking a disabled look with full interactivity
+left live (the action still fires). Both are accessibility regressions we'd
+rather not see in the wild.
+
+## What Changes
+
+Add an opt-in boolean prop **`allowFocusWhenDisabled`** to `Button` (default
+`false`). It only has an effect together with `isDisabled` (or the deprecated
+`disabled`). When both are set, the button is **soft-disabled**:
+
+- **Stays focusable and in the natural tab order** (`tabIndex` unchanged) — so
+  keyboard users can Tab to it and the tooltip opens on focus.
+- **Stays hoverable** — so the tooltip opens on hover.
+- **Exposes `aria-disabled="true"`** instead of the native `disabled` attribute,
+  so assistive tech announces it as disabled and the existing disabled recipe
+  styling (`_disabled`, which matches `[aria-disabled=true]`) still applies — no
+  visual change.
+- **Cannot be activated** — press, click, `Enter`/`Space`, form submit/reset,
+  and link navigation (`as="a"`) are all suppressed. `onPress`/`onClick` do not
+  fire. It looks and behaves disabled; it is merely reachable.
+
+Default behavior (`allowFocusWhenDisabled` omitted or `false`) is **completely
+unchanged**: `isDisabled` continues to apply the native `disabled` attribute via
+`useButton`. This is a purely additive, non-breaking change.
+
+The Tooltip docs gain a documented "Tooltip on a disabled Button" pattern that
+pairs `isDisabled` with `allowFocusWhenDisabled`, so the supported path is
+discoverable.
+
+## What does NOT change
+
+- `IconButton` / other button-derived components are out of scope for this
+  change; they can adopt the same prop in a follow-up if demand exists.
+- No automatic detection of a wrapping `Tooltip` — the behavior is explicit and
+  opt-in, because silently changing disabled semantics based on ancestry would
+  be surprising and fragile.
+- `excludeFromTabOrder` still works and composes: a consumer may keep a
+  soft-disabled button focusable-but-out-of-sequence if they have a reason to.
+
+## Impact
+
+- **Affected specs:** `nimbus-button` (modified — Disabled State, useButton
+  integration, ARIA attributes; new requirement for focusable-disabled
+  behavior).
+- **Affected code:**
+  - **MODIFIED**: `packages/nimbus/src/components/button/button.tsx` —
+    soft-disable branch (withhold native `disabled` from `useButton`, set
+    `aria-disabled`, suppress activation).
+  - **MODIFIED**: `packages/nimbus/src/components/button/button.types.ts` — add
+    `allowFocusWhenDisabled` to the public props with JSDoc.
+  - **MODIFIED**: `packages/nimbus/src/components/button/button.stories.tsx` —
+    play-function coverage for the soft-disabled behavior + Tooltip pairing.
+  - **MODIFIED**: `packages/nimbus/src/components/button/button.docs.spec.tsx` —
+    consumer example for a Tooltip on a disabled Button.
+  - **MODIFIED**: `packages/nimbus/src/components/tooltip/tooltip.dev.mdx` (and
+    `button.dev.mdx` as appropriate) — documented disabled-Button pattern.
+- **Breaking:** No — additive opt-in prop; default behavior is identical.
+- **Consumers:** unblocks tooltips-on-disabled-buttons across the Merchant
+  Center frontends; no migration required.

--- a/openspec/changes/add-button-allow-focus-when-disabled/specs/nimbus-button/spec.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/specs/nimbus-button/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Disabled State
+
+The component SHALL support disabled state, with an opt-in variant that remains
+focusable so it can host a `Tooltip` (or other focus/hover-driven affordance).
+
+#### Scenario: Disabled via isDisabled
+
+- **WHEN** `isDisabled={true}` is set
+- **THEN** SHALL apply disabled styles (reduced opacity)
+- **AND** SHALL prevent click/keyboard interactions
+- **AND** `useButton` SHALL set appropriate disabled attributes based on element
+  type
+- **AND** SHALL show not-allowed cursor
+
+#### Scenario: Disabled via deprecated disabled prop
+
+- **WHEN** `disabled={true}` is set (deprecated)
+- **THEN** SHALL behave identically to `isDisabled={true}`
+- **AND** `isDisabled` SHALL take precedence if both are provided
+
+#### Scenario: Focusable disabled via allowFocusWhenDisabled
+
+- **WHEN** `isDisabled={true}` AND `allowFocusWhenDisabled={true}` are both set
+- **THEN** SHALL render `aria-disabled="true"` and SHALL NOT render the native
+  `disabled` attribute
+- **AND** SHALL remain focusable and stay in the natural tab order (so keyboard
+  users can reach it), unless `excludeFromTabOrder` is also set
+- **AND** SHALL remain hoverable so hover/focus-driven affordances (e.g.
+  `Tooltip`) can open
+- **AND** SHALL apply the same disabled styling as a natively-disabled button
+  (via the recipe `_disabled` / `[aria-disabled=true]` selector)
+- **AND** SHALL suppress activation: `onPress` and `onClick` SHALL NOT fire, and
+  `Enter`/`Space`, form submit/reset, and link navigation SHALL NOT occur
+
+#### Scenario: allowFocusWhenDisabled without isDisabled
+
+- **WHEN** `allowFocusWhenDisabled={true}` is set but the button is not disabled
+- **THEN** SHALL behave as a normal enabled button (the prop has no effect)
+
+### Requirement: ARIA Attributes
+
+The component SHALL provide appropriate ARIA attributes per nimbus-core
+standards.
+
+#### Scenario: Accessible name
+
+- **WHEN** button renders
+- **THEN** SHALL have accessible name from children text
+- **OR** SHALL use aria-label if provided
+- **AND** icon-only buttons SHALL require aria-label
+
+#### Scenario: State announcements
+
+- **WHEN** loading state changes
+- **THEN** SHALL announce to screen readers via aria-busy
+- **WHEN** disabled
+- **THEN** SHALL set aria-disabled="true"
+- **WHEN** disabled with `allowFocusWhenDisabled`
+- **THEN** SHALL set `aria-disabled="true"` while keeping the element in the
+  accessibility tree and focusable, so any associated tooltip description is
+  announced on focus
+
+### Requirement: useButton Hook Integration
+
+The component SHALL delegate behavior and accessibility concerns to React Aria's
+`useButton` hook for the default path, and SHALL layer soft-disable behavior on
+top only when `allowFocusWhenDisabled` is engaged.
+
+#### Scenario: Handler processing
+
+- **WHEN** component receives event handlers from props or ButtonContext
+- **THEN** SHALL pass all props to `useButton` for processing
+- **AND** `useButton`'s output SHALL overwrite raw handlers via JSX spread
+  ordering (`{...contextProps} {...buttonProps}`)
+- **AND** SHALL NOT use `mergeProps` to combine context and hook output (to
+  prevent double-firing)
+
+#### Scenario: Disabled state delegation (default)
+
+- **WHEN** `isDisabled` is set (via props or ButtonContext) and
+  `allowFocusWhenDisabled` is not engaged
+- **THEN** `useButton` SHALL manage `disabled` attribute for native `<button>`
+  elements
+- **AND** `useButton` SHALL manage `aria-disabled` for non-native elements
+  (e.g., `as="a"`)
+- **AND** the component SHALL NOT manually set `aria-disabled` or
+  `data-disabled`
+
+#### Scenario: Disabled state delegation (focusable disabled)
+
+- **WHEN** `isDisabled` AND `allowFocusWhenDisabled` are both set
+- **THEN** the component SHALL pass `isDisabled: false` to `useButton` so no
+  native `disabled` attribute is emitted and the element stays focusable
+- **AND** the component SHALL set `aria-disabled="true"` itself
+- **AND** the component SHALL withhold activation handlers from `useButton` and
+  suppress the default action (via `preventDefault`/`stopPropagation` on click)
+  so the button cannot be activated by mouse, touch, keyboard, or form
+  submission

--- a/openspec/changes/add-button-allow-focus-when-disabled/tasks.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/tasks.md
@@ -26,13 +26,13 @@
 
 ## 3. Stories (behavior is tested here)
 
-- [x] 3.1 `FocusableDisabled` story: soft-disabled button is focusable via Tab,
-      exposes `aria-disabled="true"`, has no native `disabled` attribute, and
-      `onPress`/`onClick` do not fire on click or `Enter`/`Space`.
-- [x] 3.2 `FocusableDisabledFormSubmit` story: a `type="submit"` soft-disabled
-      button inside a `<form>` does not submit.
+- [x] 3.1 `DisabledButFocusable` story: soft-disabled button is focusable via
+      Tab, exposes `aria-disabled="true"`, has no native `disabled` attribute,
+      and `onPress`/`onClick` do not fire on click or `Enter`/`Space`.
+- [x] 3.2 `DisabledButFocusableDoesNotSubmit` story: a `type="submit"`
+      soft-disabled button inside a `<form>` does not submit.
 - [x] 3.3 `DisabledWithTooltip` story: pairing with `Tooltip`, the tooltip opens
-      on hover and on keyboard focus of the soft-disabled button.
+      on keyboard focus of the soft-disabled button (and is hoverable).
 - [x] 3.4 Regression: default disabled button (no `allowFocusWhenDisabled`)
       keeps the native `disabled` attribute, is not focusable, and a tooltip
       does not open.

--- a/openspec/changes/add-button-allow-focus-when-disabled/tasks.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Allow Tooltips on disabled Buttons (`allowFocusWhenDisabled`)
+
+## 1. Types
+
+- [ ] 1.1 Add `allowFocusWhenDisabled?: boolean` to the public `ButtonProps` in
+      `button.types.ts` with JSDoc explaining: pairs with `isDisabled`, keeps
+      the button focusable + hoverable + in the tab order, renders
+      `aria-disabled` instead of native `disabled`, suppresses activation, and
+      is purpose-built for tooltips on disabled buttons. Default `false`.
+
+## 2. Implementation
+
+- [ ] 2.1 In `button.tsx`, derive `isDisabled` (from `isDisabled` ?? `disabled`)
+      and `softDisabled = Boolean(isDisabled && allowFocusWhenDisabled)`.
+- [ ] 2.2 When `softDisabled`, call `useButton` with `isDisabled: false` and the
+      activation handlers withheld (`onPress`, `onPressStart`, `onPressEnd`,
+      `onPressUp`, `onPressChange`, `onClick`) so no native `disabled` attribute
+      is emitted and nothing fires. Keep the default path untouched otherwise.
+- [ ] 2.3 When `softDisabled`, set `aria-disabled={true}` on the rendered
+      element and add an `onClick` guard that calls `preventDefault()` +
+      `stopPropagation()` to suppress activation, form submit/reset, and link
+      navigation. Ensure `excludeFromTabOrder` still composes (do not force
+      `tabIndex`).
+- [ ] 2.4 Strip `allowFocusWhenDisabled` from the props forwarded to the DOM /
+      slot so it never reaches the underlying element.
+
+## 3. Stories (behavior is tested here)
+
+- [ ] 3.1 `FocusableDisabled` story: soft-disabled button is focusable via Tab,
+      exposes `aria-disabled="true"`, has no native `disabled` attribute, and
+      `onPress`/`onClick` do not fire on click or `Enter`/`Space`.
+- [ ] 3.2 `FocusableDisabledFormSubmit` story: a `type="submit"` soft-disabled
+      button inside a `<form>` does not submit.
+- [ ] 3.3 `DisabledWithTooltip` story: pairing with `Tooltip`, the tooltip opens
+      on hover and on keyboard focus of the soft-disabled button.
+- [ ] 3.4 Regression: default disabled button (no `allowFocusWhenDisabled`)
+      keeps the native `disabled` attribute, is not focusable, and a tooltip
+      does not open.
+
+## 4. Documentation
+
+- [ ] 4.1 Add a "Tooltip on a disabled Button" section to `tooltip.dev.mdx` (and
+      reference from `button.dev.mdx` as appropriate) showing the `isDisabled` +
+      `allowFocusWhenDisabled` pattern and explaining the accessibility
+      rationale (`aria-disabled`, explain _why_ it's disabled).
+- [ ] 4.2 Add a consumer example to `button.docs.spec.tsx` (a disabled button
+      with a tooltip explaining why) so it ships as copyable docs.
+
+## 5. Validation
+
+- [ ] 5.1 TypeScript compiles cleanly
+      (`pnpm --filter @commercetools/nimbus typecheck`).
+- [ ] 5.2 Storybook tests pass against source
+      (`pnpm test:storybook:dev packages/nimbus/src/components/button/button.stories.tsx`).
+- [ ] 5.3 Lint passes (`pnpm lint -- packages/nimbus/src/components/button/`).
+- [ ] 5.4 Add a changeset (minor bump on `@commercetools/nimbus`) describing the
+      new `allowFocusWhenDisabled` prop and the tooltip-on-disabled use case
+      from the consumer's perspective.

--- a/openspec/changes/add-button-allow-focus-when-disabled/tasks.md
+++ b/openspec/changes/add-button-allow-focus-when-disabled/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Types
 
-- [ ] 1.1 Add `allowFocusWhenDisabled?: boolean` to the public `ButtonProps` in
+- [x] 1.1 Add `allowFocusWhenDisabled?: boolean` to the public `ButtonProps` in
       `button.types.ts` with JSDoc explaining: pairs with `isDisabled`, keeps
       the button focusable + hoverable + in the tab order, renders
       `aria-disabled` instead of native `disabled`, suppresses activation, and
@@ -10,49 +10,49 @@
 
 ## 2. Implementation
 
-- [ ] 2.1 In `button.tsx`, derive `isDisabled` (from `isDisabled` ?? `disabled`)
+- [x] 2.1 In `button.tsx`, derive `isDisabled` (from `isDisabled` ?? `disabled`)
       and `softDisabled = Boolean(isDisabled && allowFocusWhenDisabled)`.
-- [ ] 2.2 When `softDisabled`, call `useButton` with `isDisabled: false` and the
+- [x] 2.2 When `softDisabled`, call `useButton` with `isDisabled: false` and the
       activation handlers withheld (`onPress`, `onPressStart`, `onPressEnd`,
       `onPressUp`, `onPressChange`, `onClick`) so no native `disabled` attribute
       is emitted and nothing fires. Keep the default path untouched otherwise.
-- [ ] 2.3 When `softDisabled`, set `aria-disabled={true}` on the rendered
+- [x] 2.3 When `softDisabled`, set `aria-disabled={true}` on the rendered
       element and add an `onClick` guard that calls `preventDefault()` +
       `stopPropagation()` to suppress activation, form submit/reset, and link
       navigation. Ensure `excludeFromTabOrder` still composes (do not force
       `tabIndex`).
-- [ ] 2.4 Strip `allowFocusWhenDisabled` from the props forwarded to the DOM /
+- [x] 2.4 Strip `allowFocusWhenDisabled` from the props forwarded to the DOM /
       slot so it never reaches the underlying element.
 
 ## 3. Stories (behavior is tested here)
 
-- [ ] 3.1 `FocusableDisabled` story: soft-disabled button is focusable via Tab,
+- [x] 3.1 `FocusableDisabled` story: soft-disabled button is focusable via Tab,
       exposes `aria-disabled="true"`, has no native `disabled` attribute, and
       `onPress`/`onClick` do not fire on click or `Enter`/`Space`.
-- [ ] 3.2 `FocusableDisabledFormSubmit` story: a `type="submit"` soft-disabled
+- [x] 3.2 `FocusableDisabledFormSubmit` story: a `type="submit"` soft-disabled
       button inside a `<form>` does not submit.
-- [ ] 3.3 `DisabledWithTooltip` story: pairing with `Tooltip`, the tooltip opens
+- [x] 3.3 `DisabledWithTooltip` story: pairing with `Tooltip`, the tooltip opens
       on hover and on keyboard focus of the soft-disabled button.
-- [ ] 3.4 Regression: default disabled button (no `allowFocusWhenDisabled`)
+- [x] 3.4 Regression: default disabled button (no `allowFocusWhenDisabled`)
       keeps the native `disabled` attribute, is not focusable, and a tooltip
       does not open.
 
 ## 4. Documentation
 
-- [ ] 4.1 Add a "Tooltip on a disabled Button" section to `tooltip.dev.mdx` (and
+- [x] 4.1 Add a "Tooltip on a disabled Button" section to `tooltip.dev.mdx` (and
       reference from `button.dev.mdx` as appropriate) showing the `isDisabled` +
       `allowFocusWhenDisabled` pattern and explaining the accessibility
       rationale (`aria-disabled`, explain _why_ it's disabled).
-- [ ] 4.2 Add a consumer example to `button.docs.spec.tsx` (a disabled button
+- [x] 4.2 Add a consumer example to `button.docs.spec.tsx` (a disabled button
       with a tooltip explaining why) so it ships as copyable docs.
 
 ## 5. Validation
 
-- [ ] 5.1 TypeScript compiles cleanly
+- [x] 5.1 TypeScript compiles cleanly
       (`pnpm --filter @commercetools/nimbus typecheck`).
-- [ ] 5.2 Storybook tests pass against source
+- [x] 5.2 Storybook tests pass against source
       (`pnpm test:storybook:dev packages/nimbus/src/components/button/button.stories.tsx`).
-- [ ] 5.3 Lint passes (`pnpm lint -- packages/nimbus/src/components/button/`).
-- [ ] 5.4 Add a changeset (minor bump on `@commercetools/nimbus`) describing the
+- [x] 5.3 Lint passes (`pnpm lint -- packages/nimbus/src/components/button/`).
+- [x] 5.4 Add a changeset (minor bump on `@commercetools/nimbus`) describing the
       new `allowFocusWhenDisabled` prop and the tooltip-on-disabled use case
       from the consumer's perspective.

--- a/packages/nimbus/src/components/button/button.dev.mdx
+++ b/packages/nimbus/src/components/button/button.dev.mdx
@@ -132,6 +132,29 @@ const App = () => (
 )
 ```
 
+#### Keeping a disabled button focusable (for tooltips)
+
+A natively disabled button cannot receive focus or hover, so it cannot host a
+`Tooltip` — exactly when you'd want one to explain why the action is
+unavailable. Add `allowFocusWhenDisabled` alongside `isDisabled` to keep the
+button focusable and hoverable while it stays disabled: it renders
+`aria-disabled` instead of the native `disabled` attribute, stays in the tab
+order, and suppresses activation (press, click, `Enter`/`Space`, form submit,
+and link navigation).
+
+```jsx live-dev
+const App = () => (
+  <Tooltip.Root>
+    <Button isDisabled allowFocusWhenDisabled>
+      Publish
+    </Button>
+    <Tooltip.Content>
+      Complete all required fields before publishing.
+    </Tooltip.Content>
+  </Tooltip.Root>
+)
+```
+
 ### Event handling
 
 Use `onPress` instead of `onClick` for consistent behavior across mouse, touch, and keyboard interactions.

--- a/packages/nimbus/src/components/button/button.docs.spec.tsx
+++ b/packages/nimbus/src/components/button/button.docs.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Button, NimbusProvider } from "@commercetools/nimbus";
+import { Button, NimbusProvider, Tooltip } from "@commercetools/nimbus";
 
 /**
  * @docs-section basic-rendering
@@ -179,6 +179,52 @@ describe("Button - States", () => {
     await user.tab();
 
     expect(button).not.toHaveFocus();
+  });
+});
+
+/**
+ * @docs-section disabled-with-tooltip
+ * @docs-title Tooltip on a disabled Button
+ * @docs-description Pair `isDisabled` with `allowFocusWhenDisabled` to keep a
+ * disabled button focusable and hoverable so a Tooltip can explain why the
+ * action is unavailable. The button is announced as disabled (`aria-disabled`)
+ * and its action stays suppressed.
+ * @docs-order 5
+ */
+describe("Button - Disabled with a Tooltip", () => {
+  it("stays focusable so a Tooltip can explain why it is disabled", async () => {
+    const user = userEvent.setup();
+    const handlePress = vi.fn();
+
+    render(
+      <NimbusProvider>
+        <Tooltip.Root delay={0} closeDelay={0}>
+          <Button isDisabled allowFocusWhenDisabled onPress={handlePress}>
+            Publish
+          </Button>
+          <Tooltip.Content>
+            Complete all required fields to publish.
+          </Tooltip.Content>
+        </Tooltip.Root>
+      </NimbusProvider>
+    );
+
+    const button = screen.getByRole("button", { name: /publish/i });
+
+    // Announced as disabled, but still reachable (no native `disabled`).
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(button).not.toBeDisabled();
+
+    // Keyboard users can focus it and the tooltip reveals the explanation.
+    await user.tab();
+    expect(button).toHaveFocus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      /required fields/i
+    );
+
+    // ...yet the action remains suppressed.
+    await user.click(button);
+    expect(handlePress).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nimbus/src/components/button/button.stories.tsx
+++ b/packages/nimbus/src/components/button/button.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Box, Button, type ButtonProps, Stack } from "@commercetools/nimbus";
-import { userEvent, within, expect, fn } from "storybook/test";
+import {
+  Box,
+  Button,
+  type ButtonProps,
+  Stack,
+  Tooltip,
+} from "@commercetools/nimbus";
+import { userEvent, within, expect, fn, waitFor } from "storybook/test";
 import { ArrowRight as DemoIcon } from "@commercetools/nimbus-icons";
 import { createRef, useState } from "react";
 import { SEMANTIC_COLOR_PALETTES } from "@/constants/color-palettes";
@@ -126,6 +132,143 @@ export const DisabledAsLink: Story = {
         await expect(button).not.toHaveAttribute("disabled");
       }
     );
+  },
+};
+
+/**
+ * With `allowFocusWhenDisabled`, a disabled Button stays focusable and
+ * hoverable (rendering `aria-disabled` instead of the native `disabled`
+ * attribute) while its activation is suppressed. This is what makes it possible
+ * to attach a Tooltip explaining *why* the action is unavailable.
+ */
+export const FocusableDisabled: Story = {
+  args: {
+    children: "Disabled (focusable)",
+    isDisabled: true,
+    allowFocusWhenDisabled: true,
+    onPress: fn(),
+    onClick: fn(),
+    ["data-testid"]: "test",
+  },
+  play: async ({ canvasElement, step, args }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByTestId("test");
+
+    await step(
+      "Exposes aria-disabled and no native disabled attribute",
+      async () => {
+        await expect(button).toHaveAttribute("aria-disabled", "true");
+        await expect(button).not.toBeDisabled();
+      }
+    );
+
+    await step("Remains focusable with the <tab> key", async () => {
+      await userEvent.tab();
+      await expect(button).toHaveFocus();
+    });
+
+    await step("Does not fire onPress/onClick when clicked", async () => {
+      await userEvent.click(button);
+      await expect(args.onPress).toHaveBeenCalledTimes(0);
+      await expect(args.onClick).toHaveBeenCalledTimes(0);
+    });
+
+    await step("Does not fire onPress on Enter or Space", async () => {
+      button.focus();
+      await userEvent.keyboard("{enter}");
+      await userEvent.keyboard(" ");
+      await expect(args.onPress).toHaveBeenCalledTimes(0);
+    });
+  },
+};
+
+const submitSpy = fn();
+
+/**
+ * A soft-disabled submit button must not submit its form, even though it is
+ * focusable and a real `type="submit"` button.
+ */
+export const FocusableDisabledDoesNotSubmit: Story = {
+  args: {
+    children: "Submit",
+    type: "submit",
+    isDisabled: true,
+    allowFocusWhenDisabled: true,
+    ["data-testid"]: "test",
+  },
+  render: (args) => (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        submitSpy();
+      }}
+    >
+      <Button {...args} />
+    </form>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByTestId("test");
+
+    await step(
+      "Soft-disabled submit button does not submit its form",
+      async () => {
+        submitSpy.mockClear();
+        await userEvent.click(button);
+        button.focus();
+        await userEvent.keyboard("{enter}");
+        await expect(submitSpy).toHaveBeenCalledTimes(0);
+      }
+    );
+  },
+};
+
+/**
+ * The motivating use case: a Tooltip on a disabled Button explaining why the
+ * action is unavailable. Because the button stays focusable and hoverable
+ * (not natively disabled), the tooltip can open on focus and hover — here we
+ * assert the keyboard path, mirroring the Tooltip component's own stories.
+ */
+export const DisabledWithTooltip: Story = {
+  render: () => (
+    <Tooltip.Root delay={0} closeDelay={0}>
+      <Button isDisabled allowFocusWhenDisabled data-testid="test">
+        Publish
+      </Button>
+      <Tooltip.Content>
+        Complete all required fields to publish.
+      </Tooltip.Content>
+    </Tooltip.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    // The tooltip renders in a portal, so scope queries to the parent node.
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+    const button = canvas.getByTestId("test");
+
+    await step(
+      "Disabled button is reachable and hoverable (not natively disabled)",
+      async () => {
+        await expect(button).toHaveAttribute("aria-disabled", "true");
+        await expect(button).not.toBeDisabled();
+      }
+    );
+
+    await step("Tooltip opens on keyboard focus", async () => {
+      await userEvent.tab();
+      await expect(button).toHaveFocus();
+      await expect(await canvas.findByRole("tooltip")).toHaveTextContent(
+        /required fields/i
+      );
+    });
+
+    await step("Tooltip closes on blur", async () => {
+      button.blur();
+      await waitFor(() =>
+        expect(canvas.queryByRole("tooltip")).not.toBeInTheDocument()
+      );
+    });
   },
 };
 

--- a/packages/nimbus/src/components/button/button.stories.tsx
+++ b/packages/nimbus/src/components/button/button.stories.tsx
@@ -141,7 +141,7 @@ export const DisabledAsLink: Story = {
  * attribute) while its activation is suppressed. This is what makes it possible
  * to attach a Tooltip explaining *why* the action is unavailable.
  */
-export const FocusableDisabled: Story = {
+export const DisabledButFocusable: Story = {
   args: {
     children: "Disabled (focusable)",
     isDisabled: true,
@@ -188,7 +188,7 @@ const submitSpy = fn();
  * A soft-disabled submit button must not submit its form, even though it is
  * focusable and a real `type="submit"` button.
  */
-export const FocusableDisabledDoesNotSubmit: Story = {
+export const DisabledButFocusableDoesNotSubmit: Story = {
   args: {
     children: "Submit",
     type: "submit",

--- a/packages/nimbus/src/components/button/button.tsx
+++ b/packages/nimbus/src/components/button/button.tsx
@@ -13,7 +13,14 @@ import type { ButtonProps } from "./button.types.ts";
  * @see {@link https://nimbus-documentation.vercel.app/components/inputs/button}
  */
 const ButtonComponent = (props: ButtonProps) => {
-  const { ref: forwardedRef, as, asChild, children, ...rest } = props;
+  const {
+    ref: forwardedRef,
+    as,
+    asChild,
+    children,
+    allowFocusWhenDisabled,
+    ...rest
+  } = props;
 
   // create a local ref (because the consumer may not provide a forwardedRef)
   const localRef = useRef<HTMLButtonElement>(null);
@@ -31,24 +38,61 @@ const ButtonComponent = (props: ButtonProps) => {
   // has to be manually set to something else than button
   const elementType = as || (asChild ? "a" : "button") || "button";
 
+  // Resolve disabled state from React Aria's `isDisabled` (prop or context),
+  // falling back to the deprecated native `disabled`.
+  const isDisabled = Boolean(contextProps.isDisabled ?? contextProps.disabled);
+
+  // "Soft disabled": the button is disabled but kept focusable + hoverable so
+  // it can host a Tooltip (or other hover/focus affordance). See the
+  // `allowFocusWhenDisabled` prop. We achieve this by telling `useButton` the
+  // button is *enabled* (so it omits the native `disabled` attribute and stays
+  // focusable) while withholding every activation handler, then re-applying
+  // `aria-disabled` and suppressing the default action ourselves below.
+  const softDisabled = Boolean(isDisabled && allowFocusWhenDisabled);
+
   // Let useButton process all behavior and accessibility concerns
   const { buttonProps, isPressed } = useButton(
-    {
-      ...contextProps,
-      elementType,
-    },
+    softDisabled
+      ? {
+          ...contextProps,
+          elementType,
+          isDisabled: false,
+          // Withhold activation handlers so nothing fires while soft-disabled.
+          onPress: undefined,
+          onPressStart: undefined,
+          onPressEnd: undefined,
+          onPressUp: undefined,
+          onPressChange: undefined,
+          onClick: undefined,
+        }
+      : {
+          ...contextProps,
+          elementType,
+        },
     contextRef
   );
+
+  // A native button dispatches a click for mouse, touch, and keyboard
+  // (Enter/Space) activation, and that click is what triggers form submit/reset
+  // and link navigation (`as="a"`). Suppressing it covers every activation path.
+  const suppressActivation = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
 
   return (
     <ButtonRoot
       ref={contextRef}
       {...contextProps}
       {...buttonProps}
+      {...(softDisabled && {
+        "aria-disabled": true,
+        onClick: suppressActivation,
+      })}
       as={as}
       asChild={asChild}
       slot={contextProps.slot || undefined}
-      data-pressed={isPressed || undefined}
+      data-pressed={softDisabled ? undefined : isPressed || undefined}
     >
       {children}
     </ButtonRoot>

--- a/packages/nimbus/src/components/button/button.types.ts
+++ b/packages/nimbus/src/components/button/button.types.ts
@@ -95,6 +95,22 @@ export type ButtonProps = Omit<
   RaButtonProps &
   NativePropsWithAriaEquivalents & {
     /**
+     * When `true` together with `isDisabled`, the button stays **focusable and
+     * hoverable** while disabled instead of being removed from interaction.
+     *
+     * It renders `aria-disabled="true"` (not the native `disabled` attribute),
+     * keeps the button in the natural tab order, and suppresses activation
+     * (press, click, `Enter`/`Space`, form submit/reset, and link navigation do
+     * not fire). The disabled styling is unchanged.
+     *
+     * Use this to attach a `Tooltip` (or other hover/focus affordance) to a
+     * disabled button — for example to explain *why* the action is unavailable.
+     * Has no effect unless the button is also disabled.
+     *
+     * @default false
+     */
+    allowFocusWhenDisabled?: boolean;
+    /**
      * Data attributes for testing or custom metadata
      */
     [key: `data-${string}`]: unknown;

--- a/packages/nimbus/src/components/tooltip/tooltip.dev.mdx
+++ b/packages/nimbus/src/components/tooltip/tooltip.dev.mdx
@@ -202,6 +202,37 @@ const App = () => (
 )
 ```
 
+### With disabled buttons
+
+A natively disabled button cannot host a tooltip: the `disabled` attribute
+removes it from the tab order and stops it firing hover/focus events, so the
+tooltip has nothing to open from. This is unfortunate precisely when a tooltip
+is most useful — explaining _why_ an action is unavailable.
+
+Pass `allowFocusWhenDisabled` together with `isDisabled` on the `Button`. The
+button stays focusable and hoverable and is announced as disabled via
+`aria-disabled` (instead of the native `disabled` attribute), while its action
+stays fully suppressed. The tooltip then opens on hover and keyboard focus like
+any other trigger.
+
+```jsx live-dev
+const App = () => (
+  <Tooltip.Root>
+    <Button isDisabled allowFocusWhenDisabled>
+      Publish
+    </Button>
+    <Tooltip.Content>
+      Complete all required fields before publishing.
+    </Tooltip.Content>
+  </Tooltip.Root>
+)
+```
+
+Prefer this to wrapping a disabled button in `MakeElementFocusable`: the
+`allowFocusWhenDisabled` path keeps the disabled semantics on the button itself
+(`aria-disabled`) and suppresses activation, whereas a focusable wrapper only
+adds focus and describes the wrong element.
+
 ## Component requirements
 
 ## Accessibility


### PR DESCRIPTION
## Why

Consumers want to attach a `Tooltip` to a **disabled** `Button` — almost always to explain *why* the action is unavailable ("Complete required fields", "You don't have permission"). Today that's impossible: `Button` delegates disabled state to React Aria's `useButton`, which applies the native `disabled` attribute to a `<button>`. A natively-disabled element is removed from the tab order and fires no hover/focus events, so `TooltipTrigger` (which opens on hover **and** focus and needs a focusable trigger) has nothing to bind to — for mouse *or* keyboard users. The control that most needs an explanation is the one that can't carry one.

## What changed

Adds an opt-in boolean prop **`allowFocusWhenDisabled`** to `Button` (default `false`). It only has an effect together with `isDisabled`. When both are set, the button is **soft-disabled**:

- stays **focusable** and in the natural tab order (tooltip opens on focus),
- stays **hoverable** (tooltip opens on hover),
- exposes **`aria-disabled="true"`** instead of the native `disabled` attribute (existing `_disabled` recipe styling still applies — no visual change),
- **cannot be activated** — press, click, `Enter`/`Space`, form submit/reset, and link navigation are all suppressed.

```tsx
<Tooltip.Root>
  <Button isDisabled allowFocusWhenDisabled>Publish</Button>
  <Tooltip.Content>Complete all required fields to publish.</Tooltip.Content>
</Tooltip.Root>
```

Default behavior (prop omitted/`false`) is **completely unchanged**: `isDisabled` continues to apply the native `disabled` attribute. Purely additive, non-breaking.

## How

Confined to one branch in `button.tsx`: when soft-disabled, `useButton` is told the button is *enabled* (so it omits the native `disabled` attribute and stays focusable) with activation handlers withheld; we then re-apply `aria-disabled` and a click guard (`preventDefault`/`stopPropagation`). A native button dispatches a click for mouse, touch, and keyboard activation — and that click is what triggers form submit/reset and link navigation — so a single click guard covers every activation path.

### Why suppress activation, not just visual-only `aria-disabled`?

Visual-only disable already works today via `<Button aria-disabled>`. The reason it isn't enough: `aria-disabled="true"` promises assistive tech the control is *non-operable*. Without suppression the button still fires `onPress`, and a `type="submit"` button still submits its form on Enter **with no handler wired** — a "looks/announces disabled but still acts" bug that's worse than the original limitation, and the exact case consumers ship. Getting it right means guarding press/click/keydown/submit/nav together, which is identical for every consumer, so it belongs in the component. Full rationale + rejected API shapes in the OpenSpec `design.md`.

## Spec

OpenSpec change: `openspec/changes/add-button-allow-focus-when-disabled/` (proposal, design, `nimbus-button` spec delta, tasks).

## Testing

- `pnpm --filter @commercetools/nimbus typecheck` — clean
- `pnpm lint` — clean (button)
- Storybook story tests (source): **18/18** — adds `DisabledButFocusable`, `DisabledButFocusableDoesNotSubmit`, `DisabledWithTooltip`
- Docs-spec consumer tests (source): **14/14** — adds a copyable "Tooltip on a disabled Button" example

## Docs

- `button.dev.mdx` — "Keeping a disabled button focusable (for tooltips)"
- `tooltip.dev.mdx` — "With disabled buttons"

Changeset: minor bump on `@commercetools/nimbus`.
