### PR TITLE
fix(ci): unpin node to 24.x and add Dependabot cooldown

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: "24.12"
+        node-version: "24"
         cache: pnpm
 
     - name: Update npm to latest

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
       timezone: "Europe/Berlin" # Optional: Specify timezone for the schedule time
     labels:
       - "dependencies"
+    # Delay opening update PRs until the new version has aged. This aligns
+    # Dependabot with the repo's pnpm `minimumReleaseAge: 1440` (24h) supply-chain
+    # gate in pnpm-workspace.yaml: without a cooldown, Dependabot opens PRs within
+    # hours of a release and every `pnpm install --frozen-lockfile` (CI/Vercel)
+    # then fails ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION until the package
+    # organically passes 24h. Every value is >= 2 days so the pinned version has
+    # cleared the 24h gate (with margin) by the time the PR's lockfile is built.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
     groups:
       # React ecosystem: react, react-dom, emotion, chakra-ui, next-themes
       react:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - uses: actions/setup-node@v4
         with:
-          node-version: "24.12"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       # Ensure npm 11.5.1 or later is installed for OIDC support
@@ -59,7 +59,7 @@ jobs:
       - name: Setup npm registry for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: "24.12"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Storing release version for changeset
@@ -149,7 +149,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "24.12"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
@@ -161,7 +161,7 @@ jobs:
       - name: Setup npm registry for publishing
         uses: actions/setup-node@v4
         with:
-          node-version: "24.12"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Generate GitHub token


### PR DESCRIPTION
## Why

Dependabot PRs (#1732–#1735) were failing on **two independent** checks after the pnpm 11 migration (#1729). Only the second is actually downstream of that migration.

### 1. `build-and-test` (GitHub Actions) — node/npm engine mismatch
`npm install -g npm@latest` in `.github/actions/ci/action.yml` now pulls **npm 12.0.0**, whose engines require `node ^22.22.2 || ^24.15.0 || >=26.0.0`. The workflows pinned node to `"24.12"` (< 24.15.0), so npm's engine check hard-failed with `EBADENGINE` before `pnpm install` even ran:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"11.6.2","node":"v24.12.0"}
```

The pnpm-bump commit's own `main` build passed — this only started once npm 12 published, so it's environmental, not the Dependabot content.

**Fix:** bump `node-version: "24.12"` → `"24"` (latest 24.x, ≥ 24.15.0) in the ci composite action and `release.yml` (5 pins). `npm@latest` is kept in `release.yml` for npm OIDC trusted publishing.

### 2. Vercel deploy — `minimumReleaseAge` gate
`pnpm install --frozen-lockfile` failed:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION]
  react-router@8.2.0 was published at 2026-07-08T17:22:03Z, within the minimumReleaseAge cutoff
```

The pnpm 11 migration pinned `minimumReleaseAge: 1440` (24h). Dependabot opens PRs within hours of a release, so `--frozen-lockfile` (no resolution fallback) rejected the too-new pin.

**Fix:** add a Dependabot `cooldown` to `.github/dependabot.yml`, every value ≥ 2 days so a version has cleared the 24h gate with margin before a PR is opened:

```yaml
cooldown:
  default-days: 3
  semver-major-days: 7
  semver-minor-days: 3
  semver-patch-days: 2
```

## Notes
- `cooldown` takes effect once merged to `main` (Dependabot reads config from the default branch) and governs **future** PR creation — it does not retroactively fix already-open PRs. Plan is to close #1732–#1735 and let Dependabot reopen fresh ones off the fixed `main`.
- YAML validated; changes are CI/infra config only (no runtime surface).