### PR TITLE
fix(bsm): add a gh call to enable local check

### DIFF
--- a/.github/actions/bundle-size/fetch-bundle-baseline.mjs
+++ b/.github/actions/bundle-size/fetch-bundle-baseline.mjs
@@ -17,7 +17,8 @@
  * comment chain must be established first — see docs/bundle-size-monitoring.md.
  *
  * Environment variables:
- *   GITHUB_REPOSITORY   owner/repo (set by Actions)
+ *   GITHUB_REPOSITORY   owner/repo (set by Actions; falls back to the current
+ *                       checkout via `gh repo view` when unset locally)
  *   GH_TOKEN            GitHub token for API access
  *   GITHUB_OUTPUT       Path to the output file (set by Actions)
  */
@@ -25,7 +26,6 @@
 import { execSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-const REPO = process.env.GITHUB_REPOSITORY;
 const OUTPUT_FILE = process.env.GITHUB_OUTPUT;
 
 function gh(args) {
@@ -34,6 +34,29 @@ function gh(args) {
     stdio: ["pipe", "pipe", "pipe"],
   }).trim();
 }
+
+// GITHUB_REPOSITORY is injected by Actions but absent locally, so derive the
+// slug from the checkout when it's unset. This catch only runs locally (CI
+// always sets the env var), so a hard exit here can't affect the workflow —
+// and an empty slug would only produce a misleading downstream error.
+function resolveRepo() {
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  try {
+    return gh("repo view --json nameWithOwner --jq .nameWithOwner");
+  } catch {
+    console.error(
+      [
+        "Error: could not determine the repository via the GitHub CLI.",
+        "Running check:bundle-size locally needs `gh` installed and",
+        "authenticated: install it (https://cli.github.com), run",
+        "`gh auth login`, and run the command from inside the repo directory.",
+      ].join("\n")
+    );
+    process.exit(1);
+  }
+}
+
+const REPO = resolveRepo();
 
 function writeOutput(key, value) {
   if (!OUTPUT_FILE) {

--- a/docs/bundle-size-monitoring.md
+++ b/docs/bundle-size-monitoring.md
@@ -168,9 +168,11 @@ pnpm check:bundle-size
 ```
 
 When `BUNDLE_SIZE_BASELINE` is not set (the normal local case), the script
-automatically fetches the baseline from the comment chain via `gh`. The output
-shows a table with current size, baseline, delta, and status for each tracked
-package. All sizes are displayed in KB.
+automatically fetches the baseline from the comment chain via `gh`. Run it from
+within the repo — the `GITHUB_REPOSITORY` variable that Actions provides in CI
+is absent locally, so the fetch derives the repo from your checkout via
+`gh repo view`. The output shows a table with current size, baseline, delta, and
+status for each tracked package. All sizes are displayed in KB.
 
 ## Viewing the Trend
 


### PR DESCRIPTION
check:bundle-size failed outside CI because fetch-bundle-baseline.mjs read the repo slug from GITHUB_REPOSITORY, which GitHub Actions injects but is absent locally — so the fetch queried repos/undefined/..., silently fell back, and reported the generic "No baseline available."

It now derives the slug from your checkout via gh repo view when the env var is unset, so the command resolves the real baseline from the comment chain locally; if gh isn't installed or authenticated, it fails fast with a clear message telling you how to fix it rather than a misleading fallback. Also documents the local-run behavior in docs/bundle-size-monitoring.md.