### PR TITLE
[experiment] Breadcrumbs — BEFORE docs/tooling overhaul

### DIFF
--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
@@ -1,0 +1,102 @@
+---
+title: Breadcrumbs component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import { Breadcrumbs } from "@commercetools/nimbus";
+```
+
+### Basic usage
+
+`Breadcrumbs` is a compound component built on React Aria's `Breadcrumbs`
+collection. It has two parts: `Breadcrumbs.Root` (the ordered list) and
+`Breadcrumbs.Item` (each entry). Provide an `href` on every item except the
+last; the last item, with no `href`, becomes the current page.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumbs">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/reports">Reports</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Q3 Summary</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+## Usage examples
+
+### Sizes
+
+```jsx live-dev
+const App = () => (
+  <Stack direction="column" gap="400" alignItems="flex-start">
+    <Breadcrumbs.Root size="sm" aria-label="Small breadcrumbs">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/library">Library</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Data</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+
+    <Breadcrumbs.Root size="md" aria-label="Medium breadcrumbs">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/library">Library</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Data</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  </Stack>
+);
+```
+
+### Dynamic collections
+
+Pass an array to the `items` prop with a render function. Use `onAction` to
+react to presses by the item's `id` — useful for client-side routing.
+
+```jsx live-dev
+const App = () => {
+  const items = [
+    { id: "home", label: "Home", href: "/" },
+    { id: "reports", label: "Reports", href: "/reports" },
+    { id: "q3", label: "Q3 Summary" },
+  ];
+
+  return (
+    <Breadcrumbs.Root
+      aria-label="Breadcrumbs"
+      items={items}
+      onAction={(key) => console.log("navigate", key)}
+    >
+      {(item) => (
+        <Breadcrumbs.Item href={item.href}>{item.label}</Breadcrumbs.Item>
+      )}
+    </Breadcrumbs.Root>
+  );
+};
+```
+
+## Accessibility
+
+- `Breadcrumbs.Root` should be placed in a navigation landmark by supplying an
+  `aria-label`. The component renders an ordered list (`<ol>`) of list items.
+- The current page is marked with `aria-current="page"` automatically when its
+  item omits `href`.
+- Separators are decorative (`aria-hidden`); hierarchy is conveyed by the list
+  structure, not the visual divider.
+- Links are keyboard focusable and activate with Enter.
+
+## Props
+
+### Breadcrumbs.Root
+
+Accepts the React Aria `Breadcrumbs` collection props (`items`, `onAction`,
+`isDisabled`, `aria-label`, …) plus a `size` variant (`"sm" | "md"`, default
+`"md"`) and Nimbus style props.
+
+### Breadcrumbs.Item
+
+Accepts React Aria `Breadcrumb` props (`id`) and `Link` props (`href`,
+`target`, `onPress`, routing props, `isDisabled`) plus Nimbus style props.

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
@@ -1,0 +1,75 @@
+---
+id: Components-Breadcrumbs
+title: Breadcrumbs
+exportName: Breadcrumbs
+description: Breadcrumbs show the path to the current page and let users navigate back up the hierarchy.
+lifecycleState: Experimental
+order: 999
+menu:
+  - Components
+  - Navigation
+  - Breadcrumbs
+tags:
+  - component
+  - breadcrumbs
+  - navigation
+  - hierarchy
+---
+
+## Overview
+
+Breadcrumbs display a hierarchy of links to the current page or resource,
+helping users understand where they are within an application and quickly
+navigate back to a higher level. The last item represents the current page and
+is rendered as static, non-interactive text.
+
+### Resources
+
+Deep dive into implementation details and access the Nimbus design library.
+
+[Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-breadcrumbs--docs)
+
+## Variables
+
+Get familiar with the features.
+
+### Visual options
+
+#### Size
+
+Breadcrumbs come in `sm` and `md` sizes. `md` is the default; use `sm` for
+denser layouts such as toolbars or table headers.
+
+```jsx live
+const App = () => (
+  <Stack direction="column" gap="400" alignItems="flex-start">
+    <Breadcrumbs.Root size="sm" aria-label="Small breadcrumbs">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/reports">Reports</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Q3 Summary</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+
+    <Breadcrumbs.Root size="md" aria-label="Medium breadcrumbs">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/reports">Reports</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Q3 Summary</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  </Stack>
+);
+```
+
+## Guidelines
+
+- Always place breadcrumbs in a navigation landmark by setting `aria-label` on
+  `Breadcrumbs.Root`.
+- The final item is the current page — omit its `href` so it renders as static
+  text with `aria-current="page"`.
+- Keep labels short and reflective of the page titles they link to.
+- Breadcrumbs supplement primary navigation; they should not be the only way to
+  move between sections.
+
+## Properties
+
+`Breadcrumbs.Root` accepts the React Aria `Breadcrumbs` collection props plus a
+`size` style variant. `Breadcrumbs.Item` accepts React Aria `Breadcrumb` and
+`Link` props (`href`, `onPress`, routing props, `id` for `onAction`).

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.tsx
@@ -1,0 +1,109 @@
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
+
+/**
+ * Recipe configuration for the Breadcrumbs component.
+ * Defines the styling variants and base styles using Chakra UI's recipe system.
+ */
+export const breadcrumbsSlotRecipe = defineSlotRecipe({
+  slots: ["root", "list", "item", "link", "separator"],
+  // Unique class name prefix for the component
+  className: "nimbus-breadcrumbs",
+
+  // Base styles applied to all instances of the component
+  base: {
+    // `root` is the <nav> landmark wrapper.
+    root: {
+      display: "block",
+      color: "neutral.11",
+    },
+    // `list` is the React Aria Breadcrumbs <ol>.
+    list: {
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      listStyle: "none",
+      margin: "0",
+      padding: "0",
+    },
+    item: {
+      display: "inline-flex",
+      alignItems: "center",
+    },
+    link: {
+      display: "inline-flex",
+      alignItems: "center",
+      color: "primary.11",
+      borderRadius: "100",
+      outline: "none",
+      bg: "transparent",
+      cursor: "pointer",
+      textDecoration: "none",
+      focusVisibleRing: "outside",
+      _hover: {
+        textDecoration: "underline",
+        textUnderlineOffset: "3px",
+      },
+      // The current page item is rendered as a non-link span by React Aria
+      // when no `href` is supplied. When a link is the current item React Aria
+      // sets `data-current`; style it as static, emphasized text.
+      "&[data-current]": {
+        color: "neutral.12",
+        fontWeight: "600",
+        textDecoration: "none",
+        cursor: "default",
+        pointerEvents: "none",
+      },
+      "&[data-disabled]": {
+        layerStyle: "disabled",
+        cursor: "default",
+        pointerEvents: "none",
+      },
+    },
+    separator: {
+      display: "inline-flex",
+      alignItems: "center",
+      color: "neutral.9",
+      flexShrink: "0",
+      // Hidden from assistive tech — the ordered-list structure already
+      // communicates hierarchy.
+      "& svg": {
+        width: "var(--separator-size)",
+        height: "var(--separator-size)",
+      },
+    },
+  },
+
+  // Available variants for customizing the component's appearance
+  variants: {
+    // Size variants from smallest to largest
+    size: {
+      sm: {
+        list: { gap: "100" },
+        item: { gap: "100" },
+        link: {
+          fontSize: "350",
+          lineHeight: "500",
+        },
+        separator: {
+          css: { "--separator-size": "sizes.400" },
+        },
+      },
+      md: {
+        list: { gap: "200" },
+        item: { gap: "200" },
+        link: {
+          fontSize: "400",
+          lineHeight: "600",
+        },
+        separator: {
+          css: { "--separator-size": "sizes.500" },
+        },
+      },
+    },
+  },
+
+  // Default variant values when not explicitly specified
+  defaultVariants: {
+    size: "md",
+  },
+});

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.slots.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.slots.tsx
@@ -1,0 +1,68 @@
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
+import {
+  Breadcrumbs as RaBreadcrumbs,
+  Breadcrumb as RaBreadcrumb,
+  Link as RaLink,
+} from "react-aria-components";
+import type { HTMLChakraProps } from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "@/type-utils";
+import type {
+  BreadcrumbsListProps,
+  BreadcrumbsItemProps,
+} from "./breadcrumbs.types";
+
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusBreadcrumbs",
+});
+
+/**
+ * Root slot — provides the recipe context and renders the navigation landmark
+ * (`<nav>`) that wraps the breadcrumb list.
+ */
+export type BreadcrumbsRootSlotProps = HTMLChakraProps<"nav">;
+export const BreadcrumbsRootSlot: SlotComponent<
+  HTMLElement,
+  BreadcrumbsRootSlotProps
+> = withProvider<HTMLElement, BreadcrumbsRootSlotProps>("nav", "root");
+
+/**
+ * List slot — consumes context and renders the React Aria `Breadcrumbs`
+ * collection (an `<ol>`).
+ */
+export const BreadcrumbsListSlot: SlotComponent<
+  HTMLOListElement,
+  BreadcrumbsListProps
+> = withContext<HTMLOListElement, BreadcrumbsListProps>(RaBreadcrumbs, "list");
+
+/**
+ * Item slot — consumes context and renders the React Aria `Breadcrumb`
+ * (an `<li>`).
+ */
+export const BreadcrumbsItemSlot: SlotComponent<
+  HTMLLIElement,
+  BreadcrumbsItemProps
+> = withContext<HTMLLIElement, BreadcrumbsItemProps>(RaBreadcrumb, "item");
+
+/**
+ * Link slot — consumes context and renders the React Aria `Link` (an `<a>`,
+ * or a `<span>` for the current page when no `href` is provided).
+ */
+export const BreadcrumbsLinkSlot: SlotComponent<
+  HTMLAnchorElement,
+  React.ComponentProps<typeof RaLink>
+> = withContext<HTMLAnchorElement, React.ComponentProps<typeof RaLink>>(
+  RaLink,
+  "link"
+);
+
+/**
+ * Separator slot — consumes context and renders the visual divider between
+ * items. Decorative only (`aria-hidden`); hierarchy is conveyed by the list.
+ */
+export const BreadcrumbsSeparatorSlot: SlotComponent<
+  HTMLSpanElement,
+  React.HTMLAttributes<HTMLSpanElement>
+> = withContext<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  "span",
+  "separator"
+);

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,0 +1,248 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within, expect, fn } from "storybook/test";
+import type { Key } from "react-aria-components";
+import {
+  Stack,
+  Breadcrumbs,
+  type BreadcrumbsProps,
+  Text,
+} from "@commercetools/nimbus";
+
+/**
+ * Storybook metadata configuration
+ * - title: determines the location in the sidebar
+ * - component: references the component being documented
+ */
+const meta: Meta<typeof Breadcrumbs.Root> = {
+  title: "Components/Breadcrumbs",
+  component: Breadcrumbs.Root,
+};
+
+export default meta;
+
+/**
+ * Story type for TypeScript support
+ * StoryObj provides type checking for our story configurations
+ */
+type Story = StoryObj<typeof Breadcrumbs.Root>;
+
+const trail = [
+  { id: "home", label: "Home", href: "/" },
+  { id: "reports", label: "Reports", href: "/reports" },
+  { id: "quarterly", label: "Quarterly", href: "/reports/quarterly" },
+  { id: "q3", label: "Q3 Summary" },
+];
+
+const sizes: BreadcrumbsProps["size"][] = ["sm", "md"];
+
+/**
+ * Base story
+ * Demonstrates the most basic implementation with static items. The last item
+ * omits `href`, so it is rendered as the non-interactive current page.
+ */
+export const Base: Story = {
+  args: {},
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumbs">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/reports">Reports</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Q3 Summary</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step(
+      "renders a navigation landmark with an ordered list",
+      async () => {
+        const nav = canvas.getByRole("navigation", { name: "Breadcrumbs" });
+        await expect(nav).toBeInTheDocument();
+        const list = canvas.getByRole("list");
+        await expect(list).toBeInTheDocument();
+        await expect(list.tagName).toBe("OL");
+      }
+    );
+
+    await step("renders all items", async () => {
+      const items = canvas.getAllByRole("listitem");
+      await expect(items).toHaveLength(3);
+    });
+
+    await step("non-final items are links", async () => {
+      const home = canvas.getByRole("link", { name: "Home" });
+      const reports = canvas.getByRole("link", { name: "Reports" });
+      await expect(home).toHaveAttribute("href", "/");
+      await expect(reports).toHaveAttribute("href", "/reports");
+    });
+
+    await step("final item is marked as the current page", async () => {
+      const current = canvas.getByText("Q3 Summary");
+      // React Aria marks the current item with aria-current="page" and renders
+      // it as a non-navigable element (no href, aria-disabled).
+      await expect(current).toHaveAttribute("aria-current", "page");
+      await expect(current).not.toHaveAttribute("href");
+      await expect(current).toHaveAttribute("data-current", "true");
+    });
+
+    await step("links are reachable via keyboard", async () => {
+      await userEvent.tab();
+      await expect(canvas.getByRole("link", { name: "Home" })).toHaveFocus();
+      await userEvent.tab();
+      await expect(canvas.getByRole("link", { name: "Reports" })).toHaveFocus();
+    });
+  },
+};
+
+/**
+ * Sizes story
+ * Breadcrumbs support `sm` and `md` size variants.
+ */
+export const Sizes: Story = {
+  render: (args) => (
+    <Stack direction="column" gap="400" alignItems="flex-start">
+      {sizes.map((size) => (
+        <Breadcrumbs.Root
+          key={size}
+          {...args}
+          size={size}
+          aria-label={`${size} breadcrumbs`}
+        >
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/library">Library</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Data</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("renders one breadcrumb trail per size", async () => {
+      const navs = canvas.getAllByRole("navigation");
+      await expect(navs).toHaveLength(sizes.length);
+    });
+  },
+};
+
+/**
+ * Dynamic collection
+ * Demonstrates the `items` prop with a render function and the `onAction`
+ * callback, which fires with the pressed item's `id`. When breadcrumbs drive
+ * client-side routing, omit `href` and handle navigation via `onAction`.
+ */
+export const DynamicCollection: Story = {
+  args: {
+    onAction: fn(),
+  },
+  render: ({ onAction }) => (
+    <Breadcrumbs.Root
+      aria-label="Breadcrumbs"
+      items={trail}
+      onAction={onAction}
+    >
+      {(item: (typeof trail)[number]) => (
+        <Breadcrumbs.Item>{item.label}</Breadcrumbs.Item>
+      )}
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, args, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("renders all items from the collection", async () => {
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(trail.length);
+    });
+
+    await step(
+      "onAction fires with the item id when an item is pressed",
+      async () => {
+        await userEvent.click(canvas.getByText("Reports"));
+        await expect(args.onAction).toHaveBeenCalledWith("reports");
+      }
+    );
+  },
+};
+
+/**
+ * Disabled
+ * The whole trail can be disabled via `isDisabled` on the root.
+ */
+export const Disabled: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumbs" isDisabled>
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/reports">Reports</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Q3 Summary</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("disabled links expose data-disabled", async () => {
+      const home = canvas.getByRole("link", { name: "Home" });
+      await expect(home).toHaveAttribute("data-disabled");
+    });
+  },
+};
+
+/**
+ * Controlled
+ * Pressing a breadcrumb truncates the trail to that point — a common
+ * application pattern for breadcrumbs that drive navigation state.
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [items, setItems] = useState(trail);
+
+    const navigate = (id: Key) => {
+      const index = items.findIndex((item) => item.id === id);
+      if (index >= 0) {
+        setItems(items.slice(0, index + 1));
+      }
+    };
+
+    return (
+      <Stack gap="400" alignItems="flex-start">
+        <Breadcrumbs.Root
+          aria-label="Breadcrumbs"
+          items={items}
+          onAction={navigate}
+        >
+          {(item: (typeof trail)[number]) => (
+            <Breadcrumbs.Item>{item.label}</Breadcrumbs.Item>
+          )}
+        </Breadcrumbs.Root>
+        <Text data-testid="count">Items: {items.length}</Text>
+      </Stack>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("starts with the full trail", async () => {
+      await expect(canvas.getByTestId("count")).toHaveTextContent("Items: 4");
+    });
+
+    await step("pressing an item truncates the trail", async () => {
+      await userEvent.click(canvas.getByText("Reports"));
+      await expect(canvas.getByTestId("count")).toHaveTextContent("Items: 2");
+    });
+  },
+};
+
+/**
+ * SmokeTest
+ * Comprehensive matrix of sizes for visual regression review.
+ */
+export const SmokeTest: Story = {
+  render: () => (
+    <Stack gap="600" alignItems="flex-start">
+      {sizes.map((size) => (
+        <Breadcrumbs.Root key={size} size={size} aria-label={`${size} smoke`}>
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/a">Section</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/a/b">Subsection</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Current</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      ))}
+    </Stack>
+  ),
+};

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,59 @@
+import { BreadcrumbsRoot, BreadcrumbsItem } from "./components";
+
+/**
+ * Breadcrumbs
+ * ============================================================
+ * Breadcrumbs display a hierarchy of links to the current page or resource,
+ * helping users understand and navigate their location within an application.
+ *
+ * The last item represents the current page: omit its `href` and it renders as
+ * static, non-interactive text (`aria-current="page"`).
+ *
+ * @see {@link https://nimbus-documentation.vercel.app/components/navigation/breadcrumbs}
+ *
+ * @example
+ * ```tsx
+ * <Breadcrumbs.Root aria-label="Breadcrumbs">
+ *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item href="/reports">Reports</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item>Q3 Summary</Breadcrumbs.Item>
+ * </Breadcrumbs.Root>
+ * ```
+ */
+export const Breadcrumbs = {
+  /**
+   * # Breadcrumbs.Root
+   *
+   * The root component that renders the ordered list of breadcrumb items and
+   * provides styling context to its parts. Supports both static children and
+   * dynamic collections via the `items` prop. Place inside a navigation
+   * landmark by providing an `aria-label`.
+   *
+   * @example
+   * ```tsx
+   * <Breadcrumbs.Root aria-label="Breadcrumbs" onAction={navigate}>
+   *   <Breadcrumbs.Item id="home">Home</Breadcrumbs.Item>
+   *   <Breadcrumbs.Item id="current">Details</Breadcrumbs.Item>
+   * </Breadcrumbs.Root>
+   * ```
+   */
+  Root: BreadcrumbsRoot,
+
+  /**
+   * # Breadcrumbs.Item
+   *
+   * A single entry in the breadcrumb trail. Provide an `href` to render a
+   * navigable link, or omit it on the final item to mark the current page.
+   * A decorative separator is rendered automatically after every item except
+   * the current one.
+   *
+   * @example
+   * ```tsx
+   * <Breadcrumbs.Root aria-label="Breadcrumbs">
+   *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+   *   <Breadcrumbs.Item>Current page</Breadcrumbs.Item>
+   * </Breadcrumbs.Root>
+   * ```
+   */
+  Item: BreadcrumbsItem,
+};

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -1,0 +1,87 @@
+import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  HTMLChakraProps,
+  RecipeProps,
+  SlotRecipeProps,
+} from "@chakra-ui/react/styled-system";
+import type { FC, Ref } from "react";
+import type {
+  BreadcrumbsProps as RaBreadcrumbsProps,
+  BreadcrumbProps as RaBreadcrumbProps,
+  LinkProps as RaLinkProps,
+} from "react-aria-components";
+
+// ============================================================
+// RECIPE PROPS
+// ============================================================
+
+type BreadcrumbsRecipeVariantProps = {
+  /**
+   * Size variant of the breadcrumbs.
+   * @default "md"
+   */
+  size?: SlotRecipeProps<"nimbusBreadcrumbs">["size"];
+};
+
+// ============================================================
+// SLOT PROPS
+// ============================================================
+
+// The root slot renders the <nav> landmark and carries the recipe variants.
+type BreadcrumbsRootSlotProps = HTMLChakraProps<
+  "nav",
+  BreadcrumbsRecipeVariantProps
+>;
+
+type BreadcrumbsItemSlotProps = HTMLChakraProps<"li", RecipeProps<"li">>;
+
+// ============================================================
+// MAIN PROPS
+// ============================================================
+
+/**
+ * Props for `Breadcrumbs.Root`.
+ *
+ * The Root renders a navigation landmark (`<nav>`) wrapping the React Aria
+ * `Breadcrumbs` collection. It accepts the recipe `size` variant, Nimbus style
+ * props on the `<nav>`, and the React Aria collection props (`items`,
+ * `onAction`, `isDisabled`, `children`) which are forwarded to the inner list.
+ */
+type BreadcrumbsRootProps<T extends object> = BreadcrumbsRootSlotProps &
+  RaBreadcrumbsProps<T>;
+
+export type BreadcrumbsProps<T extends object = object> =
+  BreadcrumbsRecipeVariantProps &
+    OmitInternalProps<BreadcrumbsRootProps<T>, "size"> & {
+      ref?: Ref<HTMLElement>;
+    };
+
+export type BreadcrumbsRootComponent = FC<BreadcrumbsProps>;
+
+/**
+ * Props for the inner list slot — the React Aria `Breadcrumbs` collection
+ * (`<ol>`). Style props are omitted from the public Root API and applied
+ * internally.
+ */
+export type BreadcrumbsListProps = RaBreadcrumbsProps<object> & {
+  ref?: Ref<HTMLOListElement>;
+};
+
+/**
+ * Props for `Breadcrumbs.Item`.
+ *
+ * Combines React Aria's `Breadcrumb` props (collection item semantics,
+ * `id` for `onAction`) with the props of the link it renders (`href`,
+ * `onPress`, routing props) so a single element can act as both the list item
+ * and its interactive link.
+ */
+export type BreadcrumbsItemProps = RaBreadcrumbProps &
+  Omit<RaLinkProps, "className" | "style" | "children"> &
+  OmitInternalProps<
+    BreadcrumbsItemSlotProps,
+    keyof RaBreadcrumbProps | keyof RaLinkProps
+  > & {
+    ref?: Ref<HTMLLIElement>;
+  };
+
+export type BreadcrumbsItemComponent = FC<BreadcrumbsItemProps>;

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
@@ -1,0 +1,87 @@
+import { ChevronRight } from "@commercetools/nimbus-icons";
+import { extractStyleProps } from "@/utils";
+import {
+  BreadcrumbsItemSlot,
+  BreadcrumbsLinkSlot,
+  BreadcrumbsSeparatorSlot,
+} from "../breadcrumbs.slots";
+import type { BreadcrumbsItemComponent } from "../breadcrumbs.types";
+
+/**
+ * Breadcrumbs.Item - A single entry in the breadcrumb trail.
+ *
+ * Renders a React Aria `Breadcrumb` (`<li>`) containing a `Link`. The last
+ * item in the trail represents the current page: omit `href` and React Aria
+ * marks it as current (`aria-current="page"`), rendering it as static,
+ * non-interactive text. A decorative separator is rendered after every item
+ * except the current one.
+ *
+ * @supportsStyleProps
+ */
+export const BreadcrumbsItem: BreadcrumbsItemComponent = ({
+  children,
+  id,
+  ref,
+  // React Aria Breadcrumb-level props
+  autoFocus,
+  // Link-level props (forwarded to the rendered Link)
+  href,
+  hrefLang,
+  target,
+  rel,
+  download,
+  ping,
+  referrerPolicy,
+  routerOptions,
+  onPress,
+  onPressStart,
+  onPressEnd,
+  onPressChange,
+  onPressUp,
+  isDisabled,
+  ...rest
+}) => {
+  // Separate Chakra style props (applied to the <li> item slot) from any
+  // remaining DOM/aria props.
+  const [styleProps, restProps] = extractStyleProps(rest);
+
+  const linkProps = {
+    href,
+    hrefLang,
+    target,
+    rel,
+    download,
+    ping,
+    referrerPolicy,
+    routerOptions,
+    onPress,
+    onPressStart,
+    onPressEnd,
+    onPressChange,
+    onPressUp,
+    isDisabled,
+  };
+
+  return (
+    <BreadcrumbsItemSlot
+      ref={ref}
+      id={id}
+      autoFocus={autoFocus}
+      {...styleProps}
+      {...restProps}
+    >
+      {({ isCurrent }) => (
+        <>
+          <BreadcrumbsLinkSlot {...linkProps}>{children}</BreadcrumbsLinkSlot>
+          {!isCurrent && (
+            <BreadcrumbsSeparatorSlot aria-hidden="true">
+              <ChevronRight />
+            </BreadcrumbsSeparatorSlot>
+          )}
+        </>
+      )}
+    </BreadcrumbsItemSlot>
+  );
+};
+
+BreadcrumbsItem.displayName = "Breadcrumbs.Item";

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
@@ -1,0 +1,55 @@
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
+import { extractStyleProps } from "@/utils";
+import { BreadcrumbsRootSlot, BreadcrumbsListSlot } from "../breadcrumbs.slots";
+import type { BreadcrumbsRootComponent } from "../breadcrumbs.types";
+
+/**
+ * Breadcrumbs.Root - Renders the navigation landmark (`<nav>`) and the ordered
+ * list of breadcrumb items, providing styling context to its parts.
+ *
+ * Collection props (`items`, `onAction`, `isDisabled`, `children`) are
+ * forwarded to the React Aria `Breadcrumbs` list; labelling props
+ * (`aria-label`, `aria-labelledby`) and style props apply to the `<nav>`.
+ *
+ * @supportsStyleProps
+ */
+export const BreadcrumbsRoot: BreadcrumbsRootComponent = (props) => {
+  // Collection + labelling props are destructured from the typed props; the
+  // rest is split into recipe variants (size) and Chakra style props that
+  // apply to the <nav>.
+  const {
+    children,
+    items,
+    onAction,
+    isDisabled,
+    ref,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
+    ...rest
+  } = props;
+
+  const recipe = useSlotRecipe({ key: "nimbusBreadcrumbs" });
+  const [recipeProps, restRecipeProps] = recipe.splitVariantProps(rest);
+  const [styleProps, navProps] = extractStyleProps(restRecipeProps);
+
+  return (
+    <BreadcrumbsRootSlot
+      ref={ref}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      {...recipeProps}
+      {...styleProps}
+      {...navProps}
+    >
+      <BreadcrumbsListSlot
+        items={items}
+        onAction={onAction}
+        isDisabled={isDisabled}
+      >
+        {children}
+      </BreadcrumbsListSlot>
+    </BreadcrumbsRootSlot>
+  );
+};
+
+BreadcrumbsRoot.displayName = "Breadcrumbs.Root";

--- a/packages/nimbus/src/components/breadcrumbs/components/index.ts
+++ b/packages/nimbus/src/components/breadcrumbs/components/index.ts
@@ -1,0 +1,2 @@
+export { BreadcrumbsRoot } from "./breadcrumbs.root";
+export { BreadcrumbsItem } from "./breadcrumbs.item";

--- a/packages/nimbus/src/components/breadcrumbs/index.ts
+++ b/packages/nimbus/src/components/breadcrumbs/index.ts
@@ -1,0 +1,2 @@
+export * from "./breadcrumbs";
+export * from "./breadcrumbs.types";

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -42,6 +42,7 @@ export * from "./spacer";
 export * from "./accordion";
 export * from "./alert";
 export * from "./badge";
+export * from "./breadcrumbs";
 export * from "./card";
 export * from "./form-field";
 export * from "./icon";

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -1,4 +1,5 @@
 import { accordionSlotRecipe } from "@/components/accordion/accordion.recipe";
+import { breadcrumbsSlotRecipe } from "@/components/breadcrumbs/breadcrumbs.recipe";
 import { scrollAreaSlotRecipe } from "@/components/scroll-area/scroll-area.recipe";
 import { defaultPageSlotRecipe } from "@/components/default-page/default-page.recipe";
 import { stepsSlotRecipe } from "@/components/steps/steps.recipe";
@@ -75,6 +76,7 @@ import { buttonGroupRecipe } from "@/components/toggle-button-group/toggle-butto
  */
 export const slotRecipes = {
   nimbusAccordion: accordionSlotRecipe,
+  nimbusBreadcrumbs: breadcrumbsSlotRecipe,
   nimbusAlert: alertRecipe,
   nimbusCalendar: calendarSlotRecipe,
   nimbusCard: cardRecipe,


### PR DESCRIPTION
## ⚗️ A/B experiment — please do not merge

This is **one arm of a two-PR experiment** measuring whether the `new-dev-docs`
documentation + `.claude/` tooling overhaul actually changes what an AI agent
produces. **Sibling (AFTER) PR:** #1693

Both PRs were produced by the **same model, same task, same prompt**, each told
to build a `Breadcrumbs` component bootstrapping **only** from the repo's own
`CLAUDE.md` / `docs/` / `.claude/`. The **only** variable is the state of those
docs/tooling files.

- **This PR = BEFORE**: docs/tooling as of `1356a4063` (pre-overhaul `main`).
- Both branches are based on the **same `main` commit** (`1356a4063`), so each
  diff is purely "add Breadcrumbs" and the two are directly comparable.

Committed **exactly as the agent produced it — no human fix-ups** — so the
comparison reflects the tooling, not my editing.

### Independently re-run validation (ground truth, not the agent's self-report)

Brought to the same fully-built state as the AFTER arm and run through the same
authoritative checks:

| Check                                                                               | Result                                                                                                               |
| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| `pnpm --filter @commercetools/nimbus typecheck` (`tsc --noEmit`, **incl. stories**) | ❌ **4 errors** in `breadcrumbs.stories.tsx` (React Aria collection render-prop typing + a `size`-as-`key` mismatch) |
| `eslint` (breadcrumbs)                                                              | ✅ clean                                                                                                             |
| story tests (source, Playwright)                                                    | ✅ 6/6                                                                                                               |

> The generating agent self-reported "typecheck PASS" only because it scoped
> `tsc` to non-story files, hiding the 4 story errors. CI here is expected red.

### What this arm produced — 11 files, 894 lines

- Recipe file named **`breadcrumbs.recipe.tsx`** (wrong extension — recipes are `.ts`)
- **No** `breadcrumbs.a11y.mdx`
- **No** `breadcrumbs.docs.spec.tsx` (consumer implementation tests)
- Separator handled inline

Compare against the AFTER arm's file set and CI status.
