### PR TITLE
feat(breadcrumbs): add Breadcrumbs component

### DIFF
--- a/.changeset/add-breadcrumbs-component.md
+++ b/.changeset/add-breadcrumbs-component.md
@@ -3,20 +3,35 @@
 ---
 
 **Breadcrumbs**: new component for showing the hierarchical path to the current
-page as an ordered list of links.
+page as an ordered list of links. Built on React Aria Components'
+`Breadcrumbs`/`Breadcrumb`.
 
 - `Breadcrumbs.Root` renders a `<nav>` landmark wrapping an ordered list; give
   it an `aria-label` (e.g. `"Breadcrumb"`) and an optional `separator` (any
-  node, defaults to `/`).
-- `Breadcrumbs.Item` renders a link. Set `isCurrent` on the last item to mark
-  the current page — it renders as non-interactive text with
-  `aria-current="page"` and is removed from the tab order. Items also support
-  `isDisabled`, `target`, and `rel`.
+  node, defaults to `›`). It accepts either compound `Breadcrumbs.Item` children
+  or a declarative `items` array, and an `onAction(id)` handler for client-side
+  routing.
+- The **last** item is the current page automatically — it renders as
+  non-interactive text with `aria-current="page"` and is removed from the tab
+  order. There is no `isCurrent` prop.
+- `Breadcrumbs.Item` renders a link and supports `href`, `target`, `rel`,
+  `routerOptions`, and `isDisabled`. `size` (`sm`/`md`) is set on the root.
 
 ```tsx
+// Compound API
 <Breadcrumbs.Root aria-label="Breadcrumb">
   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
   <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-  <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
 </Breadcrumbs.Root>
+
+// Data-driven API — the last entry is the current page
+<Breadcrumbs.Root
+  aria-label="Breadcrumb"
+  items={[
+    { id: "home", label: "Home", href: "/" },
+    { id: "orders", label: "Orders", href: "/orders" },
+    { id: "detail", label: "Order #123" },
+  ]}
+/>
 ```

--- a/.changeset/add-breadcrumbs-component.md
+++ b/.changeset/add-breadcrumbs-component.md
@@ -2,36 +2,14 @@
 "@commercetools/nimbus": minor
 ---
 
-**Breadcrumbs**: new component for showing the hierarchical path to the current
-page as an ordered list of links. Built on React Aria Components'
-`Breadcrumbs`/`Breadcrumb`.
+`Breadcrumbs`: new component for showing the hierarchical path to the current
+page as an ordered list of links.
 
-- `Breadcrumbs.Root` renders a `<nav>` landmark wrapping an ordered list; give
-  it an `aria-label` (e.g. `"Breadcrumb"`) and an optional `separator` (any
-  node, defaults to `›`). It accepts either compound `Breadcrumbs.Item` children
-  or a declarative `items` array, and an `onAction(id)` handler for client-side
+- Build trails from compound `Breadcrumbs.Item` children or a declarative
+  `items` array, with an optional `onAction(id)` handler for client-side
   routing.
-- The **last** item is the current page automatically — it renders as
-  non-interactive text with `aria-current="page"` and is removed from the tab
-  order. There is no `isCurrent` prop.
-- `Breadcrumbs.Item` renders a link and supports `href`, `target`, `rel`,
-  `routerOptions`, and `isDisabled`. `size` (`sm`/`md`) is set on the root.
-
-```tsx
-// Compound API
-<Breadcrumbs.Root aria-label="Breadcrumb">
-  <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
-  <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-  <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
-</Breadcrumbs.Root>
-
-// Data-driven API — the last entry is the current page
-<Breadcrumbs.Root
-  aria-label="Breadcrumb"
-  items={[
-    { id: "home", label: "Home", href: "/" },
-    { id: "orders", label: "Orders", href: "/orders" },
-    { id: "detail", label: "Order #123" },
-  ]}
-/>
-```
+- The last item is automatically the current page (`aria-current="page"`,
+  non-interactive, removed from the tab order) — there is no `isCurrent` prop.
+- `Breadcrumbs.Item` supports `href`, `target`, `rel`, `routerOptions`, and
+  `isDisabled`; set the `separator` (default `›`) and `size` (`sm`/`md`) on the
+  root.

--- a/.changeset/add-breadcrumbs-component.md
+++ b/.changeset/add-breadcrumbs-component.md
@@ -1,0 +1,22 @@
+---
+"@commercetools/nimbus": minor
+---
+
+**Breadcrumbs**: new component for showing the hierarchical path to the current
+page as an ordered list of links.
+
+- `Breadcrumbs.Root` renders a `<nav>` landmark wrapping an ordered list; give
+  it an `aria-label` (e.g. `"Breadcrumb"`) and an optional `separator` (any
+  node, defaults to `/`).
+- `Breadcrumbs.Item` renders a link. Set `isCurrent` on the last item to mark
+  the current page — it renders as non-interactive text with
+  `aria-current="page"` and is removed from the tab order. Items also support
+  `isDisabled`, `target`, and `rel`.
+
+```tsx
+<Breadcrumbs.Root aria-label="Breadcrumb">
+  <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+  <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+  <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+</Breadcrumbs.Root>
+```

--- a/openspec/changes/add-breadcrumbs-component/.openspec.yaml
+++ b/openspec/changes/add-breadcrumbs-component/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/add-breadcrumbs-component/design.md
+++ b/openspec/changes/add-breadcrumbs-component/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Nimbus needs a breadcrumb navigation component. React Aria Components ships `Breadcrumbs` and
+`Breadcrumb` primitives, and Nimbus's `architecture-decisions.md` requires using the RAC
+primitive when one exists (as `Tabs` does). This design describes how to build the Nimbus
+`Breadcrumbs` component on those primitives with the design system's recipe/slot styling.
+
+Relevant RAC behavior, verified against the installed bundle (`react-aria-components@1.19.0`,
+`dist/private/Breadcrumbs.mjs:61-91`):
+
+- `Breadcrumb` derives the current item as the last collection node: `isCurrent = node.nextKey == null`.
+- It publishes `{ 'aria-current': isCurrent ? 'page' : null, isDisabled: isDisabled || isCurrent,
+  onPress }` to the child `Link` via `LinkContext`. A disabled RAC `Link` renders a non-focusable
+  `<span role="link">`, so the current item is out of the tab order automatically.
+- It sets `data-current` / `data-disabled` on the `<li>` for styling and supports `onAction(key)`.
+- `Breadcrumbs` accepts a static children collection **or** a dynamic `items` + render function
+  (it extends `CollectionProps<T>`) and exposes `onAction`.
+
+Constraints: strict TypeScript (no `any`); Chakra recipes + tokens only; component tests live in
+Storybook play functions run against the built bundle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Build `Breadcrumbs` on RAC `Breadcrumbs`/`Breadcrumb`, styled with the Nimbus recipe/slot system.
+- Automatic last-is-current model — no `isCurrent` prop.
+- Both a compound (`Breadcrumbs.Root`/`Breadcrumbs.Item`) and a declarative `items` authoring API.
+- Correct list semantics under `list-style:none` (Safari/VoiceOver).
+- Typed `onAction`/`routerOptions` for router integration.
+- Public `separator` (default `›`, decorative) and `size` (`sm`/`md`) surface.
+
+**Non-Goals:**
+
+- Overflow/collapse ("Home / … / Current") truncation — tracked as follow-up.
+- RTL separator-glyph mirroring — tracked as follow-up (documented caveat only).
+- Any change to sibling components; no new npm dependency.
+
+## Decisions
+
+**D1 — `Root` on RAC `Breadcrumbs`, `Item` on RAC `Breadcrumb` + `Link`.**
+`Breadcrumbs.Root` renders `RaBreadcrumbs` (the `<ol>`), styled via the `withProvider` root/list
+slots. `Breadcrumbs.Item` renders `RaBreadcrumb` (the `<li>`) containing a `RaLink` styled via the
+link slot (`asChild`). RAC owns current/disabled/`aria-current`/tab-order.
+_Alternative considered:_ hand-roll the nav/ol/li structure and only use RAC for the link.
+Rejected — it duplicates what RAC provides and diverges from the architecture decision; RAC's
+current-item handling (non-focusable, `aria-current`) works out of the box.
+
+**D2 — No `isCurrent` prop; current = last item.**
+RAC ties current strictly to the last collection node. Deriving currentness from position (rather
+than a consumer-set flag) removes the entire class of invalid states (zero, multiple, or
+misplaced current) by construction.
+_Alternative considered:_ an explicit `isCurrent` override — rejected as it fights RAC's model and
+reintroduces those invalid states.
+
+**D3 — Dual authoring API.**
+Expose `items` + render function (native to RAC collections) alongside compound children,
+mirroring `Tabs`. Nav semantics and last-is-current apply identically in both paths.
+
+**D4 — Separator via a Nimbus slot.**
+Render the decorative separator (`aria-hidden`) as a Nimbus separator slot between items, hiding
+the leading one via a `:first-of-type` recipe rule (robust for dynamic collections). Default `›`.
+Source the separator through RAC's provided context/render mechanism so both authoring APIs share
+one code path.
+_Alternative considered:_ CSS `::before content` — rejected because an arbitrary configurable
+ReactNode (e.g. an icon) can't be expressed purely in `content`.
+
+**D5 — Explicit `role="list"` on the `<ol>`.**
+WebKit strips list semantics under `list-style:none`. Apply `role="list"` to the list slot unless
+RAC already emits it. Assert the attribute in a story (the Chromium test runner won't reproduce the
+WebKit-specific loss, so assert at the DOM-attribute level).
+
+**D6 — Dev-time warning for missing `aria-label`; no default string.**
+Keep the component free of translatable strings (correct i18n posture — the consumer owns the
+landmark label). Instead of a hardcoded default, warn in development when `aria-label` is absent.
+
+## Risks / Trade-offs
+
+- [Separator composition differs between compound and `items` APIs] → Mitigation: centralize
+  separator rendering in the `Item`/slot layer so both paths share one code path; cover both in
+  stories.
+- [WebKit list-role loss not reproducible in the Chromium story runner] → Mitigation: assert the
+  `role="list"` attribute directly rather than relying on the AX tree; note the limitation.
+- [RAC `Link` uses `onPress`, not `onClick`] → Mitigation: type the public item API against the RAC
+  link options (like `Link` does) so router/handler props are typed and discoverable.
+- [Recipe styling depends on RAC-managed `data-current`/`data-disabled`] → Mitigation: target those
+  attributes in `breadcrumbs.recipe.ts` and document that RAC sets them.
+
+## Open Questions
+
+- Does RAC `Breadcrumbs` already emit `role="list"` on its `<ol>` in 1.19.0? Confirm during
+  implementation; apply the explicit role only if absent (D5).
+- Final shape of the `items` render API — element-per-item vs. object-with-fields — to be settled
+  against RAC's `CollectionProps` ergonomics and `Tabs`' precedent during implementation.

--- a/openspec/changes/add-breadcrumbs-component/proposal.md
+++ b/openspec/changes/add-breadcrumbs-component/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Nimbus has no breadcrumb navigation component. Applications with nested hierarchies
+(catalog → category → product, settings sections, multi-step flows) need an accessible,
+consistent way to show the path to the current page and let users step back up it. Adding
+a first-class `Breadcrumbs` component fills that gap with WCAG 2.1 AA navigation semantics
+and the design system's token-based styling.
+
+## What Changes
+
+- Add a `Breadcrumbs` compound component built on React Aria Components'
+  `Breadcrumbs`/`Breadcrumb` primitives (per Nimbus's "use the RAC primitive when one
+  exists" architecture decision), styled with a Chakra recipe and Nimbus tokens.
+- Provide two authoring APIs: a compound API (`Breadcrumbs.Root` + `Breadcrumbs.Item`) and a
+  declarative `items` + render-function API for data-driven trails (mirroring `Tabs`).
+- Treat the **last** item as the current page automatically — `aria-current="page"`,
+  non-interactive, and out of the tab order. There is no per-item `isCurrent` prop; currentness
+  is derived from position.
+- Render a decorative, configurable `separator` (default `›`) between items, hidden from
+  assistive technology.
+- Support `sm`/`md` sizing (recipe variant, `md` default), per-item `href`/`target`/`rel`,
+  disabled items, and typed `onAction`/`routerOptions` for client-router integration.
+- Ship the full component file set: implementation, types, recipe, slots, stories, and docs
+  (`.mdx`, `.dev.mdx`, `.a11y.mdx`, `.docs.spec.tsx`), plus recipe registration and barrel export.
+
+## Capabilities
+
+### New Capabilities
+
+- `nimbus-breadcrumbs`: Accessible breadcrumb navigation built on React Aria Components —
+  nav landmark + ordered-list semantics, automatic last-is-current page handling
+  (non-interactive, `aria-current="page"`, out of tab order), decorative configurable
+  separator, disabled items, `sm`/`md` sizing, router integration, and both a compound
+  (`Breadcrumbs.Root`/`Breadcrumbs.Item`) and declarative (`items`) authoring API.
+
+### Modified Capabilities
+
+_None._ This introduces a new capability.
+
+## Impact
+
+- **Code**: New component under `packages/nimbus/src/components/breadcrumbs/`
+  (implementation, types, recipe, slots, stories, docs, barrel export). Recipe registered in
+  the theme's slot-recipe config; component exported from the package barrel.
+- **Public API**: New `Breadcrumbs` export. No changes to other components.
+- **Dependencies**: Uses `Breadcrumbs`/`Breadcrumb` from the already-installed
+  `react-aria-components@1.19.0`. No new dependency.
+- **Out of scope (follow-up)**: overflow/collapse ("Home / … / Current") truncation behavior,
+  and RTL separator-glyph direction. Noted so they are tracked, not silently dropped.

--- a/openspec/changes/add-breadcrumbs-component/specs/nimbus-breadcrumbs/spec.md
+++ b/openspec/changes/add-breadcrumbs-component/specs/nimbus-breadcrumbs/spec.md
@@ -1,0 +1,185 @@
+## ADDED Requirements
+
+### Requirement: Namespace Structure
+
+The component SHALL export as a compound component namespace built on React Aria
+Components' `Breadcrumbs` and `Breadcrumb` primitives.
+
+#### Scenario: Component parts
+
+- **WHEN** Breadcrumbs is imported
+- **THEN** SHALL provide `Breadcrumbs.Root` as the navigation container
+- **AND** SHALL provide `Breadcrumbs.Item` for individual breadcrumb entries
+- **AND** `Root` SHALL be the first property in the namespace
+
+#### Scenario: Basic compound usage
+
+- **WHEN** consumer renders `<Breadcrumbs.Root>` with `<Breadcrumbs.Item>` children
+- **THEN** SHALL render a `<nav>` landmark containing an ordered list of items
+- **AND** SHALL render each non-current item as a navigable link
+
+### Requirement: React Aria Foundation
+
+The component SHALL be built on React Aria Components' `Breadcrumbs`/`Breadcrumb`
+primitives, per Nimbus architecture decisions.
+
+#### Scenario: Uses RAC primitives
+
+- **WHEN** the component is implemented
+- **THEN** `Breadcrumbs.Root` SHALL render via RAC `Breadcrumbs`
+- **AND** `Breadcrumbs.Item` SHALL render via RAC `Breadcrumb` composing a RAC `Link`
+- **AND** current-item and disabled handling SHALL be delegated to the RAC primitives
+
+#### Scenario: React Aria import convention
+
+- **WHEN** React Aria Components are imported
+- **THEN** imports SHALL use the `Ra` prefix alias convention (e.g. `RaBreadcrumbs`, `RaLink`)
+
+### Requirement: Semantic HTML
+
+The component SHALL use proper navigation and list semantics that survive
+`list-style: none` styling in all supported browsers.
+
+#### Scenario: Landmark and list structure
+
+- **WHEN** `Breadcrumbs.Root` is rendered
+- **THEN** SHALL render a `<nav>` landmark element
+- **AND** SHALL render an ordered list (`<ol>`) of breadcrumb items
+- **AND** each item SHALL be a list item (`<li>`)
+
+#### Scenario: List role preserved under list-style none
+
+- **WHEN** the ordered list is styled with `list-style: none`
+- **THEN** the list SHALL still expose list semantics to assistive technology (an explicit `role="list"` SHALL be applied if the underlying primitive does not already guarantee it in WebKit)
+
+### Requirement: Accessible Labeling
+
+The navigation landmark SHALL be identifiable to assistive technology.
+
+#### Scenario: Consumer-supplied label
+
+- **WHEN** consumer passes `aria-label` to `Breadcrumbs.Root`
+- **THEN** SHALL apply it to the `<nav>` landmark
+
+#### Scenario: Missing label guidance
+
+- **WHEN** `Breadcrumbs.Root` is rendered without an `aria-label`
+- **THEN** the component SHALL emit a development-time warning advising a label
+- **AND** SHALL NOT ship a hardcoded untranslated default label
+
+### Requirement: Automatic Current Page
+
+The last breadcrumb SHALL represent the current page automatically. The component
+SHALL NOT expose a per-item `isCurrent` prop.
+
+#### Scenario: Last item is current
+
+- **WHEN** a breadcrumb trail is rendered
+- **THEN** the final item SHALL carry `aria-current="page"`
+- **AND** SHALL render as non-interactive (not a navigable link)
+- **AND** SHALL be removed from the tab sequence
+
+#### Scenario: Non-final items are links
+
+- **WHEN** a breadcrumb trail is rendered
+- **THEN** every item except the last SHALL render as a focusable link pointing to its `href`
+- **AND** SHALL NOT carry `aria-current`
+
+#### Scenario: No isCurrent prop
+
+- **WHEN** consumer inspects the public API of `Breadcrumbs.Item`
+- **THEN** there SHALL be no `isCurrent` prop
+- **AND** currentness SHALL be derived solely from position (last item)
+
+#### Scenario: Single item trail
+
+- **WHEN** a trail contains exactly one item
+- **THEN** that item SHALL be treated as current (non-interactive, `aria-current="page"`)
+
+### Requirement: Declarative Items API
+
+The component SHALL support a declarative, data-driven authoring API in addition
+to the compound children API.
+
+#### Scenario: Items with render function
+
+- **WHEN** consumer passes an `items` array and a render function to `Breadcrumbs.Root`
+- **THEN** SHALL render one breadcrumb per item in order
+- **AND** SHALL apply the same automatic last-is-current semantics as the compound API
+
+#### Scenario: Empty items
+
+- **WHEN** `items` is an empty array (or no children are provided)
+- **THEN** SHALL render the `<nav>`/`<ol>` structure with no breadcrumb items and SHALL NOT throw
+
+### Requirement: Disabled Items
+
+Individual non-current items SHALL be disable-able.
+
+#### Scenario: Disabled item is non-interactive
+
+- **WHEN** an item is rendered with `isDisabled`
+- **THEN** SHALL expose `aria-disabled="true"`
+- **AND** SHALL NOT expose an `href`
+- **AND** SHALL be removed from the tab sequence
+
+### Requirement: Configurable Separator
+
+The component SHALL render a decorative separator between items, configurable on
+the root.
+
+#### Scenario: Default separator
+
+- **WHEN** `Breadcrumbs.Root` is rendered without a `separator` prop
+- **THEN** SHALL render `›` between adjacent items
+- **AND** SHALL NOT render a leading separator before the first item
+
+#### Scenario: Custom separator
+
+- **WHEN** consumer passes a `separator` node to `Breadcrumbs.Root`
+- **THEN** SHALL render that node between adjacent items
+
+#### Scenario: Separator is decorative
+
+- **WHEN** any separator is rendered
+- **THEN** SHALL be hidden from assistive technology via `aria-hidden="true"`
+
+### Requirement: Sizing
+
+The component SHALL support size variants driven by the recipe.
+
+#### Scenario: Size variants
+
+- **WHEN** `Breadcrumbs.Root` is rendered with `size="sm"` or `size="md"`
+- **THEN** SHALL apply the corresponding font-size and gap from the recipe
+- **AND** `md` SHALL be the default when `size` is omitted
+
+### Requirement: Link Navigation Props
+
+Item links SHALL support standard anchor navigation and client-router integration.
+
+#### Scenario: Anchor attributes
+
+- **WHEN** an item is rendered with `href`, `target`, and/or `rel`
+- **THEN** SHALL forward them to the rendered link
+
+#### Scenario: Router integration
+
+- **WHEN** consumer provides `routerOptions` on an item and/or `onAction` on the root
+- **THEN** SHALL forward `routerOptions` to the underlying React Aria link
+- **AND** SHALL invoke `onAction` with the activated item's key on press
+
+### Requirement: WCAG 2.1 AA Keyboard Access
+
+The component SHALL be fully operable by keyboard.
+
+#### Scenario: Tab traverses links in order
+
+- **WHEN** the user presses Tab repeatedly
+- **THEN** focus SHALL move through the non-current, non-disabled links in document order
+
+#### Scenario: Current and disabled items skipped
+
+- **WHEN** the user tabs through the trail
+- **THEN** the current (last) item SHALL NOT receive focus
+- **AND** any disabled item SHALL NOT receive focus

--- a/openspec/changes/add-breadcrumbs-component/tasks.md
+++ b/openspec/changes/add-breadcrumbs-component/tasks.md
@@ -1,0 +1,48 @@
+## 1. Confirm RAC behavior (spike)
+
+- [x] 1.1 Verify whether RAC `Breadcrumbs` emits `role="list"` on its `<ol>` in 1.19.0; decide if an explicit `role="list"` is needed (design D5)
+- [x] 1.2 Confirm the RAC `items` + render-function collection shape and how `onAction(key)` keys are derived, to fix the declarative API surface (design D3, Open Questions)
+- [x] 1.3 Confirm how a decorative separator can be injected once and shared by both the compound and `items` paths (design D4)
+
+## 2. Types (public API)
+
+- [x] 2.1 Rewrite `breadcrumbs.types.ts`: remove `isCurrent`; keep `separator` (default `›`) and `size` on Root; keep `href`/`target`/`rel`/`isDisabled` on Item
+- [x] 2.2 Add declarative `items` (+ render function) typing to the Root props
+- [x] 2.3 Add typed `onAction` on Root and `routerOptions` on Item (parity with `Tabs`/`Link`); type link handlers against RAC link options, not raw anchor `onClick`
+- [x] 2.4 JSDoc every prop; correct `@default` and `@example` (default separator `›`)
+
+## 3. Failing tests first (TDD — stories)
+
+- [x] 3.1 Base: nav landmark + `aria-label`, `<ol>` with `role="list"`, listitem count, non-final items are links to `href`
+- [x] 3.2 Automatic current: last item has `aria-current="page"`, is non-interactive, exposes no `link` role, and is skipped by Tab
+- [x] 3.3 Separator: assert the separator renders between items, has the expected text/node, carries `aria-hidden="true"`, and no leading separator before the first item
+- [x] 3.4 Sizes: assert a real `sm`-vs-`md` difference (e.g. differing computed font-size / gap), not just that two navs render
+- [x] 3.5 Disabled item: `aria-disabled="true"`, no `href`, and NOT focusable across a full Tab sweep
+- [x] 3.6 Declarative `items` API renders an equivalent trail with the same last-is-current semantics
+- [x] 3.7 Edge cases: single-item trail (that item is current); empty items/children render nav+ol without throwing
+- [x] 3.8 Router: `onAction` fires with the item key on press; `routerOptions` is forwarded
+
+## 4. Implementation
+
+- [x] 4.1 Implement `components/breadcrumbs.root.tsx` on `RaBreadcrumbs` (root/list slots via `withProvider`), supporting compound children and `items` render function; wire `aria-label`, `onAction`, `size`
+- [x] 4.2 Implement `components/breadcrumbs.item.tsx` on `RaBreadcrumb` composing `RaLink` (link slot via `asChild`); forward `href`/`target`/`rel`/`isDisabled`/`routerOptions`; use `Ra`-prefixed import aliases
+- [x] 4.3 Render the decorative `aria-hidden` separator between items via the separator slot, shared by both authoring paths
+- [x] 4.4 Apply explicit `role="list"` on the list slot if step 1.1 showed RAC does not guarantee it
+- [x] 4.5 Add a dev-time warning when `Breadcrumbs.Root` is rendered without `aria-label` (no hardcoded default string)
+- [x] 4.6 Author `breadcrumbs.slots.tsx` and `breadcrumbs.recipe.ts`: namespaced `--breadcrumbs-*` vars, `:first-of-type` separator hiding, and current/disabled styling targeting RAC-managed `data-current`/`data-disabled`
+- [x] 4.7 Author `breadcrumbs.tsx` namespace exports + JSDoc examples, including the `_`-prefixed docgen exports pattern
+- [x] 4.8 Register the recipe in the theme slot-recipe config and export `Breadcrumbs` from the package barrel
+
+## 5. Docs
+
+- [x] 5.1 Author `breadcrumbs.mdx`, `breadcrumbs.dev.mdx`, `breadcrumbs.a11y.mdx` and `breadcrumbs.docs.spec.tsx` (compound + `items` examples, no `isCurrent`); ensure examples compile against the real API
+- [x] 5.2 Add a "when to use / when NOT to use" guidelines block (do's and don'ts)
+- [x] 5.3 Document the RAC rationale (why the component is built on `Breadcrumbs`/`Breadcrumb`) in the engineering doc
+- [x] 5.4 Note the out-of-scope follow-ups (overflow/collapse, RTL separator glyph) in the docs
+
+## 6. Verify
+
+- [x] 6.1 `pnpm --filter @commercetools/nimbus typecheck:dev` clean
+- [x] 6.2 Build the package, then run `pnpm test packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx` against `dist` — all play functions green
+- [x] 6.3 `pnpm lint` clean for the touched files
+- [x] 6.4 Add a changeset describing the new Breadcrumbs component (consumer-facing)

--- a/openspec/changes/add-breadcrumbs-component/tasks.md
+++ b/openspec/changes/add-breadcrumbs-component/tasks.md
@@ -46,3 +46,9 @@
 - [x] 6.2 Build the package, then run `pnpm test packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx` against `dist` — all play functions green
 - [x] 6.3 `pnpm lint` clean for the touched files
 - [x] 6.4 Add a changeset describing the new Breadcrumbs component (consumer-facing)
+
+## 7. Chromatic visual regression (added after FCT-1100 landed)
+
+- [x] 7.1 Instrument `breadcrumbs.stories.tsx` for Chromatic per `docs/chromatic-visual-testing.md`: opt visual-state stories in via `tags: ["vrt"]` + `chromatic: { disableSnapshot: false }` (Sizes, CustomSeparator, Focused, Disabled, SmokeTest); explicitly opt behaviour-only stories out (`disableSnapshot: true`)
+- [x] 7.2 Add a render-only `Disabled` visual story (dimmed item, no focus) and a `Focused` story that ends focused to capture the focus-visible ring — keeping the tab-skipping behaviour assertions in `WithDisabledItem`/`KeyboardNavigation` snapshot-off (no stray focus rings in visual baselines)
+- [ ] 7.3 Accept the initial Breadcrumbs snapshots as baselines on the Chromatic `UI Tests` build once the PR runs (out-of-band, in the Chromatic UI)

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
@@ -43,7 +43,11 @@ const App = () => (
   navigation. The `Tab` key moves focus to the next link and `Shift + Tab` moves
   to the previous link. Arrow keys do **not** cycle focus between items.
 - **Disabled items:** Disabled items carry `aria-disabled="true"` and are
-  excluded from the tab sequence, so keyboard users skip them naturally.
+  excluded from the tab sequence, so keyboard users skip them naturally. Avoid
+  disabling the **last** item: it is already the non-interactive current page,
+  and because a disabled item renders as a plain `<span>` outside React Aria's
+  collection context, a disabled final item will not receive
+  `aria-current="page"`.
 - **Contrast:** Ensure sufficient contrast between link text and the background
   in all states (default, hover, current, focused, disabled). The focus
   indicator must be clearly visible.

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
@@ -15,9 +15,9 @@ const App = () => (
     <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/products/apparel">Apparel</Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Shoes</Breadcrumbs.Item>
   </Breadcrumbs.Root>
-)
+);
 ```
 
 ### Accessibility standards
@@ -27,14 +27,16 @@ const App = () => (
   to identify the landmark, especially when a page contains multiple `<nav>`
   elements.
 - **List semantics:** Items are rendered inside an ordered list (`<ol>` with
-  `<li>` children), which communicates the hierarchical, sequential nature of
-  the trail to assistive technologies.
-- **Link semantics:** Each interactive item renders an `<a>` element with the
+  `<li>` children) carrying an explicit `role="list"`, which communicates the
+  hierarchical, sequential nature of the trail to assistive technologies — and
+  keeps list semantics under `list-style: none`, which WebKit (Safari +
+  VoiceOver) otherwise strips.
+- **Link semantics:** Each navigable item renders an `<a>` element with the
   implicit `link` role.
-- **Current page indication:** The current (last) item uses
-  `aria-current="page"` — **not** `aria-selected`. Screen readers announce this
-  as "current page". The current item renders as non-interactive text and is
-  removed from the tab sequence.
+- **Current page indication:** The current (last) item is derived automatically
+  (no `isCurrent` prop). It uses `aria-current="page"` — **not** `aria-selected`
+  — which screen readers announce as "current page". It renders as a
+  non-focusable `<span role="link">` and is removed from the tab sequence.
 - **Decorative separators:** Separators between items are decorative and carry
   `aria-hidden="true"`, so they are not announced by screen readers.
 - **Keyboard navigation:** Breadcrumbs use standard sequential keyboard

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.a11y.mdx
@@ -1,0 +1,47 @@
+---
+tab-title: Accessibility
+tab-order: 4
+---
+
+## Accessibility
+
+Accessibility ensures that digital content and functionality are usable by
+everyone, including people with disabilities, by addressing visual, auditory,
+cognitive, and physical limitations.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/products/apparel">Apparel</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```
+
+### Accessibility standards
+
+- **Landmark role:** `Breadcrumbs.Root` renders a `<nav>` HTML element — a
+  navigation landmark. Always provide an `aria-label` (commonly `"Breadcrumb"`)
+  to identify the landmark, especially when a page contains multiple `<nav>`
+  elements.
+- **List semantics:** Items are rendered inside an ordered list (`<ol>` with
+  `<li>` children), which communicates the hierarchical, sequential nature of
+  the trail to assistive technologies.
+- **Link semantics:** Each interactive item renders an `<a>` element with the
+  implicit `link` role.
+- **Current page indication:** The current (last) item uses
+  `aria-current="page"` — **not** `aria-selected`. Screen readers announce this
+  as "current page". The current item renders as non-interactive text and is
+  removed from the tab sequence.
+- **Decorative separators:** Separators between items are decorative and carry
+  `aria-hidden="true"`, so they are not announced by screen readers.
+- **Keyboard navigation:** Breadcrumbs use standard sequential keyboard
+  navigation. The `Tab` key moves focus to the next link and `Shift + Tab` moves
+  to the previous link. Arrow keys do **not** cycle focus between items.
+- **Disabled items:** Disabled items carry `aria-disabled="true"` and are
+  excluded from the tab sequence, so keyboard users skip them naturally.
+- **Contrast:** Ensure sufficient contrast between link text and the background
+  in all states (default, hover, current, focused, disabled). The focus
+  indicator must be clearly visible.

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
@@ -19,38 +19,46 @@ import {
 ### Basic usage
 
 `Breadcrumbs` is a compound component for **hierarchical page navigation**. It
-renders a `<nav>` landmark containing an ordered list of `<a>` elements. Mark
-the last item with `isCurrent` to represent the current page.
+renders a `<nav>` landmark containing an ordered list of `<a>` elements. The
+last item is treated as the current page automatically — there is no `isCurrent`
+prop.
 
 ```jsx live-dev
 const App = () => (
   <Breadcrumbs.Root aria-label="Breadcrumb">
     <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
   </Breadcrumbs.Root>
 );
 ```
+
+> [!NOTE]\
+> Breadcrumbs is built on React Aria Components' `Breadcrumbs`/`Breadcrumb`
+> primitives. React Aria owns the collection semantics: it derives the current
+> page (the last item), applies `aria-current="page"`, and removes that item
+> from the tab order automatically. This is why there is no `isCurrent` prop and
+> why the API mirrors other React-Aria-backed Nimbus components.
 
 ## Usage examples
 
 ### Current page
 
-Mark the final item with `isCurrent`. This strips the `href`, renders the item
-as non-interactive text, and sets `aria-current="page"`.
+The final item is the current page automatically. React Aria strips its `href`,
+renders it as non-interactive text, and sets `aria-current="page"`.
 
 ```jsx live-dev
 const App = () => (
   <Breadcrumbs.Root aria-label="Breadcrumb">
     <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Shoes</Breadcrumbs.Item>
   </Breadcrumbs.Root>
 );
 ```
 
 When using a client-side router, derive the trail from the current route and
-render the deepest segment with `isCurrent`:
+render the deepest segment last — it becomes current automatically:
 
 ```tsx
 import { useLocation } from "react-router-dom";
@@ -62,24 +70,44 @@ const ProductBreadcrumbs = ({ category }: { category: string }) => {
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
       <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>{category}</Breadcrumbs.Item>
+      <Breadcrumbs.Item>{category}</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   );
 };
 ```
 
+### Data-driven trail (`items`)
+
+For trails built from data, pass an `items` array instead of compound children.
+The last entry is the current page, and `onAction` receives the activated
+entry's `id`.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root
+    aria-label="Breadcrumb"
+    items={[
+      { id: "home", label: "Home", href: "/" },
+      { id: "products", label: "Products", href: "/products" },
+      { id: "apparel", label: "Apparel", href: "/products/apparel" },
+      { id: "shoes", label: "Shoes" },
+    ]}
+  />
+);
+```
+
 ### Custom separator
 
-The default separator is `/`. Pass any React node (string or icon) via the
+The default separator is `›`. Pass any React node (string or icon) via the
 `separator` prop on `Breadcrumbs.Root`. Separators are decorative and hidden
 from assistive technologies.
 
 ```jsx live-dev
 const App = () => (
-  <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+  <Breadcrumbs.Root aria-label="Breadcrumb" separator="/">
     <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Apparel</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Apparel</Breadcrumbs.Item>
   </Breadcrumbs.Root>
 );
 ```
@@ -97,7 +125,7 @@ const App = () => (
       <Breadcrumbs.Root aria-label="Breadcrumb (sm)" size="sm">
         <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-        <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
       </Breadcrumbs.Root>
     </Stack>
     <Stack direction="column" gap="200">
@@ -105,7 +133,7 @@ const App = () => (
       <Breadcrumbs.Root aria-label="Breadcrumb (md)" size="md">
         <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
         <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-        <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
       </Breadcrumbs.Root>
     </Stack>
   </Stack>
@@ -116,7 +144,7 @@ const App = () => (
 
 Use `isDisabled` to render an ancestor item that exists in the trail but cannot
 currently be navigated to. Disabled items are visually dimmed, removed from the
-tab sequence, and their `href` is stripped.
+tab sequence, and non-interactive.
 
 ```jsx live-dev
 const App = () => (
@@ -125,7 +153,7 @@ const App = () => (
     <Breadcrumbs.Item href="/orders" isDisabled>
       Orders
     </Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
   </Breadcrumbs.Root>
 );
 ```
@@ -138,10 +166,14 @@ Use `target` and `rel` to open a breadcrumb in a new browser tab. Always pair
 ```jsx live-dev
 const App = () => (
   <Breadcrumbs.Root aria-label="Breadcrumb">
-    <Breadcrumbs.Item href="https://docs.example.com" target="_blank" rel="noopener noreferrer">
+    <Breadcrumbs.Item
+      href="https://docs.example.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       Docs ↗
     </Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Current page</Breadcrumbs.Item>
   </Breadcrumbs.Root>
 );
 ```
@@ -151,22 +183,25 @@ const App = () => (
 ### Accessibility
 
 The Breadcrumbs component uses semantic HTML for navigation. Accessibility is
-handled natively by the browser's `<nav>` landmark, ordered-list structure, and
-`<a>` anchor semantics, combined with React Aria's `Link` for consistent
-interaction handling.
+handled by the browser's `<nav>` landmark and ordered-list structure, combined
+with React Aria's `Breadcrumbs`/`Breadcrumb`/`Link` primitives for current-page
+and interaction handling.
 
 #### Role
 
-- `Breadcrumbs.Root` renders a `<nav>` HTML element — a navigation landmark
-- Items are rendered inside an `<ol>`/`<li>` structure
-- Each interactive item renders an `<a>` HTML element with the implicit `link`
-  role
-- The current item uses `aria-current="page"` — **not** `aria-selected`
+- `Breadcrumbs.Root` renders a `<nav>` HTML element — a navigation landmark —
+  wrapping an `<ol>` (with an explicit `role="list"`, which keeps list semantics
+  under `list-style: none` in Safari/VoiceOver).
+- Items are rendered inside an `<ol>`/`<li>` structure.
+- Each navigable item renders an `<a>` element with the implicit `link` role.
+- The current (last) item renders as a non-focusable `<span role="link">` with
+  `aria-current="page"` — **not** `aria-selected`.
 
 #### Labeling
 
 Always provide an `aria-label` on `Breadcrumbs.Root` (commonly `"Breadcrumb"`)
-to describe the navigation region.
+to describe the navigation region. A development-time warning is logged if it is
+omitted. In localized apps, translate the label.
 
 ```tsx
 <Breadcrumbs.Root aria-label="Breadcrumb">...</Breadcrumbs.Root>
@@ -174,8 +209,8 @@ to describe the navigation region.
 
 #### Keyboard navigation
 
-Breadcrumbs use standard sequential keyboard navigation — no roving tabindex,
-no arrow key cycling.
+Breadcrumbs use standard sequential keyboard navigation — no roving tabindex, no
+arrow key cycling.
 
 | Key           | Action                          |
 | ------------- | ------------------------------- |
@@ -183,7 +218,8 @@ no arrow key cycling.
 | `Shift + Tab` | Move focus to the previous link |
 | `Enter`       | Activate the focused link       |
 
-The current (last) item is non-interactive and is skipped in the tab sequence.
+The current (last) item and any disabled items are non-interactive and skipped
+in the tab sequence.
 
 ## API reference
 
@@ -193,30 +229,31 @@ The current (last) item is non-interactive and is skipped in the tab sequence.
 
 ### Building a trail from data
 
-Render breadcrumbs from an array, marking the last entry as current.
+Prefer the declarative `items` API — it owns the last-is-current logic for you,
+so there is no index bookkeeping:
 
 ```tsx
 const trail = [
-  { href: "/", label: "Home" },
-  { href: "/products", label: "Products" },
-  { href: "/products/apparel", label: "Apparel" },
-  { label: "Shoes" }, // current page — no href
+  { id: "home", label: "Home", href: "/" },
+  { id: "products", label: "Products", href: "/products" },
+  { id: "apparel", label: "Apparel", href: "/products/apparel" },
+  { id: "shoes", label: "Shoes" }, // last entry is the current page
 ];
 
 const ProductTrail = () => (
-  <Breadcrumbs.Root aria-label="Breadcrumb">
-    {trail.map((entry, index) => (
-      <Breadcrumbs.Item
-        key={entry.href ?? entry.label}
-        href={entry.href}
-        isCurrent={index === trail.length - 1}
-      >
-        {entry.label}
-      </Breadcrumbs.Item>
-    ))}
-  </Breadcrumbs.Root>
+  <Breadcrumbs.Root aria-label="Breadcrumb" items={trail} />
 );
 ```
+
+## Out of scope
+
+The following are intentionally **not** handled by this component today:
+
+- **Overflow / collapsing** long trails (e.g. `Home / … / Current`). Keep trails
+  short, or truncate labels in your own layout.
+- **RTL separator glyphs.** The layout mirrors in RTL, but a directional glyph
+  such as `›` does not flip — supply a direction-neutral separator (e.g. `/`)
+  for RTL locales.
 
 ## Testing your implementation
 

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.dev.mdx
@@ -1,0 +1,234 @@
+---
+title: Breadcrumbs Component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import {
+  Breadcrumbs,
+  type BreadcrumbsProps,
+  type BreadcrumbsItemProps,
+} from "@commercetools/nimbus";
+```
+
+### Basic usage
+
+`Breadcrumbs` is a compound component for **hierarchical page navigation**. It
+renders a `<nav>` landmark containing an ordered list of `<a>` elements. Mark
+the last item with `isCurrent` to represent the current page.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+## Usage examples
+
+### Current page
+
+Mark the final item with `isCurrent`. This strips the `href`, renders the item
+as non-interactive text, and sets `aria-current="page"`.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+When using a client-side router, derive the trail from the current route and
+render the deepest segment with `isCurrent`:
+
+```tsx
+import { useLocation } from "react-router-dom";
+
+const ProductBreadcrumbs = ({ category }: { category: string }) => {
+  const { pathname } = useLocation();
+
+  return (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>{category}</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  );
+};
+```
+
+### Custom separator
+
+The default separator is `/`. Pass any React node (string or icon) via the
+`separator` prop on `Breadcrumbs.Root`. Separators are decorative and hidden
+from assistive technologies.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Apparel</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+### Size variants
+
+The `size` prop controls font size and spacing. Available sizes: `sm`, `md`
+(default).
+
+```jsx live-dev
+const App = () => (
+  <Stack direction="column" gap="600">
+    <Stack direction="column" gap="200">
+      <Text fontWeight="500">Small</Text>
+      <Breadcrumbs.Root aria-label="Breadcrumb (sm)" size="sm">
+        <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+        <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      </Breadcrumbs.Root>
+    </Stack>
+    <Stack direction="column" gap="200">
+      <Text fontWeight="500">Medium (default)</Text>
+      <Breadcrumbs.Root aria-label="Breadcrumb (md)" size="md">
+        <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+        <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+        <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      </Breadcrumbs.Root>
+    </Stack>
+  </Stack>
+);
+```
+
+### Disabled items
+
+Use `isDisabled` to render an ancestor item that exists in the trail but cannot
+currently be navigated to. Disabled items are visually dimmed, removed from the
+tab sequence, and their `href` is stripped.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders" isDisabled>
+      Orders
+    </Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+### External links
+
+Use `target` and `rel` to open a breadcrumb in a new browser tab. Always pair
+`target="_blank"` with `rel="noopener noreferrer"` for security.
+
+```jsx live-dev
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="https://docs.example.com" target="_blank" rel="noopener noreferrer">
+      Docs ↗
+    </Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+);
+```
+
+## Component requirements
+
+### Accessibility
+
+The Breadcrumbs component uses semantic HTML for navigation. Accessibility is
+handled natively by the browser's `<nav>` landmark, ordered-list structure, and
+`<a>` anchor semantics, combined with React Aria's `Link` for consistent
+interaction handling.
+
+#### Role
+
+- `Breadcrumbs.Root` renders a `<nav>` HTML element — a navigation landmark
+- Items are rendered inside an `<ol>`/`<li>` structure
+- Each interactive item renders an `<a>` HTML element with the implicit `link`
+  role
+- The current item uses `aria-current="page"` — **not** `aria-selected`
+
+#### Labeling
+
+Always provide an `aria-label` on `Breadcrumbs.Root` (commonly `"Breadcrumb"`)
+to describe the navigation region.
+
+```tsx
+<Breadcrumbs.Root aria-label="Breadcrumb">...</Breadcrumbs.Root>
+```
+
+#### Keyboard navigation
+
+Breadcrumbs use standard sequential keyboard navigation — no roving tabindex,
+no arrow key cycling.
+
+| Key           | Action                          |
+| ------------- | ------------------------------- |
+| `Tab`         | Move focus to the next link     |
+| `Shift + Tab` | Move focus to the previous link |
+| `Enter`       | Activate the focused link       |
+
+The current (last) item is non-interactive and is skipped in the tab sequence.
+
+## API reference
+
+<PropsTable id="Breadcrumbs" />
+
+## Common patterns
+
+### Building a trail from data
+
+Render breadcrumbs from an array, marking the last entry as current.
+
+```tsx
+const trail = [
+  { href: "/", label: "Home" },
+  { href: "/products", label: "Products" },
+  { href: "/products/apparel", label: "Apparel" },
+  { label: "Shoes" }, // current page — no href
+];
+
+const ProductTrail = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    {trail.map((entry, index) => (
+      <Breadcrumbs.Item
+        key={entry.href ?? entry.label}
+        href={entry.href}
+        isCurrent={index === trail.length - 1}
+      >
+        {entry.label}
+      </Breadcrumbs.Item>
+    ))}
+  </Breadcrumbs.Root>
+);
+```
+
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using
+Breadcrumbs within your application. As the component's internal functionality
+is already tested by Nimbus, these patterns help you verify your integration and
+application-specific logic.
+
+{{docs-tests: breadcrumbs.docs.spec.tsx}}
+
+## Resources
+
+- [React Aria Breadcrumbs](https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html)
+- [ARIA: navigation landmark](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role)
+- [aria-current attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current)

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.docs.spec.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.docs.spec.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Breadcrumbs, NimbusProvider } from "@commercetools/nimbus";
+
+/**
+ * @docs-section basic-rendering
+ * @docs-title Basic Rendering Tests
+ * @docs-description Verify the Breadcrumbs component renders a nav landmark with an ordered list of links
+ * @docs-order 1
+ */
+describe("Breadcrumbs - Basic rendering", () => {
+  it("renders a navigation landmark with an ordered list", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Breadcrumb" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("list").tagName).toBe("OL");
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("renders link items as anchors with the correct href", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(screen.getByRole("link", { name: "Orders" })).toHaveAttribute(
+      "href",
+      "/orders"
+    );
+  });
+});
+
+/**
+ * @docs-section current-page
+ * @docs-title Current Page Tests
+ * @docs-description Verify aria-current="page" is applied to the current (last) item and not to ancestors
+ * @docs-order 2
+ */
+describe("Breadcrumbs - Current page", () => {
+  it("sets aria-current='page' on the current item", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Order #123")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("renders the current item as non-interactive text, not a link", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    // An <a> without href exposes no `link` role, so the current page is
+    // non-interactive and absent from the list of links.
+    expect(
+      screen.queryByRole("link", { name: "Order #123" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Order #123")).not.toHaveAttribute("href");
+  });
+
+  it("does not set aria-current on ancestor items", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    );
+    expect(screen.getByRole("link", { name: "Orders" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+});
+
+/**
+ * @docs-section disabled-items
+ * @docs-title Disabled Item Tests
+ * @docs-description Verify disabled items are marked inaccessible and stripped of their href
+ * @docs-order 3
+ */
+describe("Breadcrumbs - Disabled items", () => {
+  it("marks disabled items with aria-disabled='true' and strips href", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders" isDisabled>
+            Orders
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    const disabled = screen.getByRole("link", { name: "Orders" });
+    expect(disabled).toHaveAttribute("aria-disabled", "true");
+    expect(disabled).not.toHaveAttribute("href");
+  });
+});
+
+/**
+ * @docs-section external-links
+ * @docs-title External Link Tests
+ * @docs-description Verify target and rel attributes for external breadcrumb items
+ * @docs-order 4
+ */
+describe("Breadcrumbs - External links", () => {
+  it("applies target and rel to external link items", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item
+            href="https://docs.example.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Docs ↗
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    const external = screen.getByRole("link", { name: "Docs ↗" });
+    expect(external).toHaveAttribute("target", "_blank");
+    expect(external).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});
+
+/**
+ * @docs-section interactions
+ * @docs-title Interaction Tests
+ * @docs-description Verify click handling and keyboard focus
+ * @docs-order 5
+ */
+describe("Breadcrumbs - Interactions", () => {
+  it("calls onClick when a link is clicked", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/" onClick={handleClick}>
+            Home
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    await user.click(screen.getByRole("link", { name: "Home" }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it("focuses link items with the Tab key", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    await user.tab();
+    expect(screen.getByRole("link", { name: "Home" })).toHaveFocus();
+  });
+});
+
+/**
+ * @docs-section accessibility
+ * @docs-title Accessibility Tests
+ * @docs-description Verify accessible labels and that the widget does not use aria-selected
+ * @docs-order 6
+ */
+describe("Breadcrumbs - Accessibility", () => {
+  it("supports aria-label on the root for landmark identification", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(
+      screen.getByRole("navigation", { name: "Breadcrumb" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not use aria-selected (navigation, not a widget)", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root aria-label="Breadcrumb">
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Order #123")).not.toHaveAttribute("aria-selected");
+  });
+});

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.docs.spec.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.docs.spec.tsx
@@ -16,7 +16,7 @@ describe("Breadcrumbs - Basic rendering", () => {
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -34,6 +34,7 @@ describe("Breadcrumbs - Basic rendering", () => {
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Current</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -47,21 +48,46 @@ describe("Breadcrumbs - Basic rendering", () => {
       "/orders"
     );
   });
+
+  it("builds a trail from a data array via the items prop", () => {
+    render(
+      <NimbusProvider>
+        <Breadcrumbs.Root
+          aria-label="Breadcrumb"
+          items={[
+            { id: "home", label: "Home", href: "/" },
+            { id: "orders", label: "Orders", href: "/orders" },
+            { id: "detail", label: "Order #123" },
+          ]}
+        />
+      </NimbusProvider>
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(screen.getByText("Order #123")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
 });
 
 /**
  * @docs-section current-page
  * @docs-title Current Page Tests
- * @docs-description Verify aria-current="page" is applied to the current (last) item and not to ancestors
+ * @docs-description Verify aria-current="page" is applied to the last item automatically and not to ancestors
  * @docs-order 2
  */
 describe("Breadcrumbs - Current page", () => {
-  it("sets aria-current='page' on the current item", () => {
+  it("sets aria-current='page' on the last item automatically", () => {
     render(
       <NimbusProvider>
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -72,22 +98,21 @@ describe("Breadcrumbs - Current page", () => {
     );
   });
 
-  it("renders the current item as non-interactive text, not a link", () => {
+  it("renders the current item as non-navigable (no href)", () => {
     render(
       <NimbusProvider>
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
 
-    // An <a> without href exposes no `link` role, so the current page is
-    // non-interactive and absent from the list of links.
-    expect(
-      screen.queryByRole("link", { name: "Order #123" })
-    ).not.toBeInTheDocument();
-    expect(screen.getByText("Order #123")).not.toHaveAttribute("href");
+    // React Aria renders the current item as a <span> (not an anchor) with no
+    // href, so it is not a navigable link.
+    const current = screen.getByText("Order #123");
+    expect(current).not.toHaveAttribute("href");
+    expect(current.tagName).toBe("SPAN");
   });
 
   it("does not set aria-current on ancestor items", () => {
@@ -96,7 +121,7 @@ describe("Breadcrumbs - Current page", () => {
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -125,12 +150,12 @@ describe("Breadcrumbs - Disabled items", () => {
           <Breadcrumbs.Item href="/orders" isDisabled>
             Orders
           </Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
 
-    const disabled = screen.getByRole("link", { name: "Orders" });
+    const disabled = screen.getByText("Orders");
     expect(disabled).toHaveAttribute("aria-disabled", "true");
     expect(disabled).not.toHaveAttribute("href");
   });
@@ -154,7 +179,7 @@ describe("Breadcrumbs - External links", () => {
           >
             Docs ↗
           </Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Current page</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -168,27 +193,30 @@ describe("Breadcrumbs - External links", () => {
 /**
  * @docs-section interactions
  * @docs-title Interaction Tests
- * @docs-description Verify click handling and keyboard focus
+ * @docs-description Verify onAction fires with the activated breadcrumb's id
  * @docs-order 5
  */
 describe("Breadcrumbs - Interactions", () => {
-  it("calls onClick when a link is clicked", async () => {
+  it("calls onAction with the item id when a breadcrumb is activated", async () => {
     const user = userEvent.setup();
-    const handleClick = vi.fn();
+    const handleAction = vi.fn();
 
     render(
       <NimbusProvider>
-        <Breadcrumbs.Root aria-label="Breadcrumb">
-          <Breadcrumbs.Item href="/" onClick={handleClick}>
+        <Breadcrumbs.Root aria-label="Breadcrumb" onAction={handleAction}>
+          <Breadcrumbs.Item id="home" href="/">
             Home
           </Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item id="orders" href="/orders">
+            Orders
+          </Breadcrumbs.Item>
+          <Breadcrumbs.Item id="detail">Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
 
-    await user.click(screen.getByRole("link", { name: "Home" }));
-    expect(handleClick).toHaveBeenCalled();
+    await user.click(screen.getByRole("link", { name: "Orders" }));
+    expect(handleAction).toHaveBeenCalledWith("orders");
   });
 
   it("focuses link items with the Tab key", async () => {
@@ -198,7 +226,7 @@ describe("Breadcrumbs - Interactions", () => {
       <NimbusProvider>
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -220,6 +248,7 @@ describe("Breadcrumbs - Accessibility", () => {
       <NimbusProvider>
         <Breadcrumbs.Root aria-label="Breadcrumb">
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Current</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );
@@ -233,7 +262,8 @@ describe("Breadcrumbs - Accessibility", () => {
     render(
       <NimbusProvider>
         <Breadcrumbs.Root aria-label="Breadcrumb">
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </NimbusProvider>
     );

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
@@ -17,11 +17,11 @@ tags:
 
 ## Overview
 
-Breadcrumbs display the hierarchical path to the current page as an ordered
-list of links. They render a `<nav>` landmark containing an `<ol>` of `<a>`
-elements. Each item except the last navigates to an ancestor page; the last
-item represents the current page and is rendered as non-interactive text with
-`aria-current="page"`.
+Breadcrumbs display the hierarchical path to the current page as an ordered list
+of links. They render a `<nav>` landmark containing an `<ol>` of `<a>` elements.
+Each item except the last navigates to an ancestor page; the last item is
+treated as the current page automatically and is rendered as non-interactive
+text with `aria-current="page"`.
 
 Use breadcrumbs in pages that sit several levels deep in a hierarchy (e.g.
 `/products/apparel/shoes`) to help users understand where they are and to move
@@ -32,6 +32,23 @@ back up the tree.
 Deep dive into implementation details and access the Nimbus design library.
 
 [React Aria Breadcrumbs](https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html)
+
+## Guidelines
+
+> [!TIP]\
+> **When to use**
+>
+> - The page sits **three or more levels deep** in a clear hierarchy.
+> - Every level in the trail is a real, navigable page.
+> - Users benefit from seeing where they are and stepping back up the tree.
+
+> [!CAUTION]\
+> **When not to use**
+>
+> - As a substitute for a **back button** or the browser's history.
+> - On flat or two-level sites where the hierarchy adds no value.
+> - To represent a **multi-step flow or wizard** — use progress steps instead.
+> - Keep labels short and match them to the destination page titles.
 
 ## Variables
 
@@ -51,27 +68,46 @@ const App = () => (
         <Breadcrumbs.Root aria-label={`Breadcrumb (${size})`} size={size}>
           <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
           <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
         </Breadcrumbs.Root>
       </Stack>
     ))}
   </Stack>
-)
+);
 ```
 
 ### Current page
 
-Mark the last item with `isCurrent`. This renders it as non-interactive text
-with `aria-current="page"`, which screen readers announce as "current page".
+The **last** item is the current page automatically — there is no `isCurrent`
+prop. It renders as non-interactive text with `aria-current="page"`, which
+screen readers announce as "current page".
 
 ```jsx live
 const App = () => (
   <Breadcrumbs.Root aria-label="Breadcrumb">
     <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
   </Breadcrumbs.Root>
-)
+);
+```
+
+### Data-driven trail
+
+Pass an `items` array to render a trail from data. The last entry is the current
+page.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root
+    aria-label="Breadcrumb"
+    items={[
+      { id: "home", label: "Home", href: "/" },
+      { id: "catalog", label: "Catalog", href: "/catalog" },
+      { id: "shoes", label: "Shoes" },
+    ]}
+  />
+);
 ```
 
 ### Custom separator
@@ -81,12 +117,12 @@ separator is decorative and hidden from assistive technologies.
 
 ```jsx live
 const App = () => (
-  <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+  <Breadcrumbs.Root aria-label="Breadcrumb" separator="/">
     <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
     <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Shoes</Breadcrumbs.Item>
   </Breadcrumbs.Root>
-)
+);
 ```
 
 ### Disabled item
@@ -102,7 +138,7 @@ const App = () => (
     <Breadcrumbs.Item href="/orders" isDisabled>
       Orders
     </Breadcrumbs.Item>
-    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
   </Breadcrumbs.Root>
-)
+);
 ```

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.mdx
@@ -1,0 +1,108 @@
+---
+id: Components-Breadcrumbs
+title: Breadcrumbs
+exportName: Breadcrumbs
+description: A navigation trail showing the path to the current page.
+lifecycleState: Stable
+order: 999
+menu:
+  - Components
+  - Navigation
+  - Breadcrumbs
+tags:
+  - component
+  - navigation
+  - breadcrumbs
+---
+
+## Overview
+
+Breadcrumbs display the hierarchical path to the current page as an ordered
+list of links. They render a `<nav>` landmark containing an `<ol>` of `<a>`
+elements. Each item except the last navigates to an ancestor page; the last
+item represents the current page and is rendered as non-interactive text with
+`aria-current="page"`.
+
+Use breadcrumbs in pages that sit several levels deep in a hierarchy (e.g.
+`/products/apparel/shoes`) to help users understand where they are and to move
+back up the tree.
+
+### Resources
+
+Deep dive into implementation details and access the Nimbus design library.
+
+[React Aria Breadcrumbs](https://react-spectrum.adobe.com/react-aria/Breadcrumbs.html)
+
+## Variables
+
+Get familiar with the features.
+
+### Sizes
+
+`Breadcrumbs` supports two size variants — `sm` and `md` (default) — that
+control the font size and spacing between items.
+
+```jsx live
+const App = () => (
+  <Stack direction="column" gap="600">
+    {["sm", "md"].map((size) => (
+      <Stack key={size} direction="column" gap="200">
+        <Text fontWeight="600">{size}</Text>
+        <Breadcrumbs.Root aria-label={`Breadcrumb (${size})`} size={size}>
+          <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+          <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+          <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+        </Breadcrumbs.Root>
+      </Stack>
+    ))}
+  </Stack>
+)
+```
+
+### Current page
+
+Mark the last item with `isCurrent`. This renders it as non-interactive text
+with `aria-current="page"`, which screen readers announce as "current page".
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```
+
+### Custom separator
+
+Supply any React node via the `separator` prop on `Breadcrumbs.Root`. The
+separator is decorative and hidden from assistive technologies.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```
+
+### Disabled item
+
+Use `isDisabled` to render an item that is part of the trail but cannot be
+navigated to. Disabled items are visually dimmed and excluded from the tab
+sequence.
+
+```jsx live
+const App = () => (
+  <Breadcrumbs.Root aria-label="Breadcrumb">
+    <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item href="/orders" isDisabled>
+      Orders
+    </Breadcrumbs.Item>
+    <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+  </Breadcrumbs.Root>
+)
+```

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
@@ -1,0 +1,103 @@
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
+
+/**
+ * Recipe configuration for the Breadcrumbs component.
+ * Defines the styling variants and base styles using Chakra UI's recipe system.
+ *
+ * Renders navigation semantics (`<nav>` landmark + ordered list of `<a>`
+ * elements) for the path to the current page. The last item represents the
+ * current page and is rendered as non-interactive text with
+ * `aria-current="page"`.
+ */
+export const breadcrumbsSlotRecipe = defineSlotRecipe({
+  slots: ["root", "list", "item", "link", "separator"],
+
+  className: "nimbus-breadcrumbs",
+
+  base: {
+    root: {
+      display: "block",
+      width: "100%",
+    },
+    list: {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      listStyle: "none",
+      margin: "0",
+      padding: "0",
+      gap: "var(--breadcrumbs-gap)",
+    },
+    item: {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      gap: "var(--breadcrumbs-gap)",
+      fontSize: "var(--breadcrumbs-font-size)",
+    },
+    link: {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: "200",
+      color: "neutral.11",
+      textDecoration: "none",
+      cursor: "pointer",
+      borderRadius: "200",
+      transition: "color 150ms ease",
+      focusVisibleRing: "outside",
+      _hover: {
+        color: "primary.11",
+        textDecoration: "underline",
+      },
+      // React Aria sets data-current on the current (last) breadcrumb's link.
+      "&[data-current]": {
+        color: "neutral.12",
+        fontWeight: "500",
+        textDecoration: "none",
+        cursor: "default",
+        pointerEvents: "none",
+      },
+      _disabled: {
+        layerStyle: "disabled",
+      },
+    },
+    separator: {
+      display: "inline-flex",
+      alignItems: "center",
+      color: "neutral.9",
+      userSelect: "none",
+      // The first breadcrumb has no preceding separator.
+      "li:first-of-type > &": {
+        display: "none",
+      },
+    },
+  },
+
+  variants: {
+    size: {
+      sm: {
+        item: {
+          "--breadcrumbs-font-size": "fontSizes.300",
+          "--breadcrumbs-gap": "{spacing.100}",
+        },
+        list: {
+          "--breadcrumbs-gap": "{spacing.100}",
+        },
+      },
+      md: {
+        item: {
+          "--breadcrumbs-font-size": "fontSizes.350",
+          "--breadcrumbs-gap": "{spacing.200}",
+        },
+        list: {
+          "--breadcrumbs-gap": "{spacing.200}",
+        },
+      },
+    },
+  },
+
+  defaultVariants: {
+    size: "md",
+  },
+});

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
@@ -34,7 +34,8 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
       flexDirection: "row",
       alignItems: "center",
       gap: "var(--breadcrumbs-gap)",
-      fontSize: "var(--breadcrumbs-font-size)",
+      // Type ramp (font-size + paired line-height) is set per size variant via
+      // `textStyle`; link/separator children inherit it.
     },
     link: {
       display: "inline-flex",
@@ -82,8 +83,8 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
     size: {
       sm: {
         item: {
-          // Aligned with the `sm` textStyle font-size (fontSizes.350 = 14px).
-          "--breadcrumbs-font-size": "fontSizes.350",
+          // `sm` type ramp: fontSize.350 (14px) + its paired line-height.
+          textStyle: "sm",
           "--breadcrumbs-gap": "{spacing.100}",
         },
         list: {
@@ -92,9 +93,9 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
       },
       md: {
         item: {
-          // Aligned with the `md` textStyle font-size (fontSizes.400 = 16px),
-          // i.e. Nimbus's primary body size (matches Link/Button `md`).
-          "--breadcrumbs-font-size": "fontSizes.400",
+          // `md` type ramp: fontSize.400 (16px) + its paired line-height;
+          // md is Nimbus's primary body size (matches Link/Button `md`).
+          textStyle: "md",
           "--breadcrumbs-gap": "{spacing.200}",
         },
         list: {

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
@@ -50,7 +50,8 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
         color: "primary.11",
         textDecoration: "underline",
       },
-      // React Aria sets data-current on the current (last) breadcrumb's link.
+      // React Aria's Breadcrumb sets data-current on the current (last) item's
+      // link automatically.
       "&[data-current]": {
         color: "neutral.12",
         fontWeight: "500",
@@ -58,7 +59,10 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
         cursor: "default",
         pointerEvents: "none",
       },
-      _disabled: {
+      // React Aria marks the current item as disabled too (it sets
+      // `data-disabled` on it), so scope the dimmed disabled styling to
+      // genuinely disabled, non-current items only.
+      "&[data-disabled]:not([data-current])": {
         layerStyle: "disabled",
       },
     },

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.recipe.ts
@@ -82,7 +82,8 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
     size: {
       sm: {
         item: {
-          "--breadcrumbs-font-size": "fontSizes.300",
+          // Aligned with the `sm` textStyle font-size (fontSizes.350 = 14px).
+          "--breadcrumbs-font-size": "fontSizes.350",
           "--breadcrumbs-gap": "{spacing.100}",
         },
         list: {
@@ -91,7 +92,9 @@ export const breadcrumbsSlotRecipe = defineSlotRecipe({
       },
       md: {
         item: {
-          "--breadcrumbs-font-size": "fontSizes.350",
+          // Aligned with the `md` textStyle font-size (fontSizes.400 = 16px),
+          // i.e. Nimbus's primary body size (matches Link/Button `md`).
+          "--breadcrumbs-font-size": "fontSizes.400",
           "--breadcrumbs-gap": "{spacing.200}",
         },
         list: {

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.slots.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.slots.tsx
@@ -1,0 +1,61 @@
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "@/type-utils";
+import type {
+  BreadcrumbsRootSlotProps,
+  BreadcrumbsListSlotProps,
+  BreadcrumbsItemSlotProps,
+  BreadcrumbsLinkSlotProps,
+  BreadcrumbsSeparatorSlotProps,
+} from "./breadcrumbs.types";
+
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusBreadcrumbs",
+});
+
+/**
+ * Root slot component providing the styling context for the Breadcrumbs
+ * component. Renders a `<nav>` landmark element.
+ */
+export const BreadcrumbsRootSlot: SlotComponent<
+  HTMLElement,
+  BreadcrumbsRootSlotProps
+> = withProvider<HTMLElement, BreadcrumbsRootSlotProps>("nav", "root");
+
+/**
+ * List slot component for the ordered list of breadcrumbs.
+ * Renders as an `<ol>` element.
+ */
+export const BreadcrumbsListSlot: SlotComponent<
+  HTMLOListElement,
+  BreadcrumbsListSlotProps
+> = withContext<HTMLOListElement, BreadcrumbsListSlotProps>("ol", "list");
+
+/**
+ * Item slot component for an individual breadcrumb.
+ * Renders as an `<li>` element.
+ */
+export const BreadcrumbsItemSlot: SlotComponent<
+  HTMLLIElement,
+  BreadcrumbsItemSlotProps
+> = withContext<HTMLLIElement, BreadcrumbsItemSlotProps>("li", "item");
+
+/**
+ * Link slot component for an individual breadcrumb link.
+ * Renders as an `<a>` element.
+ */
+export const BreadcrumbsLinkSlot: SlotComponent<
+  HTMLAnchorElement,
+  BreadcrumbsLinkSlotProps
+> = withContext<HTMLAnchorElement, BreadcrumbsLinkSlotProps>("a", "link");
+
+/**
+ * Separator slot component rendered between breadcrumb items.
+ * Renders as a decorative `<span>` element.
+ */
+export const BreadcrumbsSeparatorSlot: SlotComponent<
+  HTMLSpanElement,
+  BreadcrumbsSeparatorSlotProps
+> = withContext<HTMLSpanElement, BreadcrumbsSeparatorSlotProps>(
+  "span",
+  "separator"
+);

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -4,7 +4,9 @@ import { Breadcrumbs, Stack, Text } from "@commercetools/nimbus";
 
 /**
  * `Breadcrumbs` displays the hierarchical path to the current page as an
- * ordered list of navigation links.
+ * ordered list of navigation links. Built on React Aria Components'
+ * `Breadcrumbs`/`Breadcrumb`; the last item is treated as the current page
+ * automatically.
  */
 const meta: Meta<typeof Breadcrumbs.Root> = {
   title: "Components/Breadcrumbs",
@@ -24,22 +26,23 @@ const meta: Meta<typeof Breadcrumbs.Root> = {
 
 export default meta;
 
-/**
- * Story type for TypeScript support
- * StoryObj provides type checking for our story configurations
- */
 type Story = StoryObj<typeof Breadcrumbs.Root>;
 
+/** Returns the decorative separator elements (aria-hidden spans). */
+const getSeparators = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('[aria-hidden="true"]'));
+
 /**
- * The default Breadcrumbs usage with three items. The first two are links and
- * the last item is marked as the current page with `isCurrent`.
+ * The default Breadcrumbs usage with three items. The first two are links; the
+ * last item is automatically the current page (`aria-current="page"`, no
+ * `isCurrent` prop needed).
  */
 export const Base: Story = {
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
       <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   ),
   play: async ({ canvasElement, step }) => {
@@ -50,42 +53,72 @@ export const Base: Story = {
       await expect(nav).toBeInTheDocument();
     });
 
-    await step("Renders an ordered list", async () => {
+    await step("Renders an ordered list with role=list", async () => {
       const list = canvas.getByRole("list");
       await expect(list.tagName).toBe("OL");
+      await expect(list).toHaveAttribute("role", "list");
     });
 
     await step("Renders one list item per breadcrumb", async () => {
-      const items = canvas.getAllByRole("listitem");
-      await expect(items).toHaveLength(3);
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(3);
     });
 
-    await step("Link items point to their href", async () => {
+    await step("Non-current items link to their href", async () => {
       const home = canvas.getByRole("link", { name: "Home" });
       const orders = canvas.getByRole("link", { name: "Orders" });
       await expect(home).toHaveAttribute("href", "/");
       await expect(orders).toHaveAttribute("href", "/orders");
+      await expect(home).not.toHaveAttribute("aria-current");
     });
 
-    await step("Current item is text with aria-current='page'", async () => {
+    await step("Last item is the current page, non-interactive", async () => {
       const current = canvas.getByText("Order #123");
       await expect(current).toHaveAttribute("aria-current", "page");
-    });
-
-    await step("Current item is not a link (no href)", async () => {
-      const current = canvas.getByText("Order #123");
+      // Rendered as a <span>, not a navigable anchor.
       await expect(current).not.toHaveAttribute("href");
-      // An <a> without href exposes no `link` role, so it is non-interactive.
-      await expect(
-        canvas.queryByRole("link", { name: "Order #123" })
-      ).not.toBeInTheDocument();
+      await expect(current.tagName).toBe("SPAN");
     });
   },
 };
 
 /**
- * Demonstrates the two size variants: `sm` and `md` (default). Size controls
- * the font size and gap between items.
+ * Data-driven usage via the declarative `items` API. The last entry is the
+ * current page automatically, exactly as with compound children.
+ */
+export const DeclarativeItems: Story = {
+  render: () => (
+    <Breadcrumbs.Root
+      aria-label="Breadcrumb"
+      items={[
+        { id: "home", label: "Home", href: "/" },
+        { id: "orders", label: "Orders", href: "/orders" },
+        { id: "detail", label: "Order #123" },
+      ]}
+    />
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders one item per entry", async () => {
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(3);
+      await expect(canvas.getByRole("link", { name: "Home" })).toHaveAttribute(
+        "href",
+        "/"
+      );
+    });
+
+    await step("Last entry is current", async () => {
+      await expect(canvas.getByText("Order #123")).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
+    });
+  },
+};
+
+/**
+ * The two size variants: `sm` and `md` (default). Size controls the font size
+ * and the gap between items.
  */
 export const Sizes: Story = {
   render: () => (
@@ -96,7 +129,7 @@ export const Sizes: Story = {
           <Breadcrumbs.Root aria-label={`Breadcrumb (${size})`} size={size}>
             <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
             <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-            <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+            <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
           </Breadcrumbs.Root>
         </Stack>
       ))}
@@ -105,24 +138,30 @@ export const Sizes: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Both size variants render nav landmarks", async () => {
+    await step("sm renders a smaller font size than md", async () => {
+      // Compare the first listitem font-size of each size variant.
       const navs = canvas.getAllByRole("navigation");
-      await expect(navs).toHaveLength(2);
+      const smItem = within(navs[0]).getAllByRole("listitem")[0];
+      const mdItem = within(navs[1]).getAllByRole("listitem")[0];
+      const smSize = parseFloat(getComputedStyle(smItem).fontSize);
+      const mdSize = parseFloat(getComputedStyle(mdItem).fontSize);
+      await expect(smSize).toBeGreaterThan(0);
+      await expect(smSize).toBeLessThan(mdSize);
     });
   },
 };
 
 /**
- * Demonstrates a custom separator. Any React node may be supplied via the
- * `separator` prop on `Breadcrumbs.Root`; it is decorative and hidden from
- * assistive technologies.
+ * A custom separator. Any React node may be supplied via the `separator` prop
+ * on `Breadcrumbs.Root`; it is decorative and hidden from assistive
+ * technologies. The leading separator (before the first item) is not shown.
  */
 export const CustomSeparator: Story = {
   render: () => (
-    <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+    <Breadcrumbs.Root aria-label="Breadcrumb" separator="/">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
       <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Shoes</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   ),
   play: async ({ canvasElement, step }) => {
@@ -134,16 +173,34 @@ export const CustomSeparator: Story = {
       ).toBeInTheDocument();
     });
 
-    await step("Current item renders with the expected label", async () => {
-      const current = canvas.getByText("Shoes");
-      await expect(current).toHaveAttribute("aria-current", "page");
+    await step("A separator is rendered for each item", async () => {
+      const separators = getSeparators(canvasElement);
+      await expect(separators).toHaveLength(3);
+    });
+
+    await step(
+      "Separators show the custom '/' and are decorative",
+      async () => {
+        for (const sep of getSeparators(canvasElement)) {
+          await expect(sep).toHaveTextContent("/");
+          await expect(sep).toHaveAttribute("aria-hidden", "true");
+        }
+      }
+    );
+
+    await step("The leading separator is visually hidden", async () => {
+      const [first, ...rest] = getSeparators(canvasElement);
+      await expect(getComputedStyle(first).display).toBe("none");
+      for (const sep of rest) {
+        await expect(getComputedStyle(sep).display).not.toBe("none");
+      }
     });
   },
 };
 
 /**
- * Demonstrates `isDisabled` on an individual item. Disabled items are visually
- * dimmed, cannot be activated, and carry `aria-disabled="true"`.
+ * `isDisabled` on an individual item. Disabled items are visually dimmed,
+ * cannot be activated, carry `aria-disabled="true"`, and are skipped by Tab.
  */
 export const WithDisabledItem: Story = {
   render: () => (
@@ -152,63 +209,69 @@ export const WithDisabledItem: Story = {
       <Breadcrumbs.Item href="/orders" isDisabled>
         Orders
       </Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders/123">Order #123</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Item detail</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Disabled item has aria-disabled", async () => {
-      const disabled = canvas.getByRole("link", { name: "Orders" });
+    await step("Disabled item has aria-disabled and no href", async () => {
+      const disabled = canvas.getByText("Orders");
       await expect(disabled).toHaveAttribute("aria-disabled", "true");
+      await expect(disabled).not.toHaveAttribute("href");
     });
 
-    await step("Disabled item has no href", async () => {
-      const disabled = canvas.getByRole("link", { name: "Orders" });
-      await expect(disabled).not.toHaveAttribute("href");
+    await step("Tab skips the disabled item and the current item", async () => {
+      await userEvent.tab();
+      await expect(canvas.getByRole("link", { name: "Home" })).toHaveFocus();
+
+      await userEvent.tab();
+      // Focus jumps straight to the next enabled link, skipping "Orders".
+      await expect(
+        canvas.getByRole("link", { name: "Order #123" })
+      ).toHaveFocus();
+      await expect(canvas.getByText("Orders")).not.toHaveFocus();
+
+      await userEvent.tab();
+      // The current (last) item is never focused.
+      await expect(canvas.getByText("Item detail")).not.toHaveFocus();
     });
   },
 };
 
 /**
- * Demonstrates keyboard navigation. Breadcrumbs use standard sequential Tab key
- * navigation (no roving tabindex). The current (last) item is non-interactive
- * and is skipped in the tab sequence.
+ * Keyboard navigation. Breadcrumbs use standard sequential Tab navigation (no
+ * roving tabindex). The current (last) item is skipped in the tab sequence.
  */
 export const KeyboardNavigation: Story = {
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
       <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Tab moves focus to the first link", async () => {
-      const home = canvas.getByRole("link", { name: "Home" });
+    await step("Tab moves focus through the links in order", async () => {
       await userEvent.tab();
-      await expect(home).toHaveFocus();
-    });
-
-    await step("Tab moves focus to the second link", async () => {
-      const orders = canvas.getByRole("link", { name: "Orders" });
+      await expect(canvas.getByRole("link", { name: "Home" })).toHaveFocus();
       await userEvent.tab();
-      await expect(orders).toHaveFocus();
+      await expect(canvas.getByRole("link", { name: "Orders" })).toHaveFocus();
     });
 
     await step("Current item is not focusable (skipped)", async () => {
-      const current = canvas.getByText("Order #123");
       await userEvent.tab();
-      await expect(current).not.toHaveFocus();
+      await expect(canvas.getByText("Order #123")).not.toHaveFocus();
     });
   },
 };
 
 /**
- * Demonstrates `target` and `rel` for opening a breadcrumb in a new browser
- * tab — standard anchor semantics for external references.
+ * `target` and `rel` for opening a breadcrumb in a new browser tab — standard
+ * anchor semantics for external references.
  */
 export const WithExternalLink: Story = {
   render: () => (
@@ -220,20 +283,38 @@ export const WithExternalLink: Story = {
       >
         Example ↗
       </Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Current page</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("External link has target=_blank", async () => {
+    await step("External link has target and rel", async () => {
       const external = canvas.getByRole("link", { name: "Example ↗" });
       await expect(external).toHaveAttribute("target", "_blank");
-    });
-
-    await step("External link has rel=noopener noreferrer", async () => {
-      const external = canvas.getByRole("link", { name: "Example ↗" });
       await expect(external).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  },
+};
+
+/**
+ * A single-item trail. With only one item, that item is the current page.
+ */
+export const SingleItem: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item>Dashboard</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("The only item is current", async () => {
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(1);
+      await expect(canvas.getByText("Dashboard")).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
     });
   },
 };
@@ -248,32 +329,25 @@ export const SmokeTest: Story = {
       <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
       <Breadcrumbs.Item href="/products/apparel">Apparel</Breadcrumbs.Item>
       <Breadcrumbs.Item href="/products/apparel/shoes">Shoes</Breadcrumbs.Item>
-      <Breadcrumbs.Item isCurrent>Running shoes</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Running shoes</Breadcrumbs.Item>
     </Breadcrumbs.Root>
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Renders nav landmark", async () => {
+    await step("Renders nav landmark and five list items", async () => {
       await expect(canvas.getByRole("navigation")).toBeInTheDocument();
-    });
-
-    await step("Renders all five list items", async () => {
       await expect(canvas.getAllByRole("listitem")).toHaveLength(5);
     });
 
     await step("Only the last item is current", async () => {
-      const current = canvas.getByText("Running shoes");
-      await expect(current).toHaveAttribute("aria-current", "page");
-
-      const home = canvas.getByRole("link", { name: "Home" });
-      await expect(home).not.toHaveAttribute("aria-current");
-    });
-
-    await step("Link items keep their href", async () => {
+      await expect(canvas.getByText("Running shoes")).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
       await expect(
-        canvas.getByRole("link", { name: "Products" })
-      ).toHaveAttribute("href", "/products");
+        canvas.getByRole("link", { name: "Home" })
+      ).not.toHaveAttribute("aria-current");
     });
   },
 };

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { Breadcrumbs, Stack, Text } from "@commercetools/nimbus";
 
 /**
@@ -160,10 +160,13 @@ export const Sizes: Story = {
     const canvas = within(canvasElement);
 
     await step("sm renders a smaller font size than md", async () => {
-      // Compare the first listitem font-size of each size variant.
+      // React Aria builds the list as a collection: the <li> items hydrate a
+      // tick after render — slower in the production Storybook bundle Chromatic
+      // renders than in the dev test env — so wait for them with findAllByRole
+      // rather than reading synchronously.
       const navs = canvas.getAllByRole("navigation");
-      const smItem = within(navs[0]).getAllByRole("listitem")[0];
-      const mdItem = within(navs[1]).getAllByRole("listitem")[0];
+      const [smItem] = await within(navs[0]).findAllByRole("listitem");
+      const [mdItem] = await within(navs[1]).findAllByRole("listitem");
       const smSize = parseFloat(getComputedStyle(smItem).fontSize);
       const mdSize = parseFloat(getComputedStyle(mdItem).fontSize);
       await expect(smSize).toBeGreaterThan(0);
@@ -199,8 +202,9 @@ export const CustomSeparator: Story = {
     });
 
     await step("A separator is rendered for each item", async () => {
-      const separators = getSeparators(canvasElement);
-      await expect(separators).toHaveLength(3);
+      // Wait for React Aria's collection to hydrate the items (and their
+      // separators) — slower in the production bundle Chromatic renders.
+      await waitFor(() => expect(getSeparators(canvasElement)).toHaveLength(3));
     });
 
     await step(
@@ -240,8 +244,10 @@ export const Focused: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // Ensure the collection has hydrated the link before tabbing to it.
+    const home = await canvas.findByRole("link", { name: "Home" });
     await userEvent.tab();
-    await expect(canvas.getByRole("link", { name: "Home" })).toHaveFocus();
+    await expect(home).toHaveFocus();
   },
 };
 
@@ -424,7 +430,10 @@ export const SmokeTest: Story = {
 
     await step("Renders nav landmark and five list items", async () => {
       await expect(canvas.getByRole("navigation")).toBeInTheDocument();
-      await expect(canvas.getAllByRole("listitem")).toHaveLength(5);
+      // Wait for the collection to hydrate the <li> items before counting.
+      await waitFor(() =>
+        expect(canvas.getAllByRole("listitem")).toHaveLength(5)
+      );
     });
 
     await step("Only the last item is current", async () => {

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -7,11 +7,20 @@ import { Breadcrumbs, Stack, Text } from "@commercetools/nimbus";
  * ordered list of navigation links. Built on React Aria Components'
  * `Breadcrumbs`/`Breadcrumb`; the last item is treated as the current page
  * automatically.
+ *
+ * ## Chromatic visual regression
+ *
+ * Snapshots are opt-in (the project default in `.storybook/preview.tsx`
+ * disables them). The stories tagged `["vrt"]` with
+ * `chromatic: { disableSnapshot: false }` are the visual baselines — one per
+ * distinct prop-driven look (sizes, custom separator, focus ring, disabled
+ * item, deep/wrapping trail). Behaviour-only stories (semantics, keyboard,
+ * attribute assertions) stay opted-out so we don't create redundant baselines.
+ * See `docs/chromatic-visual-testing.md`.
  */
 const meta: Meta<typeof Breadcrumbs.Root> = {
   title: "Components/Breadcrumbs",
   component: Breadcrumbs.Root,
-  tags: ["autodocs"],
   parameters: {
     layout: "padded",
   },
@@ -36,8 +45,12 @@ const getSeparators = (root: HTMLElement) =>
  * The default Breadcrumbs usage with three items. The first two are links; the
  * last item is automatically the current page (`aria-current="page"`, no
  * `isCurrent` prop needed).
+ *
+ * Behaviour test — its look is captured by `Sizes` (md) and `SmokeTest`, so it
+ * is opted out of Chromatic.
  */
 export const Base: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
@@ -84,8 +97,11 @@ export const Base: Story = {
 /**
  * Data-driven usage via the declarative `items` API. The last entry is the
  * current page automatically, exactly as with compound children.
+ *
+ * API variant — visually identical to `Base`, so it is opted out of Chromatic.
  */
 export const DeclarativeItems: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Breadcrumbs.Root
       aria-label="Breadcrumb"
@@ -119,8 +135,13 @@ export const DeclarativeItems: Story = {
 /**
  * The two size variants: `sm` and `md` (default). Size controls the font size
  * and the gap between items.
+ *
+ * Visual baseline — captures the default trail look (links + current page) at
+ * both sizes. No focus is moved, so nothing leaves a stray focus ring.
  */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <Stack direction="column" gap="600">
       {(["sm", "md"] as const).map((size) => (
@@ -155,8 +176,12 @@ export const Sizes: Story = {
  * A custom separator. Any React node may be supplied via the `separator` prop
  * on `Breadcrumbs.Root`; it is decorative and hidden from assistive
  * technologies. The leading separator (before the first item) is not shown.
+ *
+ * Visual baseline — captures the custom separator look.
  */
 export const CustomSeparator: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb" separator="/">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
@@ -199,10 +224,57 @@ export const CustomSeparator: Story = {
 };
 
 /**
+ * Visual baseline for the focus-visible ring on a breadcrumb link. Tab moves
+ * focus to the first link and the play function ends focused, so Chromatic
+ * captures the ring intentionally (mirrors the button family's `Focused`).
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+      <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.tab();
+    await expect(canvas.getByRole("link", { name: "Home" })).toHaveFocus();
+  },
+};
+
+/**
+ * Visual baseline for a disabled item. A disabled non-current item is visually
+ * dimmed (the shared `disabled` layer style). Render-only — no focus is moved,
+ * so the snapshot shows the dimmed state without a stray focus ring. The
+ * disabled *behaviour* (tab-skipping, `aria-disabled`) is asserted in
+ * `WithDisabledItem`.
+ */
+export const Disabled: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders" isDisabled>
+        Orders
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+};
+
+/**
  * `isDisabled` on an individual item. Disabled items are visually dimmed,
  * cannot be activated, carry `aria-disabled="true"`, and are skipped by Tab.
+ *
+ * Behaviour test — the play function leaves focus on a link, so it is opted out
+ * of Chromatic; the dimmed look is captured by `Disabled`.
  */
 export const WithDisabledItem: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
@@ -243,8 +315,11 @@ export const WithDisabledItem: Story = {
 /**
  * Keyboard navigation. Breadcrumbs use standard sequential Tab navigation (no
  * roving tabindex). The current (last) item is skipped in the tab sequence.
+ *
+ * Behaviour test — opted out of Chromatic (focus ring is captured by `Focused`).
  */
 export const KeyboardNavigation: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
@@ -272,8 +347,12 @@ export const KeyboardNavigation: Story = {
 /**
  * `target` and `rel` for opening a breadcrumb in a new browser tab — standard
  * anchor semantics for external references.
+ *
+ * Attribute test — visually equivalent to `Base`, so it is opted out of
+ * Chromatic.
  */
 export const WithExternalLink: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item
@@ -299,8 +378,11 @@ export const WithExternalLink: Story = {
 
 /**
  * A single-item trail. With only one item, that item is the current page.
+ *
+ * Edge-case semantics test — opted out of Chromatic.
  */
 export const SingleItem: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item>Dashboard</Breadcrumbs.Item>
@@ -321,8 +403,13 @@ export const SingleItem: Story = {
 
 /**
  * Comprehensive smoke test with a deeper hierarchy and a single current item.
+ *
+ * Visual baseline — captures a deep, potentially wrapping trail (links +
+ * current page). No focus is moved, so nothing leaves a stray focus ring.
  */
 export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <Breadcrumbs.Root aria-label="Breadcrumb">
       <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,0 +1,279 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { Breadcrumbs, Stack, Text } from "@commercetools/nimbus";
+
+/**
+ * `Breadcrumbs` displays the hierarchical path to the current page as an
+ * ordered list of navigation links.
+ */
+const meta: Meta<typeof Breadcrumbs.Root> = {
+  title: "Components/Breadcrumbs",
+  component: Breadcrumbs.Root,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+      description: "Size of the breadcrumb items",
+    },
+  },
+};
+
+export default meta;
+
+/**
+ * Story type for TypeScript support
+ * StoryObj provides type checking for our story configurations
+ */
+type Story = StoryObj<typeof Breadcrumbs.Root>;
+
+/**
+ * The default Breadcrumbs usage with three items. The first two are links and
+ * the last item is marked as the current page with `isCurrent`.
+ */
+export const Base: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders a nav landmark", async () => {
+      const nav = canvas.getByRole("navigation", { name: "Breadcrumb" });
+      await expect(nav).toBeInTheDocument();
+    });
+
+    await step("Renders an ordered list", async () => {
+      const list = canvas.getByRole("list");
+      await expect(list.tagName).toBe("OL");
+    });
+
+    await step("Renders one list item per breadcrumb", async () => {
+      const items = canvas.getAllByRole("listitem");
+      await expect(items).toHaveLength(3);
+    });
+
+    await step("Link items point to their href", async () => {
+      const home = canvas.getByRole("link", { name: "Home" });
+      const orders = canvas.getByRole("link", { name: "Orders" });
+      await expect(home).toHaveAttribute("href", "/");
+      await expect(orders).toHaveAttribute("href", "/orders");
+    });
+
+    await step("Current item is text with aria-current='page'", async () => {
+      const current = canvas.getByText("Order #123");
+      await expect(current).toHaveAttribute("aria-current", "page");
+    });
+
+    await step("Current item is not a link (no href)", async () => {
+      const current = canvas.getByText("Order #123");
+      await expect(current).not.toHaveAttribute("href");
+      // An <a> without href exposes no `link` role, so it is non-interactive.
+      await expect(
+        canvas.queryByRole("link", { name: "Order #123" })
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Demonstrates the two size variants: `sm` and `md` (default). Size controls
+ * the font size and gap between items.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <Stack direction="column" gap="600">
+      {(["sm", "md"] as const).map((size) => (
+        <Stack key={size} direction="column" gap="200">
+          <Text fontWeight="600">{size}</Text>
+          <Breadcrumbs.Root aria-label={`Breadcrumb (${size})`} size={size}>
+            <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+            <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+            <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+          </Breadcrumbs.Root>
+        </Stack>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Both size variants render nav landmarks", async () => {
+      const navs = canvas.getAllByRole("navigation");
+      await expect(navs).toHaveLength(2);
+    });
+  },
+};
+
+/**
+ * Demonstrates a custom separator. Any React node may be supplied via the
+ * `separator` prop on `Breadcrumbs.Root`; it is decorative and hidden from
+ * assistive technologies.
+ */
+export const CustomSeparator: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/catalog">Catalog</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Shoes</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders the nav landmark", async () => {
+      await expect(
+        canvas.getByRole("navigation", { name: "Breadcrumb" })
+      ).toBeInTheDocument();
+    });
+
+    await step("Current item renders with the expected label", async () => {
+      const current = canvas.getByText("Shoes");
+      await expect(current).toHaveAttribute("aria-current", "page");
+    });
+  },
+};
+
+/**
+ * Demonstrates `isDisabled` on an individual item. Disabled items are visually
+ * dimmed, cannot be activated, and carry `aria-disabled="true"`.
+ */
+export const WithDisabledItem: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders" isDisabled>
+        Orders
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Disabled item has aria-disabled", async () => {
+      const disabled = canvas.getByRole("link", { name: "Orders" });
+      await expect(disabled).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await step("Disabled item has no href", async () => {
+      const disabled = canvas.getByRole("link", { name: "Orders" });
+      await expect(disabled).not.toHaveAttribute("href");
+    });
+  },
+};
+
+/**
+ * Demonstrates keyboard navigation. Breadcrumbs use standard sequential Tab key
+ * navigation (no roving tabindex). The current (last) item is non-interactive
+ * and is skipped in the tab sequence.
+ */
+export const KeyboardNavigation: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Tab moves focus to the first link", async () => {
+      const home = canvas.getByRole("link", { name: "Home" });
+      await userEvent.tab();
+      await expect(home).toHaveFocus();
+    });
+
+    await step("Tab moves focus to the second link", async () => {
+      const orders = canvas.getByRole("link", { name: "Orders" });
+      await userEvent.tab();
+      await expect(orders).toHaveFocus();
+    });
+
+    await step("Current item is not focusable (skipped)", async () => {
+      const current = canvas.getByText("Order #123");
+      await userEvent.tab();
+      await expect(current).not.toHaveFocus();
+    });
+  },
+};
+
+/**
+ * Demonstrates `target` and `rel` for opening a breadcrumb in a new browser
+ * tab — standard anchor semantics for external references.
+ */
+export const WithExternalLink: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item
+        href="https://example.com"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Example ↗
+      </Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Current page</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("External link has target=_blank", async () => {
+      const external = canvas.getByRole("link", { name: "Example ↗" });
+      await expect(external).toHaveAttribute("target", "_blank");
+    });
+
+    await step("External link has rel=noopener noreferrer", async () => {
+      const external = canvas.getByRole("link", { name: "Example ↗" });
+      await expect(external).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  },
+};
+
+/**
+ * Comprehensive smoke test with a deeper hierarchy and a single current item.
+ */
+export const SmokeTest: Story = {
+  render: () => (
+    <Breadcrumbs.Root aria-label="Breadcrumb">
+      <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products">Products</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products/apparel">Apparel</Breadcrumbs.Item>
+      <Breadcrumbs.Item href="/products/apparel/shoes">Shoes</Breadcrumbs.Item>
+      <Breadcrumbs.Item isCurrent>Running shoes</Breadcrumbs.Item>
+    </Breadcrumbs.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Renders nav landmark", async () => {
+      await expect(canvas.getByRole("navigation")).toBeInTheDocument();
+    });
+
+    await step("Renders all five list items", async () => {
+      await expect(canvas.getAllByRole("listitem")).toHaveLength(5);
+    });
+
+    await step("Only the last item is current", async () => {
+      const current = canvas.getByText("Running shoes");
+      await expect(current).toHaveAttribute("aria-current", "page");
+
+      const home = canvas.getByRole("link", { name: "Home" });
+      await expect(home).not.toHaveAttribute("aria-current");
+    });
+
+    await step("Link items keep their href", async () => {
+      await expect(
+        canvas.getByRole("link", { name: "Products" })
+      ).toHaveAttribute("href", "/products");
+    });
+  },
+};

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
@@ -4,8 +4,9 @@ import { BreadcrumbsRoot, BreadcrumbsItem } from "./components";
  * Breadcrumbs
  * ============================================================
  * A navigation component that displays the hierarchical path to the current
- * page as an ordered list of links. The last item represents the current page
- * and is rendered as non-interactive text.
+ * page as an ordered list of links. Built on React Aria Components'
+ * `Breadcrumbs`/`Breadcrumb`; the last item is treated as the current page
+ * automatically (non-interactive text with `aria-current="page"`).
  *
  * Renders proper navigation semantics (`<nav>` landmark, `<ol>`/`<li>`
  * structure, `<a>` elements, `aria-current="page"`) for WCAG 2.1 AA compliant
@@ -18,7 +19,7 @@ import { BreadcrumbsRoot, BreadcrumbsItem } from "./components";
  * <Breadcrumbs.Root aria-label="Breadcrumb">
  *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
  *   <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
- *   <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
  * </Breadcrumbs.Root>
  * ```
  */
@@ -28,13 +29,14 @@ export const Breadcrumbs = {
    *
    * The root container for the breadcrumbs. Renders a `<nav>` landmark wrapping
    * an ordered list of `Breadcrumbs.Item` links. Provide an `aria-label` (e.g.
-   * `"Breadcrumb"`) and an optional `separator` node.
+   * `"Breadcrumb"`) and an optional `separator` node. Accepts compound
+   * `Breadcrumbs.Item` children or a declarative `items` array.
    *
    * @example
    * ```tsx
-   * <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+   * <Breadcrumbs.Root aria-label="Breadcrumb" separator="/">
    *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
-   *   <Breadcrumbs.Item isCurrent>Settings</Breadcrumbs.Item>
+   *   <Breadcrumbs.Item>Settings</Breadcrumbs.Item>
    * </Breadcrumbs.Root>
    * ```
    */
@@ -42,14 +44,15 @@ export const Breadcrumbs = {
   /**
    * # Breadcrumbs.Item
    *
-   * An individual breadcrumb. Renders an `<li>` containing an `<a>` link. Use
-   * `isCurrent` on the last item to mark the current page (rendered as
-   * non-interactive text with `aria-current="page"`).
+   * An individual breadcrumb. Renders an `<li>` containing an `<a>` link. The
+   * last item in a `Breadcrumbs.Root` automatically becomes the current page
+   * (non-interactive text with `aria-current="page"`) — there is no `isCurrent`
+   * prop.
    *
    * @example
    * ```tsx
    * <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
-   * <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+   * <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
    * ```
    */
   Item: BreadcrumbsItem,

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,71 @@
+import { BreadcrumbsRoot, BreadcrumbsItem } from "./components";
+
+/**
+ * Breadcrumbs
+ * ============================================================
+ * A navigation component that displays the hierarchical path to the current
+ * page as an ordered list of links. The last item represents the current page
+ * and is rendered as non-interactive text.
+ *
+ * Renders proper navigation semantics (`<nav>` landmark, `<ol>`/`<li>`
+ * structure, `<a>` elements, `aria-current="page"`) for WCAG 2.1 AA compliant
+ * page navigation.
+ *
+ * @see {@link https://nimbus-documentation.vercel.app/components/navigation/breadcrumbs}
+ *
+ * @example
+ * ```tsx
+ * <Breadcrumbs.Root aria-label="Breadcrumb">
+ *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+ *   <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+ * </Breadcrumbs.Root>
+ * ```
+ */
+export const Breadcrumbs = {
+  /**
+   * # Breadcrumbs.Root
+   *
+   * The root container for the breadcrumbs. Renders a `<nav>` landmark wrapping
+   * an ordered list of `Breadcrumbs.Item` links. Provide an `aria-label` (e.g.
+   * `"Breadcrumb"`) and an optional `separator` node.
+   *
+   * @example
+   * ```tsx
+   * <Breadcrumbs.Root aria-label="Breadcrumb" separator="›">
+   *   <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
+   *   <Breadcrumbs.Item isCurrent>Settings</Breadcrumbs.Item>
+   * </Breadcrumbs.Root>
+   * ```
+   */
+  Root: BreadcrumbsRoot,
+  /**
+   * # Breadcrumbs.Item
+   *
+   * An individual breadcrumb. Renders an `<li>` containing an `<a>` link. Use
+   * `isCurrent` on the last item to mark the current page (rendered as
+   * non-interactive text with `aria-current="page"`).
+   *
+   * @example
+   * ```tsx
+   * <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
+   * <Breadcrumbs.Item isCurrent>Order #123</Breadcrumbs.Item>
+   * ```
+   */
+  Item: BreadcrumbsItem,
+};
+
+export type {
+  BreadcrumbsProps,
+  BreadcrumbsItemProps,
+} from "./breadcrumbs.types";
+
+/**
+ * todo: get rid of this, this is needed for the react-docgen-typescript script
+ * that is parsing the typescript types for our documentation. The _ underscores
+ * serve as a reminder that this exports are awkward and should not be used.
+ */
+export {
+  BreadcrumbsRoot as _BreadcrumbsRoot,
+  BreadcrumbsItem as _BreadcrumbsItem,
+};

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -81,6 +81,11 @@ export type BreadcrumbItem = {
   /**
    * Whether this breadcrumb is disabled (non-interactive, dimmed, skipped in
    * the tab sequence).
+   *
+   * Note: disabling the *last* item is not recommended. The last item is
+   * already treated as the current page (non-interactive), and a disabled item
+   * renders as a plain `<span>` that bypasses React Aria's collection context —
+   * so a disabled final item will not carry `aria-current="page"`.
    */
   isDisabled?: boolean;
   /**

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -4,6 +4,7 @@ import type {
   SlotRecipeProps,
   UnstyledProp,
 } from "@chakra-ui/react/styled-system";
+import type { RouterOptions } from "../nimbus-provider/nimbus-provider.types";
 
 // ============================================================
 // RECIPE PROPS
@@ -47,21 +48,81 @@ export type BreadcrumbsSeparatorSlotProps = HTMLChakraProps<
 >;
 
 // ============================================================
+// HELPER TYPES
+// ============================================================
+
+/**
+ * A single entry for the declarative, data-driven `items` API of
+ * `Breadcrumbs.Root`. The last entry in the array is treated as the current
+ * page automatically.
+ */
+export type BreadcrumbItem = {
+  /**
+   * A unique key for the breadcrumb, passed to `Breadcrumbs.Root`'s `onAction`
+   * handler when the breadcrumb is activated.
+   */
+  id: string | number;
+  /**
+   * The label content displayed inside the breadcrumb.
+   */
+  label: React.ReactNode;
+  /**
+   * The URL this breadcrumb links to. Ignored for the last (current) item.
+   */
+  href?: string;
+  /**
+   * The target window for the link.
+   */
+  target?: React.HTMLAttributeAnchorTarget;
+  /**
+   * The relationship between the current document and the linked URL.
+   */
+  rel?: string;
+  /**
+   * Whether this breadcrumb is disabled (non-interactive, dimmed, skipped in
+   * the tab sequence).
+   */
+  isDisabled?: boolean;
+  /**
+   * Options forwarded to the client-side router for this link.
+   */
+  routerOptions?: RouterOptions;
+};
+
+// ============================================================
 // MAIN PROPS
 // ============================================================
 
 /**
  * Props for the Breadcrumbs.Root component.
  * Renders a `<nav>` landmark containing an ordered list of breadcrumb links.
+ * The last item is treated as the current page automatically.
  */
 export type BreadcrumbsProps = OmitInternalProps<BreadcrumbsRootSlotProps> & {
   /**
    * The visible separator rendered between breadcrumb items. Accepts any
    * React node (e.g. a string like "/" or an icon). The separator is
    * decorative and hidden from assistive technologies.
-   * @default "/"
+   * @default "›"
    */
   separator?: React.ReactNode;
+  /**
+   * Data-driven list of breadcrumbs. When provided, one `Breadcrumbs.Item` is
+   * rendered per entry (in order) and `children` is ignored. The last entry is
+   * the current page. Prefer this for trails built from data; use compound
+   * `Breadcrumbs.Item` children for static trails.
+   */
+  items?: BreadcrumbItem[];
+  /**
+   * Handler called with a breadcrumb's `id` when it is activated (clicked or
+   * via keyboard). Useful for client-side routing.
+   */
+  onAction?: (key: string | number) => void;
+  /**
+   * The breadcrumb items. Provide `Breadcrumbs.Item` children for a static
+   * trail. Ignored when `items` is provided.
+   */
+  children?: React.ReactNode;
   /**
    * A ref to the root `<nav>` element.
    */
@@ -71,26 +132,28 @@ export type BreadcrumbsProps = OmitInternalProps<BreadcrumbsRootSlotProps> & {
 
 /**
  * Props for the Breadcrumbs.Item component.
- * Renders an `<li>` containing a navigation link. The last item in a
- * `Breadcrumbs.Root` should set `isCurrent` to represent the current page.
+ * Renders an `<li>` containing a navigation link. The last item rendered inside
+ * a `Breadcrumbs.Root` automatically represents the current page (non-interactive
+ * text with `aria-current="page"`, removed from the tab sequence) — there is no
+ * `isCurrent` prop.
  */
 export type BreadcrumbsItemProps =
-  OmitInternalProps<BreadcrumbsLinkSlotProps> & {
+  // Omit `id` from the anchor slot props (typed `string`) so we can widen it to
+  // React Aria's collection `Key` (`string | number`).
+  Omit<OmitInternalProps<BreadcrumbsLinkSlotProps>, "id"> & {
     /**
-     * The URL this breadcrumb links to. Omit (or pair with `isCurrent`) for the
-     * current page, which renders as non-interactive text.
+     * A unique key for the breadcrumb, passed to `Breadcrumbs.Root`'s `onAction`
+     * handler when this item is activated.
+     */
+    id?: string | number;
+    /**
+     * The URL this breadcrumb links to. Ignored for the last (current) item,
+     * which renders as non-interactive text.
      */
     href?: string;
     /**
-     * Whether this item represents the current page. When true, the item renders
-     * as non-interactive text with `aria-current="page"` and no `href` is
-     * applied. Set this on the last breadcrumb.
-     * @default false
-     */
-    isCurrent?: boolean;
-    /**
-     * Whether the item is disabled. Disabled items cannot be interacted with and
-     * are visually dimmed.
+     * Whether the item is disabled. Disabled items cannot be interacted with,
+     * are visually dimmed, and are removed from the tab sequence.
      * @default false
      */
     isDisabled?: boolean;
@@ -104,6 +167,10 @@ export type BreadcrumbsItemProps =
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#rel
      */
     rel?: string;
+    /**
+     * Options forwarded to the client-side router for this link.
+     */
+    routerOptions?: RouterOptions;
     /**
      * The label content displayed inside the breadcrumb.
      */

--- a/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/packages/nimbus/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -1,0 +1,116 @@
+import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  HTMLChakraProps,
+  SlotRecipeProps,
+  UnstyledProp,
+} from "@chakra-ui/react/styled-system";
+
+// ============================================================
+// RECIPE PROPS
+// ============================================================
+
+type BreadcrumbsRecipeProps = {
+  /**
+   * Size of the breadcrumb items.
+   * @default "md"
+   */
+  size?: SlotRecipeProps<"nimbusBreadcrumbs">["size"];
+} & UnstyledProp;
+
+// ============================================================
+// SLOT PROPS
+// ============================================================
+
+export type BreadcrumbsRootSlotProps = HTMLChakraProps<
+  "nav",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsListSlotProps = HTMLChakraProps<
+  "ol",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsItemSlotProps = HTMLChakraProps<
+  "li",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsLinkSlotProps = HTMLChakraProps<
+  "a",
+  BreadcrumbsRecipeProps
+>;
+
+export type BreadcrumbsSeparatorSlotProps = HTMLChakraProps<
+  "span",
+  BreadcrumbsRecipeProps
+>;
+
+// ============================================================
+// MAIN PROPS
+// ============================================================
+
+/**
+ * Props for the Breadcrumbs.Root component.
+ * Renders a `<nav>` landmark containing an ordered list of breadcrumb links.
+ */
+export type BreadcrumbsProps = OmitInternalProps<BreadcrumbsRootSlotProps> & {
+  /**
+   * The visible separator rendered between breadcrumb items. Accepts any
+   * React node (e.g. a string like "/" or an icon). The separator is
+   * decorative and hidden from assistive technologies.
+   * @default "/"
+   */
+  separator?: React.ReactNode;
+  /**
+   * A ref to the root `<nav>` element.
+   */
+  ref?: React.Ref<HTMLElement>;
+  [key: `data-${string}`]: unknown;
+};
+
+/**
+ * Props for the Breadcrumbs.Item component.
+ * Renders an `<li>` containing a navigation link. The last item in a
+ * `Breadcrumbs.Root` should set `isCurrent` to represent the current page.
+ */
+export type BreadcrumbsItemProps =
+  OmitInternalProps<BreadcrumbsLinkSlotProps> & {
+    /**
+     * The URL this breadcrumb links to. Omit (or pair with `isCurrent`) for the
+     * current page, which renders as non-interactive text.
+     */
+    href?: string;
+    /**
+     * Whether this item represents the current page. When true, the item renders
+     * as non-interactive text with `aria-current="page"` and no `href` is
+     * applied. Set this on the last breadcrumb.
+     * @default false
+     */
+    isCurrent?: boolean;
+    /**
+     * Whether the item is disabled. Disabled items cannot be interacted with and
+     * are visually dimmed.
+     * @default false
+     */
+    isDisabled?: boolean;
+    /**
+     * The target window for the link.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
+     */
+    target?: React.HTMLAttributeAnchorTarget;
+    /**
+     * The relationship between the current document and the linked URL.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#rel
+     */
+    rel?: string;
+    /**
+     * The label content displayed inside the breadcrumb.
+     */
+    children?: React.ReactNode;
+    /**
+     * A ref to the underlying `<a>` element.
+     */
+    ref?: React.Ref<HTMLAnchorElement>;
+    [key: `data-${string}`]: unknown;
+  };

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.context.ts
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.context.ts
@@ -1,24 +1,17 @@
 import { createContext, useContext } from "react";
 
-export interface BreadcrumbsContextValue {
-  /**
-   * The separator node rendered before each item except the first.
-   */
-  separator: React.ReactNode;
-}
-
-export const BreadcrumbsContext = createContext<
-  BreadcrumbsContextValue | undefined
->(undefined);
+/**
+ * Carries the decorative separator node configured on `Breadcrumbs.Root` down
+ * to each `Breadcrumbs.Item`, so the same separator is shared by both the
+ * compound (`Breadcrumbs.Item` children) and declarative (`items`) APIs.
+ *
+ * Defaults to `›` when an item is rendered without a surrounding
+ * `Breadcrumbs.Root` provider.
+ */
+export const BreadcrumbsSeparatorContext = createContext<React.ReactNode>("›");
 
 /**
- * Returns the breadcrumbs context provided by `Breadcrumbs.Root`.
- * Throws if a `Breadcrumbs.Item` is rendered outside of a `Breadcrumbs.Root`.
+ * Returns the decorative separator node provided by `Breadcrumbs.Root`.
  */
-export const useBreadcrumbsContext = (): BreadcrumbsContextValue => {
-  const context = useContext(BreadcrumbsContext);
-  if (!context) {
-    throw new Error("Breadcrumbs.Item must be used within Breadcrumbs.Root");
-  }
-  return context;
-};
+export const useBreadcrumbsSeparator = (): React.ReactNode =>
+  useContext(BreadcrumbsSeparatorContext);

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.context.ts
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.context.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+
+export interface BreadcrumbsContextValue {
+  /**
+   * The separator node rendered before each item except the first.
+   */
+  separator: React.ReactNode;
+}
+
+export const BreadcrumbsContext = createContext<
+  BreadcrumbsContextValue | undefined
+>(undefined);
+
+/**
+ * Returns the breadcrumbs context provided by `Breadcrumbs.Root`.
+ * Throws if a `Breadcrumbs.Item` is rendered outside of a `Breadcrumbs.Root`.
+ */
+export const useBreadcrumbsContext = (): BreadcrumbsContextValue => {
+  const context = useContext(BreadcrumbsContext);
+  if (!context) {
+    throw new Error("Breadcrumbs.Item must be used within Breadcrumbs.Root");
+  }
+  return context;
+};

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
@@ -1,0 +1,73 @@
+import { Link as RALink } from "react-aria-components";
+import { extractStyleProps } from "@/utils";
+import {
+  BreadcrumbsItemSlot,
+  BreadcrumbsLinkSlot,
+  BreadcrumbsSeparatorSlot,
+} from "../breadcrumbs.slots";
+import type { BreadcrumbsItemProps } from "../breadcrumbs.types";
+import { useBreadcrumbsContext } from "./breadcrumbs.context";
+
+/**
+ * # Breadcrumbs.Item
+ *
+ * An individual breadcrumb. Renders an `<li>` containing a navigation link
+ * (`<a>`). The decorative separator inherited from `Breadcrumbs.Root` is
+ * rendered before every item except the first.
+ *
+ * When `isCurrent` is true the item represents the current page: it renders as
+ * non-interactive text (not a link) with `aria-current="page"`, and is removed
+ * from the tab sequence.
+ *
+ * @supportsStyleProps
+ */
+export const BreadcrumbsItem = ({
+  children,
+  href,
+  isCurrent,
+  isDisabled,
+  target,
+  rel,
+  ref,
+  ...rest
+}: BreadcrumbsItemProps) => {
+  const { separator } = useBreadcrumbsContext();
+  const [styleProps, restProps] = extractStyleProps(rest);
+
+  return (
+    <BreadcrumbsItemSlot>
+      <BreadcrumbsSeparatorSlot aria-hidden="true">
+        {separator}
+      </BreadcrumbsSeparatorSlot>
+      {isCurrent ? (
+        // The current page is non-interactive text — not a link — so it is not
+        // in the tab order. React Aria's Link would remain focusable, so we
+        // render the styled slot element directly instead.
+        <BreadcrumbsLinkSlot
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          aria-current="page"
+          data-current="true"
+          {...styleProps}
+          {...restProps}
+        >
+          {children}
+        </BreadcrumbsLinkSlot>
+      ) : (
+        <BreadcrumbsLinkSlot asChild {...styleProps}>
+          <RALink
+            ref={ref}
+            href={isDisabled ? undefined : href}
+            isDisabled={isDisabled}
+            target={target}
+            rel={rel}
+            {...restProps}
+          >
+            {children}
+          </RALink>
+        </BreadcrumbsLinkSlot>
+      )}
+    </BreadcrumbsItemSlot>
+  );
+};
+
+BreadcrumbsItem.displayName = "Breadcrumbs.Item";

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
@@ -1,4 +1,7 @@
-import { Link as RALink } from "react-aria-components";
+import {
+  Breadcrumb as RaBreadcrumb,
+  Link as RaLink,
+} from "react-aria-components";
 import { extractStyleProps } from "@/utils";
 import {
   BreadcrumbsItemSlot,
@@ -6,66 +9,70 @@ import {
   BreadcrumbsSeparatorSlot,
 } from "../breadcrumbs.slots";
 import type { BreadcrumbsItemProps } from "../breadcrumbs.types";
-import { useBreadcrumbsContext } from "./breadcrumbs.context";
+import { useBreadcrumbsSeparator } from "./breadcrumbs.context";
 
 /**
  * # Breadcrumbs.Item
  *
- * An individual breadcrumb. Renders an `<li>` containing a navigation link
- * (`<a>`). The decorative separator inherited from `Breadcrumbs.Root` is
- * rendered before every item except the first.
+ * An individual breadcrumb. Renders an `<li>` (via React Aria's `Breadcrumb`)
+ * containing a navigation link (via React Aria's `Link`). The decorative
+ * separator configured on `Breadcrumbs.Root` is rendered before every item
+ * except the first.
  *
- * When `isCurrent` is true the item represents the current page: it renders as
- * non-interactive text (not a link) with `aria-current="page"`, and is removed
- * from the tab sequence.
+ * When this is the last item in a `Breadcrumbs.Root`, React Aria marks it as the
+ * current page automatically: it becomes non-interactive text with
+ * `aria-current="page"` and is removed from the tab sequence. There is no
+ * `isCurrent` prop — currentness is derived from position.
  *
  * @supportsStyleProps
  */
 export const BreadcrumbsItem = ({
   children,
+  id,
   href,
-  isCurrent,
   isDisabled,
   target,
   rel,
+  routerOptions,
   ref,
   ...rest
 }: BreadcrumbsItemProps) => {
-  const { separator } = useBreadcrumbsContext();
+  const separator = useBreadcrumbsSeparator();
   const [styleProps, restProps] = extractStyleProps(rest);
 
   return (
-    <BreadcrumbsItemSlot>
-      <BreadcrumbsSeparatorSlot aria-hidden="true">
-        {separator}
-      </BreadcrumbsSeparatorSlot>
-      {isCurrent ? (
-        // The current page is non-interactive text — not a link — so it is not
-        // in the tab order. React Aria's Link would remain focusable, so we
-        // render the styled slot element directly instead.
-        <BreadcrumbsLinkSlot
-          ref={ref as React.Ref<HTMLAnchorElement>}
-          aria-current="page"
-          data-current="true"
-          {...styleProps}
-          {...restProps}
-        >
-          {children}
-        </BreadcrumbsLinkSlot>
-      ) : (
-        <BreadcrumbsLinkSlot asChild {...styleProps}>
-          <RALink
-            ref={ref}
-            href={isDisabled ? undefined : href}
-            isDisabled={isDisabled}
-            target={target}
-            rel={rel}
-            {...restProps}
-          >
-            {children}
-          </RALink>
-        </BreadcrumbsLinkSlot>
-      )}
+    <BreadcrumbsItemSlot asChild>
+      <RaBreadcrumb id={id}>
+        <BreadcrumbsSeparatorSlot aria-hidden="true">
+          {separator}
+        </BreadcrumbsSeparatorSlot>
+        {isDisabled ? (
+          // React Aria's Breadcrumb overrides the nested Link's `isDisabled`
+          // via context (it only disables the current item), so per-item
+          // disabling is handled here: render non-interactive, unfocusable text.
+          <BreadcrumbsLinkSlot asChild {...styleProps}>
+            <span aria-disabled="true" data-disabled="true">
+              {children}
+            </span>
+          </BreadcrumbsLinkSlot>
+        ) : (
+          <BreadcrumbsLinkSlot asChild {...styleProps}>
+            {/* React Aria's Breadcrumb passes `isDisabled`/`aria-current` to
+                this Link via context for the current (last) item, so it renders
+                as a non-focusable `<span role="link">` automatically. */}
+            <RaLink
+              ref={ref}
+              href={href}
+              target={target}
+              rel={rel}
+              routerOptions={routerOptions}
+              {...restProps}
+            >
+              {children}
+            </RaLink>
+          </BreadcrumbsLinkSlot>
+        )}
+      </RaBreadcrumb>
     </BreadcrumbsItemSlot>
   );
 };

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.item.tsx
@@ -51,7 +51,7 @@ export const BreadcrumbsItem = ({
           // via context (it only disables the current item), so per-item
           // disabling is handled here: render non-interactive, unfocusable text.
           <BreadcrumbsLinkSlot asChild {...styleProps}>
-            <span aria-disabled="true" data-disabled="true">
+            <span aria-disabled="true" data-disabled="true" {...restProps}>
               {children}
             </span>
           </BreadcrumbsLinkSlot>
@@ -62,7 +62,7 @@ export const BreadcrumbsItem = ({
                 as a non-focusable `<span role="link">` automatically. */}
             <RaLink
               ref={ref}
-              href={href}
+              {...(href ? { href } : {})}
               target={target}
               rel={rel}
               routerOptions={routerOptions}

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
@@ -1,40 +1,76 @@
-import { useMemo } from "react";
+import { Breadcrumbs as RaBreadcrumbs } from "react-aria-components";
 import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { extractStyleProps } from "@/utils";
 import { BreadcrumbsRootSlot, BreadcrumbsListSlot } from "../breadcrumbs.slots";
 import type { BreadcrumbsProps } from "../breadcrumbs.types";
-import { BreadcrumbsContext } from "./breadcrumbs.context";
+import { BreadcrumbsSeparatorContext } from "./breadcrumbs.context";
+import { BreadcrumbsItem } from "./breadcrumbs.item";
 
 /**
  * # Breadcrumbs.Root
  *
  * The root container for the Breadcrumbs component. Renders a `<nav>` landmark
- * wrapping an ordered list (`<ol>`) of `Breadcrumbs.Item` links, and provides
- * the styling context and separator configuration for all child items.
+ * wrapping an ordered list (`<ol>`) of breadcrumb items, built on React Aria
+ * Components' `Breadcrumbs`. The last item is treated as the current page
+ * automatically.
  *
- * Always provide an `aria-label` (e.g. `"Breadcrumb"`) to identify the
+ * Accepts either compound `Breadcrumbs.Item` children or a declarative `items`
+ * array. Always provide an `aria-label` (e.g. `"Breadcrumb"`) to identify the
  * navigation landmark.
  *
  * @supportsStyleProps
  */
 export const BreadcrumbsRoot = (props: BreadcrumbsProps) => {
-  const { children, separator = "/", ...elementProps } = props;
+  const { children, items, separator = "›", onAction, ...elementProps } = props;
 
-  // Standard pattern: split recipe variants first.
+  if (process.env.NODE_ENV !== "production") {
+    const labelProps = elementProps as Record<string, unknown>;
+    if (!labelProps["aria-label"] && !labelProps["aria-labelledby"]) {
+      console.warn(
+        'Breadcrumbs.Root: provide an `aria-label` (e.g. "Breadcrumb") to name the navigation landmark.'
+      );
+    }
+  }
+
+  // Standard pattern: split recipe variants first, then style props.
   const recipe = useSlotRecipe({ key: "nimbusBreadcrumbs" });
   const [recipeProps, restRecipeProps] = recipe.splitVariantProps(elementProps);
-
-  // Standard pattern: extract style props from the remaining props.
   const [styleProps, rest] = extractStyleProps(restRecipeProps);
 
-  const contextValue = useMemo(() => ({ separator }), [separator]);
-
   return (
-    <BreadcrumbsContext.Provider value={contextValue}>
+    <BreadcrumbsSeparatorContext.Provider value={separator}>
       <BreadcrumbsRootSlot {...recipeProps} {...styleProps} {...rest}>
-        <BreadcrumbsListSlot>{children}</BreadcrumbsListSlot>
+        {/* role="list" keeps list semantics under `list-style: none`, which
+            WebKit otherwise strips (Safari + VoiceOver). React Aria does not
+            forward `role` (neither via the slot nor as a prop), so set it
+            directly on the rendered <ol> node. */}
+        <BreadcrumbsListSlot asChild>
+          <RaBreadcrumbs
+            ref={(node: HTMLOListElement | null) =>
+              node?.setAttribute("role", "list")
+            }
+            items={items}
+            onAction={onAction}
+          >
+            {items
+              ? (item) => (
+                  <BreadcrumbsItem
+                    key={item.id}
+                    id={item.id}
+                    href={item.href}
+                    target={item.target}
+                    rel={item.rel}
+                    isDisabled={item.isDisabled}
+                    routerOptions={item.routerOptions}
+                  >
+                    {item.label}
+                  </BreadcrumbsItem>
+                )
+              : children}
+          </RaBreadcrumbs>
+        </BreadcrumbsListSlot>
       </BreadcrumbsRootSlot>
-    </BreadcrumbsContext.Provider>
+    </BreadcrumbsSeparatorContext.Provider>
   );
 };
 

--- a/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
+++ b/packages/nimbus/src/components/breadcrumbs/components/breadcrumbs.root.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+import { useSlotRecipe } from "@chakra-ui/react/styled-system";
+import { extractStyleProps } from "@/utils";
+import { BreadcrumbsRootSlot, BreadcrumbsListSlot } from "../breadcrumbs.slots";
+import type { BreadcrumbsProps } from "../breadcrumbs.types";
+import { BreadcrumbsContext } from "./breadcrumbs.context";
+
+/**
+ * # Breadcrumbs.Root
+ *
+ * The root container for the Breadcrumbs component. Renders a `<nav>` landmark
+ * wrapping an ordered list (`<ol>`) of `Breadcrumbs.Item` links, and provides
+ * the styling context and separator configuration for all child items.
+ *
+ * Always provide an `aria-label` (e.g. `"Breadcrumb"`) to identify the
+ * navigation landmark.
+ *
+ * @supportsStyleProps
+ */
+export const BreadcrumbsRoot = (props: BreadcrumbsProps) => {
+  const { children, separator = "/", ...elementProps } = props;
+
+  // Standard pattern: split recipe variants first.
+  const recipe = useSlotRecipe({ key: "nimbusBreadcrumbs" });
+  const [recipeProps, restRecipeProps] = recipe.splitVariantProps(elementProps);
+
+  // Standard pattern: extract style props from the remaining props.
+  const [styleProps, rest] = extractStyleProps(restRecipeProps);
+
+  const contextValue = useMemo(() => ({ separator }), [separator]);
+
+  return (
+    <BreadcrumbsContext.Provider value={contextValue}>
+      <BreadcrumbsRootSlot {...recipeProps} {...styleProps} {...rest}>
+        <BreadcrumbsListSlot>{children}</BreadcrumbsListSlot>
+      </BreadcrumbsRootSlot>
+    </BreadcrumbsContext.Provider>
+  );
+};
+
+BreadcrumbsRoot.displayName = "Breadcrumbs.Root";

--- a/packages/nimbus/src/components/breadcrumbs/components/index.ts
+++ b/packages/nimbus/src/components/breadcrumbs/components/index.ts
@@ -1,0 +1,2 @@
+export { BreadcrumbsRoot } from "./breadcrumbs.root";
+export { BreadcrumbsItem } from "./breadcrumbs.item";

--- a/packages/nimbus/src/components/breadcrumbs/index.ts
+++ b/packages/nimbus/src/components/breadcrumbs/index.ts
@@ -1,0 +1,2 @@
+export * from "./breadcrumbs";
+export * from "./breadcrumbs.types";

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -80,6 +80,7 @@ export * from "./pagination";
 export * from "./drawer";
 export * from "./tab-nav";
 export * from "./tabs";
+export * from "./breadcrumbs";
 export * from "./localized-field";
 export * from "./steps";
 export * from "./modal-page";

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -1,4 +1,5 @@
 import { accordionSlotRecipe } from "@/components/accordion/accordion.recipe";
+import { breadcrumbsSlotRecipe } from "@/components/breadcrumbs/breadcrumbs.recipe";
 import { scrollAreaSlotRecipe } from "@/components/scroll-area/scroll-area.recipe";
 import { defaultPageSlotRecipe } from "@/components/default-page/default-page.recipe";
 import { stepsSlotRecipe } from "@/components/steps/steps.recipe";
@@ -80,6 +81,7 @@ import { buttonGroupRecipe } from "@/components/toggle-button-group/toggle-butto
 export const slotRecipes = {
   nimbusAccordion: accordionSlotRecipe,
   nimbusAlert: alertRecipe,
+  nimbusBreadcrumbs: breadcrumbsSlotRecipe,
   nimbusCalendar: calendarSlotRecipe,
   nimbusCard: cardRecipe,
   nimbusChatMessage: chatMessageSlotRecipe,


### PR DESCRIPTION
## What

Adds a **Breadcrumbs** component — a navigation control that shows the hierarchical path to the current page as an ordered list of links.

<img width="466" height="386" alt="image" src="https://github.com/user-attachments/assets/31fc147c-a038-45ed-bd04-bf31078bbbbc" />

- `Breadcrumbs.Root` — renders a `<nav>` landmark wrapping an `<ol>`; takes an `aria-label` and an optional `separator` (any node, default `›`).
- `Breadcrumbs.Item` — renders an `<li>` containing a React Aria `Link`. The **last** item is automatically treated as the current page (non-interactive text with `aria-current="page"`, removed from the tab order) — currentness is derived from position, so there is no `isCurrent` prop. Also supports `isDisabled` (renders as a non-interactive `<span>`), `target`, `rel`, and `routerOptions`.

Two authoring styles share the same separator context: compound `Breadcrumbs.Item` children (static trails) or a declarative `items` array on `Breadcrumbs.Root` with an `onAction` handler (data-driven trails).

```tsx
<Breadcrumbs.Root aria-label="Breadcrumb">
  <Breadcrumbs.Item href="/">Home</Breadcrumbs.Item>
  <Breadcrumbs.Item href="/orders">Orders</Breadcrumbs.Item>
  <Breadcrumbs.Item>Order #123</Breadcrumbs.Item>
</Breadcrumbs.Root>
```

## Why

Breadcrumb was a feature-parity gap vs. every major component library (shadcn, MUI, Ant, Carbon, Polaris) and has no prior equivalent in Nimbus. It's a Tier-1 item on our component parity backlog.

## Provenance

The implementation originated on the exploratory branch `exp/breadcrumbs-after-docs` (a docs/tooling A/B experiment). This PR cherry-picks the single, self-contained component commit onto current `main` — no other experiment changes are included — and adds a changeset + a clean commit message. It was subsequently rebuilt on React Aria Components primitives (see the `refactor: rebuild on React Aria Components primitives` commit): current-page detection moved from an `isCurrent` prop to position-derived, the default separator became `›`, and disabled items now render as a `<span>` rather than a neutralized `Link`.

## Included

Full component per Nimbus conventions: main (`breadcrumbs.tsx`), `Root`/`Item`/context, `types`, `recipe` (registered as the `nimbusBreadcrumbs` slot recipe), `slots`, stories with play functions, docs (`.dev.mdx`, `.a11y.mdx`, `.mdx`), and a consumer docs spec. Changeset: `minor`.

## Verification

- `typecheck:dev` (source surface): clean.
- `pnpm test:dev packages/nimbus/src/components/breadcrumbs/`: **18/18 pass** (7 story + 11 docs-spec).
- Regenerated Chakra theme typings (`build-theme-typings`) so the new `nimbusBreadcrumbs` recipe is in the generated type map.

> CI's `typecheck:strict` + `test:storybook` run against the built `dist` surface and remain the merge gate.

## Known / minor

- **Disabled last item:** disabling the _last_ item is not recommended. It is already the non-interactive current page, and because a disabled item renders as a plain `<span>` outside React Aria's collection context, a disabled final item will not carry `aria-current="page"`. Documented on the `isDisabled` prop and in the a11y docs.

## Follow-ups

- Reviewer should confirm the recipe visuals against design (separator spacing, current-page treatment, disabled dimming).
