### PR TITLE
chore(deps): bump pnpm to 11.10.0 and migrate workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
   "name": "nimbus",
   "private": true,
-  "workspaces": ["packages/*", "apps/*"],
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
   "preconstruct": {
-    "packages": ["packages/tokens"]
+    "packages": [
+      "packages/tokens"
+    ]
   },
   "scripts": {
     "build": "pnpm build:tokens && pnpm run build:packages && pnpm run build:docs && pnpm run build:mcp",
@@ -39,56 +44,7 @@
     "check:package-shape": "node scripts/check-package-shape.mjs",
     "bundle-sizes:trend": "node scripts/bundle-sizes-trend.mjs"
   },
-  "packageManager": "pnpm@10.12.3+sha512.467df2c586056165580ad6dfb54ceaad94c5a30f80893ebdec5a44c5aa73c205ae4a5bb9d5ed6bb84ea7c249ece786642bbb49d06a307df218d03da41c317417",
-  "pnpm": {
-    "overrides": {
-      "rollup": "catalog:tooling",
-      "@babel/runtime": "catalog:tooling",
-      "prismjs": "^1.30.0",
-      "typescript": "catalog:tooling",
-      "react-aria": "catalog:react",
-      "react-aria-components": "catalog:react",
-      "react-stately": "catalog:react",
-      "@react-aria/interactions": "catalog:react",
-      "brace-expansion@<2": "^2.0.3",
-      "brace-expansion@2": "~2.0.3",
-      "brace-expansion@>=4.0.0 <5.0.6": ">=5.0.6",
-      "mdast-util-to-hast": "^13.2.1",
-      "js-yaml": "^3.14.2",
-      "qs": ">=6.15.2",
-      "minimatch@>=3.0.0 <3.1.4": "3.1.4",
-      "svgo": ">=3.3.3",
-      "hono": ">=4.12.21",
-      "esbuild": ">=0.28.1",
-      "shell-quote": ">=1.8.4",
-      "@babel/core": "catalog:tooling",
-      "@hono/node-server": ">=1.19.13",
-      "fast-uri": ">=3.1.2",
-      "ip-address": ">=10.1.1",
-      "postcss": ">=8.5.10",
-      "lodash@<4.18.0": ">=4.18.0",
-      "lodash-es@<4.18.0": ">=4.18.0",
-      "ajv@>=8.0.0 <8.18.0": ">=8.18.0",
-      "minimatch@>=10.0.0 <10.2.3": ">=10.2.3",
-      "flatted": ">=3.4.2",
-      "undici": ">=7.28.0 <8",
-      "picomatch@<2.3.2": ">=2.3.2",
-      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
-      "yaml@1": "1.10.3",
-      "yaml@2": ">=2.8.3",
-      "path-to-regexp@>=8.0.0 <8.4.0": ">=8.4.0",
-      "happy-dom@<20.8.9": ">=20.8.9",
-      "jsdom": "catalog:tooling"
-    },
-    "onlyBuiltDependencies": [
-      "@bundled-es-modules/glob",
-      "@swc/core",
-      "es5-ext",
-      "esbuild",
-      "msw",
-      "style-dictionary"
-    ]
-  },
+  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:tooling",
     "@babel/core": "catalog:tooling",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,90 @@ packages:
 
 catalogMode: strict
 
+# --- pnpm install & supply-chain settings (made explicit) ---
+# pnpm 11 ships these as built-in defaults. They are pinned here so the repo's
+# install behavior is visible and version-independent rather than silently
+# inherited from whichever pnpm version happens to be running. Values below
+# mirror pnpm 11's defaults, so this is documentation, not a behavior change —
+# with one deliberate exception noted on minimumReleaseAgeStrict.
+
+# Delay resolving newly published versions until they are at least this many
+# minutes old (supply-chain protection: gives the ecosystem time to catch a
+# compromised release). pnpm 11 default: 1440 (24h). Set to 0 to disable.
+minimumReleaseAge: 1440
+# Because minimumReleaseAge is set EXPLICITLY, pnpm would otherwise flip this to
+# `true` and FAIL resolution when no old-enough version satisfies a range. We
+# pin it to `false` to keep the softer default behavior (skip/warn, don't error).
+minimumReleaseAgeStrict: false
+# Don't apply the age gate to packages whose registry metadata has no publish
+# time (avoids spurious failures on such packages).
+minimumReleaseAgeIgnoreMissingTime: true
+# Fail the install if any dependency has an unreviewed build (postinstall)
+# script — every builder must be an explicit decision in `allowBuilds` below.
+strictDepBuilds: true
+# Restrict "exotic" sources (git repos, direct tarball URLs) to direct
+# dependencies only; block them as transitive subdeps.
+blockExoticSubdeps: true
+# Verify dependencies are present/consistent before `pnpm run` / `pnpm exec`.
+verifyDepsBeforeRun: install
+# Skip full re-resolution when the manifest + lockfile are unchanged.
+optimisticRepeatInstall: true
+
+# Build-script allow list. pnpm 11 removed onlyBuiltDependencies /
+# neverBuiltDependencies / ignoredBuiltDependencies in favor of this single
+# map: `true` = allowed to run build scripts, `false` = explicitly denied.
+# Anything not listed is treated as unreviewed and (with strictDepBuilds) fails
+# the install. The `true` entries were the former onlyBuiltDependencies list;
+# the `false` entries were previously reported as "Ignored build scripts".
+allowBuilds:
+  "@bundled-es-modules/glob": true
+  "@swc/core": true
+  es5-ext: true
+  esbuild: true
+  msw: true
+  style-dictionary: true
+  "@fission-ai/openspec": false
+  "@modelcontextprotocol/ext-apps": false
+
+overrides:
+  rollup: "catalog:tooling"
+  "@babel/runtime": "catalog:tooling"
+  prismjs: "^1.30.0"
+  typescript: "catalog:tooling"
+  react-aria: "catalog:react"
+  react-aria-components: "catalog:react"
+  react-stately: "catalog:react"
+  "@react-aria/interactions": "catalog:react"
+  "brace-expansion@<2": "^2.0.3"
+  "brace-expansion@2": "~2.0.3"
+  "brace-expansion@>=4.0.0 <5.0.6": ">=5.0.6"
+  mdast-util-to-hast: "^13.2.1"
+  js-yaml: "^3.14.2"
+  qs: ">=6.15.2"
+  "minimatch@>=3.0.0 <3.1.4": "3.1.4"
+  svgo: ">=3.3.3"
+  hono: ">=4.12.21"
+  esbuild: ">=0.28.1"
+  shell-quote: ">=1.8.4"
+  "@babel/core": "catalog:tooling"
+  "@hono/node-server": ">=1.19.13"
+  fast-uri: ">=3.1.2"
+  ip-address: ">=10.1.1"
+  postcss: ">=8.5.10"
+  "lodash@<4.18.0": ">=4.18.0"
+  "lodash-es@<4.18.0": ">=4.18.0"
+  "ajv@>=8.0.0 <8.18.0": ">=8.18.0"
+  "minimatch@>=10.0.0 <10.2.3": ">=10.2.3"
+  flatted: ">=3.4.2"
+  undici: ">=7.28.0 <8"
+  "picomatch@<2.3.2": ">=2.3.2"
+  "picomatch@>=4.0.0 <4.0.4": ">=4.0.4"
+  "yaml@1": "1.10.3"
+  "yaml@2": ">=2.8.3"
+  "path-to-regexp@>=8.0.0 <8.4.0": ">=8.4.0"
+  "happy-dom@<20.8.9": ">=20.8.9"
+  jsdom: "catalog:tooling"
+
 catalogs:
   tooling:
     "@figma/code-connect": ^1.4.8


### PR DESCRIPTION
## Summary

Bump pnpm `10.12.3 → 11.10.0` and migrate the workspace config to pnpm 11's
new layout. Maintainer/CI-facing only — this does **not** touch the published
`@commercetools/nimbus*` packages, so there is no consumer impact and no
changeset.

The main motivation: it kills the `DEP0169 url.parse()` deprecation warning
printed on every `pnpm install` (it came from pnpm's own bundled
`npm-package-arg`; fixed upstream in pnpm 11).

## What changed

pnpm 11 stopped reading the `pnpm` field in `package.json` and removed
`onlyBuiltDependencies` / `neverBuiltDependencies` / `ignoredBuiltDependencies`,
so the config moved to `pnpm-workspace.yaml`:

- `overrides` moved verbatim — **lockfile unchanged**, resolutions identical.
- `onlyBuiltDependencies` → the new `allowBuilds` map (previously-built deps
  `true`; previously-ignored deps `false`), preserving prior behavior.
- pnpm 11's install/supply-chain defaults pinned **explicitly** rather than
  silently inherited: `minimumReleaseAge: 1440`, `minimumReleaseAgeStrict: false`
  (pinned to preserve prior behavior — an explicit `minimumReleaseAge` would
  otherwise flip strict on), `strictDepBuilds`, `blockExoticSubdeps`,
  `verifyDepsBeforeRun`, `optimisticRepeatInstall`.

⚠️ Behavior note for maintainers: `minimumReleaseAge: 1440` now delays pulling
in dependency versions published < 24h ago (supply-chain guard). Set to `0` to
opt out.

## Test plan

- [x] `pnpm install --frozen-lockfile` → exit 0, **0 `DEP0169` warnings**, no
      `ERR_PNPM_IGNORED_BUILDS`, no lockfile drift.
- [ ] CI green

## Risk

Low — repo-local tooling/config only; no published package or lockfile change.
