### PR TITLE
[experiment] Breadcrumbs — AFTER docs/tooling overhaul

### DIFF
--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
@@ -1,0 +1,47 @@
+---
+tab-title: Accessibility
+tab-order: 4
+---
+
+## Accessibility
+
+Accessibility ensures that digital content and functionality are usable by
+everyone, including people with disabilities, by addressing visual, auditory,
+cognitive, and physical limitations.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/products/apparel">Apparel</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```
+
+### Accessibility standards
+
+- **Landmark role:** `Breadcrumbs.Root` renders a `<nav>` HTML element — a
+  navigation landmark. Always provide an `aria-label` (commonly `"Breadcrumb"`)
+  to identify the landmark, especially when a page contains multiple `<nav>`
+  elements.
+- **List semantics:** Items are rendered inside an ordered list (`<ol>` with
+  `<li>` children), which communicates the hierarchical, sequential nature of
+  the trail to assistive technologies.
+- **Link semantics:** Each interactive item renders an `<a>` element with the
+  implicit `link` role.
+- **Current page indication:** The current (last) item uses
+  `aria-current="page"` — **not** `aria-selected`. Screen readers announce this
+  as "current page". The current item renders as non-interactive text and is
+  removed from the tab sequence.
+- **Decorative separators:** Separators between items are decorative and carry
+  `aria-hidden="true"`, so they are not announced by screen readers.
+- **Keyboard navigation:** Breadcrumbs use standard sequential keyboard
+  navigation. The `Tab` key moves focus to the next link and `Shift + Tab` moves
+  to the previous link. Arrow keys do **not** cycle focus between items.
+- **Disabled items:** Disabled items carry `aria-disabled="true"` and are
+  excluded from the tab sequence, so keyboard users skip them naturally.
+- **Contrast:** Ensure sufficient contrast between link text and the background
+  in all states (default, hover, current, focused, disabled). The focus
+  indicator must be clearly visible.

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
@@ -1,0 +1,234 @@
+---
+title: Breadcrumbs Component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import {
+  Breadcrumbs,
+  type BreadcrumbsProps,
+  type BreadcrumbsItemProps,
+} from "@commercetools/nimbus";
+```
+
+### Basic usage
+
+`Breadcrumbs` is a compound component for **hierarchical page navigation**. It
+renders a `<nav>` landmark containing an ordered list of `<a>` elements. Mark
+the last item with `isCurrent` to represent the current page.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+## Usage examples
+
+### Current page
+
+Mark the final item with `isCurrent`. This strips the `href`, renders the item
+as non-interactive text, and sets `aria-current="page"`.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+When using a client-side router, derive the trail from the current route and
+render the deepest segment with `isCurrent`:
+
+```tsx
+import { useLocation } from "react-router-dom";
+
+const ProductBreadcrumbs = ({ category }: { category: string }) => {
+  const { pathname } = useLocation();
+
+  return (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>{category}</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  );
+};
+```
+
+### Custom separator
+
+The default separator is `/`. Pass any React node (string or icon) via the
+`separator` prop on `Breadcrumbs.Root`. Separators are decorative and hidden
+from assistive technologies.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Apparel</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+### Size variants
+
+The `size` prop controls font size and spacing. Available sizes: `sm`, `md`
+(default).
+
+```jsx live-dev
+const App = () => (
+  <Stack direction="column" gap="600">
+    <Stack direction="column" gap="200">
+      <Text fontWeight="500">Small</Text>
+      <Breadcrumbs.Root aria-label="Breadcrumb (sm)" size="sm">
+        <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+        <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      </Breadcrumbs.Root>
+    </Stack>
+    <Stack direction="column" gap="200">
+      <Text fontWeight="500">Medium (default)</Text>
+      <Breadcrumbs.Root aria-label="Breadcrumb (md)" size="md">
+        <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+        <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      </Breadcrumbs.Root>
+    </Stack>
+  </Stack>
+);
+```
+
+### Disabled items
+
+Use `isDisabled` to render an ancestor item that exists in the trail but cannot
+currently be navigated to. Disabled items are visually dimmed, removed from the
+tab sequence, and their `href` is stripped.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders" isDisabled>
+      Orders
+    </Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+### External links
+
+Use `target` and `rel` to open a breadcrumb in a new browser tab. Always pair
+`target="_blank"` with `rel="noopener noreferrer"` for security.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="https://docs.example.com" target="_blank" rel="noopener noreferrer">
+      Docs ↗
+    </Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+## Component requirements
+
+### Accessibility
+
+The Breadcrumbs component uses semantic HTML for navigation. Accessibility is
+handled natively by the browser's `<nav>` landmark, ordered-list structure, and
+`<a>` anchor semantics, combined with React Aria's `Link` for consistent
+interaction handling.
+
+#### Role
+
+- `Breadcrumbs.Root` renders a `<nav>` HTML element — a navigation landmark
+- Items are rendered inside an `<ol>`/`<li>` structure
+- Each interactive item renders an `<a>` HTML element with the implicit `link`
+  role
+- The current item uses `aria-current="page"` — **not** `aria-selected`
+
+#### Labeling
+
+Always provide an `aria-label` on `Breadcrumbs.Root` (commonly `"Breadcrumb"`)
+to describe the navigation region.
+
+```tsx
+<Breadcrumbs.Root aria-label="Breadcrumb">...</Breadcrumbs.Root>
+```
+
+#### Keyboard navigation
+
+Breadcrumbs use standard sequential keyboard navigation — no roving tabindex,
+no arrow key cycling.
+
+| Key           | Action                          |
+| ------------- | ------------------------------- |
+| `Tab`         | Move focus to the next link     |
+| `Shift + Tab` | Move focus to the previous link |
+| `Enter`       | Activate the focused link       |
+
+The current (last) item is non-interactive and is skipped in the tab sequence.
+
+## API reference
+
+<PropsTable id="Breadcrumbs" />
+
+## Common patterns
+
+### Building a trail from data
+
+Render breadcrumbs from an array, marking the last entry as current.
+
+```tsx
+const trail = [
+  { href: "/", label: "Home" },
+  { href: "/products", label: "Products" },
+  { href: "/products/apparel", label: "Apparel" },
+  { label: "Shoes" }, // current page — no href
+];
+
+const ProductTrail = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    {trail.map((entry, index) => (
+      <Breadcrumbs.Item
+        key={entry.href ?? entry.label}
+        href={entry.href}
+        isCurrent={index === trail.length - 1}
+      >
+        {entry.label}
+      </Breadcrumbs.Item>
+    ))}
+  </Breadcrumbs.Root>
+);
+```
+
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using
+Breadcrumbs within your application. As the component's internal functionality
+is already tested by Nimbus, these patterns help you verify your integration and
+application-specific logic.
+
+{{docs-tests: breadcrumbs.docs.spec.tsx}}
+
+## Resources
+
+- [React Aria Breadcrumbs](https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html)
+- [ARIA: navigation landmark](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role)
+- [aria-current attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current)

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.docs.spec.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.docs.spec.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Breadcrumbs, NimbusProvider } from "@commercetools/nimbus";
+
+/**
+ * @docs-section basic-rendering
+ * @docs-title Basic Rendering Tests
+ * @docs-description Verify the Breadcrumbs component renders a nav landmark with an ordered list of links
+ * @docs-order 1
+ */
+describe("Breadcrumbs - Basic rendering", () => {
+  it("renders a navigation landmark with an ordered list", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Breadcrumb" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("list").tagName).toBe("OL");
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("renders link items as anchors with the correct href", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(screen.getByRole("link", { name: "Orders" })).toHaveAttribute(
+      "href",
+      "/orders"
+    );
+  });
+});
+
+/**
+ * @docs-section current-page
+ * @docs-title Current Page Tests
+ * @docs-description Verify aria-current="page" is applied to the current (last) item and not to ancestors
+ * @docs-order 2
+ */
+describe("Breadcrumbs - Current page", () => {
+  it("sets aria-current='page' on the current item", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Order #123")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("renders the current item as non-interactive text, not a link", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    // An <a> without href exposes no `link` role, so the current page is
+    // non-interactive and absent from the list of links.
+    expect(
+      screen.queryByRole("link", { name: "Order #123" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Order #123")).not.toHaveAttribute("href");
+  });
+
+  it("does not set aria-current on ancestor items", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    );
+    expect(screen.getByRole("link", { name: "Orders" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+});
+
+/**
+ * @docs-section disabled-items
+ * @docs-title Disabled Item Tests
+ * @docs-description Verify disabled items are marked inaccessible and stripped of their href
+ * @docs-order 3
+ */
+describe("Breadcrumbs - Disabled items", () => {
+  it("marks disabled items with aria-disabled='true' and strips href", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders" isDisabled>
+            Orders
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    const disabled = screen.getByRole("link", { name: "Orders" });
+    expect(disabled).toHaveAttribute("aria-disabled", "true");
+    expect(disabled).not.toHaveAttribute("href");
+  });
+});
+
+/**
+ * @docs-section external-links
+ * @docs-title External Link Tests
+ * @docs-description Verify target and rel attributes for external breadcrumb items
+ * @docs-order 4
+ */
+describe("Breadcrumbs - External links", () => {
+  it("applies target and rel to external link items", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item
+            href="https://docs.example.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Docs ↗
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    const external = screen.getByRole("link", { name: "Docs ↗" });
+    expect(external).toHaveAttribute("target", "_blank");
+    expect(external).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});
+
+/**
+ * @docs-section interactions
+ * @docs-title Interaction Tests
+ * @docs-description Verify click handling and keyboard focus
+ * @docs-order 5
+ */
+describe("Breadcrumbs - Interactions", () => {
+  it("calls onClick when a link is clicked", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/" onClick={handleClick}>
+            Home
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    await user.click(screen.getByRole("link", { name: "Home" }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it("focuses link items with the Tab key", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    await user.tab();
+    expect(screen.getByRole("link", { name: "Home" })).toHaveFocus();
+  });
+});
+
+/**
+ * @docs-section accessibility
+ * @docs-title Accessibility Tests
+ * @docs-description Verify accessible labels and that the widget does not use aria-selected
+ * @docs-order 6
+ */
+describe("Breadcrumbs - Accessibility", () => {
+  it("supports aria-label on the root for landmark identification", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Breadcrumb" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not use aria-selected (navigation, not a widget)", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Order #123")).not.toHaveAttribute("aria-selected");
+  });
+});

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
@@ -1,0 +1,108 @@
+---
+id: Components-Breadcrumbs
+title: Breadcrumbs
+exportName: Breadcrumbs
+description: A navigation trail showing the path to the current page.
+lifecycleState: Stable
+order: 999
+menu:
+  - Components
+  - Navigation
+  - Breadcrumbs
+tags:
+  - component
+  - navigation
+  - breadcrumbs
+---
+
+## Overview
+
+Breadcrumbs display the hierarchical path to the current page as an ordered
+list of links. They render a `<nav>` landmark containing an `<ol>` of `<a>`
+elements. Each item except the last navigates to an ancestor page; the last
+item represents the current page and is rendered as non-interactive text with
+`aria-current="page"`.
+
+Use breadcrumbs in pages that sit several levels deep in a hierarchy (e.g.
+`/products/apparel/shoes`) to help users understand where they are and to move
+back up the tree.
+
+### Resources
+
+Deep dive into implementation details and access the Nimbus design library.
+
+[React Aria Breadcrumbs](https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html)
+
+## Variables
+
+Get familiar with the features.
+
+### Sizes
+
+`Breadcrumbs` supports two size variants — `sm` and `md` (default) — that
+control the font size and spacing between items.
+
+```jsx live
+const App = () => (
+  <Stack direction="column" gap="600">
+    {["sm", "md"].map((size) => (
+      <Stack key={size} direction="column" gap="200">
+        <Text fontWeight="600">{size}</Text>
+        <Breadcrumbs.Root aria-label={`Breadcrumb (${size})`} size={size}>
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </Stack>
+    ))}
+  </Stack>
+)
+```
+
+### Current page
+
+Mark the last item with `isCurrent`. This renders it as non-interactive text
+with `aria-current="page"`, which screen readers announce as "current page".
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```
+
+### Custom separator
+
+Supply any React node via the `separator` prop on `Breadcrumbs.Root`. The
+separator is decorative and hidden from assistive technologies.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```
+
+### Disabled item
+
+Use `isDisabled` to render an item that is part of the trail but cannot be
+navigated to. Disabled items are visually dimmed and excluded from the tab
+sequence.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders" isDisabled>
+      Orders
+    </Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
@@ -1,0 +1,103 @@
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
+
+/**
+ * Recipe configuration for the Breadcrumbs component.
+ * Defines the styling variants and base styles using Chakra UI's recipe system.
+ *
+ * Renders navigation semantics (`<nav>` landmark + ordered list of `<a>`
+ * elements) for the path to the current page. The last item represents the
+ * current page and is rendered as non-interactive text with
+ * `aria-current="page"`.
+ */
+export const breadcrumbsSlotRecipe = defineSlotRecipe({
+  slots: ["root", "list", "item", "link", "separator"],
+
+  className: "nimbus-breadcrumbs",
+
+  base: {
+    root: {
+      display: "block",
+      width: "100%",
+    },
+    list: {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      listStyle: "none",
+      margin: "0",
+      padding: "0",
+      gap: "var(--breadcrumbs-gap)",
+    },
+    item: {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      gap: "var(--breadcrumbs-gap)",
+      fontSize: "var(--breadcrumbs-font-size)",
+    },
+    link: {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: "200",
+      color: "neutral.11",
+      textDecoration: "none",
+      cursor: "pointer",
+      borderRadius: "200",
+      transition: "color 150ms ease",
+      focusVisibleRing: "outside",
+      _hover: {
+        color: "primary.11",
+        textDecoration: "underline",
+      },
+      // React Aria sets data-current on the current (last) breadcrumb's link.
+      "&[data-current]": {
+        color: "neutral.12",
+        fontWeight: "500",
+        textDecoration: "none",
+        cursor: "default",
+        pointerEvents: "none",
+      },
+      _disabled: {
+        layerStyle: "disabled",
+      },
+    },
+    separator: {
+      display: "inline-flex",
+      alignItems: "center",
+      color: "neutral.9",
+      userSelect: "none",
+      // The first breadcrumb has no preceding separator.
+      "li:first-of-type > &": {
+        display: "none",
+      },
+    },
+  },
+
+  variants: {
+    size: {
+      sm: {
+        item: {
+          "--breadcrumbs-font-size": "fontSizes.300",
+          "--breadcrumbs-gap": "{spacing.100}",
+        },
+        list: {
+          "--breadcrumbs-gap": "{spacing.100}",
+        },
+      },
+      md: {
+        item: {
+          "--breadcrumbs-font-size": "fontSizes.350",
+          "--breadcrumbs-gap": "{spacing.200}",
+        },
+        list: {
+          "--breadcrumbs-gap": "{spacing.200}",
+        },
+      },
+    },
+  },
+
+  defaultVariants: {
+    size: "md",
+  },
+});

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.slots.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.slots.tsx
@@ -1,0 +1,61 @@
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "@/type-utils";
+import type {
+  BreadcrumbsRootSlotProps,
+  BreadcrumbsListSlotProps,
+  BreadcrumbsItemSlotProps,
+  BreadcrumbsLinkSlotProps,
+  BreadcrumbsSeparatorSlotProps,
+} from "./breadcrumbs.types";
+
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusBreadcrumbs",
+});
+
+/**
+ * Root slot component providing the styling context for the Breadcrumbs
+ * component. Renders a `<nav>` landmark element.
+ */
+export const BreadcrumbsRootSlot: SlotComponent<
+  HTMLElement,
+  BreadcrumbsRootSlotProps
+> = withProvider<HTMLElement, BreadcrumbsRootSlotProps>("nav", "root");
+
+/**
+ * List slot component for the ordered list of breadcrumbs.
+ * Renders as an `<ol>` element.
+ */
+export const BreadcrumbsListSlot: SlotComponent<
+  HTMLOListElement,
+  BreadcrumbsListSlotProps
+> = withContext<HTMLOListElement, BreadcrumbsListSlotProps>("ol", "list");
+
+/**
+ * Item slot component for an individual breadcrumb.
+ * Renders as an `<li>` element.
+ */
+export const BreadcrumbsItemSlot: SlotComponent<
+  HTMLLIElement,
+  BreadcrumbsItemSlotProps
+> = withContext<HTMLLIElement, BreadcrumbsItemSlotProps>("li", "item");
+
+/**
+ * Link slot component for an individual breadcrumb link.
+ * Renders as an `<a>` element.
+ */
+export const BreadcrumbsLinkSlot: SlotComponent<
+  HTMLAnchorElement,
+  BreadcrumbsLinkSlotProps
+> = withContext<HTMLAnchorElement, BreadcrumbsLinkSlotProps>("a", "link");
+
+/**
+ * Separator slot component rendered between breadcrumb items.
+ * Renders as a decorative `<span>` element.
+ */
+export const BreadcrumbsSeparatorSlot: SlotComponent<
+  HTMLSpanElement,
+  BreadcrumbsSeparatorSlotProps
+> = withContext<HTMLSpanElement, BreadcrumbsSeparatorSlotProps>(
+  "span",
+  "separator"
+);

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,0 +1,279 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { Breadcrumbs, Stack, Text } from "@commercetools/nimbus";
+
+/**
+ * `Breadcrumbs` displays the hierarchical path to the current page as an
+ * ordered list of navigation links.
+ */
+const meta: Meta<typeof Breadcrumbs.Root> = {
+  title: "Components/Breadcrumbs",
+  component: Breadcrumbs.Root,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+      description: "Size of the breadcrumb items",
+    },
+  },
+};
+
+export default meta;
+
+/**
+ * Story type for TypeScript support
+ * StoryObj provides type checking for our story configurations
+ */
+type Story = StoryObj<typeof Breadcrumbs.Root>;
+
+/**
+ * The default Breadcrumbs usage with three items. The first two are links and
+ * the last item is marked as the current page with `isCurrent`.
+ */
+export const Base: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders a nav landmark", async () => {
+      const nav = canvas.getByRole("navigation", { name: "Breadcrumb" });
+      await expect(nav).toBeInTheDocument();
+    });
+
+    await step("Renders an ordered list", async () => {
+      const list = canvas.getByRole("list");
+      await expect(list.tagName).toBe("OL");
+    });
+
+    await step("Renders one list item per breadcrumb", async () => {
+      const items = canvas.getAllByRole("listitem");
+      await expect(items).toHaveLength(3);
+    });
+
+    await step("Link items point to their href", async () => {
+      const home = canvas.getByRole("link", { name: "Home" });
+      const orders = canvas.getByRole("link", { name: "Orders" });
+      await expect(home).toHaveAttribute("href", "/");
+      await expect(orders).toHaveAttribute("href", "/orders");
+    });
+
+    await step("Current item is text with aria-current='page'", async () => {
+      const current = canvas.getByText("Order #123");
+      await expect(current).toHaveAttribute("aria-current", "page");
+    });
+
+    await step("Current item is not a link (no href)", async () => {
+      const current = canvas.getByText("Order #123");
+      await expect(current).not.toHaveAttribute("href");
+      // An <a> without href exposes no `link` role, so it is non-interactive.
+      await expect(
+        canvas.queryByRole("link", { name: "Order #123" })
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Demonstrates the two size variants: `sm` and `md` (default). Size controls
+ * the font size and gap between items.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <Stack direction="column" gap="600">
+      {(["sm", "md"] as const).map((size) => (
+        <Stack key={size} direction="column" gap="200">
+          <Text fontWeight="600">{size}</Text>
+          <Breadcrumbs.Root aria-label={`Breadcrumb (${size})`} size={size}>
+            <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+            <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+            <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          </Breadcrumbs.Root>
+        </Stack>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Both size variants render nav landmarks", async () => {
+      const navs = canvas.getAllByRole("navigation");
+      await expect(navs).toHaveLength(2);
+    });
+  },
+};
+
+/**
+ * Demonstrates a custom separator. Any React node may be supplied via the
+ * `separator` prop on `Breadcrumbs.Root`; it is decorative and hidden from
+ * assistive technologies.
+ */
+export const CustomSeparator: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders the nav landmark", async () => {
+      await expect(
+        canvas.getByRole("navigation", { name: "Breadcrumb" })
+      ).toBeInTheDocument();
+    });
+
+    await step("Current item renders with the expected label", async () => {
+      const current = canvas.getByText("Shoes");
+      await expect(current).toHaveAttribute("aria-current", "page");
+    });
+  },
+};
+
+/**
+ * Demonstrates `isDisabled` on an individual item. Disabled items are visually
+ * dimmed, cannot be activated, and carry `aria-disabled="true"`.
+ */
+export const WithDisabledItem: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders" isDisabled>
+        Orders
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Disabled item has aria-disabled", async () => {
+      const disabled = canvas.getByRole("link", { name: "Orders" });
+      await expect(disabled).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await step("Disabled item has no href", async () => {
+      const disabled = canvas.getByRole("link", { name: "Orders" });
+      await expect(disabled).not.toHaveAttribute("href");
+    });
+  },
+};
+
+/**
+ * Demonstrates keyboard navigation. Breadcrumbs use standard sequential Tab key
+ * navigation (no roving tabindex). The current (last) item is non-interactive
+ * and is skipped in the tab sequence.
+ */
+export const KeyboardNavigation: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Tab moves focus to the first link", async () => {
+      const home = canvas.getByRole("link", { name: "Home" });
+      await userEvent.tab();
+      await expect(home).toHaveFocus();
+    });
+
+    await step("Tab moves focus to the second link", async () => {
+      const orders = canvas.getByRole("link", { name: "Orders" });
+      await userEvent.tab();
+      await expect(orders).toHaveFocus();
+    });
+
+    await step("Current item is not focusable (skipped)", async () => {
+      const current = canvas.getByText("Order #123");
+      await userEvent.tab();
+      await expect(current).not.toHaveFocus();
+    });
+  },
+};
+
+/**
+ * Demonstrates `target` and `rel` for opening a breadcrumb in a new browser
+ * tab — standard anchor semantics for external references.
+ */
+export const WithExternalLink: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item
+        href="https://example.com"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Example ↗
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("External link has target=_blank", async () => {
+      const external = canvas.getByRole("link", { name: "Example ↗" });
+      await expect(external).toHaveAttribute("target", "_blank");
+    });
+
+    await step("External link has rel=noopener noreferrer", async () => {
+      const external = canvas.getByRole("link", { name: "Example ↗" });
+      await expect(external).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  },
+};
+
+/**
+ * Comprehensive smoke test with a deeper hierarchy and a single current item.
+ */
+export const SmokeTest: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products/apparel">Apparel</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products/apparel/shoes">Shoes</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Running shoes</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders nav landmark", async () => {
+      await expect(canvas.getByRole("navigation")).toBeInTheDocument();
+    });
+
+    await step("Renders all five list items", async () => {
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(5);
+    });
+
+    await step("Only the last item is current", async () => {
+      const current = canvas.getByText("Running shoes");
+      await expect(current).toHaveAttribute("aria-current", "page");
+
+      const home = canvas.getByRole("link", { name: "Home" });
+      await expect(home).not.toHaveAttribute("aria-current");
+    });
+
+    await step("Link items keep their href", async () => {
+      await expect(
+        canvas.getByRole("link", { name: "Products" })
+      ).toHaveAttribute("href", "/products");
+    });
+  },
+};

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,71 @@
+import { BreadcrumbsRoot, BreadcrumbsItem } from "./components";
+
+/**
+ * Breadcrumbs
+ * ============================================================
+ * A navigation component that displays the hierarchical path to the current
+ * page as an ordered list of links. The last item represents the current page
+ * and is rendered as non-interactive text.
+ *
+ * Renders proper navigation semantics (`<nav>` landmark, `<ol>`/`<li>`
+ * structure, `<a>` elements, `aria-current="page"`) for WCAG 2.1 AA compliant
+ * page navigation.
+ *
+ * @see {@link https://nimbus-documentation.vercel.app/components/navigation/breadcrumbs}
+ *
+ * @example
+ * ```tsx
+ * <Breadcrumbs.Root aria-label="Breadcrumb">
+ *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+ * </Breadcrumbs.Root>
+ * ```
+ */
+export const Breadcrumbs = {
+  /**
+   * # Breadcrumbs.Root
+   *
+   * The root container for the breadcrumbs. Renders a `<nav>` landmark wrapping
+   * an ordered list of `Breadcrumbs.Item` links. Provide an `aria-label` (e.g.
+   * `"Breadcrumb"`) and an optional `separator` node.
+   *
+   * @example
+   * ```tsx
+   * <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+   *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+   *   <Breadcrumbs.Item isCurrent>Settings</Breadcrumbs.Item>
+   * </Breadcrumbs.Root>
+   * ```
+   */
+  Root: BreadcrumbsRoot,
+  /**
+   * # Breadcrumbs.Item
+   *
+   * An individual breadcrumb. Renders an `<li>` containing an `<a>` link. Use
+   * `isCurrent` on the last item to mark the current page (rendered as
+   * non-interactive text with `aria-current="page"`).
+   *
+   * @example
+   * ```tsx
+   * <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+   * <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+   * ```
+   */
+  Item: BreadcrumbsItem,
+};
+
+export type {
+  BreadcrumbsProps,
+  BreadcrumbsItemProps,
+} from "./breadcrumbs.types";
+
+/**
+ * todo: get rid of this, this is needed for the react-docgen-typescript script
+ * that is parsing the typescript types for our documentation. The _ underscores
+ * serve as a reminder that this exports are awkward and should not be used.
+ */
+export {
+  BreadcrumbsRoot as _BreadcrumbsRoot,
+  BreadcrumbsItem as _BreadcrumbsItem,
+};

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -1,0 +1,116 @@
+import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  HTMLChakraProps,
+  SlotRecipeProps,
+  UnstyledProp,
+} from "@chakra-ui/react/styled-system";
+
+// ============================================================
+// RECIPE PROPS
+// ============================================================
+
+type BreadcrumbsRecipeProps = {
+  /**
+   * Size of the breadcrumb items.
+   * @default "md"
+   */
+  size?: SlotRecipeProps<"nimbusBreadcrumbs">["size"];
+} & UnstyledProp;
+
+// ============================================================
+// SLOT PROPS
+// ============================================================
+
+export type BreadcrumbsRootSlotProps = HTMLChakraProps<
+  "nav",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsListSlotProps = HTMLChakraProps<
+  "ol",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsItemSlotProps = HTMLChakraProps<
+  "li",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsLinkSlotProps = HTMLChakraProps<
+  "a",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsSeparatorSlotProps = HTMLChakraProps<
+  "span",
+  BreadcrumbsRecipeProps
+>;
+
+// ============================================================
+// MAIN PROPS
+// ============================================================
+
+/**
+ * Props for the Breadcrumbs.Root component.
+ * Renders a `<nav>` landmark containing an ordered list of breadcrumb links.
+ */
+export type BreadcrumbsProps = OmitInternalProps<BreadcrumbsRootSlotProps> & {
+  /**
+   * The visible separator rendered between breadcrumb items. Accepts any
+   * React node (e.g. a string like "/" or an icon). The separator is
+   * decorative and hidden from assistive technologies.
+   * @default "/"
+   */
+  separator?: React.ReactNode;
+  /**
+   * A ref to the root `<nav>` element.
+   */
+  ref?: React.Ref<HTMLElement>;
+  [key: `data-${string}`]: unknown;
+};
+
+/**
+ * Props for the Breadcrumbs.Item component.
+ * Renders an `<li>` containing a navigation link. The last item in a
+ * `Breadcrumbs.Root` should set `isCurrent` to represent the current page.
+ */
+export type BreadcrumbsItemProps =
+  OmitInternalProps<BreadcrumbsLinkSlotProps> & {
+    /**
+     * The URL this breadcrumb links to. Omit (or pair with `isCurrent`) for the
+     * current page, which renders as non-interactive text.
+     */
+    href?: string;
+    /**
+     * Whether this item represents the current page. When true, the item renders
+     * as non-interactive text with `aria-current="page"` and no `href` is
+     * applied. Set this on the last breadcrumb.
+     * @default false
+     */
+    isCurrent?: boolean;
+    /**
+     * Whether the item is disabled. Disabled items cannot be interacted with and
+     * are visually dimmed.
+     * @default false
+     */
+    isDisabled?: boolean;
+    /**
+     * The target window for the link.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
+     */
+    target?: React.HTMLAttributeAnchorTarget;
+    /**
+     * The relationship between the current document and the linked URL.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#rel
+     */
+    rel?: string;
+    /**
+     * The label content displayed inside the breadcrumb.
+     */
+    children?: React.ReactNode;
+    /**
+     * A ref to the underlying `<a>` element.
+     */
+    ref?: React.Ref<HTMLAnchorElement>;
+    [key: `data-${string}`]: unknown;
+  };

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.context.ts
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.context.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+
+export interface BreadcrumbsContextValue {
+  /**
+   * The separator node rendered before each item except the first.
+   */
+  separator: React.ReactNode;
+}
+
+export const BreadcrumbsContext = createContext<
+  BreadcrumbsContextValue | undefined
+>(undefined);
+
+/**
+ * Returns the breadcrumbs context provided by `Breadcrumbs.Root`.
+ * Throws if a `Breadcrumbs.Item` is rendered outside of a `Breadcrumbs.Root`.
+ */
+export const useBreadcrumbsContext = (): BreadcrumbsContextValue => {
+  const context = useContext(BreadcrumbsContext);
+  if (!context) {
+    throw new Error("Breadcrumbs.Item must be used within Breadcrumbs.Root");
+  }
+  return context;
+};

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
@@ -1,0 +1,73 @@
+import { Link as RALink } from "react-aria-components";
+import { extractStyleProps } from "@/utils";
+import {
+  BreadcrumbsItemSlot,
+  BreadcrumbsLinkSlot,
+  BreadcrumbsSeparatorSlot,
+} from "../breadcrumbs.slots";
+import type { BreadcrumbsItemProps } from "../breadcrumbs.types";
+import { useBreadcrumbsContext } from "./breadcrumbs.context";
+
+/**
+ * # Breadcrumbs.Item
+ *
+ * An individual breadcrumb. Renders an `<li>` containing a navigation link
+ * (`<a>`). The decorative separator inherited from `Breadcrumbs.Root` is
+ * rendered before every item except the first.
+ *
+ * When `isCurrent` is true the item represents the current page: it renders as
+ * non-interactive text (not a link) with `aria-current="page"`, and is removed
+ * from the tab sequence.
+ *
+ * @supportsStyleProps
+ */
+export const BreadcrumbsItem = ({
+  children,
+  href,
+  isCurrent,
+  isDisabled,
+  target,
+  rel,
+  ref,
+  ...rest
+}: BreadcrumbsItemProps) => {
+  const { separator } = useBreadcrumbsContext();
+  const [styleProps, restProps] = extractStyleProps(rest);
+
+  return (
+    <BreadcrumbsItemSlot>
+      <BreadcrumbsSeparatorSlot aria-hidden="true">
+        {separator}
+      </BreadcrumbsSeparatorSlot>
+      {isCurrent ? (
+        // The current page is non-interactive text — not a link — so it is not
+        // in the tab order. React Aria's Link would remain focusable, so we
+        // render the styled slot element directly instead.
+        <BreadcrumbsLinkSlot
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          aria-current="page"
+          data-current="true"
+          {...styleProps}
+          {...restProps}
+        >
+          {children}
+        </BreadcrumbsLinkSlot>
+      ) : (
+        <BreadcrumbsLinkSlot asChild {...styleProps}>
+          <RALink
+            ref={ref}
+            href={isDisabled ? undefined : href}
+            isDisabled={isDisabled}
+            target={target}
+            rel={rel}
+            {...restProps}
+          >
+            {children}
+          </RALink>
+        </BreadcrumbsLinkSlot>
+      )}
+    </BreadcrumbsItemSlot>
+  );
+};
+
+BreadcrumbsItem.displayName = "Breadcrumbs.Item";

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
+import { extractStyleProps } from "@/utils";
+import { BreadcrumbsRootSlot, BreadcrumbsListSlot } from "../breadcrumbs.slots";
+import type { BreadcrumbsProps } from "../breadcrumbs.types";
+import { BreadcrumbsContext } from "./breadcrumbs.context";
+
+/**
+ * # Breadcrumbs.Root
+ *
+ * The root container for the Breadcrumbs component. Renders a `<nav>` landmark
+ * wrapping an ordered list (`<ol>`) of `Breadcrumbs.Item` links, and provides
+ * the styling context and separator configuration for all child items.
+ *
+ * Always provide an `aria-label` (e.g. `"Breadcrumb"`) to identify the
+ * navigation landmark.
+ *
+ * @supportsStyleProps
+ */
+export const BreadcrumbsRoot = (props: BreadcrumbsProps) => {
+  const { children, separator = "/", ...elementProps } = props;
+
+  // Standard pattern: split recipe variants first.
+  const recipe = useSlotRecipe({ key: "nimbusBreadcrumbs" });
+  const [recipeProps, restRecipeProps] = recipe.splitVariantProps(elementProps);
+
+  // Standard pattern: extract style props from the remaining props.
+  const [styleProps, rest] = extractStyleProps(restRecipeProps);
+
+  const contextValue = useMemo(() => ({ separator }), [separator]);
+
+  return (
+    <BreadcrumbsContext.Provider value={contextValue}>
+      <BreadcrumbsRootSlot {...recipeProps} {...styleProps} {...rest}>
+        <BreadcrumbsListSlot>{children}</BreadcrumbsListSlot>
+      </BreadcrumbsRootSlot>
+    </BreadcrumbsContext.Provider>
+  );
+};
+
+BreadcrumbsRoot.displayName = "Breadcrumbs.Root";

--- a/packages/nimbus/src/components/breadcrumbs/components/index.ts
+++ b/packages/nimbus/src/components/breadcrumbs/components/index.ts
@@ -1,0 +1,2 @@
+export { BreadcrumbsRoot } from "./breadcrumbs.root";
+export { BreadcrumbsItem } from "./breadcrumbs.item";

--- a/packages/nimbus/src/components/breadcrumbs/index.ts
+++ b/packages/nimbus/src/components/breadcrumbs/index.ts
@@ -1,0 +1,2 @@
+export * from "./breadcrumbs";
+export * from "./breadcrumbs.types";

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -74,6 +74,7 @@ export * from "./pagination";
 export * from "./drawer";
 export * from "./tab-nav";
 export * from "./tabs";
+export * from "./breadcrumbs";
 export * from "./localized-field";
 export * from "./steps";
 export * from "./modal-page";

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -1,4 +1,5 @@
 import { accordionSlotRecipe } from "@/components/accordion/accordion.recipe";
+import { breadcrumbsSlotRecipe } from "@/components/breadcrumbs/breadcrumbs.recipe";
 import { scrollAreaSlotRecipe } from "@/components/scroll-area/scroll-area.recipe";
 import { defaultPageSlotRecipe } from "@/components/default-page/default-page.recipe";
 import { stepsSlotRecipe } from "@/components/steps/steps.recipe";
@@ -76,6 +77,7 @@ import { buttonGroupRecipe } from "@/components/toggle-button-group/toggle-butto
 export const slotRecipes = {
   nimbusAccordion: accordionSlotRecipe,
   nimbusAlert: alertRecipe,
+  nimbusBreadcrumbs: breadcrumbsSlotRecipe,
   nimbusCalendar: calendarSlotRecipe,
   nimbusCard: cardRecipe,
   nimbusCheckbox: checkboxSlotRecipe,


### PR DESCRIPTION
## ⚗️ A/B experiment — please do not merge

This is **one arm of a two-PR experiment** measuring whether the `new-dev-docs`
documentation + `.claude/` tooling overhaul actually changes what an AI agent
produces. **Sibling (BEFORE) PR:** #1692

Both PRs were produced by the **same model, same task, same prompt**, each told
to build a `Breadcrumbs` component bootstrapping **only** from the repo's own
`CLAUDE.md` / `docs/` / `.claude/`. The **only** variable is the state of those
docs/tooling files.

- **This PR = AFTER**: docs/tooling as of `7f0dcc30c` (the `new-dev-docs`
  overhaul — `docs/` as enforced source of truth, drift guardrail, audited
  agents/skills, consumer API contract, component checklist, `figma-code-connect`
  guideline, enforced `readme.md` index).
- Both branches are based on the **same `main` commit** (`1356a4063`), so each
  diff is purely "add Breadcrumbs" and the two are directly comparable.

Committed **exactly as the agent produced it — no human fix-ups** — so the
comparison reflects the tooling, not my editing.

### Independently re-run validation (ground truth)

| Check                                                                               | Result          |
| ----------------------------------------------------------------------------------- | --------------- |
| `pnpm --filter @commercetools/nimbus typecheck` (`tsc --noEmit`, **incl. stories**) | ✅ **0 errors** |
| `eslint` (breadcrumbs)                                                              | ✅ clean        |
| story + consumer tests (source, Playwright)                                         | ✅ 18/18        |

### What this arm produced — 14 files, 1404 lines

- Recipe file correctly named **`breadcrumbs.recipe.ts`**
- **`breadcrumbs.a11y.mdx`** — dedicated accessibility doc
- **`breadcrumbs.docs.spec.tsx`** — consumer implementation tests (the external
  contract the API-contract doc calls for)
- Separator extracted into a dedicated `components/breadcrumbs.context.ts`
- Fuller engineering docs (`dev.mdx` 234 vs 102 lines) and richer prop types

Compare against the BEFORE arm's smaller file set and red CI.
