### PR TITLE
fix(ci): pin npm to v11 to avoid npm@12 sigstore bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      # Ensure npm 11.5.1 or later is installed for OIDC support
+      # Ensure npm >=11.5.1 for OIDC support (npm@12 has a broken sigstore dependency)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Verify npm version
         run: npm --version
@@ -153,7 +153,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install and build
         uses: ./.github/actions/ci


### PR DESCRIPTION
## Summary

- Pins `npm install -g npm@latest` to `npm install -g npm@11` in both `release` and `canary-from-pr` jobs
- npm@12.0.0 removed `sigstore` as a bundled dependency but `libnpmpublish` still requires it for provenance during publish, causing `MODULE_NOT_FOUND` errors for every package

## Test plan

- [ ] CI passes
- [ ] Next release publish succeeds without `MODULE_NOT_FOUND: sigstore` errors