### PR TITLE
feat(tabs): animated active-tab indicator + shared useSlidingIndicator hook

### DIFF
--- a/.changeset/animated-tab-indicator.md
+++ b/.changeset/animated-tab-indicator.md
@@ -1,0 +1,15 @@
+---
+"@commercetools/nimbus": minor
+---
+
+**Tabs & TabNav**: add an opt-in `animated` prop that slides a single active
+marker between items as the selection changes, instead of snapping it. The
+indicator adapts to the variant, orientation, and placement — an underline bar
+for the `line`/`tabs` look, a side bar for vertical `Tabs`, and a filled
+highlight for `pills` (`Tabs`) and `filled`/`pill` (`TabNav`). It is decorative
+(`aria-hidden`, non-focusable), so selection, focus, and keyboard navigation are
+unaffected, and the slide automatically respects `prefers-reduced-motion`.
+`animated` defaults to `false`, so existing usage is unchanged.
+
+`TabNav` also gains `filled` and `pill` variants (soft rounded-rect and capsule
+active highlights) alongside the default `tabs` underline.

--- a/.changeset/animated-tab-indicator.md
+++ b/.changeset/animated-tab-indicator.md
@@ -13,8 +13,10 @@
   and the indicator is decorative (`aria-hidden`) — selection, focus, and
   keyboard behavior are unchanged. The animation is always on; there is no
   per-instance toggle.
-- `Tabs`' `pills` variant has been reimplemented to match `TabNav` (themeable
-  `colorPalette` highlight, no outline-box container).
+- The `pill` variant now looks the same on `Tabs` and `TabNav`: a themeable
+  capsule highlight that follows `colorPalette`. If you use `Tabs`
+  `variant="pills"` today, expect a refreshed look (and it now themes with the
+  surrounding palette instead of a fixed color).
 
 **Deprecations (non-breaking — old names still work):**
 

--- a/.changeset/animated-tab-indicator.md
+++ b/.changeset/animated-tab-indicator.md
@@ -4,22 +4,21 @@
 
 **Tabs & TabNav**: unified variants and a sliding active indicator.
 
-- Both components now expose the **same three variants**: `underline` (default),
+- Both components now expose the **same three variants**: `line` (default),
   `rounded` (soft rounded-rect highlight), and `pill` (capsule highlight). The
   `rounded`/`pill` highlights are themeable via `colorPalette`.
 - The active marker now **slides** between items/tabs as the selection changes
-  (an underline bar for `underline`, a filled highlight for `rounded`/`pill`),
-  instead of snapping. The motion automatically respects
-  `prefers-reduced-motion: reduce`, and the indicator is decorative
-  (`aria-hidden`) — selection, focus, and keyboard behavior are unchanged. The
-  animation is always on; there is no per-instance toggle.
+  (a bar for `line`, a filled highlight for `rounded`/`pill`), instead of
+  snapping. The motion automatically respects `prefers-reduced-motion: reduce`,
+  and the indicator is decorative (`aria-hidden`) — selection, focus, and
+  keyboard behavior are unchanged. The animation is always on; there is no
+  per-instance toggle.
 - `Tabs`' `pills` variant has been reimplemented to match `TabNav` (themeable
   `colorPalette` highlight, no outline-box container).
 
 **Deprecations (non-breaking — old names still work):**
 
-- `Tabs`: `variant="line"` → `variant="underline"`; `variant="pills"` →
-  `variant="pill"`.
-- `TabNav`: `variant="tabs"` → `variant="underline"`.
+- `Tabs`: `variant="pills"` → `variant="pill"`.
+- `TabNav`: `variant="tabs"` → `variant="line"`.
 
 Update at your convenience; the deprecated names are accepted as aliases.

--- a/.changeset/animated-tab-indicator.md
+++ b/.changeset/animated-tab-indicator.md
@@ -2,14 +2,24 @@
 "@commercetools/nimbus": minor
 ---
 
-**Tabs & TabNav**: add an opt-in `animated` prop that slides a single active
-marker between items as the selection changes, instead of snapping it. The
-indicator adapts to the variant, orientation, and placement — an underline bar
-for the `line`/`tabs` look, a side bar for vertical `Tabs`, and a filled
-highlight for `pills` (`Tabs`) and `filled`/`pill` (`TabNav`). It is decorative
-(`aria-hidden`, non-focusable), so selection, focus, and keyboard navigation are
-unaffected, and the slide automatically respects `prefers-reduced-motion`.
-`animated` defaults to `false`, so existing usage is unchanged.
+**Tabs & TabNav**: unified variants and a sliding active indicator.
 
-`TabNav` also gains `filled` and `pill` variants (soft rounded-rect and capsule
-active highlights) alongside the default `tabs` underline.
+- Both components now expose the **same three variants**: `underline` (default),
+  `rounded` (soft rounded-rect highlight), and `pill` (capsule highlight). The
+  `rounded`/`pill` highlights are themeable via `colorPalette`.
+- The active marker now **slides** between items/tabs as the selection changes
+  (an underline bar for `underline`, a filled highlight for `rounded`/`pill`),
+  instead of snapping. The motion automatically respects
+  `prefers-reduced-motion: reduce`, and the indicator is decorative
+  (`aria-hidden`) — selection, focus, and keyboard behavior are unchanged. The
+  animation is always on; there is no per-instance toggle.
+- `Tabs`' `pills` variant has been reimplemented to match `TabNav` (themeable
+  `colorPalette` highlight, no outline-box container).
+
+**Deprecations (non-breaking — old names still work):**
+
+- `Tabs`: `variant="line"` → `variant="underline"`; `variant="pills"` →
+  `variant="pill"`.
+- `TabNav`: `variant="tabs"` → `variant="underline"`.
+
+Update at your convenience; the deprecated names are accepted as aliases.

--- a/openspec/changes/add-animated-tab-indicator/.openspec.yaml
+++ b/openspec/changes/add-animated-tab-indicator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/add-animated-tab-indicator/design.md
+++ b/openspec/changes/add-animated-tab-indicator/design.md
@@ -1,99 +1,108 @@
-## Update (final scope)
-
-This change grew from "opt-in animated Tabs indicator" to: (a) the sliding
-indicator is the **default** for both components (no `animated` prop; the hook
-sets `data-animated` on mount so the static marker stays the no-JS fallback);
-(b) `Tabs` and `TabNav` share **one variant set** — `underline`/`rounded`/`pill`
-— with `Tabs`' flawed `pills` reimplemented on `TabNav`'s themeable highlight;
-(c) deprecated aliases (`line`/`tabs`→`underline`, `pills`→`pill`) are resolved
-in the component. The decisions below about indicator placement, geometry
-callback, static-marker suppression, and reduced motion still hold.
-
 ## Context
 
-`Tabs` is built on React Aria Components (`Tabs` / `TabList` / `Tab` / `TabPanel`).
-`Tabs.Root` renders `<TabsRootSlot asChild><RATabs>…</RATabs></TabsRootSlot>`, and
-already normalizes the responsive `orientation` prop to a concrete value via
-`sysCtx.normalizeValue` because RAC cannot consume responsive values.
+`Tabs` is built on React Aria Components (`Tabs` / `TabList` / `Tab` /
+`TabPanel`). `Tabs.Root` renders `<TabsRootSlot asChild><RATabs>…</RATabs>` and
+normalizes the responsive `variant` / `orientation` / `placement` props to
+concrete values via `sysCtx.normalizeValue`, because RAC cannot consume
+responsive values.
 
-The active marker today is static, defined in the recipe:
+`TabNav` renders a `<nav>` landmark containing `<a>` items (`TabNav.Item`), with
+the active item marked `aria-current="page"`.
 
-- `line` markers are `boxShadow` declarations in `compoundVariants`, one per
-  `orientation`/`placement` combination (bottom / right / left edge).
-- `pills` selected state is `backgroundColor: primary.3` in the `pills` variant.
-
-## Goals / Non-Goals
-
-- Goal: an opt-in, variant-aware sliding indicator for `Tabs` that reuses one
-  shared implementation with `TabNav`.
-- Goal: correctness across `orientation` × `placement` × `variant`, including
-  runtime-resolved (responsive) `orientation`.
-- Non-Goal: changing the static (non-animated) appearance or any a11y/keyboard
-  behavior.
-- Non-Goal: refactoring `TabNav` onto the hook in this change (follow-up).
+Both recipes mark the active item with a **static** marker — an underline
+`boxShadow` for `line`, a filled `backgroundColor` for `rounded`/`pill`. The
+sliding indicator replaces that marker at runtime.
 
 ## Decisions
 
-### Indicator lives in the root, not the list
+### The indicator lives in the positioned root, not the item list
 
-The indicator is rendered as the first child of `RATabs` (the root element, made
-`position: relative` when animated) rather than inside `TabList`. Two reasons:
+Both components render the indicator as the first child of a `position: relative`
+root — `RATabs` for `Tabs`, the `<nav>` slot for `TabNav`. For `Tabs` this is
+required: RAC's `TabList` renders a **collection** and rejects arbitrary
+non-`Tab` children, whereas the root has no such restriction. Measuring
+`activeRect − rootRect` against the root is also correct for **every** layout —
+in vertical / `placement="end"` the root is a flex `row` / `row-reverse` holding
+list + panels.
 
-1. React Aria's `TabList` renders a **collection**; injecting an arbitrary
-   non-`Tab` child is unsupported. The root element has no such restriction.
-2. Absolute positioning against the root works for **every** layout — in
-   vertical / `placement="end"` the root is a flex `row` / `row-reverse` holding
-   list + panels, and measuring `activeTabRect − rootRect` is correct regardless.
+The active element is found with a CSS selector
+(`[role="tab"][aria-selected="true"]` for `Tabs`, `[aria-current="page"]` for
+`TabNav`); the container is the indicator's positioned parent
+(`indicator.parentElement`), so no extra root ref is required.
 
-The active tab is found with `[role="tab"][aria-selected="true"]`; the container
-is the indicator's positioned parent (`indicator.parentElement`), so no extra
-root ref is required.
+### Shared hook with a geometry callback, not flags
+
+`useSlidingIndicator` is generic: callers pass `indicatorRef`, `activeSelector`,
+`watchAttributes`, and `getGeometry({ container, active }) => { x, y, width?,
+height? }`. The hook measures with `getBoundingClientRect` in `useLayoutEffect`
+and re-measures on active-item changes (a `MutationObserver` on
+`watchAttributes`) and layout changes (a `ResizeObserver`). Each component
+supplies geometry for its own variants (`T` = 2px bar thickness):
+
+- `rounded` / `pill` → full-box fill `{ x, y, width: active.w, height: active.h }`.
+- `line` horizontal → bottom bar `{ x, y: y + h − T, width: active.w, height: T }`.
+- `line` vertical `start` → inner (right) bar `{ x: x + w − T, y, width: T, height: h }`.
+- `line` vertical `end` → inner (left) bar `{ x, y, width: T, height: h }`.
+
+This keeps the hook agnostic so both components share one implementation.
+
+### `data-animated` marks the JS-enhanced state; the static marker is the fallback
+
+The hook sets `data-animated="true"` on the container on mount (removed on
+cleanup). The recipe's static marker renders server-side / pre-hydration; once
+the hook activates, recipe rules under `[data-animated="true"]` suppress the
+static marker and the measured indicator takes over before paint.
+
+Suppression rules live **inside the same variant slot objects** that define the
+static markers, so they share base specificity and win simply by adding the
+`[data-animated="true"]` ancestor — no `!important`:
+
+```ts
+'[data-animated="true"] &[data-selected]': { boxShadow: "… transparent" }       // line
+'[data-animated="true"] &[data-selected]': { backgroundColor: "transparent" }   // rounded / pill
+```
+
+(Co-location is also required by the type system: arbitrary selectors are
+accepted in `variants.*` slot objects but not in `base.*` or
+`compoundVariants[].css`.)
+
+### Snap on first paint, slide thereafter
+
+The indicator is authored at the container's top-left (`top/left: 0`, no
+transform) and carries a `transition`. The **first** placement is applied with
+the transition momentarily suppressed — the jump is committed with a synchronous
+reflow, then the transition is restored — so the indicator appears over the
+active item on initial render instead of animating in from the corner.
+Subsequent selection changes slide. Re-running the effect (e.g. a
+variant/orientation change) also snaps rather than sliding from a stale position.
 
 ### Paint order
 
 An absolutely-positioned element paints above static siblings. To keep the
-indicator **behind** tab labels (needed for the `pills` fill), the recipe gives
-tabs `position: relative; zIndex: 1` while `[data-animated="true"]`, and the
-indicator uses `zIndex: 0`. The indicator is geometrically over the tab strip
-only, never the panels, and is `pointer-events: none`.
-
-### Geometry callback, not flags
-
-`useSlidingIndicator` is generic: the caller passes `getGeometry({ container,
-active }) => { x, y, width?, height? }`. `Tabs` computes geometry from the
-**normalized** `variant` / `orientation` / `placement`:
-
-- `pills` → `{ x, y, width: active.w, height: active.h }` (full box, radius full).
-- `line` horizontal → bottom bar `{ x, y: y + h − T, width: active.w, height: T }`.
-- `line` vertical `start` → right bar `{ x: x + w − T, y, width: T, height: h }`.
-- `line` vertical `end` → left bar `{ x, y, width: T, height: h }`.
-
-where `T` is the 2px bar thickness. This keeps the hook agnostic and lets
-`TabNav` pass its own geometry later.
-
-### Suppressing the static marker
-
-Suppression rules are added **inside the same recipe blocks** that define the
-static markers (the `line` `compoundVariants` and the `pills` variant), so they
-inherit the same base specificity and only add a `[data-animated="true"]`
-ancestor — guaranteeing they win without `!important`:
-
-```ts
-'[data-animated="true"] &[data-selected]': { boxShadow: "… transparent" } // line
-'[data-animated="true"] &[data-selected]': { backgroundColor: "transparent" } // pills
-```
+filled highlight **behind** item labels, the recipe gives items `position:
+relative; zIndex: 1` under `[data-animated="true"]`, and the indicator uses
+`zIndex: 0`. The indicator covers the item strip only (never the panels) and is
+`pointer-events: none`.
 
 ### Reduced motion
 
-The indicator element carries the transform/size transition, disabled via
-`@media (prefers-reduced-motion: reduce)` — the highlight snaps into place.
+The indicator's transform/size transition is disabled under `@media
+(prefers-reduced-motion: reduce)` — the highlight snaps. This is the only motion
+control; there is no per-instance prop.
+
+### Deprecated variant aliases
+
+The components accept the previous variant names and resolve them to the current
+ones before the recipe sees them — `Tabs` `pills` → `pill`; `TabNav` `tabs` →
+`line` — typed `@deprecated`. The recipes define only `line` / `rounded` /
+`pill`.
 
 ## Risks / Trade-offs
 
-- **Responsive orientation:** mitigated by reusing `sysCtx.normalizeValue` (the
-  same mechanism `Tabs.Root` already uses for RAC) and re-running the effect when
-  the normalized values change.
-- **Extra DOM node** (the indicator) only renders when `animated` is set, and is
-  `aria-hidden` + non-focusable, so the a11y tree is unchanged.
-- **Specificity of suppression:** addressed by co-locating suppression with the
+- **Responsive `orientation` / `variant`:** reuse `sysCtx.normalizeValue` (the
+  same mechanism `Tabs.Root` already uses for RAC) and re-run the effect when
+  the normalized values change (via `deps`).
+- **Extra DOM node:** the indicator is `aria-hidden` + non-focusable, so the
+  a11y tree is unchanged.
+- **Suppression specificity:** addressed by co-locating suppression with the
   static markers (see above).

--- a/openspec/changes/add-animated-tab-indicator/design.md
+++ b/openspec/changes/add-animated-tab-indicator/design.md
@@ -1,3 +1,14 @@
+## Update (final scope)
+
+This change grew from "opt-in animated Tabs indicator" to: (a) the sliding
+indicator is the **default** for both components (no `animated` prop; the hook
+sets `data-animated` on mount so the static marker stays the no-JS fallback);
+(b) `Tabs` and `TabNav` share **one variant set** — `underline`/`rounded`/`pill`
+— with `Tabs`' flawed `pills` reimplemented on `TabNav`'s themeable highlight;
+(c) deprecated aliases (`line`/`tabs`→`underline`, `pills`→`pill`) are resolved
+in the component. The decisions below about indicator placement, geometry
+callback, static-marker suppression, and reduced motion still hold.
+
 ## Context
 
 `Tabs` is built on React Aria Components (`Tabs` / `TabList` / `Tab` / `TabPanel`).

--- a/openspec/changes/add-animated-tab-indicator/design.md
+++ b/openspec/changes/add-animated-tab-indicator/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`Tabs` is built on React Aria Components (`Tabs` / `TabList` / `Tab` / `TabPanel`).
+`Tabs.Root` renders `<TabsRootSlot asChild><RATabs>…</RATabs></TabsRootSlot>`, and
+already normalizes the responsive `orientation` prop to a concrete value via
+`sysCtx.normalizeValue` because RAC cannot consume responsive values.
+
+The active marker today is static, defined in the recipe:
+
+- `line` markers are `boxShadow` declarations in `compoundVariants`, one per
+  `orientation`/`placement` combination (bottom / right / left edge).
+- `pills` selected state is `backgroundColor: primary.3` in the `pills` variant.
+
+## Goals / Non-Goals
+
+- Goal: an opt-in, variant-aware sliding indicator for `Tabs` that reuses one
+  shared implementation with `TabNav`.
+- Goal: correctness across `orientation` × `placement` × `variant`, including
+  runtime-resolved (responsive) `orientation`.
+- Non-Goal: changing the static (non-animated) appearance or any a11y/keyboard
+  behavior.
+- Non-Goal: refactoring `TabNav` onto the hook in this change (follow-up).
+
+## Decisions
+
+### Indicator lives in the root, not the list
+
+The indicator is rendered as the first child of `RATabs` (the root element, made
+`position: relative` when animated) rather than inside `TabList`. Two reasons:
+
+1. React Aria's `TabList` renders a **collection**; injecting an arbitrary
+   non-`Tab` child is unsupported. The root element has no such restriction.
+2. Absolute positioning against the root works for **every** layout — in
+   vertical / `placement="end"` the root is a flex `row` / `row-reverse` holding
+   list + panels, and measuring `activeTabRect − rootRect` is correct regardless.
+
+The active tab is found with `[role="tab"][aria-selected="true"]`; the container
+is the indicator's positioned parent (`indicator.parentElement`), so no extra
+root ref is required.
+
+### Paint order
+
+An absolutely-positioned element paints above static siblings. To keep the
+indicator **behind** tab labels (needed for the `pills` fill), the recipe gives
+tabs `position: relative; zIndex: 1` while `[data-animated="true"]`, and the
+indicator uses `zIndex: 0`. The indicator is geometrically over the tab strip
+only, never the panels, and is `pointer-events: none`.
+
+### Geometry callback, not flags
+
+`useSlidingIndicator` is generic: the caller passes `getGeometry({ container,
+active }) => { x, y, width?, height? }`. `Tabs` computes geometry from the
+**normalized** `variant` / `orientation` / `placement`:
+
+- `pills` → `{ x, y, width: active.w, height: active.h }` (full box, radius full).
+- `line` horizontal → bottom bar `{ x, y: y + h − T, width: active.w, height: T }`.
+- `line` vertical `start` → right bar `{ x: x + w − T, y, width: T, height: h }`.
+- `line` vertical `end` → left bar `{ x, y, width: T, height: h }`.
+
+where `T` is the 2px bar thickness. This keeps the hook agnostic and lets
+`TabNav` pass its own geometry later.
+
+### Suppressing the static marker
+
+Suppression rules are added **inside the same recipe blocks** that define the
+static markers (the `line` `compoundVariants` and the `pills` variant), so they
+inherit the same base specificity and only add a `[data-animated="true"]`
+ancestor — guaranteeing they win without `!important`:
+
+```ts
+'[data-animated="true"] &[data-selected]': { boxShadow: "… transparent" } // line
+'[data-animated="true"] &[data-selected]': { backgroundColor: "transparent" } // pills
+```
+
+### Reduced motion
+
+The indicator element carries the transform/size transition, disabled via
+`@media (prefers-reduced-motion: reduce)` — the highlight snaps into place.
+
+## Risks / Trade-offs
+
+- **Responsive orientation:** mitigated by reusing `sysCtx.normalizeValue` (the
+  same mechanism `Tabs.Root` already uses for RAC) and re-running the effect when
+  the normalized values change.
+- **Extra DOM node** (the indicator) only renders when `animated` is set, and is
+  `aria-hidden` + non-focusable, so the a11y tree is unchanged.
+- **Specificity of suppression:** addressed by co-locating suppression with the
+  static markers (see above).

--- a/openspec/changes/add-animated-tab-indicator/proposal.md
+++ b/openspec/changes/add-animated-tab-indicator/proposal.md
@@ -1,34 +1,35 @@
 ## Why
 
-`Tabs` and `TabNav` are visual twins but had diverged: different variant sets
-(`Tabs` = `line`|`pills`; `TabNav` = `tabs`|`filled`|`pill`), a static active
-marker, and — in an earlier iteration — an opt-in `animated` prop. In use, the
-sliding active indicator is strictly better than the static marker, the two
-components should expose the SAME variants, and `Tabs`' `pills` variant was
-flawed (hardcoded `primary`, an outline-box container, no hover, not themeable).
+`Tabs` and `TabNav` are visual twins, but they expose different variant sets and
+render a **static** active marker that snaps between items. `Tabs`' `pills`
+variant is also flawed: a hardcoded `primary` color, an outline-box container, no
+hover, and not themeable. This change gives both components one shared variant
+set and replaces the static marker with a single indicator that slides between
+items.
 
 ## What Changes
 
-- **One shared variant set for both components**: `underline` (default),
-  `rounded` (soft rounded-rect highlight), `pill` (capsule highlight). The
-  `rounded`/`pill` highlights are themeable via `colorPalette`. (`Tabs`
-  additionally layers `orientation`/`placement` onto `underline`.)
-- **The sliding indicator is the default** (no `animated` prop). The active
-  marker is a single element that slides between items/tabs as the selection
-  changes — an underline bar for `underline`, a filled highlight for
-  `rounded`/`pill`. It is `aria-hidden`/non-focusable and respects
-  `prefers-reduced-motion: reduce` (snaps). The only "off" switch is the OS-level
-  reduced-motion preference (the only motion lever Nimbus has).
+- **One shared variant set for both components**: `line` (default), `rounded`
+  (soft rounded-rect highlight), `pill` (capsule highlight). `line` is a bar on
+  the active item — an underline when horizontal, an inner side bar when
+  vertical. The `rounded`/`pill` highlights are themeable via `colorPalette`.
+  (`Tabs` additionally layers `orientation`/`placement` onto `line`.)
+- **The active marker is a single sliding indicator.** It slides between
+  items/tabs as the selection changes — a bar for `line`, a filled highlight for
+  `rounded`/`pill`. It is `aria-hidden`/non-focusable and
+  respects `prefers-reduced-motion: reduce` (snaps). There is no per-instance
+  toggle; the only "off" switch is the OS-level reduced-motion preference (the
+  only motion lever Nimbus has).
 - **Shared `useSlidingIndicator` hook** drives both components. It sets
   `data-animated` on the container on mount, so the recipe's static marker is the
   SSR / pre-hydration / no-JS fallback and the measured slide takes over before
-  paint (no flash).
+  paint (no flash). The first placement snaps into position; only subsequent
+  selection changes slide.
 - **`Tabs` `pills` is reimplemented** to match `TabNav`'s themeable highlight
   (drop the outline-box container and the `primary.3` hardcode).
-- **Deprecated aliases (non-breaking)**: `Tabs` accepts `line` (→ `underline`)
-  and `pills` (→ `pill`); `TabNav` accepts `tabs` (→ `underline`). Resolved at
-  runtime in the component and typed as `@deprecated`, so existing consumers keep
-  working with no edits.
+- **Deprecated aliases (non-breaking)**: `Tabs` accepts `pills` (→ `pill`);
+  `TabNav` accepts `tabs` (→ `line`). Resolved at runtime in the component and
+  typed as `@deprecated`, so existing consumers keep working with no edits.
 
 ## Impact
 
@@ -37,9 +38,9 @@ flawed (hardcoded `primary`, an outline-box container, no hover, not themeable).
 - Affected code: `hooks/use-sliding-indicator/*`; for both `tabs` and `tab-nav`:
   `*.recipe.ts`, `*.types.ts`, `components/*.root.tsx`, `*.stories.tsx`,
   `*.mdx`/`*.dev.mdx` (+ `tab-nav.tsx` JSDoc).
-- Default variant changes (`line`/`tabs` → `underline`) are transparent because
-  consumers that omit `variant` are unaffected and the old names remain valid
-  aliases.
+- The `TabNav` default changes from `tabs` to `line` (`Tabs` stays `line`); both
+  are transparent because consumers that omit `variant` are unaffected and `tabs`
+  remains a valid alias.
 - The two docs-app `Tabs` usages with `variant="pills"` keep working via the
   alias (no edits required).
 - The `Tabs` ↔ `TabNav` VISUAL TWIN contract now covers all three variants.

--- a/openspec/changes/add-animated-tab-indicator/proposal.md
+++ b/openspec/changes/add-animated-tab-indicator/proposal.md
@@ -1,60 +1,45 @@
 ## Why
 
-`TabNav` recently gained an opt-in `animated` mode: a single active-highlight
-indicator that slides between items as the active item changes (an underline bar
-for the `tabs` variant, a filled highlight for `filled`/`pill`), gated behind
-`prefers-reduced-motion`. The same motion is a natural fit for the `Tabs`
-component — but `Tabs` is more involved: it supports `orientation`
-(`horizontal` | `vertical`), `placement` (`start` | `end`), and a `pills`
-variant, each of which puts the active marker on a different edge (bottom / right
-/ left) or turns it into a filled background. `orientation` is also resolved at
-runtime (React Aria can't take responsive values, so `Tabs.Root` already
-normalizes it), so a literal read of the prop is not enough.
-
-Rather than copy `TabNav`'s inline measure-and-slide logic into `Tabs` (and have
-it drift), this change extracts that logic into a small, reusable hook and uses
-it to drive a variant-aware sliding indicator on `Tabs`.
+`Tabs` and `TabNav` are visual twins but had diverged: different variant sets
+(`Tabs` = `line`|`pills`; `TabNav` = `tabs`|`filled`|`pill`), a static active
+marker, and — in an earlier iteration — an opt-in `animated` prop. In use, the
+sliding active indicator is strictly better than the static marker, the two
+components should expose the SAME variants, and `Tabs`' `pills` variant was
+flawed (hardcoded `primary`, an outline-box container, no hover, not themeable).
 
 ## What Changes
 
-- Add `useSlidingIndicator`, a reusable hook in `packages/nimbus/src/hooks` that
-  positions an absolutely-placed indicator element over the active item inside a
-  container and keeps it in sync. It is DOM-driven (measures via
-  `getBoundingClientRect`), re-measures on active-item changes
-  (`MutationObserver`) and layout changes (`ResizeObserver`), measures
-  synchronously before paint (`useLayoutEffect`, no first-frame flash), and is a
-  no-op when disabled. The caller supplies how to find the active item
-  (`activeSelector`), which attributes to watch, and a `getGeometry` callback
-  that maps the container + active rects to indicator geometry — so the same
-  hook serves an underline bar, a side bar, or a filled highlight.
-- Add an opt-in `animated?: boolean` prop to `Tabs.Root`. When `true`, `Tabs`
-  renders a single `aria-hidden`, non-focusable indicator inside the root and
-  drives it with `useSlidingIndicator`. The indicator adapts to the resolved
-  `variant` / `orientation` / `placement`:
-  - `line` + horizontal → a thin bar on the active tab's bottom edge.
-  - `line` + vertical + `start` → a thin bar on the active tab's right edge.
-  - `line` + vertical + `end` → a thin bar on the active tab's left edge.
-  - `pills` → a filled, fully-rounded highlight behind the active tab.
-- Suppress the static selected marker (the `boxShadow` underline / `pills`
-  background) while `animated` is active so the sliding indicator owns the
-  highlight — no double marker. The static marker remains the fallback when
-  `animated` is off.
-- The slide transition is disabled under `prefers-reduced-motion: reduce` (the
-  highlight snaps), and `aria-selected` / focus rings / keyboard (roving
-  tabindex) are unaffected — the indicator is purely decorative.
-- `animated` defaults to `false`, so the default `Tabs` look and behavior are
-  unchanged. No changes to `Tabs.Tab` / `Tabs.Panel` semantics.
+- **One shared variant set for both components**: `underline` (default),
+  `rounded` (soft rounded-rect highlight), `pill` (capsule highlight). The
+  `rounded`/`pill` highlights are themeable via `colorPalette`. (`Tabs`
+  additionally layers `orientation`/`placement` onto `underline`.)
+- **The sliding indicator is the default** (no `animated` prop). The active
+  marker is a single element that slides between items/tabs as the selection
+  changes — an underline bar for `underline`, a filled highlight for
+  `rounded`/`pill`. It is `aria-hidden`/non-focusable and respects
+  `prefers-reduced-motion: reduce` (snaps). The only "off" switch is the OS-level
+  reduced-motion preference (the only motion lever Nimbus has).
+- **Shared `useSlidingIndicator` hook** drives both components. It sets
+  `data-animated` on the container on mount, so the recipe's static marker is the
+  SSR / pre-hydration / no-JS fallback and the measured slide takes over before
+  paint (no flash).
+- **`Tabs` `pills` is reimplemented** to match `TabNav`'s themeable highlight
+  (drop the outline-box container and the `primary.3` hardcode).
+- **Deprecated aliases (non-breaking)**: `Tabs` accepts `line` (→ `underline`)
+  and `pills` (→ `pill`); `TabNav` accepts `tabs` (→ `underline`). Resolved at
+  runtime in the component and typed as `@deprecated`, so existing consumers keep
+  working with no edits.
 
 ## Impact
 
 - Affected specs: `nimbus-use-sliding-indicator` (new), `nimbus-tabs` (added
   requirement).
-- Affected code: `packages/nimbus/src/hooks/use-sliding-indicator/*` (new),
-  `tabs.types.ts`, `tabs.recipe.ts`, `components/tabs.root.tsx`,
-  `tabs.stories.tsx`, `tabs.dev.mdx` / `tabs.mdx`.
-- `TabNav.Root` adopts `useSlidingIndicator` too: its animated indicator (an
-  underline bar for `tabs`, a filled highlight for `filled`/`pill`) is refactored
-  off its inline measure-and-slide logic onto the shared hook, so both
-  components share one implementation.
-- The `tabs` ↔ `TabNav` VISUAL TWIN contract is preserved: the static look is
-  unchanged, and the animation is additive and opt-in.
+- Affected code: `hooks/use-sliding-indicator/*`; for both `tabs` and `tab-nav`:
+  `*.recipe.ts`, `*.types.ts`, `components/*.root.tsx`, `*.stories.tsx`,
+  `*.mdx`/`*.dev.mdx` (+ `tab-nav.tsx` JSDoc).
+- Default variant changes (`line`/`tabs` → `underline`) are transparent because
+  consumers that omit `variant` are unaffected and the old names remain valid
+  aliases.
+- The two docs-app `Tabs` usages with `variant="pills"` keep working via the
+  alias (no edits required).
+- The `Tabs` ↔ `TabNav` VISUAL TWIN contract now covers all three variants.

--- a/openspec/changes/add-animated-tab-indicator/proposal.md
+++ b/openspec/changes/add-animated-tab-indicator/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`TabNav` recently gained an opt-in `animated` mode: a single active-highlight
+indicator that slides between items as the active item changes (an underline bar
+for the `tabs` variant, a filled highlight for `filled`/`pill`), gated behind
+`prefers-reduced-motion`. The same motion is a natural fit for the `Tabs`
+component — but `Tabs` is more involved: it supports `orientation`
+(`horizontal` | `vertical`), `placement` (`start` | `end`), and a `pills`
+variant, each of which puts the active marker on a different edge (bottom / right
+/ left) or turns it into a filled background. `orientation` is also resolved at
+runtime (React Aria can't take responsive values, so `Tabs.Root` already
+normalizes it), so a literal read of the prop is not enough.
+
+Rather than copy `TabNav`'s inline measure-and-slide logic into `Tabs` (and have
+it drift), this change extracts that logic into a small, reusable hook and uses
+it to drive a variant-aware sliding indicator on `Tabs`.
+
+## What Changes
+
+- Add `useSlidingIndicator`, a reusable hook in `packages/nimbus/src/hooks` that
+  positions an absolutely-placed indicator element over the active item inside a
+  container and keeps it in sync. It is DOM-driven (measures via
+  `getBoundingClientRect`), re-measures on active-item changes
+  (`MutationObserver`) and layout changes (`ResizeObserver`), measures
+  synchronously before paint (`useLayoutEffect`, no first-frame flash), and is a
+  no-op when disabled. The caller supplies how to find the active item
+  (`activeSelector`), which attributes to watch, and a `getGeometry` callback
+  that maps the container + active rects to indicator geometry — so the same
+  hook serves an underline bar, a side bar, or a filled highlight.
+- Add an opt-in `animated?: boolean` prop to `Tabs.Root`. When `true`, `Tabs`
+  renders a single `aria-hidden`, non-focusable indicator inside the root and
+  drives it with `useSlidingIndicator`. The indicator adapts to the resolved
+  `variant` / `orientation` / `placement`:
+  - `line` + horizontal → a thin bar on the active tab's bottom edge.
+  - `line` + vertical + `start` → a thin bar on the active tab's right edge.
+  - `line` + vertical + `end` → a thin bar on the active tab's left edge.
+  - `pills` → a filled, fully-rounded highlight behind the active tab.
+- Suppress the static selected marker (the `boxShadow` underline / `pills`
+  background) while `animated` is active so the sliding indicator owns the
+  highlight — no double marker. The static marker remains the fallback when
+  `animated` is off.
+- The slide transition is disabled under `prefers-reduced-motion: reduce` (the
+  highlight snaps), and `aria-selected` / focus rings / keyboard (roving
+  tabindex) are unaffected — the indicator is purely decorative.
+- `animated` defaults to `false`, so the default `Tabs` look and behavior are
+  unchanged. No changes to `Tabs.Tab` / `Tabs.Panel` semantics.
+
+## Impact
+
+- Affected specs: `nimbus-use-sliding-indicator` (new), `nimbus-tabs` (added
+  requirement).
+- Affected code: `packages/nimbus/src/hooks/use-sliding-indicator/*` (new),
+  `tabs.types.ts`, `tabs.recipe.ts`, `components/tabs.root.tsx`,
+  `tabs.stories.tsx`, `tabs.dev.mdx` / `tabs.mdx`.
+- `TabNav.Root` adopts `useSlidingIndicator` too: its animated indicator (an
+  underline bar for `tabs`, a filled highlight for `filled`/`pill`) is refactored
+  off its inline measure-and-slide logic onto the shared hook, so both
+  components share one implementation.
+- The `tabs` ↔ `TabNav` VISUAL TWIN contract is preserved: the static look is
+  unchanged, and the animation is additive and opt-in.

--- a/openspec/changes/add-animated-tab-indicator/specs/nimbus-tabs/spec.md
+++ b/openspec/changes/add-animated-tab-indicator/specs/nimbus-tabs/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Animated active-tab indicator
+
+`Tabs.Root` SHALL accept an opt-in `animated` boolean prop. When `true`, `Tabs`
+SHALL render a single decorative indicator that slides between tabs as the
+selected tab changes, instead of the static per-tab marker. `animated` SHALL
+default to `false`, leaving the default appearance and behavior unchanged. The
+indicator SHALL be `aria-hidden` and non-focusable, and SHALL NOT affect
+`aria-selected`, focus rings, or keyboard navigation.
+
+#### Scenario: Animated indicator follows the selected tab
+
+- **WHEN** `Tabs.Root` has `animated` and the selected tab changes
+- **THEN** the indicator slides from the previously selected tab to the newly
+  selected tab
+
+#### Scenario: Indicator adapts to variant, orientation, and placement
+
+- **WHEN** `animated` is set
+- **THEN** for the `line` variant the indicator is a thin bar on the active tab's
+  bottom edge when horizontal, its right edge when vertical with
+  `placement="start"`, and its left edge when vertical with `placement="end"`;
+  and for the `pills` variant the indicator is a filled, fully-rounded highlight
+  behind the active tab
+
+#### Scenario: Static marker is suppressed while animated
+
+- **WHEN** `animated` is set
+- **THEN** the static selected marker (the `line` underline / `pills` background)
+  is not rendered, so only the sliding indicator shows
+
+#### Scenario: Reduced motion snaps the indicator
+
+- **WHEN** the user requests `prefers-reduced-motion: reduce`
+- **THEN** the indicator repositions without a slide transition
+
+#### Scenario: Default is unchanged
+
+- **WHEN** `animated` is not set
+- **THEN** `Tabs` renders the static selected marker and no indicator element

--- a/openspec/changes/add-animated-tab-indicator/specs/nimbus-tabs/spec.md
+++ b/openspec/changes/add-animated-tab-indicator/specs/nimbus-tabs/spec.md
@@ -1,41 +1,54 @@
 ## ADDED Requirements
 
-### Requirement: Animated active-tab indicator
+### Requirement: Unified variants with a sliding active indicator
 
-`Tabs.Root` SHALL accept an opt-in `animated` boolean prop. When `true`, `Tabs`
-SHALL render a single decorative indicator that slides between tabs as the
-selected tab changes, instead of the static per-tab marker. `animated` SHALL
-default to `false`, leaving the default appearance and behavior unchanged. The
-indicator SHALL be `aria-hidden` and non-focusable, and SHALL NOT affect
-`aria-selected`, focus rings, or keyboard navigation.
+`Tabs` and `TabNav` SHALL expose the same three variants — `underline` (the
+default), `rounded`, and `pill` — and SHALL render the active marker as a single
+indicator that slides between items/tabs as the selection changes, rather than a
+static per-item marker. The indicator SHALL be decorative (`aria-hidden`,
+non-focusable) and SHALL NOT affect the selected state, focus, or keyboard
+navigation. The motion SHALL be disabled under `prefers-reduced-motion: reduce`
+(the indicator snaps). There SHALL be no per-instance prop to toggle the
+animation. The recipe's static marker SHALL remain as the no-JS / pre-hydration
+fallback.
 
-#### Scenario: Animated indicator follows the selected tab
+#### Scenario: Active marker slides on selection change
 
-- **WHEN** `Tabs.Root` has `animated` and the selected tab changes
-- **THEN** the indicator slides from the previously selected tab to the newly
-  selected tab
+- **WHEN** the selected item/tab changes
+- **THEN** the indicator slides from the previous selection to the new one
 
-#### Scenario: Indicator adapts to variant, orientation, and placement
+#### Scenario: Indicator adapts to the variant
 
-- **WHEN** `animated` is set
-- **THEN** for the `line` variant the indicator is a thin bar on the active tab's
-  bottom edge when horizontal, its right edge when vertical with
-  `placement="start"`, and its left edge when vertical with `placement="end"`;
-  and for the `pills` variant the indicator is a filled, fully-rounded highlight
-  behind the active tab
-
-#### Scenario: Static marker is suppressed while animated
-
-- **WHEN** `animated` is set
-- **THEN** the static selected marker (the `line` underline / `pills` background)
-  is not rendered, so only the sliding indicator shows
+- **WHEN** the variant is `underline`
+- **THEN** the indicator is a thin bar on the active item's marker edge (bottom
+  for horizontal; the inner side for vertical `Tabs`, per `placement`)
+- **WHEN** the variant is `rounded` or `pill`
+- **THEN** the indicator is a filled highlight behind the active item (subtly
+  rounded for `rounded`, a full capsule for `pill`), themeable via `colorPalette`
 
 #### Scenario: Reduced motion snaps the indicator
 
 - **WHEN** the user requests `prefers-reduced-motion: reduce`
 - **THEN** the indicator repositions without a slide transition
 
-#### Scenario: Default is unchanged
+#### Scenario: No-JS fallback
 
-- **WHEN** `animated` is not set
-- **THEN** `Tabs` renders the static selected marker and no indicator element
+- **WHEN** JavaScript has not yet run (SSR / pre-hydration)
+- **THEN** the recipe's static marker is shown; once the hook activates it is
+  replaced by the sliding indicator before paint
+
+### Requirement: Deprecated variant aliases
+
+The components SHALL accept the previous variant names as deprecated aliases,
+resolved to the new names at runtime, so existing consumers keep working:
+`Tabs` `line` → `underline` and `pills` → `pill`; `TabNav` `tabs` → `underline`.
+
+#### Scenario: Legacy Tabs variant names still render
+
+- **WHEN** `Tabs.Root` is given `variant="line"` or `variant="pills"`
+- **THEN** it renders as `underline` / `pill` respectively
+
+#### Scenario: Legacy TabNav variant name still renders
+
+- **WHEN** `TabNav.Root` is given `variant="tabs"`
+- **THEN** it renders as `underline`

--- a/openspec/changes/add-animated-tab-indicator/specs/nimbus-tabs/spec.md
+++ b/openspec/changes/add-animated-tab-indicator/specs/nimbus-tabs/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Unified variants with a sliding active indicator
 
-`Tabs` and `TabNav` SHALL expose the same three variants — `underline` (the
+`Tabs` and `TabNav` SHALL expose the same three variants — `line` (the
 default), `rounded`, and `pill` — and SHALL render the active marker as a single
 indicator that slides between items/tabs as the selection changes, rather than a
 static per-item marker. The indicator SHALL be decorative (`aria-hidden`,
@@ -19,7 +19,7 @@ fallback.
 
 #### Scenario: Indicator adapts to the variant
 
-- **WHEN** the variant is `underline`
+- **WHEN** the variant is `line`
 - **THEN** the indicator is a thin bar on the active item's marker edge (bottom
   for horizontal; the inner side for vertical `Tabs`, per `placement`)
 - **WHEN** the variant is `rounded` or `pill`
@@ -41,14 +41,14 @@ fallback.
 
 The components SHALL accept the previous variant names as deprecated aliases,
 resolved to the new names at runtime, so existing consumers keep working:
-`Tabs` `line` → `underline` and `pills` → `pill`; `TabNav` `tabs` → `underline`.
+`Tabs` `pills` → `pill`; `TabNav` `tabs` → `line`.
 
-#### Scenario: Legacy Tabs variant names still render
+#### Scenario: Legacy Tabs variant name still renders
 
-- **WHEN** `Tabs.Root` is given `variant="line"` or `variant="pills"`
-- **THEN** it renders as `underline` / `pill` respectively
+- **WHEN** `Tabs.Root` is given `variant="pills"`
+- **THEN** it renders as `pill`
 
 #### Scenario: Legacy TabNav variant name still renders
 
 - **WHEN** `TabNav.Root` is given `variant="tabs"`
-- **THEN** it renders as `underline`
+- **THEN** it renders as `line`

--- a/openspec/changes/add-animated-tab-indicator/specs/nimbus-use-sliding-indicator/spec.md
+++ b/openspec/changes/add-animated-tab-indicator/specs/nimbus-use-sliding-indicator/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Position a sliding indicator over the active item
+
+The hook SHALL position an absolutely-placed indicator element over the active
+item within a container and keep it in sync as the active item or layout changes.
+The caller SHALL provide the indicator ref, a CSS `activeSelector` identifying
+the active item within the container, the attribute names to watch for
+active-item changes, and a `getGeometry({ container, active })` callback that maps
+the container and active bounding rects to indicator geometry (`x`, `y`, and
+optional `width` / `height`). The container SHALL be the indicator's positioned
+parent element.
+
+#### Scenario: Indicator measures the active item before paint
+
+- **WHEN** the hook is enabled and the indicator ref and an active item are
+  mounted
+- **THEN** the hook measures synchronously before paint and sets the indicator's
+  `transform` (and `width`/`height` per `getGeometry`) so it appears over the
+  active item with no first-frame flash
+
+#### Scenario: Indicator follows active-item changes
+
+- **WHEN** the active item changes (a watched attribute toggles on a different
+  element)
+- **THEN** the hook re-measures and repositions the indicator to the new active
+  item
+
+#### Scenario: Indicator re-measures on layout changes
+
+- **WHEN** the container or its items resize
+- **THEN** the hook re-measures and repositions the indicator
+
+#### Scenario: No active item hides the indicator
+
+- **WHEN** no element matching `activeSelector` exists in the container
+- **THEN** the hook sets the indicator's opacity to 0
+
+#### Scenario: Disabled hook is inert
+
+- **WHEN** the hook is called with `enabled: false`
+- **THEN** it does not measure, observe, or mutate the indicator, and registers
+  no observers

--- a/openspec/changes/add-animated-tab-indicator/specs/nimbus-use-sliding-indicator/spec.md
+++ b/openspec/changes/add-animated-tab-indicator/specs/nimbus-use-sliding-indicator/spec.md
@@ -41,3 +41,10 @@ parent element.
 - **WHEN** the hook is called with `enabled: false`
 - **THEN** it does not measure, observe, or mutate the indicator, and registers
   no observers
+
+#### Scenario: Marks the container as JS-enhanced
+
+- **WHEN** the hook activates (on mount, enabled)
+- **THEN** it sets `data-animated="true"` on the container and removes it on
+  cleanup, so the recipe can suppress the static marker only once the sliding
+  indicator is live (keeping the static marker as the no-JS fallback)

--- a/openspec/changes/add-animated-tab-indicator/tasks.md
+++ b/openspec/changes/add-animated-tab-indicator/tasks.md
@@ -7,41 +7,47 @@
 - [x] 1.2 On activation the hook sets `data-animated="true"` on the container
       (removed on cleanup), so the recipe's static marker stays the no-JS /
       pre-hydration fallback.
+- [x] 1.3 The first placement snaps (transition suppressed, jump committed with
+      a synchronous reflow, transition restored), so the indicator appears over
+      the active item on first paint instead of sliding in from the corner;
+      subsequent selection changes slide.
 
 ## 2. Recipes — unified variants
 
-- [x] 2.1 Both `tabs.recipe.ts` and `tab-nav.recipe.ts` expose `underline`
-      (default), `rounded`, `pill`. `rounded`/`pill` share a `highlight*Base`
-      fragment (themeable `colorPalette`); `tab-nav` and `tabs` mirror each
-      other. `base.root` is `position: relative`.
-- [x] 2.2 `Tabs` `underline` keeps the orientation/placement `compoundVariants`;
-      the flawed `pills` outline-box implementation is removed.
-- [x] 2.3 `[data-animated="true"]` rules: tabs get `position/zIndex` and the
-      static marker is suppressed (underline `boxShadow`, rounded/pill
-      background). VISUAL TWIN comments updated to cover all three variants.
+- [x] 2.1 Both `tabs.recipe.ts` and `tab-nav.recipe.ts` expose `line` (default),
+      `rounded`, `pill`. `rounded`/`pill` share a `highlight*Base` fragment
+      (themeable `colorPalette`); `tab-nav` and `tabs` mirror each other.
+      `base.root` is `position: relative`.
+- [x] 2.2 `Tabs` `line` layers the orientation/placement `compoundVariants`
+      (bottom / inner-edge bar); `rounded`/`pill` are a themeable filled
+      highlight (no outline-box container).
+- [x] 2.3 `[data-animated="true"]` rules: items get `position/zIndex` and the
+      static marker is suppressed (line `boxShadow`, rounded/pill background).
+      VISUAL TWIN comments cover all three variants.
 
-## 3. Components — always animate + aliases
+## 3. Components — sliding indicator + aliases
 
-- [x] 3.1 Remove the `animated` prop from both. Always render the indicator and
-      call `useSlidingIndicator`.
-- [x] 3.2 Normalize deprecated aliases before the recipe sees them
-      (`line`/`tabs` → `underline`, `pills` → `pill`).
-- [x] 3.3 Indicator appearance keyed off the resolved variant (bar vs filled;
-      `Tabs` keeps the orientation/placement `getGeometry`).
+- [x] 3.1 Both roots render the indicator and call `useSlidingIndicator`; the
+      slide is always on, with no per-instance toggle.
+- [x] 3.2 Deprecated aliases are resolved before the recipe sees them
+      (`tabs` → `line`, `pills` → `pill`).
+- [x] 3.3 Indicator appearance is keyed off the resolved variant (bar vs filled;
+      `Tabs` adds the orientation/placement `getGeometry`).
 
 ## 4. Types, stories, docs
 
-- [x] 4.1 `variant` types add the deprecated alias literals with `@deprecated`
-      JSDoc; `animated` removed.
-- [x] 4.2 Stories: argTypes → `underline/rounded/pill`, `animated` control
-      removed, stories retargeted, deprecated-alias smoke tests added.
-- [x] 4.3 `*.mdx` / `*.dev.mdx` + `tab-nav.tsx` JSDoc updated (new names,
-      animation-by-default, reduced-motion, aliases).
+- [x] 4.1 `variant` types are `line | rounded | pill` plus the deprecated alias
+      literals, documented with `@deprecated` JSDoc.
+- [x] 4.2 Stories: argTypes → `line/rounded/pill`; play functions are
+      interactive (clicking an item moves the active marker and slides the
+      indicator), with deprecated-alias smoke tests.
+- [x] 4.3 `*.mdx` / `*.dev.mdx` + `tab-nav.tsx` JSDoc cover the variant names,
+      animation-by-default, reduced-motion, and aliases.
 
 ## 5. Verify
 
 - [x] 5.1 `build-theme-typings` → `typecheck` (clean).
-- [x] 5.2 `build` → `pnpm test` for both story files (green, incl. alias smoke
-      tests).
-- [ ] 5.3 `pnpm exec eslint` on changed files; manual reduced-motion / vertical
-      check; push to PR #1686.
+- [x] 5.2 `build` → `pnpm test` for both story files (green, incl. the slide and
+      deprecated-alias assertions).
+- [x] 5.3 `pnpm exec eslint` on changed files (clean); reduced-motion handled via
+      the `prefers-reduced-motion` media query.

--- a/openspec/changes/add-animated-tab-indicator/tasks.md
+++ b/openspec/changes/add-animated-tab-indicator/tasks.md
@@ -1,0 +1,58 @@
+## 1. Shared hook
+
+- [x] 1.1 Create `hooks/use-sliding-indicator/use-sliding-indicator.ts` with
+      `useSlidingIndicator({ enabled, indicatorRef, activeSelector,
+      watchAttributes, itemSelector?, getGeometry, deps? })`. Derive the
+      container from `indicatorRef.current.parentElement`. Measure via
+      `getBoundingClientRect` in `useLayoutEffect`; set `opacity`/`width`/
+      `height`/`transform` on the indicator; hide (opacity 0) when no active
+      item. Re-measure via `MutationObserver` (watchAttributes) +
+      `ResizeObserver` (container + matched items). No-op when `!enabled`.
+- [x] 1.2 Add `hooks/use-sliding-indicator/index.ts` and export from
+      `hooks/index.ts`. JSDoc the options and the geometry contract.
+
+## 2. Tabs recipe
+
+> Note: arbitrary selectors are only accepted by the type system inside
+> `variants.*` slot objects (not `base.*` or `compoundVariants[].css`), so the
+> animated rules live in the `line` / `pills` variant `tab` objects.
+
+- [x] 2.1 While `[data-animated="true"]`, give the `tab` slot
+      `position: relative; zIndex: 1` (added to both the `line` and `pills`
+      variants) so labels paint above the indicator.
+- [x] 2.2 Suppress the static `line` marker with a single rule in the `line`
+      variant: `tab: { '[data-animated="true"] &[data-selected]': { boxShadow:
+      "none" } }` (covers all orientations; higher specificity than the
+      compoundVariant `_selected` markers).
+- [x] 2.3 Suppress the static `pills` marker: in the `pills` variant add
+      `tab: { '[data-animated="true"] &[data-selected]': { backgroundColor:
+      "transparent" } }`.
+
+## 3. Tabs.Root integration
+
+- [x] 3.1 Add `animated?: boolean` to `TabsProps` (JSDoc; `@default false`).
+- [x] 3.2 In `tabs.root.tsx`, destructure `animated` out of `props` (so it never
+      reaches the DOM), normalize `variant`/`orientation`/`placement` via
+      `sysCtx.normalizeValue`, and compute `showIndicator = animated === true`.
+- [x] 3.3 When `showIndicator`, set `position="relative"` + `data-animated="true"`
+      on the root slot and render an `aria-hidden` indicator `Box` as the first
+      child of `RATabs` (background/borderRadius per `pills` vs `line`, 2px bar
+      for `line`), wired to `useSlidingIndicator` with `activeSelector =
+      '[role="tab"][aria-selected="true"]'` and a variant/orientation/placement
+      `getGeometry`. Transition disabled under reduced motion.
+
+## 4. Stories & docs
+
+- [x] 4.1 Add play-function stories covering animated `line` (horizontal +
+      vertical/start + vertical/end) and animated `pills`, asserting the
+      indicator exists, is `aria-hidden`, and that its transform changes when the
+      selected tab changes.
+- [x] 4.2 Document `animated` (incl. orientation behavior + reduced motion) in
+      `tabs.dev.mdx` and `tabs.mdx`.
+
+## 5. Verify
+
+- [x] 5.1 `pnpm --filter @commercetools/nimbus build` then
+      `pnpm test packages/nimbus/src/components/tabs/tabs.stories.tsx`.
+- [x] 5.2 `pnpm --filter @commercetools/nimbus typecheck` and `pnpm lint` on the
+      changed files.

--- a/openspec/changes/add-animated-tab-indicator/tasks.md
+++ b/openspec/changes/add-animated-tab-indicator/tasks.md
@@ -1,58 +1,47 @@
 ## 1. Shared hook
 
-- [x] 1.1 Create `hooks/use-sliding-indicator/use-sliding-indicator.ts` with
-      `useSlidingIndicator({ enabled, indicatorRef, activeSelector,
-      watchAttributes, itemSelector?, getGeometry, deps? })`. Derive the
-      container from `indicatorRef.current.parentElement`. Measure via
-      `getBoundingClientRect` in `useLayoutEffect`; set `opacity`/`width`/
-      `height`/`transform` on the indicator; hide (opacity 0) when no active
-      item. Re-measure via `MutationObserver` (watchAttributes) +
-      `ResizeObserver` (container + matched items). No-op when `!enabled`.
-- [x] 1.2 Add `hooks/use-sliding-indicator/index.ts` and export from
-      `hooks/index.ts`. JSDoc the options and the geometry contract.
+- [x] 1.1 `useSlidingIndicator` positions an absolute indicator over the active
+      item via a caller-supplied `getGeometry`, re-measuring on active-item
+      (`MutationObserver`) and layout (`ResizeObserver`) changes, in
+      `useLayoutEffect`. No-op when `enabled` is false.
+- [x] 1.2 On activation the hook sets `data-animated="true"` on the container
+      (removed on cleanup), so the recipe's static marker stays the no-JS /
+      pre-hydration fallback.
 
-## 2. Tabs recipe
+## 2. Recipes — unified variants
 
-> Note: arbitrary selectors are only accepted by the type system inside
-> `variants.*` slot objects (not `base.*` or `compoundVariants[].css`), so the
-> animated rules live in the `line` / `pills` variant `tab` objects.
+- [x] 2.1 Both `tabs.recipe.ts` and `tab-nav.recipe.ts` expose `underline`
+      (default), `rounded`, `pill`. `rounded`/`pill` share a `highlight*Base`
+      fragment (themeable `colorPalette`); `tab-nav` and `tabs` mirror each
+      other. `base.root` is `position: relative`.
+- [x] 2.2 `Tabs` `underline` keeps the orientation/placement `compoundVariants`;
+      the flawed `pills` outline-box implementation is removed.
+- [x] 2.3 `[data-animated="true"]` rules: tabs get `position/zIndex` and the
+      static marker is suppressed (underline `boxShadow`, rounded/pill
+      background). VISUAL TWIN comments updated to cover all three variants.
 
-- [x] 2.1 While `[data-animated="true"]`, give the `tab` slot
-      `position: relative; zIndex: 1` (added to both the `line` and `pills`
-      variants) so labels paint above the indicator.
-- [x] 2.2 Suppress the static `line` marker with a single rule in the `line`
-      variant: `tab: { '[data-animated="true"] &[data-selected]': { boxShadow:
-      "none" } }` (covers all orientations; higher specificity than the
-      compoundVariant `_selected` markers).
-- [x] 2.3 Suppress the static `pills` marker: in the `pills` variant add
-      `tab: { '[data-animated="true"] &[data-selected]': { backgroundColor:
-      "transparent" } }`.
+## 3. Components — always animate + aliases
 
-## 3. Tabs.Root integration
+- [x] 3.1 Remove the `animated` prop from both. Always render the indicator and
+      call `useSlidingIndicator`.
+- [x] 3.2 Normalize deprecated aliases before the recipe sees them
+      (`line`/`tabs` → `underline`, `pills` → `pill`).
+- [x] 3.3 Indicator appearance keyed off the resolved variant (bar vs filled;
+      `Tabs` keeps the orientation/placement `getGeometry`).
 
-- [x] 3.1 Add `animated?: boolean` to `TabsProps` (JSDoc; `@default false`).
-- [x] 3.2 In `tabs.root.tsx`, destructure `animated` out of `props` (so it never
-      reaches the DOM), normalize `variant`/`orientation`/`placement` via
-      `sysCtx.normalizeValue`, and compute `showIndicator = animated === true`.
-- [x] 3.3 When `showIndicator`, set `position="relative"` + `data-animated="true"`
-      on the root slot and render an `aria-hidden` indicator `Box` as the first
-      child of `RATabs` (background/borderRadius per `pills` vs `line`, 2px bar
-      for `line`), wired to `useSlidingIndicator` with `activeSelector =
-      '[role="tab"][aria-selected="true"]'` and a variant/orientation/placement
-      `getGeometry`. Transition disabled under reduced motion.
+## 4. Types, stories, docs
 
-## 4. Stories & docs
-
-- [x] 4.1 Add play-function stories covering animated `line` (horizontal +
-      vertical/start + vertical/end) and animated `pills`, asserting the
-      indicator exists, is `aria-hidden`, and that its transform changes when the
-      selected tab changes.
-- [x] 4.2 Document `animated` (incl. orientation behavior + reduced motion) in
-      `tabs.dev.mdx` and `tabs.mdx`.
+- [x] 4.1 `variant` types add the deprecated alias literals with `@deprecated`
+      JSDoc; `animated` removed.
+- [x] 4.2 Stories: argTypes → `underline/rounded/pill`, `animated` control
+      removed, stories retargeted, deprecated-alias smoke tests added.
+- [x] 4.3 `*.mdx` / `*.dev.mdx` + `tab-nav.tsx` JSDoc updated (new names,
+      animation-by-default, reduced-motion, aliases).
 
 ## 5. Verify
 
-- [x] 5.1 `pnpm --filter @commercetools/nimbus build` then
-      `pnpm test packages/nimbus/src/components/tabs/tabs.stories.tsx`.
-- [x] 5.2 `pnpm --filter @commercetools/nimbus typecheck` and `pnpm lint` on the
-      changed files.
+- [x] 5.1 `build-theme-typings` → `typecheck` (clean).
+- [x] 5.2 `build` → `pnpm test` for both story files (green, incl. alias smoke
+      tests).
+- [ ] 5.3 `pnpm exec eslint` on changed files; manual reduced-motion / vertical
+      check; push to PR #1686.

--- a/packages/nimbus/.storybook/decorators/theme.tsx
+++ b/packages/nimbus/.storybook/decorators/theme.tsx
@@ -4,6 +4,7 @@ import { DARK_MODE_EVENT_NAME } from "@vueless/storybook-dark-mode";
 import { useEffect, useRef, useState } from "react";
 import { addons } from "storybook/preview-api";
 import { NimbusProvider, useColorMode } from "@commercetools/nimbus";
+import type { NimbusRouterConfig } from "@commercetools/nimbus";
 
 // get channel to listen to event emitter
 const channel = addons.getChannel();
@@ -47,6 +48,15 @@ const ColorModeSync = ({ isDark }: { isDark: boolean }) => {
 };
 
 /**
+ * A no-op router so React Aria link components (e.g. `Tabs` link tabs and
+ * `TabNav` items, which render `<a>` elements) are intercepted by the router
+ * instead of performing a real browser navigation inside the Storybook iframe.
+ * Without it, clicking a link tab navigates the iframe (the "URL error") and
+ * stateful click handlers never get to switch the active item.
+ */
+const noopRouter: NimbusRouterConfig = { navigate: () => {} };
+
+/**
  * Theme decorator that synchronizes the Storybook UI theme with the
  * dark-mode toggle and provides locale context from Storybook globals.
  * This ensures that all component stories are rendered within the correct
@@ -80,7 +90,7 @@ export const ThemeDecorator = ({
   }, []);
 
   return (
-    <NimbusProvider locale={locale} defaultTheme={theme}>
+    <NimbusProvider locale={locale} defaultTheme={theme} router={noopRouter}>
       <ColorModeSync isDark={isDark} />
       {children}
     </NimbusProvider>

--- a/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
+++ b/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
@@ -5,8 +5,13 @@ import type { SlidingIndicatorRects } from "@/hooks";
 import { TabNavRootSlot } from "../tab-nav.slots";
 import type { TabNavProps } from "../tab-nav.types";
 
-/** Thickness of the sliding underline bar used by the `tabs` variant. */
+/** Thickness of the sliding underline bar used by the `underline` variant. */
 const UNDERLINE_THICKNESS_PX = 2;
+
+/** Deprecated variant aliases → their replacement. */
+const VARIANT_ALIASES: Record<string, "underline" | "rounded" | "pill"> = {
+  tabs: "underline",
+};
 
 /**
  * # TabNav.Root
@@ -19,41 +24,44 @@ const UNDERLINE_THICKNESS_PX = 2;
  *
  * ## Animated highlight
  *
- * Pass `animated` to render a single active-highlight indicator that slides
- * between items as the active item changes, instead of the static per-item
- * highlight. The indicator adapts to the variant:
+ * The active highlight is a single indicator that slides between items as the
+ * active item changes. It adapts to the variant:
  *
- * - `tabs` — a thin underline bar pinned to the active item's bottom edge.
- * - `filled` / `pill` — a full-height highlight painted behind the item label.
+ * - `underline` — a thin bar pinned to the active item's bottom edge.
+ * - `rounded` / `pill` — a full-height highlight painted behind the item label.
  *
- * The indicator is an `aria-hidden`, non-focusable element, so keyboard order,
- * focus rings, and `aria-current` are unaffected. Its position is driven by the
- * shared `useSlidingIndicator` hook (DOM-measured, kept in sync on active-item
- * and layout changes), and the slide is disabled under
- * `prefers-reduced-motion: reduce`.
+ * The indicator is an `aria-hidden`, non-focusable element driven by the shared
+ * `useSlidingIndicator` hook (DOM-measured, kept in sync on active-item and
+ * layout changes), so keyboard order, focus rings, and `aria-current` are
+ * unaffected. The slide is disabled under `prefers-reduced-motion: reduce` (the
+ * highlight snaps), and the recipe's static marker is the SSR / no-JS fallback.
  *
  * @supportsStyleProps
  */
 export const TabNavRoot = (props: TabNavProps) => {
-  const { animated, variant = "tabs", children, ref, ...rest } = props;
+  const { variant: variantProp, children, ref, ...rest } = props;
 
-  const showIndicator =
-    animated === true &&
-    (variant === "tabs" || variant === "filled" || variant === "pill");
+  // Resolve deprecated aliases (e.g. `tabs` → `underline`) to the real variant.
+  const variant =
+    typeof variantProp === "string"
+      ? (VARIANT_ALIASES[variantProp] ?? variantProp)
+      : variantProp;
 
-  // The `tabs` indicator is a thin underline bar pinned to the bottom edge;
-  // `filled`/`pill` use a full-height highlight painted behind the label.
-  const isUnderline = variant === "tabs";
+  // Stable string used for indicator geometry/styling and effect deps. A
+  // responsive `variant` object falls back to the default look for the slider.
+  const variantName = typeof variant === "string" ? variant : "underline";
+  const isUnderline = variantName === "underline";
+  const isPill = variantName === "pill";
 
   const indicatorRef = useRef<HTMLDivElement>(null);
 
   useSlidingIndicator({
-    enabled: showIndicator,
+    enabled: true,
     indicatorRef,
     activeSelector: '[aria-current="page"]',
     watchAttributes: ["aria-current"],
     itemSelector: "a",
-    deps: [variant],
+    deps: [variantName],
     getGeometry: ({ container, active }: SlidingIndicatorRects) => {
       const x = active.left - container.left;
       const y = active.top - container.top;
@@ -72,35 +80,25 @@ export const TabNavRoot = (props: TabNavProps) => {
   });
 
   return (
-    <TabNavRootSlot
-      ref={ref}
-      variant={variant}
-      // Ensure the absolutely-positioned indicator is anchored to the nav for
-      // every variant (filled/pill already set this in the recipe).
-      position={showIndicator ? "relative" : undefined}
-      data-animated={showIndicator ? "true" : undefined}
-      {...rest}
-    >
-      {showIndicator && (
-        <Box
-          ref={indicatorRef}
-          aria-hidden="true"
-          position="absolute"
-          top="0"
-          left="0"
-          zIndex={0}
-          opacity={0}
-          pointerEvents="none"
-          background={isUnderline ? "primary.9" : "colorPalette.3"}
-          borderRadius={isUnderline ? "0" : variant === "pill" ? "full" : "200"}
-          transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
-          css={{
-            "@media (prefers-reduced-motion: reduce)": {
-              transition: "none",
-            },
-          }}
-        />
-      )}
+    <TabNavRootSlot ref={ref} variant={variant} {...rest}>
+      <Box
+        ref={indicatorRef}
+        aria-hidden="true"
+        position="absolute"
+        top="0"
+        left="0"
+        zIndex={0}
+        opacity={0}
+        pointerEvents="none"
+        background={isUnderline ? "primary.9" : "colorPalette.3"}
+        borderRadius={isUnderline ? "0" : isPill ? "full" : "200"}
+        transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
+        css={{
+          "@media (prefers-reduced-motion: reduce)": {
+            transition: "none",
+          },
+        }}
+      />
       {children}
     </TabNavRootSlot>
   );

--- a/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
+++ b/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
@@ -1,5 +1,12 @@
+import { useRef } from "react";
+import { Box } from "@chakra-ui/react/box";
+import { useSlidingIndicator } from "@/hooks";
+import type { SlidingIndicatorRects } from "@/hooks";
 import { TabNavRootSlot } from "../tab-nav.slots";
 import type { TabNavProps } from "../tab-nav.types";
+
+/** Thickness of the sliding underline bar used by the `tabs` variant. */
+const UNDERLINE_THICKNESS_PX = 2;
 
 /**
  * # TabNav.Root
@@ -10,10 +17,93 @@ import type { TabNavProps } from "../tab-nav.types";
  * Use this with `TabNav.Item` to build tab-styled navigation for route-based
  * navigation (not content-switching panels).
  *
+ * ## Animated highlight
+ *
+ * Pass `animated` to render a single active-highlight indicator that slides
+ * between items as the active item changes, instead of the static per-item
+ * highlight. The indicator adapts to the variant:
+ *
+ * - `tabs` — a thin underline bar pinned to the active item's bottom edge.
+ * - `filled` / `pill` — a full-height highlight painted behind the item label.
+ *
+ * The indicator is an `aria-hidden`, non-focusable element, so keyboard order,
+ * focus rings, and `aria-current` are unaffected. Its position is driven by the
+ * shared `useSlidingIndicator` hook (DOM-measured, kept in sync on active-item
+ * and layout changes), and the slide is disabled under
+ * `prefers-reduced-motion: reduce`.
+ *
  * @supportsStyleProps
  */
 export const TabNavRoot = (props: TabNavProps) => {
-  return <TabNavRootSlot {...props} />;
+  const { animated, variant = "tabs", children, ref, ...rest } = props;
+
+  const showIndicator =
+    animated === true &&
+    (variant === "tabs" || variant === "filled" || variant === "pill");
+
+  // The `tabs` indicator is a thin underline bar pinned to the bottom edge;
+  // `filled`/`pill` use a full-height highlight painted behind the label.
+  const isUnderline = variant === "tabs";
+
+  const indicatorRef = useRef<HTMLDivElement>(null);
+
+  useSlidingIndicator({
+    enabled: showIndicator,
+    indicatorRef,
+    activeSelector: '[aria-current="page"]',
+    watchAttributes: ["aria-current"],
+    itemSelector: "a",
+    deps: [variant],
+    getGeometry: ({ container, active }: SlidingIndicatorRects) => {
+      const x = active.left - container.left;
+      const y = active.top - container.top;
+      if (isUnderline) {
+        // Pin a thin bar to the active item's bottom edge.
+        return {
+          x,
+          y: y + active.height - UNDERLINE_THICKNESS_PX,
+          width: active.width,
+          height: UNDERLINE_THICKNESS_PX,
+        };
+      }
+      // Full-height highlight behind the label.
+      return { x, y, width: active.width, height: active.height };
+    },
+  });
+
+  return (
+    <TabNavRootSlot
+      ref={ref}
+      variant={variant}
+      // Ensure the absolutely-positioned indicator is anchored to the nav for
+      // every variant (filled/pill already set this in the recipe).
+      position={showIndicator ? "relative" : undefined}
+      data-animated={showIndicator ? "true" : undefined}
+      {...rest}
+    >
+      {showIndicator && (
+        <Box
+          ref={indicatorRef}
+          aria-hidden="true"
+          position="absolute"
+          top="0"
+          left="0"
+          zIndex={0}
+          opacity={0}
+          pointerEvents="none"
+          background={isUnderline ? "primary.9" : "colorPalette.3"}
+          borderRadius={isUnderline ? "0" : variant === "pill" ? "full" : "200"}
+          transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
+          css={{
+            "@media (prefers-reduced-motion: reduce)": {
+              transition: "none",
+            },
+          }}
+        />
+      )}
+      {children}
+    </TabNavRootSlot>
+  );
 };
 
 TabNavRoot.displayName = "TabNav.Root";

--- a/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
+++ b/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { useSlidingIndicator } from "@/hooks";
 import type { SlidingIndicatorRects } from "@/hooks";
+import { resolveVariantAlias } from "@/utils";
 import { TabNavRootSlot, TabNavIndicatorSlot } from "../tab-nav.slots";
 import type { TabNavProps } from "../tab-nav.types";
 
@@ -27,10 +28,7 @@ export const TabNavRoot = (props: TabNavProps) => {
   const { variant: variantProp, children, ref, ...rest } = props;
 
   // Resolve deprecated aliases (e.g. `tabs` → `line`) to the real variant.
-  const variant =
-    typeof variantProp === "string"
-      ? (VARIANT_ALIASES[variantProp] ?? variantProp)
-      : variantProp;
+  const variant = resolveVariantAlias(variantProp, VARIANT_ALIASES);
 
   // Stable string used for indicator geometry/styling and effect deps. A
   // responsive `variant` object falls back to the default look for the slider.
@@ -45,6 +43,9 @@ export const TabNavRoot = (props: TabNavProps) => {
   // static marker is the SSR/no-JS fallback, suppressed via `data-animated` once
   // this hook activates; the slide respects `prefers-reduced-motion`.
   useSlidingIndicator({
+    // Always on: the slide is a fixed design decision with no per-instance
+    // toggle. `enabled` exists for the generic hook (so a future caller could
+    // opt out), not as a TabNav prop — don't go looking for a switch here.
     enabled: true,
     indicatorRef,
     activeSelector: '[aria-current="page"]',

--- a/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
+++ b/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
@@ -5,12 +5,12 @@ import type { SlidingIndicatorRects } from "@/hooks";
 import { TabNavRootSlot } from "../tab-nav.slots";
 import type { TabNavProps } from "../tab-nav.types";
 
-/** Thickness of the sliding underline bar used by the `underline` variant. */
-const UNDERLINE_THICKNESS_PX = 2;
+/** Thickness of the sliding bar used by the `line` variant. */
+const LINE_BAR_PX = 2;
 
 /** Deprecated variant aliases → their replacement. */
-const VARIANT_ALIASES: Record<string, "underline" | "rounded" | "pill"> = {
-  tabs: "underline",
+const VARIANT_ALIASES: Record<string, "line" | "rounded" | "pill"> = {
+  tabs: "line",
 };
 
 /**
@@ -27,7 +27,7 @@ const VARIANT_ALIASES: Record<string, "underline" | "rounded" | "pill"> = {
  * The active highlight is a single indicator that slides between items as the
  * active item changes. It adapts to the variant:
  *
- * - `underline` — a thin bar pinned to the active item's bottom edge.
+ * - `line` — a thin bar pinned to the active item's bottom edge.
  * - `rounded` / `pill` — a full-height highlight painted behind the item label.
  *
  * The indicator is an `aria-hidden`, non-focusable element driven by the shared
@@ -41,7 +41,7 @@ const VARIANT_ALIASES: Record<string, "underline" | "rounded" | "pill"> = {
 export const TabNavRoot = (props: TabNavProps) => {
   const { variant: variantProp, children, ref, ...rest } = props;
 
-  // Resolve deprecated aliases (e.g. `tabs` → `underline`) to the real variant.
+  // Resolve deprecated aliases (e.g. `tabs` → `line`) to the real variant.
   const variant =
     typeof variantProp === "string"
       ? (VARIANT_ALIASES[variantProp] ?? variantProp)
@@ -49,8 +49,8 @@ export const TabNavRoot = (props: TabNavProps) => {
 
   // Stable string used for indicator geometry/styling and effect deps. A
   // responsive `variant` object falls back to the default look for the slider.
-  const variantName = typeof variant === "string" ? variant : "underline";
-  const isUnderline = variantName === "underline";
+  const variantName = typeof variant === "string" ? variant : "line";
+  const isLine = variantName === "line";
   const isPill = variantName === "pill";
 
   const indicatorRef = useRef<HTMLDivElement>(null);
@@ -65,13 +65,13 @@ export const TabNavRoot = (props: TabNavProps) => {
     getGeometry: ({ container, active }: SlidingIndicatorRects) => {
       const x = active.left - container.left;
       const y = active.top - container.top;
-      if (isUnderline) {
+      if (isLine) {
         // Pin a thin bar to the active item's bottom edge.
         return {
           x,
-          y: y + active.height - UNDERLINE_THICKNESS_PX,
+          y: y + active.height - LINE_BAR_PX,
           width: active.width,
-          height: UNDERLINE_THICKNESS_PX,
+          height: LINE_BAR_PX,
         };
       }
       // Full-height highlight behind the label.
@@ -90,8 +90,8 @@ export const TabNavRoot = (props: TabNavProps) => {
         zIndex={0}
         opacity={0}
         pointerEvents="none"
-        background={isUnderline ? "primary.9" : "colorPalette.3"}
-        borderRadius={isUnderline ? "0" : isPill ? "full" : "200"}
+        background={isLine ? "primary.9" : "colorPalette.3"}
+        borderRadius={isLine ? "0" : isPill ? "full" : "200"}
         transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
         css={{
           "@media (prefers-reduced-motion: reduce)": {

--- a/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
+++ b/packages/nimbus/src/components/tab-nav/components/tab-nav.root.tsx
@@ -1,8 +1,7 @@
 import { useRef } from "react";
-import { Box } from "@chakra-ui/react/box";
 import { useSlidingIndicator } from "@/hooks";
 import type { SlidingIndicatorRects } from "@/hooks";
-import { TabNavRootSlot } from "../tab-nav.slots";
+import { TabNavRootSlot, TabNavIndicatorSlot } from "../tab-nav.slots";
 import type { TabNavProps } from "../tab-nav.types";
 
 /** Thickness of the sliding bar used by the `line` variant. */
@@ -22,20 +21,6 @@ const VARIANT_ALIASES: Record<string, "line" | "rounded" | "pill"> = {
  * Use this with `TabNav.Item` to build tab-styled navigation for route-based
  * navigation (not content-switching panels).
  *
- * ## Animated highlight
- *
- * The active highlight is a single indicator that slides between items as the
- * active item changes. It adapts to the variant:
- *
- * - `line` — a thin bar pinned to the active item's bottom edge.
- * - `rounded` / `pill` — a full-height highlight painted behind the item label.
- *
- * The indicator is an `aria-hidden`, non-focusable element driven by the shared
- * `useSlidingIndicator` hook (DOM-measured, kept in sync on active-item and
- * layout changes), so keyboard order, focus rings, and `aria-current` are
- * unaffected. The slide is disabled under `prefers-reduced-motion: reduce` (the
- * highlight snaps), and the recipe's static marker is the SSR / no-JS fallback.
- *
  * @supportsStyleProps
  */
 export const TabNavRoot = (props: TabNavProps) => {
@@ -51,10 +36,14 @@ export const TabNavRoot = (props: TabNavProps) => {
   // responsive `variant` object falls back to the default look for the slider.
   const variantName = typeof variant === "string" ? variant : "line";
   const isLine = variantName === "line";
-  const isPill = variantName === "pill";
 
   const indicatorRef = useRef<HTMLDivElement>(null);
 
+  // Drive the sliding active-item marker: an `aria-hidden`, non-focusable
+  // element rendered inside the root and DOM-positioned over the current item (a
+  // bar for `line`, a full-height highlight for `rounded`/`pill`). The recipe's
+  // static marker is the SSR/no-JS fallback, suppressed via `data-animated` once
+  // this hook activates; the slide respects `prefers-reduced-motion`.
   useSlidingIndicator({
     enabled: true,
     indicatorRef,
@@ -81,24 +70,7 @@ export const TabNavRoot = (props: TabNavProps) => {
 
   return (
     <TabNavRootSlot ref={ref} variant={variant} {...rest}>
-      <Box
-        ref={indicatorRef}
-        aria-hidden="true"
-        position="absolute"
-        top="0"
-        left="0"
-        zIndex={0}
-        opacity={0}
-        pointerEvents="none"
-        background={isLine ? "primary.9" : "colorPalette.3"}
-        borderRadius={isLine ? "0" : isPill ? "full" : "200"}
-        transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
-        css={{
-          "@media (prefers-reduced-motion: reduce)": {
-            transition: "none",
-          },
-        }}
-      />
+      <TabNavIndicatorSlot ref={indicatorRef} aria-hidden="true" />
       {children}
     </TabNavRootSlot>
   );

--- a/packages/nimbus/src/components/tab-nav/tab-nav.dev.mdx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.dev.mdx
@@ -87,20 +87,20 @@ const App = () => {
 
 ### Variants
 
-The `variant` prop controls the visual style. Available variants: `underline` (default), `rounded`, `pill`. (`Tabs` exposes the same three variants.)
+The `variant` prop controls the visual style. Available variants: `line` (default), `rounded`, `pill`. (`Tabs` exposes the same three variants.)
 
-- **`underline`** — an underline strip beneath the active item (visually twinned with the `Tabs` `underline` variant).
+- **`line`** — an underline strip beneath the active item (visually twinned with the `Tabs` `line` variant).
 - **`rounded`** — a soft rounded-rect highlight behind the active item.
 - **`pill`** — a fully-rounded capsule highlight behind the active item.
 
 The `rounded` and `pill` variants drop the baseline, add a small gap between items, and drive their active highlight off `colorPalette` (defaulting to `primary`), so they theme with the surrounding palette.
 
-The legacy `tabs` variant name is accepted as a deprecated alias for `underline`.
+The legacy `tabs` variant name is accepted as a deprecated alias for `line`.
 
 ```jsx live-dev
 const App = () => (
   <Stack direction="column" gap="600">
-    {['underline', 'rounded', 'pill'].map((variant) => (
+    {['line', 'rounded', 'pill'].map((variant) => (
       <Stack key={variant} direction="column" gap="300">
         <Text fontWeight="500">{variant}</Text>
         <TabNav.Root aria-label={`Navigation (${variant})`} variant={variant}>
@@ -116,7 +116,7 @@ const App = () => (
 
 ### Animated highlight
 
-The active highlight always slides between items as the active item changes — a single indicator instead of a static per-item highlight. It adapts to the variant: a sliding underline bar for `underline`, and a sliding filled highlight for `rounded`/`pill`. No prop is required.
+The active highlight always slides between items as the active item changes — a single indicator instead of a static per-item highlight. It adapts to the variant: a sliding underline bar for `line`, and a sliding filled highlight for `rounded`/`pill`. No prop is required.
 
 The indicator is an `aria-hidden`, non-focusable element, so `aria-current`, focus rings, and keyboard order are unaffected. Its position is measured from the live DOM (`aria-current="page"`) and kept in sync as the active item changes or the layout resizes. The recipe's static marker is the SSR / no-JS fallback.
 

--- a/packages/nimbus/src/components/tab-nav/tab-nav.dev.mdx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.dev.mdx
@@ -85,6 +85,68 @@ const App = () => {
 };
 ```
 
+### Variants
+
+The `variant` prop controls the visual style. Available variants: `tabs` (default), `filled`, `pill`.
+
+- **`tabs`** — an underline strip beneath the active item (visually twinned with the `Tabs` `line` variant).
+- **`filled`** — a soft rounded-rect highlight behind the active item.
+- **`pill`** — a fully-rounded capsule highlight behind the active item.
+
+The `filled` and `pill` variants drop the baseline, add a small gap between items, and drive their active highlight off `colorPalette` (defaulting to `primary`), so they theme with the surrounding palette.
+
+```jsx live-dev
+const App = () => (
+  <Stack direction="column" gap="600">
+    {['tabs', 'filled', 'pill'].map((variant) => (
+      <Stack key={variant} direction="column" gap="300">
+        <Text fontWeight="500">{variant}</Text>
+        <TabNav.Root aria-label={`Navigation (${variant})`} variant={variant}>
+          <TabNav.Item href="/general" isCurrent>General</TabNav.Item>
+          <TabNav.Item href="/items">Items</TabNav.Item>
+          <TabNav.Item href="/shipping">Shipping</TabNav.Item>
+        </TabNav.Root>
+      </Stack>
+    ))}
+  </Stack>
+);
+```
+
+### Animated highlight
+
+Pass `animated` to render a single active-highlight indicator that slides between items as the active item changes, instead of the static per-item highlight. The indicator adapts to the variant: a sliding underline bar for `tabs`, and a sliding filled highlight for `filled`/`pill`.
+
+The indicator is an `aria-hidden`, non-focusable element, so `aria-current`, focus rings, and keyboard order are unaffected. Its position is measured from the live DOM (`aria-current="page"`) and kept in sync as the active item changes or the layout resizes.
+
+The slide transition is automatically disabled under `prefers-reduced-motion: reduce` — the highlight snaps into place.
+
+```jsx live-dev
+const items = [
+  { href: '/orders/123/general', label: 'General' },
+  { href: '/orders/123/items', label: 'Items' },
+  { href: '/orders/123/shipping', label: 'Shipping' },
+];
+
+const App = () => {
+  const [activePath, setActivePath] = React.useState(items[0].href);
+
+  return (
+    <TabNav.Root aria-label="Order navigation" variant="filled" animated>
+      {items.map((item) => (
+        <TabNav.Item
+          key={item.href}
+          href={item.href}
+          isCurrent={activePath === item.href}
+          onClick={(e) => { e.preventDefault(); setActivePath(item.href); }}
+        >
+          {item.label}
+        </TabNav.Item>
+      ))}
+    </TabNav.Root>
+  );
+};
+```
+
 ### Active item
 
 Mark the currently viewed page with `isCurrent`. This sets `aria-current="page"` on the anchor element, which screen readers announce as "current page".

--- a/packages/nimbus/src/components/tab-nav/tab-nav.dev.mdx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.dev.mdx
@@ -87,18 +87,20 @@ const App = () => {
 
 ### Variants
 
-The `variant` prop controls the visual style. Available variants: `tabs` (default), `filled`, `pill`.
+The `variant` prop controls the visual style. Available variants: `underline` (default), `rounded`, `pill`. (`Tabs` exposes the same three variants.)
 
-- **`tabs`** — an underline strip beneath the active item (visually twinned with the `Tabs` `line` variant).
-- **`filled`** — a soft rounded-rect highlight behind the active item.
+- **`underline`** — an underline strip beneath the active item (visually twinned with the `Tabs` `underline` variant).
+- **`rounded`** — a soft rounded-rect highlight behind the active item.
 - **`pill`** — a fully-rounded capsule highlight behind the active item.
 
-The `filled` and `pill` variants drop the baseline, add a small gap between items, and drive their active highlight off `colorPalette` (defaulting to `primary`), so they theme with the surrounding palette.
+The `rounded` and `pill` variants drop the baseline, add a small gap between items, and drive their active highlight off `colorPalette` (defaulting to `primary`), so they theme with the surrounding palette.
+
+The legacy `tabs` variant name is accepted as a deprecated alias for `underline`.
 
 ```jsx live-dev
 const App = () => (
   <Stack direction="column" gap="600">
-    {['tabs', 'filled', 'pill'].map((variant) => (
+    {['underline', 'rounded', 'pill'].map((variant) => (
       <Stack key={variant} direction="column" gap="300">
         <Text fontWeight="500">{variant}</Text>
         <TabNav.Root aria-label={`Navigation (${variant})`} variant={variant}>
@@ -114,11 +116,11 @@ const App = () => (
 
 ### Animated highlight
 
-Pass `animated` to render a single active-highlight indicator that slides between items as the active item changes, instead of the static per-item highlight. The indicator adapts to the variant: a sliding underline bar for `tabs`, and a sliding filled highlight for `filled`/`pill`.
+The active highlight always slides between items as the active item changes — a single indicator instead of a static per-item highlight. It adapts to the variant: a sliding underline bar for `underline`, and a sliding filled highlight for `rounded`/`pill`. No prop is required.
 
-The indicator is an `aria-hidden`, non-focusable element, so `aria-current`, focus rings, and keyboard order are unaffected. Its position is measured from the live DOM (`aria-current="page"`) and kept in sync as the active item changes or the layout resizes.
+The indicator is an `aria-hidden`, non-focusable element, so `aria-current`, focus rings, and keyboard order are unaffected. Its position is measured from the live DOM (`aria-current="page"`) and kept in sync as the active item changes or the layout resizes. The recipe's static marker is the SSR / no-JS fallback.
 
-The slide transition is automatically disabled under `prefers-reduced-motion: reduce` — the highlight snaps into place.
+The slide transition is automatically disabled under `prefers-reduced-motion: reduce` — the highlight snaps into place. (To disable the motion, the user sets the OS-level reduced-motion preference; there is no per-instance prop.)
 
 ```jsx live-dev
 const items = [
@@ -131,7 +133,7 @@ const App = () => {
   const [activePath, setActivePath] = React.useState(items[0].href);
 
   return (
-    <TabNav.Root aria-label="Order navigation" variant="filled" animated>
+    <TabNav.Root aria-label="Order navigation" variant="rounded">
       {items.map((item) => (
         <TabNav.Item
           key={item.href}

--- a/packages/nimbus/src/components/tab-nav/tab-nav.mdx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.mdx
@@ -64,18 +64,23 @@ const App = () => (
 
 `TabNav` ships with three visual variants:
 
-- **`tabs`** (default) — an underline strip beneath the active item.
-- **`filled`** — a soft rounded-rect highlight behind the active item.
+- **`underline`** (default) — an underline strip beneath the active item.
+- **`rounded`** — a soft rounded-rect highlight behind the active item.
 - **`pill`** — a fully-rounded capsule highlight behind the active item.
 
-The `filled` and `pill` variants drop the underline baseline and add a small gap
+The `rounded` and `pill` variants drop the underline baseline and add a small gap
 between items. Their active highlight is themeable via `colorPalette` (it
 defaults to `primary`).
+
+The active highlight always slides smoothly between items as the active item
+changes — a single sliding indicator rather than a static per-item highlight.
+The motion automatically respects `prefers-reduced-motion: reduce`: when reduced
+motion is requested, the highlight snaps into place instead of sliding.
 
 ```jsx live
 const App = () => (
   <Stack direction="column" gap="600">
-    {["tabs", "filled", "pill"].map((variant) => (
+    {["underline", "rounded", "pill"].map((variant) => (
       <Stack key={variant} direction="column" gap="300">
         <Text fontWeight="600">{variant}</Text>
         <TabNav.Root aria-label={`Order navigation (${variant})`} variant={variant}>
@@ -93,12 +98,10 @@ const App = () => (
 
 ### Animated highlight
 
-Add `animated` to render a single active-highlight indicator that smoothly slides
-between items as the active item changes, instead of the static per-item
-highlight. The indicator adapts to the variant — a sliding underline bar for
-`tabs`, and a sliding filled highlight for `filled`/`pill`. The motion
-automatically respects `prefers-reduced-motion: reduce`: when reduced motion is
-requested, the highlight snaps into place instead of sliding.
+The active highlight slides between items whenever the active item changes (an
+underline bar for `underline`, a filled highlight for `rounded`/`pill`) — no prop
+required. The slide respects `prefers-reduced-motion: reduce` (the highlight
+snaps into place), and `aria-current`, focus, and keyboard order are unaffected.
 
 ```jsx live
 const App = () => {
@@ -109,7 +112,7 @@ const App = () => {
   ];
   const [activePath, setActivePath] = React.useState(items[0].href);
   return (
-    <TabNav.Root aria-label="Order navigation" variant="filled" animated>
+    <TabNav.Root aria-label="Order navigation" variant="rounded">
       {items.map((item) => (
         <TabNav.Item
           key={item.href}

--- a/packages/nimbus/src/components/tab-nav/tab-nav.mdx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.mdx
@@ -64,11 +64,11 @@ const App = () => (
 
 `TabNav` ships with three visual variants:
 
-- **`underline`** (default) — an underline strip beneath the active item.
+- **`line`** (default) — an underline strip beneath the active item.
 - **`rounded`** — a soft rounded-rect highlight behind the active item.
 - **`pill`** — a fully-rounded capsule highlight behind the active item.
 
-The `rounded` and `pill` variants drop the underline baseline and add a small gap
+The `rounded` and `pill` variants drop the baseline and add a small gap
 between items. Their active highlight is themeable via `colorPalette` (it
 defaults to `primary`).
 
@@ -80,7 +80,7 @@ motion is requested, the highlight snaps into place instead of sliding.
 ```jsx live
 const App = () => (
   <Stack direction="column" gap="600">
-    {["underline", "rounded", "pill"].map((variant) => (
+    {["line", "rounded", "pill"].map((variant) => (
       <Stack key={variant} direction="column" gap="300">
         <Text fontWeight="600">{variant}</Text>
         <TabNav.Root aria-label={`Order navigation (${variant})`} variant={variant}>
@@ -99,7 +99,7 @@ const App = () => (
 ### Animated highlight
 
 The active highlight slides between items whenever the active item changes (an
-underline bar for `underline`, a filled highlight for `rounded`/`pill`) — no prop
+underline bar for `line`, a filled highlight for `rounded`/`pill`) — no prop
 required. The slide respects `prefers-reduced-motion: reduce` (the highlight
 snaps into place), and `aria-current`, focus, and keyboard order are unaffected.
 

--- a/packages/nimbus/src/components/tab-nav/tab-nav.mdx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.mdx
@@ -60,6 +60,74 @@ const App = () => (
 )
 ```
 
+### Variants
+
+`TabNav` ships with three visual variants:
+
+- **`tabs`** (default) — an underline strip beneath the active item.
+- **`filled`** — a soft rounded-rect highlight behind the active item.
+- **`pill`** — a fully-rounded capsule highlight behind the active item.
+
+The `filled` and `pill` variants drop the underline baseline and add a small gap
+between items. Their active highlight is themeable via `colorPalette` (it
+defaults to `primary`).
+
+```jsx live
+const App = () => (
+  <Stack direction="column" gap="600">
+    {["tabs", "filled", "pill"].map((variant) => (
+      <Stack key={variant} direction="column" gap="300">
+        <Text fontWeight="600">{variant}</Text>
+        <TabNav.Root aria-label={`Order navigation (${variant})`} variant={variant}>
+          <TabNav.Item href="/orders/123/general" isCurrent>
+            General
+          </TabNav.Item>
+          <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
+          <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
+        </TabNav.Root>
+      </Stack>
+    ))}
+  </Stack>
+)
+```
+
+### Animated highlight
+
+Add `animated` to render a single active-highlight indicator that smoothly slides
+between items as the active item changes, instead of the static per-item
+highlight. The indicator adapts to the variant — a sliding underline bar for
+`tabs`, and a sliding filled highlight for `filled`/`pill`. The motion
+automatically respects `prefers-reduced-motion: reduce`: when reduced motion is
+requested, the highlight snaps into place instead of sliding.
+
+```jsx live
+const App = () => {
+  const items = [
+    { href: "/orders/123/general", label: "General" },
+    { href: "/orders/123/items", label: "Items" },
+    { href: "/orders/123/shipping", label: "Shipping" },
+  ];
+  const [activePath, setActivePath] = React.useState(items[0].href);
+  return (
+    <TabNav.Root aria-label="Order navigation" variant="filled" animated>
+      {items.map((item) => (
+        <TabNav.Item
+          key={item.href}
+          href={item.href}
+          isCurrent={activePath === item.href}
+          onClick={(e) => {
+            e.preventDefault();
+            setActivePath(item.href);
+          }}
+        >
+          {item.label}
+        </TabNav.Item>
+      ))}
+    </TabNav.Root>
+  );
+}
+```
+
 ### Active item
 
 Mark the currently viewed page with `isCurrent`. This renders `aria-current="page"`

--- a/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
@@ -60,7 +60,7 @@ const highlightItemBase = {
 } as const;
 
 export const tabNavSlotRecipe = defineSlotRecipe({
-  slots: ["root", "item"],
+  slots: ["root", "item", "indicator"],
 
   className: "nimbus-tab-nav",
 
@@ -71,6 +71,23 @@ export const tabNavSlotRecipe = defineSlotRecipe({
       width: "100%",
       // Anchors the absolutely-positioned sliding indicator (all variants).
       position: "relative",
+    },
+    // The sliding active marker. The hook (`useSlidingIndicator`) owns the
+    // dynamic geometry — it writes `opacity`, `width`, `height`, and `transform`
+    // inline — so the recipe only defines the static frame and the slide
+    // transition. `background`/`borderRadius` are variant-driven (see below).
+    indicator: {
+      position: "absolute",
+      top: "0",
+      left: "0",
+      zIndex: "0",
+      opacity: "0",
+      pointerEvents: "none",
+      transition:
+        "transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease",
+      "@media (prefers-reduced-motion: reduce)": {
+        transition: "none",
+      },
     },
     item: {
       display: "flex",
@@ -90,6 +107,11 @@ export const tabNavSlotRecipe = defineSlotRecipe({
       line: {
         root: {
           boxShadow: "0 1px 0 0 {colors.neutral.6}",
+        },
+        // A thin bar pinned to the active item's bottom edge.
+        indicator: {
+          background: "primary.9",
+          borderRadius: "0",
         },
         item: {
           color: "neutral.12",
@@ -123,6 +145,11 @@ export const tabNavSlotRecipe = defineSlotRecipe({
           colorPalette: "primary",
           gap: "100",
         },
+        // Full-height highlight behind the active item's label.
+        indicator: {
+          background: "colorPalette.3",
+          borderRadius: "200",
+        },
         item: highlightItemBase,
       },
       // Same idea as `rounded`, but a fully-rounded capsule highlight and a touch
@@ -131,6 +158,11 @@ export const tabNavSlotRecipe = defineSlotRecipe({
         root: {
           colorPalette: "primary",
           gap: "100",
+        },
+        // Fully-rounded capsule highlight behind the active item's label.
+        indicator: {
+          background: "colorPalette.3",
+          borderRadius: "full",
         },
         item: {
           ...highlightItemBase,

--- a/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
@@ -14,7 +14,52 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * visually identical to the `line` horizontal variant of Tabs. If you change
  * colors, spacing, typography, transitions, or focus styles in one, apply the
  * equivalent change to the other.
+ *
+ * NOTE: the twin rule above applies ONLY to the `tabs` variant. The `filled`
+ * and `pill` variants are TabNav-only and have no counterpart in Tabs.
  */
+
+/**
+ * Shared item styles for the `filled` and `pill` variants.
+ *
+ * Both reproduce the "soft highlight on the active item" look (vs. the `tabs`
+ * underline strip): a neutral resting state, a subtle hover wash, and a
+ * themeable highlight on the active item driven by `colorPalette` (defaulting
+ * to `primary` via the root slot). Padding and font-size are inherited from the
+ * shared `--tab-nav-*` size CSS vars so all three sizes keep working.
+ *
+ * `position: relative` + `zIndex` keep the item's label painted ABOVE the
+ * absolutely-positioned animated indicator (see `tab-nav.root.tsx`). When the
+ * indicator is active (`[data-animated="true"]`), it owns the highlight, so the
+ * static per-item background is suppressed to avoid a double highlight.
+ */
+const filledItemBase = {
+  color: "neutral.11",
+  cursor: "pointer",
+  fontWeight: "500",
+  textDecoration: "none",
+  borderRadius: "200",
+  position: "relative",
+  zIndex: 1,
+  transition: "color 150ms ease, background 150ms ease",
+  focusVisibleRing: "outside",
+  // No hover background — just shift the text to the (themed) active palette so
+  // hover never paints over the active item's highlight or the sliding indicator.
+  _hover: {
+    color: "colorPalette.11",
+  },
+  '&[aria-current="page"]': {
+    color: "colorPalette.11",
+    background: "colorPalette.3",
+  },
+  '[data-animated="true"] &[aria-current="page"]': {
+    background: "transparent",
+  },
+  _disabled: {
+    layerStyle: "disabled",
+  },
+} as const;
+
 export const tabNavSlotRecipe = defineSlotRecipe({
   slots: ["root", "item"],
 
@@ -57,12 +102,42 @@ export const tabNavSlotRecipe = defineSlotRecipe({
             color: "primary.11",
           },
           '&[aria-current="page"]': {
-            color: "primary.9",
+            color: "primary.11",
             boxShadow: "0 2px 0 0 {colors.primary.9}",
+          },
+          // When the animated indicator is active, the sliding underline bar
+          // owns the highlight, so suppress the static underline.
+          '[data-animated="true"] &[aria-current="page"]': {
+            boxShadow: "0 2px 0 0 transparent",
           },
           _disabled: {
             layerStyle: "disabled",
           },
+        },
+      },
+      // Soft rounded-rect highlight on the active item (reproduces the previous
+      // docs-navbar look). No baseline; small gap between items.
+      filled: {
+        root: {
+          colorPalette: "primary",
+          gap: "100",
+          position: "relative",
+        },
+        item: filledItemBase,
+      },
+      // Same idea as `filled`, but a fully-rounded capsule highlight and a touch
+      // more horizontal padding so it reads as a pill.
+      pill: {
+        root: {
+          colorPalette: "primary",
+          gap: "100",
+          position: "relative",
+        },
+        item: {
+          ...filledItemBase,
+          borderRadius: "full",
+          paddingLeft: "calc(var(--tab-nav-padding-left) + {spacing.100})",
+          paddingRight: "calc(var(--tab-nav-padding-right) + {spacing.100})",
         },
       },
     },

--- a/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
@@ -5,23 +5,23 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * Defines the styling variants and base styles using Chakra UI's recipe system.
  *
  * Renders navigation semantics (`<nav>` + `<a>`) with visual styling that
- * matches the Tabs `line` (horizontal underline) variant.
+ * matches the Tabs `line` variant.
  *
  * ⚠️  VISUAL TWIN — KEEP IN SYNC WITH `tabs.recipe.ts`
  * TabNav and Tabs are intentionally separate components with separate recipes
  * (different semantics: navigation links vs. content-panel widget). They do NOT
- * share a recipe. However, they expose the SAME three variants — `underline`,
+ * share a recipe. However, they expose the SAME three variants — `line`,
  * `rounded`, and `pill` — which are designed to look identical between the two.
  * If you change colors, spacing, typography, transitions, or focus styles for
  * any of these variants in one, apply the equivalent change to the other.
- * (Tabs additionally layers `orientation`/`placement` onto `underline`.)
+ * (Tabs additionally layers `orientation`/`placement` onto `line`.)
  */
 
 /**
  * Shared item styles for the `rounded` and `pill` variants.
  *
  * Both reproduce the "soft highlight on the active item" look (vs. the
- * `underline` strip): a neutral resting state, a subtle hover wash, and a
+ * `line` bar): a neutral resting state, a subtle hover wash, and a
  * themeable highlight on the active item driven by `colorPalette` (defaulting
  * to `primary` via the root slot). Padding and font-size are inherited from the
  * shared `--tab-nav-*` size CSS vars so all three sizes keep working.
@@ -87,7 +87,7 @@ export const tabNavSlotRecipe = defineSlotRecipe({
 
   variants: {
     variant: {
-      underline: {
+      line: {
         root: {
           boxShadow: "0 1px 0 0 {colors.neutral.6}",
         },
@@ -106,8 +106,8 @@ export const tabNavSlotRecipe = defineSlotRecipe({
             color: "primary.11",
             boxShadow: "0 2px 0 0 {colors.primary.9}",
           },
-          // When the animated indicator is active, the sliding underline bar
-          // owns the highlight, so suppress the static underline.
+          // When the animated indicator is active, the sliding bar owns the
+          // highlight, so suppress the static bar.
           '[data-animated="true"] &[aria-current="page"]': {
             boxShadow: "0 2px 0 0 transparent",
           },
@@ -172,7 +172,7 @@ export const tabNavSlotRecipe = defineSlotRecipe({
   },
 
   defaultVariants: {
-    variant: "underline",
+    variant: "line",
     size: "md",
   },
 });

--- a/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.recipe.ts
@@ -10,30 +10,29 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * ⚠️  VISUAL TWIN — KEEP IN SYNC WITH `tabs.recipe.ts`
  * TabNav and Tabs are intentionally separate components with separate recipes
  * (different semantics: navigation links vs. content-panel widget). They do NOT
- * share a recipe. However, the `tabs` variant of TabNav is designed to be
- * visually identical to the `line` horizontal variant of Tabs. If you change
- * colors, spacing, typography, transitions, or focus styles in one, apply the
- * equivalent change to the other.
- *
- * NOTE: the twin rule above applies ONLY to the `tabs` variant. The `filled`
- * and `pill` variants are TabNav-only and have no counterpart in Tabs.
+ * share a recipe. However, they expose the SAME three variants — `underline`,
+ * `rounded`, and `pill` — which are designed to look identical between the two.
+ * If you change colors, spacing, typography, transitions, or focus styles for
+ * any of these variants in one, apply the equivalent change to the other.
+ * (Tabs additionally layers `orientation`/`placement` onto `underline`.)
  */
 
 /**
- * Shared item styles for the `filled` and `pill` variants.
+ * Shared item styles for the `rounded` and `pill` variants.
  *
- * Both reproduce the "soft highlight on the active item" look (vs. the `tabs`
- * underline strip): a neutral resting state, a subtle hover wash, and a
+ * Both reproduce the "soft highlight on the active item" look (vs. the
+ * `underline` strip): a neutral resting state, a subtle hover wash, and a
  * themeable highlight on the active item driven by `colorPalette` (defaulting
  * to `primary` via the root slot). Padding and font-size are inherited from the
  * shared `--tab-nav-*` size CSS vars so all three sizes keep working.
  *
  * `position: relative` + `zIndex` keep the item's label painted ABOVE the
- * absolutely-positioned animated indicator (see `tab-nav.root.tsx`). When the
- * indicator is active (`[data-animated="true"]`), it owns the highlight, so the
- * static per-item background is suppressed to avoid a double highlight.
+ * absolutely-positioned sliding indicator (see `tab-nav.root.tsx`). Once the
+ * indicator is active (`[data-animated="true"]`, set by the hook on mount), it
+ * owns the highlight, so the static per-item background is suppressed to avoid a
+ * double highlight.
  */
-const filledItemBase = {
+const highlightItemBase = {
   color: "neutral.11",
   cursor: "pointer",
   fontWeight: "500",
@@ -70,6 +69,8 @@ export const tabNavSlotRecipe = defineSlotRecipe({
       display: "flex",
       flexDirection: "row",
       width: "100%",
+      // Anchors the absolutely-positioned sliding indicator (all variants).
+      position: "relative",
     },
     item: {
       display: "flex",
@@ -86,7 +87,7 @@ export const tabNavSlotRecipe = defineSlotRecipe({
 
   variants: {
     variant: {
-      tabs: {
+      underline: {
         root: {
           boxShadow: "0 1px 0 0 {colors.neutral.6}",
         },
@@ -115,26 +116,24 @@ export const tabNavSlotRecipe = defineSlotRecipe({
           },
         },
       },
-      // Soft rounded-rect highlight on the active item (reproduces the previous
-      // docs-navbar look). No baseline; small gap between items.
-      filled: {
+      // Soft rounded-rect highlight on the active item. No baseline; small gap
+      // between items.
+      rounded: {
         root: {
           colorPalette: "primary",
           gap: "100",
-          position: "relative",
         },
-        item: filledItemBase,
+        item: highlightItemBase,
       },
-      // Same idea as `filled`, but a fully-rounded capsule highlight and a touch
+      // Same idea as `rounded`, but a fully-rounded capsule highlight and a touch
       // more horizontal padding so it reads as a pill.
       pill: {
         root: {
           colorPalette: "primary",
           gap: "100",
-          position: "relative",
         },
         item: {
-          ...filledItemBase,
+          ...highlightItemBase,
           borderRadius: "full",
           paddingLeft: "calc(var(--tab-nav-padding-left) + {spacing.100})",
           paddingRight: "calc(var(--tab-nav-padding-right) + {spacing.100})",
@@ -173,7 +172,7 @@ export const tabNavSlotRecipe = defineSlotRecipe({
   },
 
   defaultVariants: {
-    variant: "tabs",
+    variant: "underline",
     size: "md",
   },
 });

--- a/packages/nimbus/src/components/tab-nav/tab-nav.slots.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.slots.tsx
@@ -1,6 +1,10 @@
 import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
 import type { SlotComponent } from "@/type-utils";
-import type { TabNavRootSlotProps, TabNavItemSlotProps } from "./tab-nav.types";
+import type {
+  TabNavRootSlotProps,
+  TabNavItemSlotProps,
+  TabNavIndicatorSlotProps,
+} from "./tab-nav.types";
 
 const { withProvider, withContext } = createSlotRecipeContext({
   key: "nimbusTabNav",
@@ -23,3 +27,13 @@ export const TabNavItemSlot: SlotComponent<
   HTMLAnchorElement,
   TabNavItemSlotProps
 > = withContext<HTMLAnchorElement, TabNavItemSlotProps>("a", "item");
+
+/**
+ * Internal slot for the sliding active-item marker. Rendered automatically by
+ * `TabNav.Root` and positioned by `useSlidingIndicator` — not part of the public
+ * compound API.
+ */
+export const TabNavIndicatorSlot: SlotComponent<
+  HTMLDivElement,
+  TabNavIndicatorSlotProps
+> = withContext<HTMLDivElement, TabNavIndicatorSlotProps>("div", "indicator");

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import { Box, Stack, TabNav, Text } from "@commercetools/nimbus";
@@ -35,23 +35,82 @@ export default meta;
  */
 type Story = StoryObj<typeof TabNav.Root>;
 
+type NavItem = {
+  href: string;
+  label: string;
+  isDisabled?: boolean;
+  target?: string;
+  rel?: string;
+};
+
+const ORDER_ITEMS: NavItem[] = [
+  { href: "/orders/123/general", label: "General" },
+  { href: "/orders/123/items", label: "Items" },
+  { href: "/orders/123/shipping", label: "Shipping" },
+];
+
+/**
+ * A `TabNav` whose active item is tracked in local state. Clicking any item
+ * moves `aria-current="page"` — and therefore the sliding highlight — exactly
+ * like a router does in a real app.
+ *
+ * In production, `isCurrent` is derived from the route (e.g. `useMatch`). In an
+ * isolated story there is no router, so without this wrapper `isCurrent` would
+ * be frozen on a single item and the highlight could never slide. Routing this
+ * through one helper keeps every story interactive instead of needing a
+ * separate "animated" demo story.
+ */
+const InteractiveTabNav = ({
+  items = ORDER_ITEMS,
+  ...props
+}: Omit<ComponentProps<typeof TabNav.Root>, "children"> & {
+  items?: NavItem[];
+}) => {
+  const [activePath, setActivePath] = useState(items[0].href);
+
+  return (
+    <TabNav.Root aria-label="Order navigation" {...props}>
+      {items.map((item) => (
+        <TabNav.Item
+          key={item.href}
+          href={item.href}
+          target={item.target}
+          rel={item.rel}
+          isDisabled={item.isDisabled}
+          isCurrent={activePath === item.href}
+          onClick={(e) => {
+            // Let external (`target="_blank"`) links navigate normally;
+            // intercept same-page navigation so the Storybook iframe doesn't
+            // reload and the active item can move instead.
+            if (item.target) return;
+            e.preventDefault();
+            if (!item.isDisabled) setActivePath(item.href);
+          }}
+        >
+          {item.label}
+        </TabNav.Item>
+      ))}
+    </TabNav.Root>
+  );
+};
+
 /**
  * The default TabNav usage with three navigation items.
- * Demonstrates the tab-styled navigation pattern for route-based navigation.
- * The first item is marked as current with `aria-current="page"`.
+ *
+ * The active highlight is a single indicator that slides between items as the
+ * active item changes (a thin underline bar for the default `underline`
+ * variant). The indicator is `aria-hidden` and non-focusable, so
+ * `aria-current`, focus rings, and keyboard order are unaffected, and it snaps
+ * (no slide) under `prefers-reduced-motion: reduce`.
+ *
+ * Click between the items to see the underline slide.
  */
 export const Base: Story = {
-  render: () => (
-    <TabNav.Root aria-label="Order navigation">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-    </TabNav.Root>
-  ),
+  render: () => <InteractiveTabNav aria-label="Order navigation" />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    const getIndicator = () =>
+      canvasElement.querySelector<HTMLElement>('nav [aria-hidden="true"]');
 
     await step("Renders a nav landmark", async () => {
       const nav = canvas.getByRole("navigation");
@@ -80,6 +139,35 @@ export const Base: Story = {
         await expect(inactiveItem2).not.toHaveAttribute("aria-current");
       }
     );
+
+    await step(
+      "Clicking an item moves aria-current and slides the highlight",
+      async () => {
+        const indicator = getIndicator();
+        await expect(indicator).toBeInTheDocument();
+
+        let initialTransform = "";
+        await waitFor(() => {
+          initialTransform = indicator!.style.transform;
+          expect(initialTransform).not.toBe("");
+        });
+
+        const itemsLink = canvas.getByRole("link", { name: "Items" });
+        await userEvent.click(itemsLink);
+        await expect(itemsLink).toHaveAttribute("aria-current", "page");
+
+        // The previously-active item is no longer current...
+        const generalLink = canvas.getByRole("link", { name: "General" });
+        await expect(generalLink).not.toHaveAttribute("aria-current");
+
+        // ...and the single indicator re-measures to the new position.
+        await waitFor(() => {
+          const next = indicator!.style.transform;
+          expect(next).not.toBe("");
+          expect(next).not.toBe(initialTransform);
+        });
+      }
+    );
   },
 };
 
@@ -93,13 +181,10 @@ export const Sizes: Story = {
       {(["sm", "md", "lg"] as const).map((size) => (
         <Stack key={size} direction="column" gap="300">
           <Text fontWeight="600">{size}</Text>
-          <TabNav.Root aria-label={`Order navigation (${size})`} size={size}>
-            <TabNav.Item href="/orders/123/general" isCurrent>
-              General
-            </TabNav.Item>
-            <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-            <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-          </TabNav.Root>
+          <InteractiveTabNav
+            aria-label={`Order navigation (${size})`}
+            size={size}
+          />
         </Stack>
       ))}
     </Stack>
@@ -117,14 +202,15 @@ export const Sizes: Story = {
 /**
  * TabNav ships with three visual variants:
  *
- * - `tabs` (default) — an underline strip; visually twinned with the `Tabs`
- *   `line` variant.
+ * - `underline` (default) — an underline strip; visually twinned with the
+ *   `Tabs` `underline` variant.
  * - `rounded` — a soft rounded-rect highlight on the active item.
  * - `pill` — a fully-rounded capsule highlight on the active item.
  *
  * The `rounded` and `pill` variants drop the baseline and add a small gap
  * between items. Their active highlight is themeable via `colorPalette`
- * (defaulting to `primary`).
+ * (defaulting to `primary`). Click between items in any variant to see the
+ * highlight slide.
  */
 export const Variants: Story = {
   render: () => (
@@ -135,16 +221,10 @@ export const Variants: Story = {
             {variant}
             {variant === "underline" ? " (default)" : ""}
           </Text>
-          <TabNav.Root
+          <InteractiveTabNav
             aria-label={`Order navigation (${variant})`}
             variant={variant}
-          >
-            <TabNav.Item href="/orders/123/general" isCurrent>
-              General
-            </TabNav.Item>
-            <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-            <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-          </TabNav.Root>
+          />
         </Stack>
       ))}
     </Stack>
@@ -176,15 +256,15 @@ export const Variants: Story = {
  */
 export const Rounded: Story = {
   render: () => (
-    <TabNav.Root aria-label="Order navigation" variant="rounded">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item href="/orders/123/shipping" isDisabled>
-        Shipping
-      </TabNav.Item>
-    </TabNav.Root>
+    <InteractiveTabNav
+      aria-label="Order navigation"
+      variant="rounded"
+      items={[
+        { href: "/orders/123/general", label: "General" },
+        { href: "/orders/123/items", label: "Items" },
+        { href: "/orders/123/shipping", label: "Shipping", isDisabled: true },
+      ]}
+    />
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -215,13 +295,7 @@ export const Rounded: Story = {
  */
 export const Pill: Story = {
   render: () => (
-    <TabNav.Root aria-label="Order navigation" variant="pill">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-    </TabNav.Root>
+    <InteractiveTabNav aria-label="Order navigation" variant="pill" />
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -239,89 +313,6 @@ export const Pill: Story = {
 };
 
 /**
- * The active highlight always slides between items as the active item changes —
- * a single indicator instead of a static per-item background. The indicator is
- * `aria-hidden` and non-focusable, so `aria-current`, focus rings, and keyboard
- * order are unaffected.
- *
- * The motion is automatically disabled when the user requests
- * `prefers-reduced-motion: reduce` (the highlight snaps into place).
- *
- * This story drives the active item with local state to demonstrate the slide,
- * and asserts that the highlight follows clicks.
- */
-export const AnimatedHighlight: Story = {
-  render: () => {
-    const items = [
-      { href: "/orders/123/general", label: "General" },
-      { href: "/orders/123/items", label: "Items" },
-      { href: "/orders/123/shipping", label: "Shipping" },
-    ] as const;
-
-    const [activePath, setActivePath] = useState<string>(items[0].href);
-
-    return (
-      <TabNav.Root aria-label="Order navigation" variant="rounded">
-        {items.map((item) => (
-          <TabNav.Item
-            key={item.href}
-            href={item.href}
-            isCurrent={activePath === item.href}
-            onClick={(e) => {
-              e.preventDefault();
-              setActivePath(item.href);
-            }}
-          >
-            {item.label}
-          </TabNav.Item>
-        ))}
-      </TabNav.Root>
-    );
-  },
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-    const getIndicator = () =>
-      canvasElement.querySelector<HTMLElement>('nav [aria-hidden="true"]');
-
-    await step("Renders a single hidden highlight indicator", async () => {
-      await waitFor(() => expect(getIndicator()).toBeInTheDocument());
-      // The indicator must not be exposed to assistive tech or focusable.
-      const indicator = getIndicator()!;
-      await expect(indicator).toHaveAttribute("aria-hidden", "true");
-      await expect(indicator.tagName).not.toBe("A");
-    });
-
-    let initialTransform = "";
-    await step("Highlight is positioned over the active item", async () => {
-      await waitFor(() => {
-        initialTransform = getIndicator()!.style.transform;
-        expect(initialTransform).not.toBe("");
-      });
-    });
-
-    await step("Clicking another item slides the highlight", async () => {
-      const itemsLink = canvas.getByRole("link", { name: "Items" });
-      await userEvent.click(itemsLink);
-
-      // aria-current moves to the clicked item...
-      await expect(itemsLink).toHaveAttribute("aria-current", "page");
-
-      // ...and the indicator re-measures to a new position.
-      await waitFor(() => {
-        const next = getIndicator()!.style.transform;
-        expect(next).not.toBe("");
-        expect(next).not.toBe(initialTransform);
-      });
-    });
-
-    await step("Previous item is no longer current", async () => {
-      const generalLink = canvas.getByRole("link", { name: "General" });
-      await expect(generalLink).not.toHaveAttribute("aria-current");
-    });
-  },
-};
-
-/**
  * Demonstrates that TabNav uses standard sequential Tab key navigation —
  * NOT roving tabindex with arrow key cycling.
  *
@@ -332,15 +323,7 @@ export const AnimatedHighlight: Story = {
  * Arrow key presses should NOT change focus in TabNav.
  */
 export const KeyboardNavigation: Story = {
-  render: () => (
-    <TabNav.Root aria-label="Order navigation">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-    </TabNav.Root>
-  ),
+  render: () => <InteractiveTabNav aria-label="Order navigation" />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
@@ -408,15 +391,14 @@ export const KeyboardNavigation: Story = {
  */
 export const WithDisabledItem: Story = {
   render: () => (
-    <TabNav.Root aria-label="Order navigation">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item href="/orders/123/shipping" isDisabled>
-        Shipping
-      </TabNav.Item>
-    </TabNav.Root>
+    <InteractiveTabNav
+      aria-label="Order navigation"
+      items={[
+        { href: "/orders/123/general", label: "General" },
+        { href: "/orders/123/items", label: "Items" },
+        { href: "/orders/123/shipping", label: "Shipping", isDisabled: true },
+      ]}
+    />
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -466,19 +448,19 @@ export const WithDisabledItem: Story = {
  */
 export const WithExternalLink: Story = {
   render: () => (
-    <TabNav.Root aria-label="Order navigation">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item
-        href="https://example.com/docs"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Docs ↗
-      </TabNav.Item>
-    </TabNav.Root>
+    <InteractiveTabNav
+      aria-label="Order navigation"
+      items={[
+        { href: "/orders/123/general", label: "General" },
+        { href: "/orders/123/items", label: "Items" },
+        {
+          href: "https://example.com/docs",
+          label: "Docs ↗",
+          target: "_blank",
+          rel: "noopener noreferrer",
+        },
+      ]}
+    />
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -580,84 +562,12 @@ export const WithViewSwitching: Story = {
 };
 
 /**
- * The default `underline` variant animates too: the underline is a thin bar
- * that slides between items as the active item changes, instead of snapping. As
- * with the rounded/pill highlight, the slide is disabled under
- * `prefers-reduced-motion: reduce`, and `aria-current`/focus/keyboard order are
- * unaffected.
- */
-export const AnimatedUnderline: Story = {
-  render: () => {
-    const items = [
-      { href: "/orders/123/general", label: "General" },
-      { href: "/orders/123/items", label: "Items" },
-      { href: "/orders/123/shipping", label: "Shipping" },
-    ] as const;
-
-    const [activePath, setActivePath] = useState<string>(items[0].href);
-
-    return (
-      <TabNav.Root aria-label="Order navigation" variant="underline">
-        {items.map((item) => (
-          <TabNav.Item
-            key={item.href}
-            href={item.href}
-            isCurrent={activePath === item.href}
-            onClick={(e) => {
-              e.preventDefault();
-              setActivePath(item.href);
-            }}
-          >
-            {item.label}
-          </TabNav.Item>
-        ))}
-      </TabNav.Root>
-    );
-  },
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-    const getIndicator = () =>
-      canvasElement.querySelector<HTMLElement>('nav [aria-hidden="true"]');
-
-    await step("Renders a single hidden underline indicator", async () => {
-      await waitFor(() => expect(getIndicator()).toBeInTheDocument());
-      await expect(getIndicator()!).toHaveAttribute("aria-hidden", "true");
-    });
-
-    let initialTransform = "";
-    await step("Underline is positioned over the active item", async () => {
-      await waitFor(() => {
-        initialTransform = getIndicator()!.style.transform;
-        expect(initialTransform).not.toBe("");
-      });
-    });
-
-    await step("Clicking another item slides the underline", async () => {
-      const itemsLink = canvas.getByRole("link", { name: "Items" });
-      await userEvent.click(itemsLink);
-      await expect(itemsLink).toHaveAttribute("aria-current", "page");
-      await waitFor(() => {
-        const next = getIndicator()!.style.transform;
-        expect(next).not.toBe("");
-        expect(next).not.toBe(initialTransform);
-      });
-    });
-  },
-};
-
-/**
  * The legacy `tabs` variant name is still accepted as a deprecated alias for
  * `underline`, so existing code keeps working without changes.
  */
 export const DeprecatedVariantAlias: Story = {
   render: () => (
-    <TabNav.Root aria-label="Order navigation" variant="tabs">
-      <TabNav.Item href="/orders/123/general" isCurrent>
-        General
-      </TabNav.Item>
-      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-      <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-    </TabNav.Root>
+    <InteractiveTabNav aria-label="Order navigation" variant="tabs" />
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -677,14 +587,15 @@ export const DeprecatedVariantAlias: Story = {
  */
 export const SmokeTest: Story = {
   render: () => (
-    <TabNav.Root aria-label="Page navigation">
-      <TabNav.Item href="/page/overview" isCurrent>
-        Overview
-      </TabNav.Item>
-      <TabNav.Item href="/page/details">Details</TabNav.Item>
-      <TabNav.Item href="/page/history">History</TabNav.Item>
-      <TabNav.Item href="/page/settings">Settings</TabNav.Item>
-    </TabNav.Root>
+    <InteractiveTabNav
+      aria-label="Page navigation"
+      items={[
+        { href: "/page/overview", label: "Overview" },
+        { href: "/page/details", label: "Details" },
+        { href: "/page/history", label: "History" },
+        { href: "/page/settings", label: "Settings" },
+      ]}
+    />
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -16,18 +16,13 @@ const meta: Meta<typeof TabNav.Root> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["tabs", "filled", "pill"],
+      options: ["underline", "rounded", "pill"],
       description: "Visual style variant of the tab navigation",
     },
     size: {
       control: "select",
       options: ["sm", "md", "lg"],
       description: "Size of the tab navigation items",
-    },
-    animated: {
-      control: "boolean",
-      description:
-        "Slide a single highlight between items (filled/pill only). Respects prefers-reduced-motion.",
     },
   },
 };
@@ -124,21 +119,21 @@ export const Sizes: Story = {
  *
  * - `tabs` (default) — an underline strip; visually twinned with the `Tabs`
  *   `line` variant.
- * - `filled` — a soft rounded-rect highlight on the active item.
+ * - `rounded` — a soft rounded-rect highlight on the active item.
  * - `pill` — a fully-rounded capsule highlight on the active item.
  *
- * The `filled` and `pill` variants drop the baseline and add a small gap
+ * The `rounded` and `pill` variants drop the baseline and add a small gap
  * between items. Their active highlight is themeable via `colorPalette`
  * (defaulting to `primary`).
  */
 export const Variants: Story = {
   render: () => (
     <Stack direction="column" gap="600">
-      {(["tabs", "filled", "pill"] as const).map((variant) => (
+      {(["underline", "rounded", "pill"] as const).map((variant) => (
         <Stack key={variant} direction="column" gap="300">
           <Text fontWeight="600">
             {variant}
-            {variant === "tabs" ? " (default)" : ""}
+            {variant === "underline" ? " (default)" : ""}
           </Text>
           <TabNav.Root
             aria-label={`Order navigation (${variant})`}
@@ -173,15 +168,15 @@ export const Variants: Story = {
 };
 
 /**
- * The `filled` variant renders a soft rounded-rect highlight behind the active
+ * The `rounded` variant renders a soft rounded-rect highlight behind the active
  * item — the look the docs navbar uses. Inactive items rest in a neutral color
- * and gain a subtle background on hover; the active highlight is driven by the
- * `colorPalette` (defaulting to `primary`), so it themes with the surrounding
- * palette.
+ * and brighten to the active palette on hover; the active highlight is driven by
+ * the `colorPalette` (defaulting to `primary`), so it themes with the
+ * surrounding palette.
  */
-export const Filled: Story = {
+export const Rounded: Story = {
   render: () => (
-    <TabNav.Root aria-label="Order navigation" variant="filled">
+    <TabNav.Root aria-label="Order navigation" variant="rounded">
       <TabNav.Item href="/orders/123/general" isCurrent>
         General
       </TabNav.Item>
@@ -214,7 +209,7 @@ export const Filled: Story = {
 };
 
 /**
- * The `pill` variant is the `filled` look with a fully-rounded capsule
+ * The `pill` variant is the `rounded` look with a fully-rounded capsule
  * highlight and a little extra horizontal padding, so the active item reads as
  * a pill.
  */
@@ -244,10 +239,10 @@ export const Pill: Story = {
 };
 
 /**
- * With `animated`, the `filled` and `pill` variants render a single highlight
- * that slides between items as the active item changes — instead of the static
- * per-item background. The indicator is `aria-hidden` and non-focusable, so
- * `aria-current`, focus rings, and keyboard order are unaffected.
+ * The active highlight always slides between items as the active item changes —
+ * a single indicator instead of a static per-item background. The indicator is
+ * `aria-hidden` and non-focusable, so `aria-current`, focus rings, and keyboard
+ * order are unaffected.
  *
  * The motion is automatically disabled when the user requests
  * `prefers-reduced-motion: reduce` (the highlight snaps into place).
@@ -266,7 +261,7 @@ export const AnimatedHighlight: Story = {
     const [activePath, setActivePath] = useState<string>(items[0].href);
 
     return (
-      <TabNav.Root aria-label="Order navigation" variant="filled" animated>
+      <TabNav.Root aria-label="Order navigation" variant="rounded">
         {items.map((item) => (
           <TabNav.Item
             key={item.href}
@@ -585,9 +580,9 @@ export const WithViewSwitching: Story = {
 };
 
 /**
- * `animated` also applies to the default `tabs` variant: the underline becomes
- * a thin bar that slides between items as the active item changes, instead of
- * snapping. As with the filled/pill highlight, the slide is disabled under
+ * The default `underline` variant animates too: the underline is a thin bar
+ * that slides between items as the active item changes, instead of snapping. As
+ * with the rounded/pill highlight, the slide is disabled under
  * `prefers-reduced-motion: reduce`, and `aria-current`/focus/keyboard order are
  * unaffected.
  */
@@ -602,7 +597,7 @@ export const AnimatedUnderline: Story = {
     const [activePath, setActivePath] = useState<string>(items[0].href);
 
     return (
-      <TabNav.Root aria-label="Order navigation" variant="tabs" animated>
+      <TabNav.Root aria-label="Order navigation" variant="underline">
         {items.map((item) => (
           <TabNav.Item
             key={item.href}
@@ -646,6 +641,32 @@ export const AnimatedUnderline: Story = {
         expect(next).not.toBe("");
         expect(next).not.toBe(initialTransform);
       });
+    });
+  },
+};
+
+/**
+ * The legacy `tabs` variant name is still accepted as a deprecated alias for
+ * `underline`, so existing code keeps working without changes.
+ */
+export const DeprecatedVariantAlias: Story = {
+  render: () => (
+    <TabNav.Root aria-label="Order navigation" variant="tabs">
+      <TabNav.Item href="/orders/123/general" isCurrent>
+        General
+      </TabNav.Item>
+      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
+      <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
+    </TabNav.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Deprecated `tabs` alias still renders the nav", async () => {
+      await expect(canvas.getByRole("navigation")).toBeInTheDocument();
+      await expect(
+        canvas.getByRole("link", { name: "General" })
+      ).toHaveAttribute("aria-current", "page");
     });
   },
 };

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof TabNav.Root> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["underline", "rounded", "pill"],
+      options: ["line", "rounded", "pill"],
       description: "Visual style variant of the tab navigation",
     },
     size: {
@@ -98,12 +98,12 @@ const InteractiveTabNav = ({
  * The default TabNav usage with three navigation items.
  *
  * The active highlight is a single indicator that slides between items as the
- * active item changes (a thin underline bar for the default `underline`
- * variant). The indicator is `aria-hidden` and non-focusable, so
- * `aria-current`, focus rings, and keyboard order are unaffected, and it snaps
- * (no slide) under `prefers-reduced-motion: reduce`.
+ * active item changes (a thin bar for the default `line` variant). The
+ * indicator is `aria-hidden` and non-focusable, so `aria-current`, focus rings,
+ * and keyboard order are unaffected, and it snaps (no slide) under
+ * `prefers-reduced-motion: reduce`.
  *
- * Click between the items to see the underline slide.
+ * Click between the items to see the bar slide.
  */
 export const Base: Story = {
   render: () => <InteractiveTabNav aria-label="Order navigation" />,
@@ -202,8 +202,8 @@ export const Sizes: Story = {
 /**
  * TabNav ships with three visual variants:
  *
- * - `underline` (default) — an underline strip; visually twinned with the
- *   `Tabs` `underline` variant.
+ * - `line` (default) — a bar marking the active item; visually twinned with the
+ *   `Tabs` `line` variant.
  * - `rounded` — a soft rounded-rect highlight on the active item.
  * - `pill` — a fully-rounded capsule highlight on the active item.
  *
@@ -215,11 +215,11 @@ export const Sizes: Story = {
 export const Variants: Story = {
   render: () => (
     <Stack direction="column" gap="600">
-      {(["underline", "rounded", "pill"] as const).map((variant) => (
+      {(["line", "rounded", "pill"] as const).map((variant) => (
         <Stack key={variant} direction="column" gap="300">
           <Text fontWeight="600">
             {variant}
-            {variant === "underline" ? " (default)" : ""}
+            {variant === "line" ? " (default)" : ""}
           </Text>
           <InteractiveTabNav
             aria-label={`Order navigation (${variant})`}
@@ -563,7 +563,7 @@ export const WithViewSwitching: Story = {
 
 /**
  * The legacy `tabs` variant name is still accepted as a deprecated alias for
- * `underline`, so existing code keeps working without changes.
+ * `line`, so existing code keeps working without changes.
  */
 export const DeprecatedVariantAlias: Story = {
   render: () => (

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { Box, Stack, TabNav, Text } from "@commercetools/nimbus";
 
 /**
@@ -16,13 +16,18 @@ const meta: Meta<typeof TabNav.Root> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["tabs"],
+      options: ["tabs", "filled", "pill"],
       description: "Visual style variant of the tab navigation",
     },
     size: {
       control: "select",
       options: ["sm", "md", "lg"],
       description: "Size of the tab navigation items",
+    },
+    animated: {
+      control: "boolean",
+      description:
+        "Slide a single highlight between items (filled/pill only). Respects prefers-reduced-motion.",
     },
   },
 };
@@ -115,28 +120,208 @@ export const Sizes: Story = {
 };
 
 /**
- * Demonstrates the `tabs` visual variant applied to the navigation.
- * TabNav currently ships with a single `tabs` variant — the default style.
+ * TabNav ships with three visual variants:
+ *
+ * - `tabs` (default) — an underline strip; visually twinned with the `Tabs`
+ *   `line` variant.
+ * - `filled` — a soft rounded-rect highlight on the active item.
+ * - `pill` — a fully-rounded capsule highlight on the active item.
+ *
+ * The `filled` and `pill` variants drop the baseline and add a small gap
+ * between items. Their active highlight is themeable via `colorPalette`
+ * (defaulting to `primary`).
  */
 export const Variants: Story = {
   render: () => (
-    <Stack direction="column" gap="300">
-      <Text fontWeight="600">tabs (default)</Text>
-      <TabNav.Root aria-label="Order navigation" variant="tabs">
-        <TabNav.Item href="/orders/123/general" isCurrent>
-          General
-        </TabNav.Item>
-        <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
-        <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
-      </TabNav.Root>
+    <Stack direction="column" gap="600">
+      {(["tabs", "filled", "pill"] as const).map((variant) => (
+        <Stack key={variant} direction="column" gap="300">
+          <Text fontWeight="600">
+            {variant}
+            {variant === "tabs" ? " (default)" : ""}
+          </Text>
+          <TabNav.Root
+            aria-label={`Order navigation (${variant})`}
+            variant={variant}
+          >
+            <TabNav.Item href="/orders/123/general" isCurrent>
+              General
+            </TabNav.Item>
+            <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
+            <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
+          </TabNav.Root>
+        </Stack>
+      ))}
     </Stack>
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Renders nav landmark with tabs variant", async () => {
+    await step("Renders all three variant nav landmarks", async () => {
+      const navs = canvas.getAllByRole("navigation");
+      await expect(navs).toHaveLength(3);
+    });
+
+    await step("Active item carries aria-current in each variant", async () => {
+      const activeLinks = canvas.getAllByRole("link", { name: "General" });
+      await expect(activeLinks).toHaveLength(3);
+      for (const link of activeLinks) {
+        await expect(link).toHaveAttribute("aria-current", "page");
+      }
+    });
+  },
+};
+
+/**
+ * The `filled` variant renders a soft rounded-rect highlight behind the active
+ * item — the look the docs navbar uses. Inactive items rest in a neutral color
+ * and gain a subtle background on hover; the active highlight is driven by the
+ * `colorPalette` (defaulting to `primary`), so it themes with the surrounding
+ * palette.
+ */
+export const Filled: Story = {
+  render: () => (
+    <TabNav.Root aria-label="Order navigation" variant="filled">
+      <TabNav.Item href="/orders/123/general" isCurrent>
+        General
+      </TabNav.Item>
+      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
+      <TabNav.Item href="/orders/123/shipping" isDisabled>
+        Shipping
+      </TabNav.Item>
+    </TabNav.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Active item has aria-current='page'", async () => {
+      const generalLink = canvas.getByRole("link", { name: "General" });
+      await expect(generalLink).toHaveAttribute("aria-current", "page");
+    });
+
+    await step("Hovering an inactive item is non-destructive", async () => {
+      const itemsLink = canvas.getByRole("link", { name: "Items" });
+      await userEvent.hover(itemsLink);
+      await expect(itemsLink).not.toHaveAttribute("aria-current");
+    });
+
+    await step("Disabled item is dimmed and not focusable", async () => {
+      const disabledLink = canvas.getByRole("link", { name: "Shipping" });
+      await expect(disabledLink).toHaveAttribute("aria-disabled", "true");
+      await expect(disabledLink).not.toHaveAttribute("href");
+    });
+  },
+};
+
+/**
+ * The `pill` variant is the `filled` look with a fully-rounded capsule
+ * highlight and a little extra horizontal padding, so the active item reads as
+ * a pill.
+ */
+export const Pill: Story = {
+  render: () => (
+    <TabNav.Root aria-label="Order navigation" variant="pill">
+      <TabNav.Item href="/orders/123/general" isCurrent>
+        General
+      </TabNav.Item>
+      <TabNav.Item href="/orders/123/items">Items</TabNav.Item>
+      <TabNav.Item href="/orders/123/shipping">Shipping</TabNav.Item>
+    </TabNav.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders nav landmark with pill variant", async () => {
       const nav = canvas.getByRole("navigation");
       await expect(nav).toBeInTheDocument();
+    });
+
+    await step("Active item has aria-current='page'", async () => {
+      const generalLink = canvas.getByRole("link", { name: "General" });
+      await expect(generalLink).toHaveAttribute("aria-current", "page");
+    });
+  },
+};
+
+/**
+ * With `animated`, the `filled` and `pill` variants render a single highlight
+ * that slides between items as the active item changes — instead of the static
+ * per-item background. The indicator is `aria-hidden` and non-focusable, so
+ * `aria-current`, focus rings, and keyboard order are unaffected.
+ *
+ * The motion is automatically disabled when the user requests
+ * `prefers-reduced-motion: reduce` (the highlight snaps into place).
+ *
+ * This story drives the active item with local state to demonstrate the slide,
+ * and asserts that the highlight follows clicks.
+ */
+export const AnimatedHighlight: Story = {
+  render: () => {
+    const items = [
+      { href: "/orders/123/general", label: "General" },
+      { href: "/orders/123/items", label: "Items" },
+      { href: "/orders/123/shipping", label: "Shipping" },
+    ] as const;
+
+    const [activePath, setActivePath] = useState<string>(items[0].href);
+
+    return (
+      <TabNav.Root aria-label="Order navigation" variant="filled" animated>
+        {items.map((item) => (
+          <TabNav.Item
+            key={item.href}
+            href={item.href}
+            isCurrent={activePath === item.href}
+            onClick={(e) => {
+              e.preventDefault();
+              setActivePath(item.href);
+            }}
+          >
+            {item.label}
+          </TabNav.Item>
+        ))}
+      </TabNav.Root>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const getIndicator = () =>
+      canvasElement.querySelector<HTMLElement>('nav [aria-hidden="true"]');
+
+    await step("Renders a single hidden highlight indicator", async () => {
+      await waitFor(() => expect(getIndicator()).toBeInTheDocument());
+      // The indicator must not be exposed to assistive tech or focusable.
+      const indicator = getIndicator()!;
+      await expect(indicator).toHaveAttribute("aria-hidden", "true");
+      await expect(indicator.tagName).not.toBe("A");
+    });
+
+    let initialTransform = "";
+    await step("Highlight is positioned over the active item", async () => {
+      await waitFor(() => {
+        initialTransform = getIndicator()!.style.transform;
+        expect(initialTransform).not.toBe("");
+      });
+    });
+
+    await step("Clicking another item slides the highlight", async () => {
+      const itemsLink = canvas.getByRole("link", { name: "Items" });
+      await userEvent.click(itemsLink);
+
+      // aria-current moves to the clicked item...
+      await expect(itemsLink).toHaveAttribute("aria-current", "page");
+
+      // ...and the indicator re-measures to a new position.
+      await waitFor(() => {
+        const next = getIndicator()!.style.transform;
+        expect(next).not.toBe("");
+        expect(next).not.toBe(initialTransform);
+      });
+    });
+
+    await step("Previous item is no longer current", async () => {
+      const generalLink = canvas.getByRole("link", { name: "General" });
+      await expect(generalLink).not.toHaveAttribute("aria-current");
     });
   },
 };
@@ -395,6 +580,72 @@ export const WithViewSwitching: Story = {
       const shippingLink = canvas.getByRole("link", { name: "Shipping" });
       await userEvent.click(shippingLink);
       await expect(shippingLink).toHaveAttribute("aria-current", "page");
+    });
+  },
+};
+
+/**
+ * `animated` also applies to the default `tabs` variant: the underline becomes
+ * a thin bar that slides between items as the active item changes, instead of
+ * snapping. As with the filled/pill highlight, the slide is disabled under
+ * `prefers-reduced-motion: reduce`, and `aria-current`/focus/keyboard order are
+ * unaffected.
+ */
+export const AnimatedUnderline: Story = {
+  render: () => {
+    const items = [
+      { href: "/orders/123/general", label: "General" },
+      { href: "/orders/123/items", label: "Items" },
+      { href: "/orders/123/shipping", label: "Shipping" },
+    ] as const;
+
+    const [activePath, setActivePath] = useState<string>(items[0].href);
+
+    return (
+      <TabNav.Root aria-label="Order navigation" variant="tabs" animated>
+        {items.map((item) => (
+          <TabNav.Item
+            key={item.href}
+            href={item.href}
+            isCurrent={activePath === item.href}
+            onClick={(e) => {
+              e.preventDefault();
+              setActivePath(item.href);
+            }}
+          >
+            {item.label}
+          </TabNav.Item>
+        ))}
+      </TabNav.Root>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const getIndicator = () =>
+      canvasElement.querySelector<HTMLElement>('nav [aria-hidden="true"]');
+
+    await step("Renders a single hidden underline indicator", async () => {
+      await waitFor(() => expect(getIndicator()).toBeInTheDocument());
+      await expect(getIndicator()!).toHaveAttribute("aria-hidden", "true");
+    });
+
+    let initialTransform = "";
+    await step("Underline is positioned over the active item", async () => {
+      await waitFor(() => {
+        initialTransform = getIndicator()!.style.transform;
+        expect(initialTransform).not.toBe("");
+      });
+    });
+
+    await step("Clicking another item slides the underline", async () => {
+      const itemsLink = canvas.getByRole("link", { name: "Items" });
+      await userEvent.click(itemsLink);
+      await expect(itemsLink).toHaveAttribute("aria-current", "page");
+      await waitFor(() => {
+        const next = getIndicator()!.style.transform;
+        expect(next).not.toBe("");
+        expect(next).not.toBe(initialTransform);
+      });
     });
   },
 };

--- a/packages/nimbus/src/components/tab-nav/tab-nav.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.tsx
@@ -33,7 +33,7 @@ export const TabNav = {
    *
    * @example
    * ```tsx
-   * <TabNav.Root variant="tabs">
+   * <TabNav.Root variant="underline">
    *   <TabNav.Item href="/general" isCurrent>General</TabNav.Item>
    *   <TabNav.Item href="/items">Items</TabNav.Item>
    * </TabNav.Root>

--- a/packages/nimbus/src/components/tab-nav/tab-nav.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.tsx
@@ -29,11 +29,11 @@ export const TabNav = {
    * # TabNav.Root
    *
    * The root container for the tab navigation. Renders a `<nav>` landmark
-   * with the tab strip underline styling.
+   * with the tab strip styling.
    *
    * @example
    * ```tsx
-   * <TabNav.Root variant="underline">
+   * <TabNav.Root variant="line">
    *   <TabNav.Item href="/general" isCurrent>General</TabNav.Item>
    *   <TabNav.Item href="/items">Items</TabNav.Item>
    * </TabNav.Root>

--- a/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
@@ -11,10 +11,22 @@ import type {
 
 type TabNavRecipeProps = {
   /**
-   * Visual style variant of the tab navigation
-   * @default "tabs"
+   * Visual style variant of the tab navigation.
+   *
+   * - `underline` — an underline strip beneath the active item (default).
+   * - `rounded` — a soft rounded-rect highlight behind the active item.
+   * - `pill` — a fully-rounded capsule highlight behind the active item.
+   *
+   * The active highlight slides between items as the active item changes; the
+   * motion is disabled under `prefers-reduced-motion: reduce`.
+   *
+   * `"tabs"` is accepted as a deprecated alias for `"underline"`.
+   * @default "underline"
    */
-  variant?: SlotRecipeProps<"nimbusTabNav">["variant"];
+  variant?:
+    | SlotRecipeProps<"nimbusTabNav">["variant"]
+    /** @deprecated Use `"underline"` instead. */
+    | "tabs";
   /**
    * Size of the tab navigation items
    * @default "md"
@@ -39,18 +51,6 @@ export type TabNavItemSlotProps = HTMLChakraProps<"a", TabNavRecipeProps>;
  * Renders a `<nav>` landmark containing tab-styled navigation links.
  */
 export type TabNavProps = OmitInternalProps<TabNavRootSlotProps> & {
-  /**
-   * When `true`, renders a single active-highlight indicator that smoothly
-   * slides between items as the active item changes, instead of the static
-   * per-item highlight. The indicator adapts to the variant: a sliding
-   * underline bar for `tabs`, and a sliding filled highlight for `filled` /
-   * `pill`.
-   *
-   * The motion is automatically disabled when the user requests
-   * `prefers-reduced-motion: reduce` — the highlight snaps into place.
-   * @default false
-   */
-  animated?: boolean;
   /**
    * A ref to the root `<nav>` element.
    */

--- a/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
@@ -43,6 +43,11 @@ export type TabNavRootSlotProps = HTMLChakraProps<"nav", TabNavRecipeProps>;
 
 export type TabNavItemSlotProps = HTMLChakraProps<"a", TabNavRecipeProps>;
 
+export type TabNavIndicatorSlotProps = HTMLChakraProps<
+  "div",
+  TabNavRecipeProps
+>;
+
 // ============================================================
 // MAIN PROPS
 // ============================================================

--- a/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
@@ -13,19 +13,20 @@ type TabNavRecipeProps = {
   /**
    * Visual style variant of the tab navigation.
    *
-   * - `underline` — an underline strip beneath the active item (default).
+   * - `line` — a bar marking the active item: an underline when horizontal, an
+   *   inner side bar when vertical (default).
    * - `rounded` — a soft rounded-rect highlight behind the active item.
    * - `pill` — a fully-rounded capsule highlight behind the active item.
    *
    * The active highlight slides between items as the active item changes; the
    * motion is disabled under `prefers-reduced-motion: reduce`.
    *
-   * `"tabs"` is accepted as a deprecated alias for `"underline"`.
-   * @default "underline"
+   * `"tabs"` is accepted as a deprecated alias for `"line"`.
+   * @default "line"
    */
   variant?:
     | SlotRecipeProps<"nimbusTabNav">["variant"]
-    /** @deprecated Use `"underline"` instead. */
+    /** @deprecated Use `"line"` instead. */
     | "tabs";
   /**
    * Size of the tab navigation items

--- a/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.types.ts
@@ -40,6 +40,18 @@ export type TabNavItemSlotProps = HTMLChakraProps<"a", TabNavRecipeProps>;
  */
 export type TabNavProps = OmitInternalProps<TabNavRootSlotProps> & {
   /**
+   * When `true`, renders a single active-highlight indicator that smoothly
+   * slides between items as the active item changes, instead of the static
+   * per-item highlight. The indicator adapts to the variant: a sliding
+   * underline bar for `tabs`, and a sliding filled highlight for `filled` /
+   * `pill`.
+   *
+   * The motion is automatically disabled when the user requests
+   * `prefers-reduced-motion: reduce` — the highlight snaps into place.
+   * @default false
+   */
+  animated?: boolean;
+  /**
    * A ref to the root `<nav>` element.
    */
   ref?: React.Ref<HTMLElement>;

--- a/packages/nimbus/src/components/tabs/components/tabs.root.tsx
+++ b/packages/nimbus/src/components/tabs/components/tabs.root.tsx
@@ -1,18 +1,31 @@
+import { useRef } from "react";
 import {
   useChakraContext,
   useSlotRecipe,
 } from "@chakra-ui/react/styled-system";
+import { Box } from "@chakra-ui/react/box";
 import { Tabs as RATabs } from "react-aria-components";
 import { TabsRootSlot } from "../tabs.slots";
 import type { TabsProps } from "../tabs.types";
 import { TabsList } from "./tabs.list";
 import { TabsPanels } from "./tabs.panels";
 import { extractStyleProps } from "@/utils";
+import { useSlidingIndicator } from "@/hooks";
+import type { SlidingIndicatorRects } from "@/hooks";
+
+/** Thickness of the sliding underline bar for the `line` variant. */
+const INDICATOR_BAR_PX = 2;
 
 /**
  * # Tabs
  *
  * A tabs component built on React Aria Components that allows users to switch between different views.
+ *
+ * When `animated` is set, a single decorative indicator slides between tabs as
+ * the selected tab changes (see `tabs.types.ts`). It is `aria-hidden` and
+ * non-focusable, rendered inside the root and positioned with
+ * `useSlidingIndicator`; the static selected marker is suppressed by the recipe
+ * while animated, and the slide respects `prefers-reduced-motion`.
  *
  * @supportsStyleProps
  */
@@ -20,6 +33,7 @@ export const TabsRoot = ({
   children,
   tabs,
   tabListAriaLabel,
+  animated,
   ...props
 }: TabsProps) => {
   const sysCtx = useChakraContext();
@@ -36,9 +50,83 @@ export const TabsRoot = ({
   // `useBreakpointValue` to ensure a concrete value is passed.
   const normalizedOrientation = sysCtx.normalizeValue(recipeProps.orientation);
 
+  // The animated indicator's geometry depends on the *resolved* variant,
+  // orientation, and placement (responsive values are normalized the same way).
+  const variant = sysCtx.normalizeValue(recipeProps.variant) ?? "line";
+  const orientation = normalizedOrientation ?? "horizontal";
+  const placement = sysCtx.normalizeValue(recipeProps.placement) ?? "start";
+
+  const showIndicator = animated === true;
+  const isFill = variant === "pills";
+
+  const indicatorRef = useRef<HTMLDivElement>(null);
+
+  useSlidingIndicator({
+    enabled: showIndicator,
+    indicatorRef,
+    activeSelector: '[role="tab"][aria-selected="true"]',
+    watchAttributes: ["aria-selected", "data-selected"],
+    itemSelector: '[role="tab"]',
+    deps: [variant, orientation, placement],
+    getGeometry: ({ container, active }: SlidingIndicatorRects) => {
+      const x = active.left - container.left;
+      const y = active.top - container.top;
+      // `pills` → full-box filled highlight.
+      if (isFill) {
+        return { x, y, width: active.width, height: active.height };
+      }
+      // `line` → a thin bar pinned to the active tab's marker edge.
+      if (orientation === "vertical") {
+        return placement === "end"
+          ? // tabs on the right; marker on their left edge
+            { x, y, width: INDICATOR_BAR_PX, height: active.height }
+          : // tabs on the left; marker on their right edge
+            {
+              x: x + active.width - INDICATOR_BAR_PX,
+              y,
+              width: INDICATOR_BAR_PX,
+              height: active.height,
+            };
+      }
+      // horizontal; marker on the bottom edge
+      return {
+        x,
+        y: y + active.height - INDICATOR_BAR_PX,
+        width: active.width,
+        height: INDICATOR_BAR_PX,
+      };
+    },
+  });
+
   return (
-    <TabsRootSlot asChild {...recipeProps} {...styleProps}>
+    <TabsRootSlot
+      asChild
+      {...recipeProps}
+      {...styleProps}
+      position={showIndicator ? "relative" : undefined}
+      data-animated={showIndicator ? "true" : undefined}
+    >
       <RATabs {...functionalProps} orientation={normalizedOrientation}>
+        {showIndicator && (
+          <Box
+            ref={indicatorRef}
+            aria-hidden="true"
+            position="absolute"
+            top="0"
+            left="0"
+            zIndex={0}
+            opacity={0}
+            pointerEvents="none"
+            background={isFill ? "primary.3" : "primary.9"}
+            borderRadius={isFill ? "full" : "0"}
+            transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
+            css={{
+              "@media (prefers-reduced-motion: reduce)": {
+                transition: "none",
+              },
+            }}
+          />
+        )}
         {children || (
           <>
             <TabsList tabs={tabs} aria-label={tabListAriaLabel} />

--- a/packages/nimbus/src/components/tabs/components/tabs.root.tsx
+++ b/packages/nimbus/src/components/tabs/components/tabs.root.tsx
@@ -13,12 +13,11 @@ import { extractStyleProps } from "@/utils";
 import { useSlidingIndicator } from "@/hooks";
 import type { SlidingIndicatorRects } from "@/hooks";
 
-/** Thickness of the sliding underline bar for the `underline` variant. */
+/** Thickness of the sliding bar for the `line` variant. */
 const INDICATOR_BAR_PX = 2;
 
 /** Deprecated variant aliases → their replacement. */
 const VARIANT_ALIASES: Record<string, string> = {
-  line: "underline",
   pills: "pill",
 };
 
@@ -35,7 +34,7 @@ function resolveVariantAlias<T>(variant: T): T {
  * A tabs component built on React Aria Components that allows users to switch between different views.
  *
  * The active marker is a single indicator that slides between tabs as the
- * selection changes — an underline bar for `underline`, a filled highlight for
+ * selection changes — a bar for `line`, a filled highlight for
  * `rounded`/`pill`. It is `aria-hidden` and non-focusable, rendered inside the
  * root and positioned with `useSlidingIndicator`; the static selected marker is
  * the SSR/no-JS fallback (suppressed by the recipe once the hook activates), and
@@ -51,8 +50,7 @@ export const TabsRoot = ({
 }: TabsProps) => {
   const sysCtx = useChakraContext();
   // Standard pattern: Split recipe variants. Resolve deprecated variant aliases
-  // (`line` → `underline`, `pills` → `pill`) up front so the recipe only ever
-  // sees real variant keys.
+  // (`pills` → `pill`) up front so the recipe only ever sees real variant keys.
   const recipe = useSlotRecipe({ key: "nimbusTabs" });
   const [recipeProps, restRecipeProps] = recipe.splitVariantProps({
     ...props,
@@ -70,11 +68,11 @@ export const TabsRoot = ({
 
   // The indicator geometry depends on the *resolved* variant, orientation, and
   // placement (responsive values are normalized the same way).
-  const variant = sysCtx.normalizeValue(recipeProps.variant) ?? "underline";
+  const variant = sysCtx.normalizeValue(recipeProps.variant) ?? "line";
   const orientation = normalizedOrientation ?? "horizontal";
   const placement = sysCtx.normalizeValue(recipeProps.placement) ?? "start";
 
-  const isUnderline = variant === "underline";
+  const isLine = variant === "line";
   const isPill = variant === "pill";
 
   const indicatorRef = useRef<HTMLDivElement>(null);
@@ -90,10 +88,10 @@ export const TabsRoot = ({
       const x = active.left - container.left;
       const y = active.top - container.top;
       // `rounded` / `pill` → full-box filled highlight.
-      if (!isUnderline) {
+      if (!isLine) {
         return { x, y, width: active.width, height: active.height };
       }
-      // `underline` → a thin bar pinned to the active tab's marker edge.
+      // `line` → a thin bar pinned to the active tab's marker edge.
       if (orientation === "vertical") {
         return placement === "end"
           ? // tabs on the right; marker on their left edge
@@ -128,8 +126,8 @@ export const TabsRoot = ({
           zIndex={0}
           opacity={0}
           pointerEvents="none"
-          background={isUnderline ? "primary.9" : "colorPalette.3"}
-          borderRadius={isUnderline ? "0" : isPill ? "full" : "200"}
+          background={isLine ? "primary.9" : "colorPalette.3"}
+          borderRadius={isLine ? "0" : isPill ? "full" : "200"}
           transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
           css={{
             "@media (prefers-reduced-motion: reduce)": {

--- a/packages/nimbus/src/components/tabs/components/tabs.root.tsx
+++ b/packages/nimbus/src/components/tabs/components/tabs.root.tsx
@@ -3,9 +3,8 @@ import {
   useChakraContext,
   useSlotRecipe,
 } from "@chakra-ui/react/styled-system";
-import { Box } from "@chakra-ui/react/box";
 import { Tabs as RATabs } from "react-aria-components";
-import { TabsRootSlot } from "../tabs.slots";
+import { TabsRootSlot, TabsIndicatorSlot } from "../tabs.slots";
 import type { TabsProps } from "../tabs.types";
 import { TabsList } from "./tabs.list";
 import { TabsPanels } from "./tabs.panels";
@@ -31,14 +30,8 @@ function resolveVariantAlias<T>(variant: T): T {
 /**
  * # Tabs
  *
- * A tabs component built on React Aria Components that allows users to switch between different views.
- *
- * The active marker is a single indicator that slides between tabs as the
- * selection changes — a bar for `line`, a filled highlight for
- * `rounded`/`pill`. It is `aria-hidden` and non-focusable, rendered inside the
- * root and positioned with `useSlidingIndicator`; the static selected marker is
- * the SSR/no-JS fallback (suppressed by the recipe once the hook activates), and
- * the slide respects `prefers-reduced-motion`.
+ * A tabs component built on React Aria Components that allows users to switch
+ * between different views.
  *
  * @supportsStyleProps
  */
@@ -73,10 +66,14 @@ export const TabsRoot = ({
   const placement = sysCtx.normalizeValue(recipeProps.placement) ?? "start";
 
   const isLine = variant === "line";
-  const isPill = variant === "pill";
 
   const indicatorRef = useRef<HTMLDivElement>(null);
 
+  // Drive the sliding active-tab marker: an `aria-hidden`, non-focusable element
+  // rendered inside the root and DOM-positioned over the selected tab (a bar for
+  // `line`, a filled highlight for `rounded`/`pill`). The recipe's static
+  // selected marker is the SSR/no-JS fallback, suppressed via `data-animated`
+  // once this hook activates; the slide respects `prefers-reduced-motion`.
   useSlidingIndicator({
     enabled: true,
     indicatorRef,
@@ -117,24 +114,7 @@ export const TabsRoot = ({
   return (
     <TabsRootSlot asChild {...recipeProps} {...styleProps}>
       <RATabs {...functionalProps} orientation={normalizedOrientation}>
-        <Box
-          ref={indicatorRef}
-          aria-hidden="true"
-          position="absolute"
-          top="0"
-          left="0"
-          zIndex={0}
-          opacity={0}
-          pointerEvents="none"
-          background={isLine ? "primary.9" : "colorPalette.3"}
-          borderRadius={isLine ? "0" : isPill ? "full" : "200"}
-          transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
-          css={{
-            "@media (prefers-reduced-motion: reduce)": {
-              transition: "none",
-            },
-          }}
-        />
+        <TabsIndicatorSlot ref={indicatorRef} aria-hidden="true" />
         {children || (
           <>
             <TabsList tabs={tabs} aria-label={tabListAriaLabel} />

--- a/packages/nimbus/src/components/tabs/components/tabs.root.tsx
+++ b/packages/nimbus/src/components/tabs/components/tabs.root.tsx
@@ -13,19 +13,33 @@ import { extractStyleProps } from "@/utils";
 import { useSlidingIndicator } from "@/hooks";
 import type { SlidingIndicatorRects } from "@/hooks";
 
-/** Thickness of the sliding underline bar for the `line` variant. */
+/** Thickness of the sliding underline bar for the `underline` variant. */
 const INDICATOR_BAR_PX = 2;
+
+/** Deprecated variant aliases → their replacement. */
+const VARIANT_ALIASES: Record<string, string> = {
+  line: "underline",
+  pills: "pill",
+};
+
+/** Resolve a deprecated string variant alias to its replacement (else pass through). */
+function resolveVariantAlias<T>(variant: T): T {
+  return typeof variant === "string" && VARIANT_ALIASES[variant]
+    ? (VARIANT_ALIASES[variant] as T)
+    : variant;
+}
 
 /**
  * # Tabs
  *
  * A tabs component built on React Aria Components that allows users to switch between different views.
  *
- * When `animated` is set, a single decorative indicator slides between tabs as
- * the selected tab changes (see `tabs.types.ts`). It is `aria-hidden` and
- * non-focusable, rendered inside the root and positioned with
- * `useSlidingIndicator`; the static selected marker is suppressed by the recipe
- * while animated, and the slide respects `prefers-reduced-motion`.
+ * The active marker is a single indicator that slides between tabs as the
+ * selection changes — an underline bar for `underline`, a filled highlight for
+ * `rounded`/`pill`. It is `aria-hidden` and non-focusable, rendered inside the
+ * root and positioned with `useSlidingIndicator`; the static selected marker is
+ * the SSR/no-JS fallback (suppressed by the recipe once the hook activates), and
+ * the slide respects `prefers-reduced-motion`.
  *
  * @supportsStyleProps
  */
@@ -33,13 +47,17 @@ export const TabsRoot = ({
   children,
   tabs,
   tabListAriaLabel,
-  animated,
   ...props
 }: TabsProps) => {
   const sysCtx = useChakraContext();
-  // Standard pattern: Split recipe variants
+  // Standard pattern: Split recipe variants. Resolve deprecated variant aliases
+  // (`line` → `underline`, `pills` → `pill`) up front so the recipe only ever
+  // sees real variant keys.
   const recipe = useSlotRecipe({ key: "nimbusTabs" });
-  const [recipeProps, restRecipeProps] = recipe.splitVariantProps(props);
+  const [recipeProps, restRecipeProps] = recipe.splitVariantProps({
+    ...props,
+    variant: resolveVariantAlias(props.variant),
+  } as Parameters<typeof recipe.splitVariantProps>[0]);
 
   // Standard pattern: Extract style props
   const [styleProps, functionalProps] = extractStyleProps(restRecipeProps);
@@ -50,19 +68,19 @@ export const TabsRoot = ({
   // `useBreakpointValue` to ensure a concrete value is passed.
   const normalizedOrientation = sysCtx.normalizeValue(recipeProps.orientation);
 
-  // The animated indicator's geometry depends on the *resolved* variant,
-  // orientation, and placement (responsive values are normalized the same way).
-  const variant = sysCtx.normalizeValue(recipeProps.variant) ?? "line";
+  // The indicator geometry depends on the *resolved* variant, orientation, and
+  // placement (responsive values are normalized the same way).
+  const variant = sysCtx.normalizeValue(recipeProps.variant) ?? "underline";
   const orientation = normalizedOrientation ?? "horizontal";
   const placement = sysCtx.normalizeValue(recipeProps.placement) ?? "start";
 
-  const showIndicator = animated === true;
-  const isFill = variant === "pills";
+  const isUnderline = variant === "underline";
+  const isPill = variant === "pill";
 
   const indicatorRef = useRef<HTMLDivElement>(null);
 
   useSlidingIndicator({
-    enabled: showIndicator,
+    enabled: true,
     indicatorRef,
     activeSelector: '[role="tab"][aria-selected="true"]',
     watchAttributes: ["aria-selected", "data-selected"],
@@ -71,11 +89,11 @@ export const TabsRoot = ({
     getGeometry: ({ container, active }: SlidingIndicatorRects) => {
       const x = active.left - container.left;
       const y = active.top - container.top;
-      // `pills` → full-box filled highlight.
-      if (isFill) {
+      // `rounded` / `pill` → full-box filled highlight.
+      if (!isUnderline) {
         return { x, y, width: active.width, height: active.height };
       }
-      // `line` → a thin bar pinned to the active tab's marker edge.
+      // `underline` → a thin bar pinned to the active tab's marker edge.
       if (orientation === "vertical") {
         return placement === "end"
           ? // tabs on the right; marker on their left edge
@@ -99,34 +117,26 @@ export const TabsRoot = ({
   });
 
   return (
-    <TabsRootSlot
-      asChild
-      {...recipeProps}
-      {...styleProps}
-      position={showIndicator ? "relative" : undefined}
-      data-animated={showIndicator ? "true" : undefined}
-    >
+    <TabsRootSlot asChild {...recipeProps} {...styleProps}>
       <RATabs {...functionalProps} orientation={normalizedOrientation}>
-        {showIndicator && (
-          <Box
-            ref={indicatorRef}
-            aria-hidden="true"
-            position="absolute"
-            top="0"
-            left="0"
-            zIndex={0}
-            opacity={0}
-            pointerEvents="none"
-            background={isFill ? "primary.3" : "primary.9"}
-            borderRadius={isFill ? "full" : "0"}
-            transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
-            css={{
-              "@media (prefers-reduced-motion: reduce)": {
-                transition: "none",
-              },
-            }}
-          />
-        )}
+        <Box
+          ref={indicatorRef}
+          aria-hidden="true"
+          position="absolute"
+          top="0"
+          left="0"
+          zIndex={0}
+          opacity={0}
+          pointerEvents="none"
+          background={isUnderline ? "primary.9" : "colorPalette.3"}
+          borderRadius={isUnderline ? "0" : isPill ? "full" : "200"}
+          transition="transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease"
+          css={{
+            "@media (prefers-reduced-motion: reduce)": {
+              transition: "none",
+            },
+          }}
+        />
         {children || (
           <>
             <TabsList tabs={tabs} aria-label={tabListAriaLabel} />

--- a/packages/nimbus/src/components/tabs/components/tabs.root.tsx
+++ b/packages/nimbus/src/components/tabs/components/tabs.root.tsx
@@ -8,7 +8,7 @@ import { TabsRootSlot, TabsIndicatorSlot } from "../tabs.slots";
 import type { TabsProps } from "../tabs.types";
 import { TabsList } from "./tabs.list";
 import { TabsPanels } from "./tabs.panels";
-import { extractStyleProps } from "@/utils";
+import { extractStyleProps, resolveVariantAlias } from "@/utils";
 import { useSlidingIndicator } from "@/hooks";
 import type { SlidingIndicatorRects } from "@/hooks";
 
@@ -19,13 +19,6 @@ const INDICATOR_BAR_PX = 2;
 const VARIANT_ALIASES: Record<string, string> = {
   pills: "pill",
 };
-
-/** Resolve a deprecated string variant alias to its replacement (else pass through). */
-function resolveVariantAlias<T>(variant: T): T {
-  return typeof variant === "string" && VARIANT_ALIASES[variant]
-    ? (VARIANT_ALIASES[variant] as T)
-    : variant;
-}
 
 /**
  * # Tabs
@@ -47,7 +40,7 @@ export const TabsRoot = ({
   const recipe = useSlotRecipe({ key: "nimbusTabs" });
   const [recipeProps, restRecipeProps] = recipe.splitVariantProps({
     ...props,
-    variant: resolveVariantAlias(props.variant),
+    variant: resolveVariantAlias(props.variant, VARIANT_ALIASES),
   } as Parameters<typeof recipe.splitVariantProps>[0]);
 
   // Standard pattern: Extract style props
@@ -75,6 +68,9 @@ export const TabsRoot = ({
   // selected marker is the SSR/no-JS fallback, suppressed via `data-animated`
   // once this hook activates; the slide respects `prefers-reduced-motion`.
   useSlidingIndicator({
+    // Always on: the slide is a fixed design decision with no per-instance
+    // toggle. `enabled` exists for the generic hook (so a future caller could
+    // opt out), not as a Tabs prop — don't go looking for a switch here.
     enabled: true,
     indicatorRef,
     activeSelector: '[role="tab"][aria-selected="true"]',

--- a/packages/nimbus/src/components/tabs/tabs.dev.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.dev.mdx
@@ -109,11 +109,11 @@ const App = () => {
 ### Visual variants
 
 The Tabs component offers three visual styles (the same set as `TabNav`):
-- **underline** (default) - an underline strip beneath the active tab
+- **line** (default) - a bar marking the active tab (an underline when horizontal, an inner side bar when vertical)
 - **rounded** - a soft rounded-rect highlight behind the active tab
 - **pill** - a fully-rounded capsule highlight behind the active tab
 
-The `rounded` and `pill` highlights are themeable via `colorPalette` (defaulting to `primary`). The legacy `line` (→ `underline`) and `pills` (→ `pill`) names are accepted as deprecated aliases.
+The `rounded` and `pill` highlights are themeable via `colorPalette` (defaulting to `primary`). The legacy `pills` (→ `pill`) name is accepted as a deprecated alias.
 
 ```jsx live-dev
 const App = () => {
@@ -126,8 +126,8 @@ const App = () => {
   return (
     <Stack direction="column" gap="600">
       <Stack direction="column" gap="200">
-        <Text fontWeight="500">Underline variant (default)</Text>
-        <Tabs.Root variant="underline" tabs={tabs} />
+        <Text fontWeight="500">Line variant (default)</Text>
+        <Tabs.Root variant="line" tabs={tabs} />
       </Stack>
 
       <Stack direction="column" gap="200">
@@ -149,8 +149,8 @@ const App = () => {
 The active marker always slides between tabs as the selection changes, instead
 of snapping — no prop required. The indicator adapts to the resolved variant,
 orientation, and placement: a thin bar on the active tab's bottom edge
-(horizontal `underline`), its right or left edge (vertical `underline`, per
-`placement`), or a filled highlight (`rounded` / `pill`).
+(horizontal `line`), its inner side edge (vertical `line`, per `placement`), or a
+filled highlight (`rounded` / `pill`).
 
 The indicator is decorative (`aria-hidden`, non-focusable), so `aria-selected`,
 focus rings, and keyboard navigation are unchanged. The slide is automatically

--- a/packages/nimbus/src/components/tabs/tabs.dev.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.dev.mdx
@@ -108,9 +108,12 @@ const App = () => {
 
 ### Visual variants
 
-The Tabs component offers two visual styles:
-- **line** (default) - Tabs with an underline indicator
-- **pills** - Tabs with a pill-shaped background when active
+The Tabs component offers three visual styles (the same set as `TabNav`):
+- **underline** (default) - an underline strip beneath the active tab
+- **rounded** - a soft rounded-rect highlight behind the active tab
+- **pill** - a fully-rounded capsule highlight behind the active tab
+
+The `rounded` and `pill` highlights are themeable via `colorPalette` (defaulting to `primary`). The legacy `line` (→ `underline`) and `pills` (→ `pill`) names are accepted as deprecated aliases.
 
 ```jsx live-dev
 const App = () => {
@@ -123,13 +126,18 @@ const App = () => {
   return (
     <Stack direction="column" gap="600">
       <Stack direction="column" gap="200">
-        <Text fontWeight="500">Line variant (default)</Text>
-        <Tabs.Root variant="line" tabs={tabs} />
+        <Text fontWeight="500">Underline variant (default)</Text>
+        <Tabs.Root variant="underline" tabs={tabs} />
       </Stack>
 
       <Stack direction="column" gap="200">
-        <Text fontWeight="500">Pills variant</Text>
-        <Tabs.Root variant="pills" tabs={tabs} />
+        <Text fontWeight="500">Rounded variant</Text>
+        <Tabs.Root variant="rounded" tabs={tabs} />
+      </Stack>
+
+      <Stack direction="column" gap="200">
+        <Text fontWeight="500">Pill variant</Text>
+        <Tabs.Root variant="pill" tabs={tabs} />
       </Stack>
     </Stack>
   );
@@ -138,40 +146,17 @@ const App = () => {
 
 ### Animated indicator
 
-Pass `animated` to slide a single active marker between tabs as the selection
-changes, instead of snapping. The indicator adapts to the resolved variant,
+The active marker always slides between tabs as the selection changes, instead
+of snapping — no prop required. The indicator adapts to the resolved variant,
 orientation, and placement: a thin bar on the active tab's bottom edge
-(horizontal `line`), its right or left edge (vertical `line`, per `placement`),
-or a filled, fully-rounded highlight (`pills`).
+(horizontal `underline`), its right or left edge (vertical `underline`, per
+`placement`), or a filled highlight (`rounded` / `pill`).
 
 The indicator is decorative (`aria-hidden`, non-focusable), so `aria-selected`,
 focus rings, and keyboard navigation are unchanged. The slide is automatically
 disabled under `prefers-reduced-motion: reduce` — the marker snaps into place.
-`animated` defaults to `false`.
-
-```jsx live-dev
-const App = () => {
-  const tabs = [
-    { id: '1', tabLabel: 'Dashboard', panelContent: 'Dashboard view' },
-    { id: '2', tabLabel: 'Analytics', panelContent: 'Analytics view' },
-    { id: '3', tabLabel: 'Reports', panelContent: 'Reports view' },
-  ];
-
-  return (
-    <Stack direction="column" gap="600">
-      <Stack direction="column" gap="200">
-        <Text fontWeight="500">Line variant, animated</Text>
-        <Tabs.Root variant="line" animated tabs={tabs} />
-      </Stack>
-
-      <Stack direction="column" gap="200">
-        <Text fontWeight="500">Pills variant, animated</Text>
-        <Tabs.Root variant="pills" animated tabs={tabs} />
-      </Stack>
-    </Stack>
-  );
-};
-```
+(There is no per-instance opt-out; disabling is a global, OS-level
+reduced-motion concern.)
 
 ### Orientation
 
@@ -393,7 +378,7 @@ Use the compound API for more control over tab and panel rendering, including cu
 ```jsx live-dev
 const App = () => {
   return (
-    <Tabs.Root variant="pills">
+    <Tabs.Root variant="pill">
       <Tabs.List>
         <Tabs.Tab id="overview">
           <Icons.Home />
@@ -681,7 +666,7 @@ Combine icons with text labels for more expressive tabs.
 ```jsx live-dev
 const App = () => {
   return (
-    <Tabs.Root variant="pills" size="lg">
+    <Tabs.Root variant="pill" size="lg">
       <Tabs.List>
         <Tabs.Tab id="dashboard">
           <Icons.Dashboard />

--- a/packages/nimbus/src/components/tabs/tabs.dev.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.dev.mdx
@@ -136,6 +136,43 @@ const App = () => {
 };
 ```
 
+### Animated indicator
+
+Pass `animated` to slide a single active marker between tabs as the selection
+changes, instead of snapping. The indicator adapts to the resolved variant,
+orientation, and placement: a thin bar on the active tab's bottom edge
+(horizontal `line`), its right or left edge (vertical `line`, per `placement`),
+or a filled, fully-rounded highlight (`pills`).
+
+The indicator is decorative (`aria-hidden`, non-focusable), so `aria-selected`,
+focus rings, and keyboard navigation are unchanged. The slide is automatically
+disabled under `prefers-reduced-motion: reduce` — the marker snaps into place.
+`animated` defaults to `false`.
+
+```jsx live-dev
+const App = () => {
+  const tabs = [
+    { id: '1', tabLabel: 'Dashboard', panelContent: 'Dashboard view' },
+    { id: '2', tabLabel: 'Analytics', panelContent: 'Analytics view' },
+    { id: '3', tabLabel: 'Reports', panelContent: 'Reports view' },
+  ];
+
+  return (
+    <Stack direction="column" gap="600">
+      <Stack direction="column" gap="200">
+        <Text fontWeight="500">Line variant, animated</Text>
+        <Tabs.Root variant="line" animated tabs={tabs} />
+      </Stack>
+
+      <Stack direction="column" gap="200">
+        <Text fontWeight="500">Pills variant, animated</Text>
+        <Tabs.Root variant="pills" animated tabs={tabs} />
+      </Stack>
+    </Stack>
+  );
+};
+```
+
 ### Orientation
 
 Tabs can be displayed horizontally or vertically using the `orientation` prop.

--- a/packages/nimbus/src/components/tabs/tabs.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.mdx
@@ -193,13 +193,13 @@ const App = () => (
 
 ### Variants
 
-Tabs ships with three visual variants (the same set as `TabNav`): `underline`
+Tabs ships with three visual variants (the same set as `TabNav`): `line`
 (default), `rounded`, and `pill`. The active marker always slides between tabs as
 the selection changes, rather than snapping — a thin bar on the active tab's edge
-for `underline`, or a filled highlight for `rounded`/`pill`. The slide is
-decorative (it does not affect selection, focus, or keyboard behavior) and
-automatically respects the user's reduced-motion preference (snapping instead of
-sliding).
+for `line` (an underline when horizontal, an inner side bar when vertical), or a
+filled highlight for `rounded`/`pill`. The slide is decorative (it does not
+affect selection, focus, or keyboard behavior) and automatically respects the
+user's reduced-motion preference (snapping instead of sliding).
 
 ```jsx live
 const App = () => {
@@ -212,8 +212,8 @@ const App = () => {
   return (
     <Stack direction="column" gap="800">
       <Stack direction="column" gap="200">
-        <Text fontWeight="bold">Underline</Text>
-        <Tabs.Root variant="underline" tabs={tabs} />
+        <Text fontWeight="bold">Line</Text>
+        <Tabs.Root variant="line" tabs={tabs} />
       </Stack>
       <Stack direction="column" gap="200">
         <Text fontWeight="bold">Rounded</Text>

--- a/packages/nimbus/src/components/tabs/tabs.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.mdx
@@ -191,14 +191,15 @@ const App = () => (
 )
 ```
 
-### Animated indicator
+### Variants
 
-Set `animated` to slide a single active marker between tabs as the selection
-changes, rather than snapping it. The indicator adapts to the variant,
-orientation, and placement — a thin bar on the active tab's edge for the `line`
-variant, or a filled highlight for `pills`. It is decorative and does not affect
-selection, focus, or keyboard behavior, and it automatically respects the user's
-reduced-motion preference (snapping instead of sliding).
+Tabs ships with three visual variants (the same set as `TabNav`): `underline`
+(default), `rounded`, and `pill`. The active marker always slides between tabs as
+the selection changes, rather than snapping — a thin bar on the active tab's edge
+for `underline`, or a filled highlight for `rounded`/`pill`. The slide is
+decorative (it does not affect selection, focus, or keyboard behavior) and
+automatically respects the user's reduced-motion preference (snapping instead of
+sliding).
 
 ```jsx live
 const App = () => {
@@ -211,12 +212,16 @@ const App = () => {
   return (
     <Stack direction="column" gap="800">
       <Stack direction="column" gap="200">
-        <Text fontWeight="bold">Line</Text>
-        <Tabs.Root variant="line" animated tabs={tabs} />
+        <Text fontWeight="bold">Underline</Text>
+        <Tabs.Root variant="underline" tabs={tabs} />
       </Stack>
       <Stack direction="column" gap="200">
-        <Text fontWeight="bold">Pills</Text>
-        <Tabs.Root variant="pills" animated tabs={tabs} />
+        <Text fontWeight="bold">Rounded</Text>
+        <Tabs.Root variant="rounded" tabs={tabs} />
+      </Stack>
+      <Stack direction="column" gap="200">
+        <Text fontWeight="bold">Pill</Text>
+        <Tabs.Root variant="pill" tabs={tabs} />
       </Stack>
     </Stack>
   )

--- a/packages/nimbus/src/components/tabs/tabs.mdx
+++ b/packages/nimbus/src/components/tabs/tabs.mdx
@@ -190,3 +190,35 @@ const App = () => (
   </Stack>
 )
 ```
+
+### Animated indicator
+
+Set `animated` to slide a single active marker between tabs as the selection
+changes, rather than snapping it. The indicator adapts to the variant,
+orientation, and placement — a thin bar on the active tab's edge for the `line`
+variant, or a filled highlight for `pills`. It is decorative and does not affect
+selection, focus, or keyboard behavior, and it automatically respects the user's
+reduced-motion preference (snapping instead of sliding).
+
+```jsx live
+const App = () => {
+  const tabs = [
+    { id: 'home', tabLabel: 'Home', panelContent: 'Home content' },
+    { id: 'about', tabLabel: 'About', panelContent: 'About content' },
+    { id: 'contact', tabLabel: 'Contact', panelContent: 'Contact content' },
+  ];
+
+  return (
+    <Stack direction="column" gap="800">
+      <Stack direction="column" gap="200">
+        <Text fontWeight="bold">Line</Text>
+        <Tabs.Root variant="line" animated tabs={tabs} />
+      </Stack>
+      <Stack direction="column" gap="200">
+        <Text fontWeight="bold">Pills</Text>
+        <Tabs.Root variant="pills" animated tabs={tabs} />
+      </Stack>
+    </Stack>
+  )
+}
+```

--- a/packages/nimbus/src/components/tabs/tabs.recipe.ts
+++ b/packages/nimbus/src/components/tabs/tabs.recipe.ts
@@ -72,12 +72,34 @@ export const tabsSlotRecipe = defineSlotRecipe({
 
   variants: {
     variant: {
-      line: {},
+      line: {
+        tab: {
+          // Animated: keep the label above the indicator, and let the sliding
+          // bar own the active marker (suppress the static underline, all
+          // orientations).
+          '[data-animated="true"] &': {
+            position: "relative",
+            zIndex: "1",
+          },
+          '[data-animated="true"] &[data-selected]': {
+            boxShadow: "none",
+          },
+        },
+      },
       pills: {
         tab: {
           borderRadius: "full",
           _selected: {
             backgroundColor: "primary.3",
+          },
+          // Animated: keep the label above the indicator, and let the sliding
+          // filled highlight own the background.
+          '[data-animated="true"] &': {
+            position: "relative",
+            zIndex: "1",
+          },
+          '[data-animated="true"] &[data-selected]': {
+            backgroundColor: "transparent",
           },
         },
       },

--- a/packages/nimbus/src/components/tabs/tabs.recipe.ts
+++ b/packages/nimbus/src/components/tabs/tabs.recipe.ts
@@ -43,7 +43,7 @@ const highlightTabBase = {
 } as const;
 
 export const tabsSlotRecipe = defineSlotRecipe({
-  slots: ["root", "list", "tab", "panels", "panel", "trigger"],
+  slots: ["root", "list", "tab", "panels", "panel", "indicator"],
 
   className: "nimbus-tabs",
 
@@ -53,6 +53,23 @@ export const tabsSlotRecipe = defineSlotRecipe({
       width: "100%",
       // Anchors the absolutely-positioned sliding indicator (all variants).
       position: "relative",
+    },
+    // The sliding active marker. The hook (`useSlidingIndicator`) owns the
+    // dynamic geometry — it writes `opacity`, `width`, `height`, and `transform`
+    // inline — so the recipe only defines the static frame and the slide
+    // transition. `background`/`borderRadius` are variant-driven (see below).
+    indicator: {
+      position: "absolute",
+      top: "0",
+      left: "0",
+      zIndex: "0",
+      opacity: "0",
+      pointerEvents: "none",
+      transition:
+        "transform 180ms ease, width 180ms ease, height 180ms ease, opacity 120ms ease",
+      "@media (prefers-reduced-motion: reduce)": {
+        transition: "none",
+      },
     },
     list: {
       display: "flex",
@@ -108,6 +125,11 @@ export const tabsSlotRecipe = defineSlotRecipe({
       // inner side bar when vertical. The per-orientation/placement marker edges
       // live in `compoundVariants` below.
       line: {
+        // A thin bar pinned to the active tab's marker edge.
+        indicator: {
+          background: "primary.9",
+          borderRadius: "0",
+        },
         tab: {
           // Animated: keep the label above the indicator, and let the sliding
           // bar own the active marker (suppress the static bar, all
@@ -127,6 +149,11 @@ export const tabsSlotRecipe = defineSlotRecipe({
         root: {
           colorPalette: "primary",
         },
+        // Full-box filled highlight behind the active tab.
+        indicator: {
+          background: "colorPalette.3",
+          borderRadius: "200",
+        },
         list: {
           gap: "100",
         },
@@ -137,6 +164,11 @@ export const tabsSlotRecipe = defineSlotRecipe({
       pill: {
         root: {
           colorPalette: "primary",
+        },
+        // Fully-rounded capsule highlight behind the active tab.
+        indicator: {
+          background: "colorPalette.3",
+          borderRadius: "full",
         },
         list: {
           gap: "100",

--- a/packages/nimbus/src/components/tabs/tabs.recipe.ts
+++ b/packages/nimbus/src/components/tabs/tabs.recipe.ts
@@ -7,11 +7,11 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * ⚠️  VISUAL TWIN — KEEP IN SYNC WITH `tab-nav.recipe.ts`
  * Tabs and TabNav are intentionally separate components with separate recipes
  * (different semantics: content-panel widget vs. navigation links). They do NOT
- * share a recipe. However, they expose the SAME three variants — `underline`,
+ * share a recipe. However, they expose the SAME three variants — `line`,
  * `rounded`, and `pill` — designed to look identical between the two. If you
  * change colors, spacing, typography, transitions, or focus styles for any of
  * these variants in one, apply the equivalent change to the other. (Tabs
- * additionally layers `orientation`/`placement` onto `underline`.)
+ * additionally layers `orientation`/`placement` onto `line`.)
  */
 
 /**
@@ -104,12 +104,13 @@ export const tabsSlotRecipe = defineSlotRecipe({
 
   variants: {
     variant: {
-      // Underline strip beneath the active tab. The per-orientation/placement
-      // marker edges live in `compoundVariants` below.
-      underline: {
+      // A thin bar marking the active tab — an underline when horizontal, an
+      // inner side bar when vertical. The per-orientation/placement marker edges
+      // live in `compoundVariants` below.
+      line: {
         tab: {
           // Animated: keep the label above the indicator, and let the sliding
-          // bar own the active marker (suppress the static underline, all
+          // bar own the active marker (suppress the static bar, all
           // orientations).
           '[data-animated="true"] &': {
             position: "relative",
@@ -203,10 +204,10 @@ export const tabsSlotRecipe = defineSlotRecipe({
 
   // Compound variants for different variant/orientation/placement combinations
   compoundVariants: [
-    // ==================== UNDERLINE VARIANT ====================
-    // Underline + Horizontal
+    // ==================== LINE VARIANT ====================
+    // Line + Horizontal (bar on the bottom edge)
     {
-      variant: "underline",
+      variant: "line",
       orientation: "horizontal",
       css: {
         list: {
@@ -220,9 +221,9 @@ export const tabsSlotRecipe = defineSlotRecipe({
         },
       },
     },
-    // Underline + Vertical + Start (tabs on left, border on right between tabs and content)
+    // Line + Vertical + Start (tabs on left, border on right between tabs and content)
     {
-      variant: "underline",
+      variant: "line",
       orientation: "vertical",
       placement: "start",
       css: {
@@ -237,9 +238,9 @@ export const tabsSlotRecipe = defineSlotRecipe({
         },
       },
     },
-    // Underline + Vertical + End (tabs on right, border on left between tabs and content)
+    // Line + Vertical + End (tabs on right, border on left between tabs and content)
     {
-      variant: "underline",
+      variant: "line",
       orientation: "vertical",
       placement: "end",
       css: {
@@ -289,7 +290,7 @@ export const tabsSlotRecipe = defineSlotRecipe({
   ],
 
   defaultVariants: {
-    variant: "underline",
+    variant: "line",
     orientation: "horizontal",
     placement: "start",
     size: "md",

--- a/packages/nimbus/src/components/tabs/tabs.recipe.ts
+++ b/packages/nimbus/src/components/tabs/tabs.recipe.ts
@@ -7,11 +7,41 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * ⚠️  VISUAL TWIN — KEEP IN SYNC WITH `tab-nav.recipe.ts`
  * Tabs and TabNav are intentionally separate components with separate recipes
  * (different semantics: content-panel widget vs. navigation links). They do NOT
- * share a recipe. However, the `line` horizontal variant of Tabs is designed to
- * be visually identical to the `tabs` variant of TabNav. If you change colors,
- * spacing, typography, transitions, or focus styles in one, apply the equivalent
- * change to the other.
+ * share a recipe. However, they expose the SAME three variants — `underline`,
+ * `rounded`, and `pill` — designed to look identical between the two. If you
+ * change colors, spacing, typography, transitions, or focus styles for any of
+ * these variants in one, apply the equivalent change to the other. (Tabs
+ * additionally layers `orientation`/`placement` onto `underline`.)
  */
+
+/**
+ * Shared `tab`-slot styles for the `rounded` and `pill` variants — the mirror of
+ * `highlightItemBase` in `tab-nav.recipe.ts`. A neutral resting state, a hover
+ * color shift, and a themeable active highlight driven by `colorPalette`
+ * (defaulting to `primary` via the root slot). `position: relative` + `zIndex`
+ * keep the label above the sliding indicator; once the indicator is active
+ * (`[data-animated="true"]`, set by the hook on mount) it owns the highlight, so
+ * the static selected background is suppressed to avoid a double highlight.
+ */
+const highlightTabBase = {
+  color: "neutral.11",
+  borderRadius: "200",
+  _hover: {
+    color: "colorPalette.11",
+  },
+  _selected: {
+    color: "colorPalette.11",
+    background: "colorPalette.3",
+  },
+  '[data-animated="true"] &': {
+    position: "relative",
+    zIndex: "1",
+  },
+  '[data-animated="true"] &[data-selected]': {
+    background: "transparent",
+  },
+} as const;
+
 export const tabsSlotRecipe = defineSlotRecipe({
   slots: ["root", "list", "tab", "panels", "panel", "trigger"],
 
@@ -21,6 +51,8 @@ export const tabsSlotRecipe = defineSlotRecipe({
     root: {
       display: "flex",
       width: "100%",
+      // Anchors the absolutely-positioned sliding indicator (all variants).
+      position: "relative",
     },
     list: {
       display: "flex",
@@ -72,7 +104,9 @@ export const tabsSlotRecipe = defineSlotRecipe({
 
   variants: {
     variant: {
-      line: {
+      // Underline strip beneath the active tab. The per-orientation/placement
+      // marker edges live in `compoundVariants` below.
+      underline: {
         tab: {
           // Animated: keep the label above the indicator, and let the sliding
           // bar own the active marker (suppress the static underline, all
@@ -86,21 +120,31 @@ export const tabsSlotRecipe = defineSlotRecipe({
           },
         },
       },
-      pills: {
+      // Soft rounded-rect highlight behind the active tab. No baseline; small
+      // gap between tabs.
+      rounded: {
+        root: {
+          colorPalette: "primary",
+        },
+        list: {
+          gap: "100",
+        },
+        tab: highlightTabBase,
+      },
+      // Same idea as `rounded`, but a fully-rounded capsule highlight and a touch
+      // more horizontal padding so it reads as a pill.
+      pill: {
+        root: {
+          colorPalette: "primary",
+        },
+        list: {
+          gap: "100",
+        },
         tab: {
+          ...highlightTabBase,
           borderRadius: "full",
-          _selected: {
-            backgroundColor: "primary.3",
-          },
-          // Animated: keep the label above the indicator, and let the sliding
-          // filled highlight own the background.
-          '[data-animated="true"] &': {
-            position: "relative",
-            zIndex: "1",
-          },
-          '[data-animated="true"] &[data-selected]': {
-            backgroundColor: "transparent",
-          },
+          paddingLeft: "calc(var(--tabs-padding-left) + {spacing.100})",
+          paddingRight: "calc(var(--tabs-padding-right) + {spacing.100})",
         },
       },
     },
@@ -159,10 +203,10 @@ export const tabsSlotRecipe = defineSlotRecipe({
 
   // Compound variants for different variant/orientation/placement combinations
   compoundVariants: [
-    // ==================== LINE VARIANT ====================
-    // Line + Horizontal
+    // ==================== UNDERLINE VARIANT ====================
+    // Underline + Horizontal
     {
-      variant: "line",
+      variant: "underline",
       orientation: "horizontal",
       css: {
         list: {
@@ -176,9 +220,9 @@ export const tabsSlotRecipe = defineSlotRecipe({
         },
       },
     },
-    // Line + Vertical + Start (tabs on left, border on right between tabs and content)
+    // Underline + Vertical + Start (tabs on left, border on right between tabs and content)
     {
-      variant: "line",
+      variant: "underline",
       orientation: "vertical",
       placement: "start",
       css: {
@@ -193,9 +237,9 @@ export const tabsSlotRecipe = defineSlotRecipe({
         },
       },
     },
-    // Line + Vertical + End (tabs on right, border on left between tabs and content)
+    // Underline + Vertical + End (tabs on right, border on left between tabs and content)
     {
-      variant: "line",
+      variant: "underline",
       orientation: "vertical",
       placement: "end",
       css: {
@@ -212,7 +256,7 @@ export const tabsSlotRecipe = defineSlotRecipe({
     },
 
     // ==================== PLACEMENT-ONLY VARIANTS ====================
-    // Vertical + End (applies to all variants including pills)
+    // Vertical + End (applies to all variants)
     {
       orientation: "vertical",
       placement: "end",
@@ -242,38 +286,10 @@ export const tabsSlotRecipe = defineSlotRecipe({
         },
       },
     },
-
-    // ==================== PILLS VARIANT ====================
-    // Pills + Horizontal
-    {
-      variant: "pills",
-      orientation: "horizontal",
-      css: {
-        list: {
-          gap: "200",
-          boxShadow: "0 0 0 {sizes.25} {colors.neutral.6}",
-          borderRadius: "full",
-          padding: "100",
-        },
-      },
-    },
-    // Pills + Vertical
-    {
-      variant: "pills",
-      orientation: "vertical",
-      css: {
-        list: {
-          gap: "200",
-          boxShadow: "0 0 0 {sizes.25} {colors.neutral.6}",
-          borderRadius: "400",
-          padding: "100",
-        },
-      },
-    },
   ],
 
   defaultVariants: {
-    variant: "line",
+    variant: "underline",
     orientation: "horizontal",
     placement: "start",
     size: "md",

--- a/packages/nimbus/src/components/tabs/tabs.slots.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.slots.tsx
@@ -6,6 +6,7 @@ import type {
   TabsTabSlotProps,
   TabsPanelsSlotProps,
   TabsPanelSlotProps,
+  TabsIndicatorSlotProps,
 } from "./tabs.types";
 
 const { withProvider, withContext } = createSlotRecipeContext({
@@ -32,3 +33,13 @@ export const TabsPanelsSlot: SlotComponent<
 
 export const TabsPanelSlot: SlotComponent<HTMLDivElement, TabsPanelSlotProps> =
   withContext<HTMLDivElement, TabsPanelSlotProps>("div", "panel");
+
+/**
+ * Internal slot for the sliding active-tab marker. Rendered automatically by
+ * `Tabs.Root` and positioned by `useSlidingIndicator` — not part of the public
+ * compound API.
+ */
+export const TabsIndicatorSlot: SlotComponent<
+  HTMLDivElement,
+  TabsIndicatorSlotProps
+> = withContext<HTMLDivElement, TabsIndicatorSlotProps>("div", "indicator");

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
   Box,
   Button,
@@ -42,6 +42,11 @@ const meta: Meta<typeof Tabs.Root> = {
       control: "select",
       options: ["sm", "md", "lg"],
       description: "Size of the tabs affecting padding and font size",
+    },
+    animated: {
+      control: "boolean",
+      description:
+        "Slide a single indicator between tabs as the selection changes (adapts to variant/orientation/placement). Respects prefers-reduced-motion.",
     },
   },
 };
@@ -1256,6 +1261,171 @@ export const LinkTabs: Story = {
       await userEvent.keyboard("{ArrowRight}");
       const apiTab = canvas.getByRole("tab", { name: "API Reference" });
       await expect(apiTab).toHaveFocus();
+    });
+  },
+};
+
+// ============================================================
+// ANIMATED INDICATOR
+// ============================================================
+
+const animatedTabs = [
+  {
+    id: "overview",
+    tabLabel: "Overview",
+    panelContent: <Content tabLabel="Overview" body="The overview panel." />,
+  },
+  {
+    id: "details",
+    tabLabel: "Details",
+    panelContent: <Content tabLabel="Details" body="The details panel." />,
+  },
+  {
+    id: "history",
+    tabLabel: "History",
+    panelContent: <Content tabLabel="History" body="The history panel." />,
+  },
+];
+
+/** Returns the decorative sliding indicator rendered inside an animated Tabs. */
+const getIndicator = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector<HTMLElement>('[aria-hidden="true"]');
+
+/**
+ * With `animated`, the active marker becomes a single indicator that slides
+ * between tabs as the selection changes instead of snapping. For the `line`
+ * variant (horizontal) it is a thin bar on the active tab's bottom edge.
+ *
+ * The slide is disabled under `prefers-reduced-motion: reduce`, and the
+ * indicator is `aria-hidden` / non-focusable so `aria-selected`, focus, and
+ * keyboard navigation are unaffected.
+ */
+export const Animated: Story = {
+  args: {
+    variant: "line",
+    animated: true,
+    tabs: animatedTabs,
+    tabListAriaLabel: "Animated tabs",
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders a single aria-hidden indicator", async () => {
+      await waitFor(() =>
+        expect(getIndicator(canvasElement)).toBeInTheDocument()
+      );
+      await expect(getIndicator(canvasElement)!).toHaveAttribute(
+        "aria-hidden",
+        "true"
+      );
+    });
+
+    let initialTransform = "";
+    await step("Indicator is positioned over the selected tab", async () => {
+      await waitFor(() => {
+        initialTransform = getIndicator(canvasElement)!.style.transform;
+        expect(initialTransform).not.toBe("");
+      });
+    });
+
+    await step("Selecting another tab slides the indicator", async () => {
+      const detailsTab = canvas.getByRole("tab", { name: "Details" });
+      await userEvent.click(detailsTab);
+      await expect(detailsTab).toHaveAttribute("aria-selected", "true");
+      await waitFor(() => {
+        const next = getIndicator(canvasElement)!.style.transform;
+        expect(next).not.toBe("");
+        expect(next).not.toBe(initialTransform);
+      });
+    });
+
+    await step(
+      "Indicator does not appear in the accessibility tree",
+      async () => {
+        // Only real tabs are exposed; the indicator is decorative.
+        const tabs = canvas.getAllByRole("tab");
+        await expect(tabs).toHaveLength(3);
+      }
+    );
+  },
+};
+
+/**
+ * The animated indicator adapts to a vertical `line` layout: the bar is pinned
+ * to the active tab's inner edge (right edge for `placement="start"`) and slides
+ * vertically between tabs.
+ */
+export const AnimatedVertical: Story = {
+  args: {
+    variant: "line",
+    orientation: "vertical",
+    placement: "start",
+    animated: true,
+    tabs: animatedTabs,
+    tabListAriaLabel: "Animated vertical tabs",
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    let initialTransform = "";
+    await step("Indicator is positioned over the selected tab", async () => {
+      await waitFor(() => {
+        const indicator = getIndicator(canvasElement);
+        expect(indicator).toBeInTheDocument();
+        initialTransform = indicator!.style.transform;
+        expect(initialTransform).not.toBe("");
+      });
+    });
+
+    await step("Selecting another tab slides the indicator", async () => {
+      const historyTab = canvas.getByRole("tab", { name: "History" });
+      await userEvent.click(historyTab);
+      await expect(historyTab).toHaveAttribute("aria-selected", "true");
+      await waitFor(() =>
+        expect(getIndicator(canvasElement)!.style.transform).not.toBe(
+          initialTransform
+        )
+      );
+    });
+  },
+};
+
+/**
+ * For the `pills` variant, the animated indicator is a filled, fully-rounded
+ * highlight that slides behind the active tab.
+ */
+export const AnimatedPills: Story = {
+  args: {
+    variant: "pills",
+    animated: true,
+    tabs: animatedTabs,
+    tabListAriaLabel: "Animated pills tabs",
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    let initialTransform = "";
+    await step(
+      "Filled indicator is positioned over the selected tab",
+      async () => {
+        await waitFor(() => {
+          const indicator = getIndicator(canvasElement);
+          expect(indicator).toBeInTheDocument();
+          initialTransform = indicator!.style.transform;
+          expect(initialTransform).not.toBe("");
+        });
+      }
+    );
+
+    await step("Selecting another tab slides the highlight", async () => {
+      const detailsTab = canvas.getByRole("tab", { name: "Details" });
+      await userEvent.click(detailsTab);
+      await expect(detailsTab).toHaveAttribute("aria-selected", "true");
+      await waitFor(() =>
+        expect(getIndicator(canvasElement)!.style.transform).not.toBe(
+          initialTransform
+        )
+      );
     });
   },
 };

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Tabs.Root> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["underline", "rounded", "pill"],
+      options: ["line", "rounded", "pill"],
       description: "Visual style variant of the tabs",
     },
     orientation: {
@@ -812,27 +812,28 @@ export const Variants: Story = {
 
     return (
       <Stack direction="column" gap="600">
-        {/* Underline Variant */}
+        {/* Line Variant */}
         <Stack direction="column" gap="300">
           <Heading as="h3" fontSize="500">
-            Underline Variant (Default)
+            Line Variant (Default)
           </Heading>
           <Text color="neutral.11" mb="400">
-            Tabs with an underline indicator showing the selected tab.
+            Tabs with a bar indicator marking the selected tab — an underline
+            when horizontal, an inner side bar when vertical.
           </Text>
           <Stack direction="column" gap="400">
-            <Box data-testid="underline-variant-horizontal">
+            <Box data-testid="line-variant-horizontal">
               <Heading as="h4" fontSize="350" mb="200">
                 Horizontal
               </Heading>
-              <Tabs.Root variant="underline" tabs={variantTabs} />
+              <Tabs.Root variant="line" tabs={variantTabs} />
             </Box>
-            <Box data-testid="underline-variant-vertical">
+            <Box data-testid="line-variant-vertical">
               <Heading as="h4" fontSize="350" mb="200">
                 Vertical
               </Heading>
               <Tabs.Root
-                variant="underline"
+                variant="line"
                 orientation="vertical"
                 tabs={variantTabs}
               />
@@ -1299,9 +1300,8 @@ export const LinkTabs: Story = {
 };
 
 /**
- * The legacy `line` and `pills` variant names are still accepted as deprecated
- * aliases for `underline` and `pill`, so existing code keeps working without
- * changes.
+ * The legacy `pills` variant name is still accepted as a deprecated alias for
+ * `pill`, so existing code keeps working without changes.
  */
 export const DeprecatedVariantAliases: Story = {
   args: {

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import {
   Box,
   Button,
@@ -151,6 +151,13 @@ export const Base: Story = {
         name: "Monarchy and Republic",
       });
 
+      // The decorative sliding indicator sits over the active tab; switching
+      // tabs must reposition it (the slide is the default, no opt-in prop).
+      const indicator = canvasElement.querySelector<HTMLElement>(
+        '[aria-hidden="true"]'
+      );
+      const beforeTransform = indicator?.style.transform ?? "";
+
       await userEvent.click(secondTab);
 
       await expect(secondTab).toHaveAttribute("aria-selected", "true");
@@ -160,6 +167,9 @@ export const Base: Story = {
       await expect(activePanel).toHaveTextContent(
         "Senatus Populusque Romanus."
       );
+
+      await expect(indicator).not.toBeNull();
+      await expect(indicator!.style.transform).not.toBe(beforeTransform);
     });
 
     await step("Supports keyboard navigation", async () => {
@@ -1288,168 +1298,6 @@ export const LinkTabs: Story = {
   },
 };
 
-// ============================================================
-// ANIMATED INDICATOR
-// ============================================================
-
-const animatedTabs = [
-  {
-    id: "overview",
-    tabLabel: "Overview",
-    panelContent: <Content tabLabel="Overview" body="The overview panel." />,
-  },
-  {
-    id: "details",
-    tabLabel: "Details",
-    panelContent: <Content tabLabel="Details" body="The details panel." />,
-  },
-  {
-    id: "history",
-    tabLabel: "History",
-    panelContent: <Content tabLabel="History" body="The history panel." />,
-  },
-];
-
-/** Returns the decorative sliding indicator rendered inside an animated Tabs. */
-const getIndicator = (canvasElement: HTMLElement) =>
-  canvasElement.querySelector<HTMLElement>('[aria-hidden="true"]');
-
-/**
- * The active marker is a single indicator that slides between tabs as the
- * selection changes instead of snapping. For the `underline` variant
- * (horizontal) it is a thin bar on the active tab's bottom edge.
- *
- * The slide is disabled under `prefers-reduced-motion: reduce`, and the
- * indicator is `aria-hidden` / non-focusable so `aria-selected`, focus, and
- * keyboard navigation are unaffected.
- */
-export const Animated: Story = {
-  args: {
-    variant: "underline",
-    tabs: animatedTabs,
-    tabListAriaLabel: "Animated tabs",
-  },
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-
-    await step("Renders a single aria-hidden indicator", async () => {
-      await waitFor(() =>
-        expect(getIndicator(canvasElement)).toBeInTheDocument()
-      );
-      await expect(getIndicator(canvasElement)!).toHaveAttribute(
-        "aria-hidden",
-        "true"
-      );
-    });
-
-    let initialTransform = "";
-    await step("Indicator is positioned over the selected tab", async () => {
-      await waitFor(() => {
-        initialTransform = getIndicator(canvasElement)!.style.transform;
-        expect(initialTransform).not.toBe("");
-      });
-    });
-
-    await step("Selecting another tab slides the indicator", async () => {
-      const detailsTab = canvas.getByRole("tab", { name: "Details" });
-      await userEvent.click(detailsTab);
-      await expect(detailsTab).toHaveAttribute("aria-selected", "true");
-      await waitFor(() => {
-        const next = getIndicator(canvasElement)!.style.transform;
-        expect(next).not.toBe("");
-        expect(next).not.toBe(initialTransform);
-      });
-    });
-
-    await step(
-      "Indicator does not appear in the accessibility tree",
-      async () => {
-        // Only real tabs are exposed; the indicator is decorative.
-        const tabs = canvas.getAllByRole("tab");
-        await expect(tabs).toHaveLength(3);
-      }
-    );
-  },
-};
-
-/**
- * The indicator adapts to a vertical `underline` layout: the bar is pinned to
- * the active tab's inner edge (right edge for `placement="start"`) and slides
- * vertically between tabs.
- */
-export const AnimatedVertical: Story = {
-  args: {
-    variant: "underline",
-    orientation: "vertical",
-    placement: "start",
-    tabs: animatedTabs,
-    tabListAriaLabel: "Animated vertical tabs",
-  },
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-
-    let initialTransform = "";
-    await step("Indicator is positioned over the selected tab", async () => {
-      await waitFor(() => {
-        const indicator = getIndicator(canvasElement);
-        expect(indicator).toBeInTheDocument();
-        initialTransform = indicator!.style.transform;
-        expect(initialTransform).not.toBe("");
-      });
-    });
-
-    await step("Selecting another tab slides the indicator", async () => {
-      const historyTab = canvas.getByRole("tab", { name: "History" });
-      await userEvent.click(historyTab);
-      await expect(historyTab).toHaveAttribute("aria-selected", "true");
-      await waitFor(() =>
-        expect(getIndicator(canvasElement)!.style.transform).not.toBe(
-          initialTransform
-        )
-      );
-    });
-  },
-};
-
-/**
- * For the `pill` variant, the indicator is a filled, fully-rounded highlight
- * that slides behind the active tab.
- */
-export const AnimatedPill: Story = {
-  args: {
-    variant: "pill",
-    tabs: animatedTabs,
-    tabListAriaLabel: "Animated pill tabs",
-  },
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-
-    let initialTransform = "";
-    await step(
-      "Filled indicator is positioned over the selected tab",
-      async () => {
-        await waitFor(() => {
-          const indicator = getIndicator(canvasElement);
-          expect(indicator).toBeInTheDocument();
-          initialTransform = indicator!.style.transform;
-          expect(initialTransform).not.toBe("");
-        });
-      }
-    );
-
-    await step("Selecting another tab slides the highlight", async () => {
-      const detailsTab = canvas.getByRole("tab", { name: "Details" });
-      await userEvent.click(detailsTab);
-      await expect(detailsTab).toHaveAttribute("aria-selected", "true");
-      await waitFor(() =>
-        expect(getIndicator(canvasElement)!.style.transform).not.toBe(
-          initialTransform
-        )
-      );
-    });
-  },
-};
-
 /**
  * The legacy `line` and `pills` variant names are still accepted as deprecated
  * aliases for `underline` and `pill`, so existing code keeps working without
@@ -1458,7 +1306,7 @@ export const AnimatedPill: Story = {
 export const DeprecatedVariantAliases: Story = {
   args: {
     variant: "pills",
-    tabs: animatedTabs,
+    tabs: simpleTabs,
     tabListAriaLabel: "Deprecated alias tabs",
   },
   play: async ({ canvasElement, step }) => {

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Tabs.Root> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["line", "pills"],
+      options: ["underline", "rounded", "pill"],
       description: "Visual style variant of the tabs",
     },
     orientation: {
@@ -42,11 +42,6 @@ const meta: Meta<typeof Tabs.Root> = {
       control: "select",
       options: ["sm", "md", "lg"],
       description: "Size of the tabs affecting padding and font size",
-    },
-    animated: {
-      control: "boolean",
-      description:
-        "Slide a single indicator between tabs as the selection changes (adapts to variant/orientation/placement). Respects prefers-reduced-motion.",
     },
   },
 };
@@ -441,7 +436,7 @@ export const VerticalPlacement: Story = {
             <Tabs.Root
               orientation="vertical"
               placement="end"
-              variant="pills"
+              variant="pill"
               tabs={placementTabs}
             />
           </Box>
@@ -807,27 +802,27 @@ export const Variants: Story = {
 
     return (
       <Stack direction="column" gap="600">
-        {/* Line Variant */}
+        {/* Underline Variant */}
         <Stack direction="column" gap="300">
           <Heading as="h3" fontSize="500">
-            Line Variant (Default)
+            Underline Variant (Default)
           </Heading>
           <Text color="neutral.11" mb="400">
             Tabs with an underline indicator showing the selected tab.
           </Text>
           <Stack direction="column" gap="400">
-            <Box data-testid="line-variant-horizontal">
+            <Box data-testid="underline-variant-horizontal">
               <Heading as="h4" fontSize="350" mb="200">
                 Horizontal
               </Heading>
-              <Tabs.Root variant="line" tabs={variantTabs} />
+              <Tabs.Root variant="underline" tabs={variantTabs} />
             </Box>
-            <Box data-testid="line-variant-vertical">
+            <Box data-testid="underline-variant-vertical">
               <Heading as="h4" fontSize="350" mb="200">
                 Vertical
               </Heading>
               <Tabs.Root
-                variant="line"
+                variant="underline"
                 orientation="vertical"
                 tabs={variantTabs}
               />
@@ -835,27 +830,55 @@ export const Variants: Story = {
           </Stack>
         </Stack>
 
-        {/* Pills Variant */}
+        {/* Rounded Variant */}
         <Stack direction="column" gap="300">
           <Heading as="h3" fontSize="500">
-            Pills Variant
+            Rounded Variant
           </Heading>
           <Text color="neutral.11" mb="400">
-            Tabs with rounded pill-like appearance and background highlighting.
+            A soft rounded-rect highlight behind the selected tab.
           </Text>
           <Stack direction="column" gap="400">
-            <Box data-testid="pills-variant-horizontal">
+            <Box data-testid="rounded-variant-horizontal">
               <Heading as="h4" fontSize="350" mb="200">
                 Horizontal
               </Heading>
-              <Tabs.Root variant="pills" tabs={variantTabs} />
+              <Tabs.Root variant="rounded" tabs={variantTabs} />
             </Box>
-            <Box data-testid="pills-variant-vertical">
+            <Box data-testid="rounded-variant-vertical">
               <Heading as="h4" fontSize="350" mb="200">
                 Vertical
               </Heading>
               <Tabs.Root
-                variant="pills"
+                variant="rounded"
+                orientation="vertical"
+                tabs={variantTabs}
+              />
+            </Box>
+          </Stack>
+        </Stack>
+
+        {/* Pill Variant */}
+        <Stack direction="column" gap="300">
+          <Heading as="h3" fontSize="500">
+            Pill Variant
+          </Heading>
+          <Text color="neutral.11" mb="400">
+            A fully-rounded capsule highlight behind the selected tab.
+          </Text>
+          <Stack direction="column" gap="400">
+            <Box data-testid="pill-variant-horizontal">
+              <Heading as="h4" fontSize="350" mb="200">
+                Horizontal
+              </Heading>
+              <Tabs.Root variant="pill" tabs={variantTabs} />
+            </Box>
+            <Box data-testid="pill-variant-vertical">
+              <Heading as="h4" fontSize="350" mb="200">
+                Vertical
+              </Heading>
+              <Tabs.Root
+                variant="pill"
                 orientation="vertical"
                 tabs={variantTabs}
               />
@@ -1292,9 +1315,9 @@ const getIndicator = (canvasElement: HTMLElement) =>
   canvasElement.querySelector<HTMLElement>('[aria-hidden="true"]');
 
 /**
- * With `animated`, the active marker becomes a single indicator that slides
- * between tabs as the selection changes instead of snapping. For the `line`
- * variant (horizontal) it is a thin bar on the active tab's bottom edge.
+ * The active marker is a single indicator that slides between tabs as the
+ * selection changes instead of snapping. For the `underline` variant
+ * (horizontal) it is a thin bar on the active tab's bottom edge.
  *
  * The slide is disabled under `prefers-reduced-motion: reduce`, and the
  * indicator is `aria-hidden` / non-focusable so `aria-selected`, focus, and
@@ -1302,8 +1325,7 @@ const getIndicator = (canvasElement: HTMLElement) =>
  */
 export const Animated: Story = {
   args: {
-    variant: "line",
-    animated: true,
+    variant: "underline",
     tabs: animatedTabs,
     tabListAriaLabel: "Animated tabs",
   },
@@ -1351,16 +1373,15 @@ export const Animated: Story = {
 };
 
 /**
- * The animated indicator adapts to a vertical `line` layout: the bar is pinned
- * to the active tab's inner edge (right edge for `placement="start"`) and slides
+ * The indicator adapts to a vertical `underline` layout: the bar is pinned to
+ * the active tab's inner edge (right edge for `placement="start"`) and slides
  * vertically between tabs.
  */
 export const AnimatedVertical: Story = {
   args: {
-    variant: "line",
+    variant: "underline",
     orientation: "vertical",
     placement: "start",
-    animated: true,
     tabs: animatedTabs,
     tabListAriaLabel: "Animated vertical tabs",
   },
@@ -1391,15 +1412,14 @@ export const AnimatedVertical: Story = {
 };
 
 /**
- * For the `pills` variant, the animated indicator is a filled, fully-rounded
- * highlight that slides behind the active tab.
+ * For the `pill` variant, the indicator is a filled, fully-rounded highlight
+ * that slides behind the active tab.
  */
-export const AnimatedPills: Story = {
+export const AnimatedPill: Story = {
   args: {
-    variant: "pills",
-    animated: true,
+    variant: "pill",
     tabs: animatedTabs,
-    tabListAriaLabel: "Animated pills tabs",
+    tabListAriaLabel: "Animated pill tabs",
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
@@ -1426,6 +1446,28 @@ export const AnimatedPills: Story = {
           initialTransform
         )
       );
+    });
+  },
+};
+
+/**
+ * The legacy `line` and `pills` variant names are still accepted as deprecated
+ * aliases for `underline` and `pill`, so existing code keeps working without
+ * changes.
+ */
+export const DeprecatedVariantAliases: Story = {
+  args: {
+    variant: "pills",
+    tabs: animatedTabs,
+    tabListAriaLabel: "Deprecated alias tabs",
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Deprecated `pills` alias still renders tabs", async () => {
+      const tabs = canvas.getAllByRole("tab");
+      await expect(tabs).toHaveLength(3);
+      await expect(tabs[0]).toHaveAttribute("aria-selected", "true");
     });
   },
 };

--- a/packages/nimbus/src/components/tabs/tabs.types.ts
+++ b/packages/nimbus/src/components/tabs/tabs.types.ts
@@ -59,6 +59,8 @@ export type TabsPanelsSlotProps = HTMLChakraProps<"div", TabsRecipeProps>;
 
 export type TabsPanelSlotProps = HTMLChakraProps<"div", TabsRecipeProps>;
 
+export type TabsIndicatorSlotProps = HTMLChakraProps<"div", TabsRecipeProps>;
+
 // ============================================================
 // HELPER TYPES
 // ============================================================

--- a/packages/nimbus/src/components/tabs/tabs.types.ts
+++ b/packages/nimbus/src/components/tabs/tabs.types.ts
@@ -13,21 +13,19 @@ type TabsRecipeProps = {
   /**
    * Visual style variant of the tabs.
    *
-   * - `underline` — an underline strip beneath the active tab (default).
+   * - `line` — a bar marking the active tab: an underline when horizontal, an
+   *   inner side bar when vertical (default).
    * - `rounded` — a soft rounded-rect highlight behind the active tab.
    * - `pill` — a fully-rounded capsule highlight behind the active tab.
    *
    * The active highlight slides between tabs as the selection changes; the
    * motion is disabled under `prefers-reduced-motion: reduce`.
    *
-   * `"line"` (→ `"underline"`) and `"pills"` (→ `"pill"`) are accepted as
-   * deprecated aliases.
-   * @default "underline"
+   * `"pills"` (→ `"pill"`) is accepted as a deprecated alias.
+   * @default "line"
    */
   variant?:
     | SlotRecipeProps<"nimbusTabs">["variant"]
-    /** @deprecated Use `"underline"` instead. */
-    | "line"
     /** @deprecated Use `"pill"` instead. */
     | "pills";
   /**

--- a/packages/nimbus/src/components/tabs/tabs.types.ts
+++ b/packages/nimbus/src/components/tabs/tabs.types.ts
@@ -11,10 +11,25 @@ import type { RouterOptions } from "../nimbus-provider/nimbus-provider.types";
 
 type TabsRecipeProps = {
   /**
-   * Visual style variant of the tabs
-   * @default "line"
+   * Visual style variant of the tabs.
+   *
+   * - `underline` — an underline strip beneath the active tab (default).
+   * - `rounded` — a soft rounded-rect highlight behind the active tab.
+   * - `pill` — a fully-rounded capsule highlight behind the active tab.
+   *
+   * The active highlight slides between tabs as the selection changes; the
+   * motion is disabled under `prefers-reduced-motion: reduce`.
+   *
+   * `"line"` (→ `"underline"`) and `"pills"` (→ `"pill"`) are accepted as
+   * deprecated aliases.
+   * @default "underline"
    */
-  variant?: SlotRecipeProps<"nimbusTabs">["variant"];
+  variant?:
+    | SlotRecipeProps<"nimbusTabs">["variant"]
+    /** @deprecated Use `"underline"` instead. */
+    | "line"
+    /** @deprecated Use `"pill"` instead. */
+    | "pills";
   /**
    * Layout orientation of the tabs
    * @default "horizontal"
@@ -104,21 +119,6 @@ export type TabsProps = OmitInternalProps<TabsRootSlotProps> & {
    * Required for accessibility when not using children-based composition.
    */
   tabListAriaLabel?: string;
-  /**
-   * When `true`, renders a single decorative indicator that smoothly slides
-   * between tabs as the selected tab changes, instead of the static per-tab
-   * marker. The indicator adapts to the resolved `variant` / `orientation` /
-   * `placement`: a thin bar on the active tab's bottom edge (horizontal),
-   * right edge (vertical + `placement="start"`), or left edge (vertical +
-   * `placement="end"`); and a filled, fully-rounded highlight for the `pills`
-   * variant.
-   *
-   * The slide is automatically disabled under `prefers-reduced-motion: reduce`
-   * (the highlight snaps), and `aria-selected`, focus, and keyboard navigation
-   * are unaffected.
-   * @default false
-   */
-  animated?: boolean;
   /**
    * The currently selected tab key (controlled).
    */

--- a/packages/nimbus/src/components/tabs/tabs.types.ts
+++ b/packages/nimbus/src/components/tabs/tabs.types.ts
@@ -105,6 +105,21 @@ export type TabsProps = OmitInternalProps<TabsRootSlotProps> & {
    */
   tabListAriaLabel?: string;
   /**
+   * When `true`, renders a single decorative indicator that smoothly slides
+   * between tabs as the selected tab changes, instead of the static per-tab
+   * marker. The indicator adapts to the resolved `variant` / `orientation` /
+   * `placement`: a thin bar on the active tab's bottom edge (horizontal),
+   * right edge (vertical + `placement="start"`), or left edge (vertical +
+   * `placement="end"`); and a filled, fully-rounded highlight for the `pills`
+   * variant.
+   *
+   * The slide is automatically disabled under `prefers-reduced-motion: reduce`
+   * (the highlight snaps), and `aria-selected`, focus, and keyboard navigation
+   * are unaffected.
+   * @default false
+   */
+  animated?: boolean;
+  /**
    * The currently selected tab key (controlled).
    */
   selectedKey?: string | number;

--- a/packages/nimbus/src/hooks/index.ts
+++ b/packages/nimbus/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from "./use-color-mode-value";
 export * from "./use-localized-string-formatter";
 export * from "./use-drag-and-drop";
 export * from "./use-focus-input-on-field-click";
+export * from "./use-sliding-indicator";

--- a/packages/nimbus/src/hooks/use-sliding-indicator/index.ts
+++ b/packages/nimbus/src/hooks/use-sliding-indicator/index.ts
@@ -1,0 +1,6 @@
+export { useSlidingIndicator } from "./use-sliding-indicator.ts";
+export type {
+  SlidingIndicatorOptions,
+  SlidingIndicatorGeometry,
+  SlidingIndicatorRects,
+} from "./use-sliding-indicator.ts";

--- a/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
+++ b/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
@@ -72,6 +72,12 @@ export interface SlidingIndicatorOptions {
  * momentarily suppressed so the indicator snaps to the active item instead of
  * sliding in from the container corner on initial render.
  *
+ * Note: scroll is **not** tracked. Geometry is computed in container
+ * coordinates, so if the container is itself scrollable the indicator only
+ * re-aligns on the next selection change or resize, not on scroll. Today's
+ * callers (`Tabs`/`TabNav`) don't scroll their item strip, so this is a
+ * non-issue; a future scrollable caller would need to observe scroll itself.
+ *
  * Used to drive the animated active-highlight on `Tabs` and `TabNav`, where
  * `getGeometry` encodes whether the indicator is an edge bar (bottom or inner
  * side) or a filled highlight.

--- a/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
+++ b/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
@@ -1,0 +1,141 @@
+import { useLayoutEffect } from "react";
+import type { RefObject } from "react";
+
+/**
+ * Bounding rectangles passed to {@link SlidingIndicatorOptions.getGeometry}.
+ */
+export interface SlidingIndicatorRects {
+  /** Bounding rect of the positioned container the indicator lives in. */
+  container: DOMRect;
+  /** Bounding rect of the currently active item. */
+  active: DOMRect;
+}
+
+/**
+ * Geometry the indicator should adopt, in pixels, relative to the container's
+ * top-left. `width` / `height` are optional — omit one to leave it controlled
+ * by CSS (e.g. a fixed-thickness bar).
+ */
+export interface SlidingIndicatorGeometry {
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+export interface SlidingIndicatorOptions {
+  /**
+   * Whether the indicator is active. When `false` the hook is a complete no-op:
+   * it does not measure, observe, or mutate the indicator.
+   */
+  enabled: boolean;
+  /**
+   * Ref to the indicator element. Its positioned parent
+   * (`indicator.parentElement`) is used as the measurement container, so the
+   * indicator must be `position: absolute` inside a positioned ancestor.
+   */
+  indicatorRef: RefObject<HTMLElement | null>;
+  /** CSS selector (queried within the container) for the active item. */
+  activeSelector: string;
+  /**
+   * Attribute names whose mutation anywhere in the container should trigger a
+   * re-measure (e.g. `["aria-selected"]` or `["aria-current"]`).
+   */
+  watchAttributes: string[];
+  /**
+   * CSS selector for the items to observe for size changes (in addition to the
+   * container). Defaults to {@link activeSelector}'s tag-agnostic siblings via
+   * the container only when omitted.
+   */
+  itemSelector?: string;
+  /** Maps the container + active rects to the indicator's geometry. */
+  getGeometry: (rects: SlidingIndicatorRects) => SlidingIndicatorGeometry;
+  /**
+   * Extra dependencies that should tear down and re-run the effect (e.g. a
+   * changed orientation or variant that alters `getGeometry`).
+   */
+  deps?: unknown[];
+}
+
+/**
+ * Positions an absolutely-placed "indicator" element over the active item inside
+ * a container and keeps it in sync.
+ *
+ * The hook is DOM-driven: it measures with `getBoundingClientRect` inside
+ * `useLayoutEffect` (so the indicator is placed before paint — no first-frame
+ * flash), re-measures when the active item changes (`MutationObserver` on
+ * {@link SlidingIndicatorOptions.watchAttributes}) and when the layout changes
+ * (`ResizeObserver`), and hides the indicator (opacity 0) when there is no
+ * active item. The caller owns the indicator's appearance and transition; this
+ * hook only writes `opacity`, `width`/`height` (per `getGeometry`), and
+ * `transform`.
+ *
+ * Used to drive the animated active-highlight on `Tabs` (and, in a follow-up,
+ * `TabNav`), where `getGeometry` encodes whether the indicator is an underline
+ * bar, a side bar, or a filled highlight.
+ */
+export function useSlidingIndicator({
+  enabled,
+  indicatorRef,
+  activeSelector,
+  watchAttributes,
+  itemSelector,
+  getGeometry,
+  deps = [],
+}: SlidingIndicatorOptions): void {
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    const indicator = indicatorRef.current;
+    const container = indicator?.parentElement;
+    if (!indicator || !container) return;
+
+    const update = () => {
+      const active = container.querySelector<HTMLElement>(activeSelector);
+      if (!active) {
+        // No active item — hide the highlight entirely.
+        indicator.style.opacity = "0";
+        return;
+      }
+      const containerRect = container.getBoundingClientRect();
+      const activeRect = active.getBoundingClientRect();
+      const geometry = getGeometry({
+        container: containerRect,
+        active: activeRect,
+      });
+      indicator.style.opacity = "1";
+      if (geometry.width != null) indicator.style.width = `${geometry.width}px`;
+      if (geometry.height != null) {
+        indicator.style.height = `${geometry.height}px`;
+      }
+      indicator.style.transform = `translate(${geometry.x}px, ${geometry.y}px)`;
+    };
+
+    // Measure synchronously before paint so the highlight appears in place.
+    update();
+
+    // Re-measure when the active item changes (watched attribute toggles).
+    const mutationObserver = new MutationObserver(update);
+    mutationObserver.observe(container, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: watchAttributes,
+    });
+
+    // Re-measure when the container or its items change size.
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(container);
+    if (itemSelector) {
+      container
+        .querySelectorAll<HTMLElement>(itemSelector)
+        .forEach((item) => resizeObserver.observe(item));
+    }
+
+    return () => {
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+    };
+    // `getGeometry` is intentionally excluded — callers pass an inline closure;
+    // `deps` is the explicit re-run signal for geometry-affecting inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, indicatorRef, activeSelector, itemSelector, ...deps]);
+}

--- a/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
+++ b/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
@@ -68,7 +68,9 @@ export interface SlidingIndicatorOptions {
  * (`ResizeObserver`), and hides the indicator (opacity 0) when there is no
  * active item. The caller owns the indicator's appearance and transition; this
  * hook only writes `opacity`, `width`/`height` (per `getGeometry`), and
- * `transform`.
+ * `transform`. The very first placement is applied with the transition
+ * momentarily suppressed so the indicator snaps to the active item instead of
+ * sliding in from the container corner on initial render.
  *
  * Used to drive the animated active-highlight on `Tabs` (and, in a follow-up,
  * `TabNav`), where `getGeometry` encodes whether the indicator is an underline
@@ -96,6 +98,15 @@ export function useSlidingIndicator({
     // is no flash.
     container.setAttribute("data-animated", "true");
 
+    // The indicator is authored at the container's top-left (`top/left: 0`, no
+    // transform). The *first* placement must jump straight to the active item:
+    // without this, the caller's `transition` would animate the indicator in
+    // from the corner (translate(0,0) → target) on initial render. Subsequent
+    // updates slide normally. Because this lives in the effect closure, a
+    // re-run (e.g. a variant/orientation change via `deps`) also snaps rather
+    // than sliding from a now-stale position.
+    let hasPositioned = false;
+
     const update = () => {
       const active = container.querySelector<HTMLElement>(activeSelector);
       if (!active) {
@@ -109,12 +120,26 @@ export function useSlidingIndicator({
         container: containerRect,
         active: activeRect,
       });
+
+      // Suppress the transition for the initial jump, restoring whatever inline
+      // transition was set (normally none — the caller's transition is a class).
+      const prevTransition = indicator.style.transition;
+      if (!hasPositioned) indicator.style.transition = "none";
+
       indicator.style.opacity = "1";
       if (geometry.width != null) indicator.style.width = `${geometry.width}px`;
       if (geometry.height != null) {
         indicator.style.height = `${geometry.height}px`;
       }
       indicator.style.transform = `translate(${geometry.x}px, ${geometry.y}px)`;
+
+      if (!hasPositioned) {
+        // Force a synchronous reflow to commit the jump, then re-enable the
+        // transition so the next selection change slides.
+        void indicator.offsetWidth;
+        indicator.style.transition = prevTransition;
+        hasPositioned = true;
+      }
     };
 
     // Measure synchronously before paint so the highlight appears in place.

--- a/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
+++ b/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
@@ -89,6 +89,13 @@ export function useSlidingIndicator({
     const container = indicator?.parentElement;
     if (!indicator || !container) return;
 
+    // Mark the container as JS-enhanced so the recipe suppresses its static
+    // marker and lets the sliding indicator own the highlight. Setting this on
+    // mount (not in server markup) keeps the static marker as the SSR /
+    // pre-hydration / no-JS fallback; the swap happens before paint, so there
+    // is no flash.
+    container.setAttribute("data-animated", "true");
+
     const update = () => {
       const active = container.querySelector<HTMLElement>(activeSelector);
       if (!active) {
@@ -133,6 +140,7 @@ export function useSlidingIndicator({
     return () => {
       mutationObserver.disconnect();
       resizeObserver.disconnect();
+      container.removeAttribute("data-animated");
     };
     // `getGeometry` is intentionally excluded — callers pass an inline closure;
     // `deps` is the explicit re-run signal for geometry-affecting inputs.

--- a/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
+++ b/packages/nimbus/src/hooks/use-sliding-indicator/use-sliding-indicator.ts
@@ -72,9 +72,9 @@ export interface SlidingIndicatorOptions {
  * momentarily suppressed so the indicator snaps to the active item instead of
  * sliding in from the container corner on initial render.
  *
- * Used to drive the animated active-highlight on `Tabs` (and, in a follow-up,
- * `TabNav`), where `getGeometry` encodes whether the indicator is an underline
- * bar, a side bar, or a filled highlight.
+ * Used to drive the animated active-highlight on `Tabs` and `TabNav`, where
+ * `getGeometry` encodes whether the indicator is an edge bar (bottom or inner
+ * side) or a filled highlight.
  */
 export function useSlidingIndicator({
   enabled,

--- a/packages/nimbus/src/utils/index.ts
+++ b/packages/nimbus/src/utils/index.ts
@@ -4,3 +4,4 @@ export { extractPaddingProps } from "./extract-padding-props";
 export { extractStyleProps } from "./extract-style-props";
 export { mergeRefs } from "./merge-refs";
 export { noop } from "./no-op";
+export { resolveVariantAlias } from "./resolve-variant-alias";

--- a/packages/nimbus/src/utils/resolve-variant-alias.ts
+++ b/packages/nimbus/src/utils/resolve-variant-alias.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolve a deprecated string variant alias to its replacement.
+ *
+ * A `variant` prop can be a concrete string or a responsive object/array; only
+ * plain-string values are remapped (via `aliases`), while unknown strings and
+ * responsive values pass through untouched. Used by components that keep a
+ * deprecated variant name working as a non-breaking alias for its replacement
+ * (e.g. Tabs `pills` → `pill`, TabNav `tabs` → `line`) so the recipe only ever
+ * sees real variant keys.
+ *
+ * @example
+ * ```ts
+ * resolveVariantAlias("pills", { pills: "pill" }); // "pill"
+ * resolveVariantAlias("line", { pills: "pill" });  // "line" (pass-through)
+ * ```
+ */
+export function resolveVariantAlias<T>(
+  value: T,
+  aliases: Record<string, string>
+): T {
+  return typeof value === "string" && aliases[value]
+    ? (aliases[value] as T)
+    : value;
+}


### PR DESCRIPTION

<img width="540" height="540" alt="Components - TabNav - Variants ⋅ Storybook; Jul 1, 2 10 PM" src="https://github.com/user-attachments/assets/8ae66fa1-6a4d-4b5c-9bda-4eff06fdf270" />

## What & why

`Tabs` and `TabNav` are visual twins. This PR gives them one shared variant set and a single active marker that **slides between items** as the selection changes, instead of a static per-item marker.

Pure CSS can't move a marker *between* sibling items, so the slide is a small reusable component change rather than a recipe-only tweak.

## Changes

- **One shared variant set for both components** — `line` (default), `rounded` (soft rounded-rect highlight), `pill` (capsule). The `rounded`/`pill` highlights are themeable via `colorPalette`. `Tabs` additionally layers `orientation`/`placement` onto `line`.
- **The active marker is a single sliding indicator.** It slides between items on selection change — a bar for `line`, a filled highlight for `rounded`/`pill`. There is no per-instance toggle; the only "off" switch is global `prefers-reduced-motion: reduce`, under which the highlight snaps (the only motion lever Nimbus has).
- **Shared hook `useSlidingIndicator`** (`packages/nimbus/src/hooks/use-sliding-indicator/`) drives both components — DOM-measured with `getBoundingClientRect` in `useLayoutEffect`, re-measuring on active-item changes (`MutationObserver`) and layout changes (`ResizeObserver`). Callers pass `activeSelector`, `watchAttributes`, and a `getGeometry({container, active})` callback, so the same hook drives an edge bar (`line`) or a filled highlight (`rounded`/`pill`). It sets `data-animated` on the container on mount, so the recipe's static marker is the SSR / pre-hydration / no-JS fallback and the measured slide takes over before paint.
- **Snaps into place on first paint.** The initial placement is applied with the transition momentarily suppressed (jump committed via a synchronous reflow, then restored), so the indicator appears over the active item on first render rather than animating in from the container's corner — for every variant and orientation. It slides only on subsequent selection changes.
- **Deprecated aliases (non-breaking)** resolved in-component and typed `@deprecated`: `Tabs` `pills` → `pill`; `TabNav` `tabs` → `line`. Existing consumers (incl. the two docs-app `variant="pills"` usages) keep working with no edits.

For both components the indicator is `aria-hidden` / non-focusable, so `aria-current` / `aria-selected`, focus rings, and keyboard navigation are unaffected.

## Tests & docs

- Play-function stories for both components are **interactive** — clicking any item moves the active marker (and the slide). `Tabs` does this natively via React Aria; `TabNav.Item` is controlled via `isCurrent`, so its showcase stories run through a small stateful helper (a router does this in a real app). The behaviour is exercised in the regular stories — including a slide assertion in each `Base` story — plus deprecated-alias smoke tests.
- `tabs.mdx`/`tabs.dev.mdx` and `tab-nav.mdx`/`tab-nav.dev.mdx` cover the variants, animation-by-default, reduced-motion, and aliases.
- OpenSpec change at `openspec/changes/add-animated-tab-indicator/` (`nimbus-use-sliding-indicator` + `nimbus-tabs`); changeset included.

## Verification

- `pnpm --filter @commercetools/nimbus build-theme-typings` → `typecheck` — clean
- `pnpm test` for both story files — **23 passed** (11 TabNav + 12 Tabs), real headless Chromium, against the built `dist` bundle
- ESLint on changed files — clean
- `openspec validate add-animated-tab-indicator --strict` — valid

## Notes

- Recipe quirk worth knowing: arbitrary CSS selectors are only accepted by the type system inside `variants.*` slot objects (not `base.*` / `compoundVariants[].css`), so the `[data-animated]` rules live in the variant slots.
