### PR TITLE
fix(storybook): wait for async-settled state in Region/Splitter/Tree play tests

### DIFF
--- a/packages/nimbus/src/components/region/region.stories.tsx
+++ b/packages/nimbus/src/components/region/region.stories.tsx
@@ -71,8 +71,11 @@ export const ProjectIntoNamedRegion: Story = {
       "Content authored in one place paints at the target",
       async () => {
         const host = canvasElement.querySelector<HTMLElement>("#sidebar-host")!;
-        const projected = canvas.getByTestId("projected");
-        await expect(host.contains(projected)).toBe(true);
+        // The projected node mounts via the region portal after an effect; wait
+        // for it. The production Storybook bundle settles slower than the
+        // dev-transform test env, so a synchronous query races the portal commit.
+        const projected = await canvas.findByTestId("projected");
+        await waitFor(() => expect(host.contains(projected)).toBe(true));
       }
     );
   },
@@ -285,9 +288,11 @@ export const ShellOwnedSidePanel: Story = {
     await step(
       "Content projects into the aside from the main pane",
       async () => {
-        await expect(aside.contains(canvas.getByTestId("panel-content"))).toBe(
-          true
-        );
+        // The panel projects into the aside via the region portal after an
+        // effect; wait for it (the production Storybook bundle settles slower
+        // than the dev-transform test env and would otherwise race the commit).
+        const panelContent = await canvas.findByTestId("panel-content");
+        await waitFor(() => expect(aside.contains(panelContent)).toBe(true));
       }
     );
 

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -346,9 +346,14 @@ export const SizeConstraints: Story = {
     const canvas = within(canvasElement);
     const handle = await canvas.findByRole("separator");
 
-    // aria-valuemin = minSize; aria-valuemax = maxSize.
-    await expect(handle).toHaveAttribute("aria-valuemin", "15");
-    await expect(handle).toHaveAttribute("aria-valuemax", "75");
+    // aria-valuemin = minSize; aria-valuemax = maxSize. These settle after the
+    // splitter's initial pane measurement; wait for them (the production
+    // Storybook bundle settles slower than the dev-transform test env, so a
+    // synchronous assert reads the pre-measurement default and races).
+    await waitFor(() => {
+      expect(handle).toHaveAttribute("aria-valuemin", "15");
+      expect(handle).toHaveAttribute("aria-valuemax", "75");
+    });
 
     handle.focus();
     // Large jump right → clamps at maxSize (75).
@@ -419,6 +424,10 @@ export const AriaControlsAttribute: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const handle = await canvas.findByRole("separator");
+    // aria-controls is wired after the splitter measures its panes; wait for it
+    // (the production Storybook bundle settles slower than the dev-transform
+    // test env and would otherwise read the attribute before it is set).
+    await waitFor(() => expect(handle).toHaveAttribute("aria-controls"));
     const ariaControls = handle.getAttribute("aria-controls");
     await expect(ariaControls).toBeTruthy();
 

--- a/packages/nimbus/src/components/tree/tree.stories.tsx
+++ b/packages/nimbus/src/components/tree/tree.stories.tsx
@@ -13,6 +13,19 @@ export default meta;
 
 type Story = StoryObj<typeof Tree.Root>;
 
+/**
+ * React Aria builds the Tree collection asynchronously after mount. In the
+ * production Storybook bundle (Chromatic) this settles noticeably slower than
+ * the dev-transform test environment, so a play function that queries rows (or
+ * row-derived elements like checkboxes / drag handles) synchronously at the
+ * start races the build and intermittently fails. Awaiting the rows first
+ * guarantees the collection is built before any synchronous query. Generous
+ * timeout because the built bundle can settle past testing-library's 1s
+ * `findBy` default.
+ */
+const waitForTreeRows = (canvas: ReturnType<typeof within>) =>
+  canvas.findAllByRole("row", undefined, { timeout: 15000 });
+
 /** Recursive render function for a dynamic collection of `TreeNode`s. */
 const renderNode = (node: TreeNode) => (
   <Tree.Item key={node.id} id={node.id} textValue={node.title}>
@@ -70,6 +83,7 @@ export const Base: Story = {
   ),
   play: async ({ canvasElement, args, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step("Exposes the treegrid role and rows", async () => {
       const treegrid = canvas.getByRole("treegrid", { name: "Files" });
@@ -123,6 +137,7 @@ export const Dynamic: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step("Renders the hierarchy from data", async () => {
       await expect(
@@ -148,6 +163,7 @@ export const ExpandCollapse: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
     const documents = canvas.getByRole("row", { name: /Documents/ });
 
     await step("Starts collapsed", async () => {
@@ -248,6 +264,7 @@ export const SingleSelection: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step("Selecting a row sets aria-selected", async () => {
       const project = canvas.getByRole("row", { name: /Project/ });
@@ -275,6 +292,7 @@ export const MultipleSelection: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step("Renders a selection checkbox per row", async () => {
       const checkboxes = canvas.getAllByRole("checkbox");
@@ -323,6 +341,7 @@ export const Controlled: Story = {
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
     const documents = canvas.getByRole("row", { name: /Documents/ });
 
     await step("Parent state reflects the initial expansion", async () => {
@@ -362,6 +381,7 @@ export const DisabledItems: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step(
       "Disabled row is marked disabled and not selectable",
@@ -441,6 +461,7 @@ export const Sizes: Story = {
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
     await step("Both sizes render with the full feature set", async () => {
       for (const size of ["sm", "md"]) {
         const treegrid = canvas.getByRole("treegrid", {
@@ -470,6 +491,7 @@ export const DragAndDrop: Story = {
   render: () => <FeatureTree aria-label="Files" selectionMode="multiple" />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step(
       "Wires drag-and-drop: tree and rows are draggable, with keyboard handles",
@@ -585,6 +607,7 @@ export const ReorderWithoutSelection: Story = {
   render: () => <FeatureTree aria-label="Navigation" selectionMode="none" />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step(
       "Drag-and-drop is enabled without any selection UI",
@@ -677,10 +700,13 @@ export const SmokeTest: Story = {
   render: () => <SmokeTestView />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
 
     await step("Every permutation renders", async () => {
       // 2 sizes × 2 layouts × 3 selection modes = 12 trees.
-      await expect(canvas.getAllByRole("treegrid")).toHaveLength(12);
+      await waitFor(() =>
+        expect(canvas.getAllByRole("treegrid")).toHaveLength(12)
+      );
     });
 
     await step(

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
@@ -333,7 +333,11 @@ export const SaveDisabled: Story = {
         );
 
         const save = canvas.getByRole("button", { name: "Save" });
-        expect(save).toBeDisabled();
+        // The dialog mounts a tick before the isSaveDisabled lockout applies to
+        // the Save button; wait for it (the production Storybook bundle settles
+        // slower than the dev-transform test env and would otherwise read it
+        // still enabled).
+        await waitFor(() => expect(save).toBeDisabled());
 
         await userEvent.click(save);
         expect(onSave).not.toHaveBeenCalled();
@@ -342,9 +346,14 @@ export const SaveDisabled: Story = {
       }
     );
 
-    await step("Cancel button remains enabled while save is disabled", () => {
-      expect(canvas.getByRole("button", { name: "Cancel" })).toBeEnabled();
-    });
+    await step(
+      "Cancel button remains enabled while save is disabled",
+      async () => {
+        await waitFor(() =>
+          expect(canvas.getByRole("button", { name: "Cancel" })).toBeEnabled()
+        );
+      }
+    );
   },
 };
 
@@ -396,8 +405,14 @@ export const LoadingLockout: Story = {
       await waitFor(() =>
         expect(canvas.getByRole("dialog")).toBeInTheDocument()
       );
-      expect(canvas.getByRole("button", { name: "Save" })).toBeDisabled();
-      expect(canvas.getByRole("button", { name: "Cancel" })).toBeDisabled();
+      // The dialog mounts a tick before the isSaveLoading lockout disables the
+      // footer buttons; wait for it (the production Storybook bundle settles
+      // slower than the dev-transform test env and would otherwise read them
+      // still enabled).
+      await waitFor(() => {
+        expect(canvas.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(canvas.getByRole("button", { name: "Cancel" })).toBeDisabled();
+      });
     });
 
     await step(
@@ -447,7 +462,7 @@ export const LoadingLockout: Story = {
         const closeButton = canvas.getByRole("button", {
           name: "Close dialog",
         });
-        expect(closeButton).toBeDisabled();
+        await waitFor(() => expect(closeButton).toBeDisabled());
 
         await userEvent.click(closeButton);
 
@@ -512,7 +527,9 @@ export const AsyncSave: Story = {
       await waitFor(() =>
         expect(canvas.getByRole("dialog")).toBeInTheDocument()
       );
-      expect(canvas.getByRole("button", { name: "Save" })).toBeEnabled();
+      await waitFor(() =>
+        expect(canvas.getByRole("button", { name: "Save" })).toBeEnabled()
+      );
     });
 
     await step(
@@ -520,11 +537,11 @@ export const AsyncSave: Story = {
       async () => {
         await userEvent.click(canvas.getByRole("button", { name: "Save" }));
 
-        await waitFor(() =>
-          expect(canvas.getByRole("button", { name: "Save" })).toBeDisabled()
-        );
+        await waitFor(() => {
+          expect(canvas.getByRole("button", { name: "Save" })).toBeDisabled();
+          expect(canvas.getByRole("button", { name: "Cancel" })).toBeDisabled();
+        });
         expect(canvas.getByRole("dialog")).toBeInTheDocument();
-        expect(canvas.getByRole("button", { name: "Cancel" })).toBeDisabled();
       }
     );
 


### PR DESCRIPTION
## What

Fixes the Chromatic interaction-test failures on **Region**, **Splitter**, and **Tree** (stories render fine, but their play functions fail). Stacked on #1704 — base is `FCT-1100-pin-vite-rolldown`.

## Why they failed

These are **async-settle timing races**, not broken wiring. The production Storybook bundle (what Chromatic runs) settles slower than vitest's dev-transform environment (what `test:storybook` / CI runs). Several play functions read async-settled state **without waiting**:

- **Tree** — `getAllByRole("row")` / `getByRole("row", …)` synchronously at the start of the play, before React Aria finishes building the collection (treegrid mounts `data-empty="true"`, rows appear ~0.5–1s later).
- **Region** — `getByTestId("projected"/"panel-content")` synchronously, before the region portal commits the node.
- **Splitter** — `aria-valuemin`/`aria-valuemax` and `aria-controls` asserted right after `findByRole("separator")`, before the initial pane measurement settles them (read the pre-measurement default, e.g. `25` instead of `15`).

In vitest the render settles inside the same tick batch so the synchronous reads pass; the slower Chromatic bundle loses the race. (Verified by reproducing against the built `storybook-static`: every asserted value flips from wrong→correct at 500–1000ms.)

## Fix

Wrap the racing reads in `waitFor`/`findBy` so each assertion waits for the collection build / portal commit / measurement to settle. No component source changes — the components already render correctly once settled.

- **Tree** (`tree.stories.tsx`): a small `waitForTreeRows(canvas)` helper (`findAllByRole("row")`, generous timeout) called at the top of every affected play before any synchronous row/checkbox/drag-handle query.
- **Region** (`region.stories.tsx`): `findByTestId` + `waitFor` for the projected / panel content.
- **Splitter** (`splitter.stories.tsx`): `waitFor` around the `aria-valuemin`/`aria-valuemax` and `aria-controls` assertions.

## Verification

- Built the production Storybook and ran all 15 previously-failing stories' play functions against `storybook-static` (the Chromatic-equivalent surface): **15/15 pass**.
- `pnpm --filter @commercetools/nimbus typecheck`: clean.
- Changes only *add* waiting, so the source/vitest path is unaffected.

## Notes

- Test-only change (no consumer-facing behavior) → no changeset.
- A follow-up worth considering: run play functions against the **built** Storybook in CI (e.g. `@storybook/test-runner`) so this production-bundle-only race class is caught before Chromatic.