### PR TITLE
feat(data-table): column align prop, default cell color, sticky backgrounds

### DIFF
--- a/.changeset/datatable-align-color-sticky.md
+++ b/.changeset/datatable-align-color-sticky.md
@@ -1,0 +1,16 @@
+---
+"@commercetools/nimbus": minor
+---
+
+**DataTable**: Add column-level `align` prop, default cell color, and sticky
+cell backgrounds.
+
+- Added `align` property to `DataTableColumnItem` with values `'start'`
+  (default), `'center'`, `'end'`, and `'stretch'`. Use `align: 'end'` for
+  right-aligned numeric columns and `align: 'stretch'` to let custom cell
+  renderers fill the full cell width.
+- Changed default body-cell text color from `neutral.11` to `neutral.12` for
+  improved contrast. Per-cell overrides via inline render JSX still take
+  precedence.
+- Applied opaque backgrounds to sticky header columns and sticky body cells
+  (selection, drag, expand, pin) so scrolled content no longer shows through.

--- a/packages/nimbus/src/components/data-table/components/data-table.header.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.header.tsx
@@ -90,6 +90,7 @@ export const DataTableHeader = <
         )}
         <RaCollection items={activeColumns}>
           {(column) => {
+            const align = column.align ?? "start";
             return (
               <DataTableColumn
                 allowsSorting={
@@ -104,6 +105,13 @@ export const DataTableHeader = <
                 minWidth={column.minWidth ?? 150}
                 maxWidth={column.maxWidth}
                 column={column}
+                textAlign={
+                  align === "center"
+                    ? "center"
+                    : align === "end" || align === "stretch"
+                      ? "end"
+                      : undefined
+                }
               >
                 <span data-multiline-header>{column.header}</span>
                 {column.headerIcon && (

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -467,13 +467,26 @@ const DataTableRowInner = <T extends DataTableRowItem = DataTableRowItem>({
           <RaCollection items={activeColumns}>
             {(col: DataTableColumnItem<T>) => {
               const cellValue = col.accessor(row);
+              const align = col.align ?? "start";
+              const isStretch = align === "stretch";
 
               return (
-                <DataTableCell isDisabled={isDisabled} key={col.id}>
+                <DataTableCell
+                  isDisabled={isDisabled}
+                  key={col.id}
+                  textAlign={
+                    align === "center"
+                      ? "center"
+                      : align === "end"
+                        ? "end"
+                        : undefined
+                  }
+                >
                   <Box
                     className={isTruncated ? "truncated-cell" : ""}
                     data-truncated={isTruncated ? "true" : "false"}
-                    display="inline-block"
+                    display={isStretch ? "block" : "inline-block"}
+                    w={isStretch ? "100%" : undefined}
                     minW="0"
                     maxW="100%"
                     position="relative"

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -1,5 +1,21 @@
 import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
 
+// Pseudo-element that extends a sticky cell's background by 2px on each side.
+// Fixes a Firefox/Safari rendering gap where the table's inset box-shadow
+// bleeds through at the edges of sticky cells in border-collapse:collapse tables.
+const stickyBgOverlap = {
+  "&::before": {
+    content: '""',
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: "-2px",
+    right: "-2px",
+    background: "inherit",
+    pointerEvents: "none",
+  },
+} as const;
+
 /**
  * Slot recipe configuration for the DataTable component.
  * Defines the styling variants, base styles, and slots using Chakra UI's slot recipe system.
@@ -39,6 +55,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           right: 0,
           zIndex: 3,
           backgroundColor: "bg",
+          ...stickyBgOverlap,
           "& [data-slot='nimbus-table-cell-pin-button']": {
             opacity: 0,
           },
@@ -50,6 +67,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           position: "sticky",
           left: 0,
           backgroundColor: "bg",
+          ...stickyBgOverlap,
         },
         "& [data-slot='drag']": {
           zIndex: 11,
@@ -305,6 +323,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         left: 0,
         zIndex: 13,
         background: "colorPalette.2",
+        ...stickyBgOverlap,
       },
       "&.drag-column-header": {
         cursor: "default",
@@ -313,6 +332,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         left: 0,
         zIndex: 13,
         background: "colorPalette.2",
+        ...stickyBgOverlap,
       },
       "&.expand-column-header": {
         cursor: "default",
@@ -321,6 +341,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         left: 0, // Default position when no selection column
         zIndex: 12,
         background: "colorPalette.2",
+        ...stickyBgOverlap,
       },
       // When drag column is present, offset selection and expand columns
       "&.drag-column-header + &.selection-column-header": {
@@ -346,6 +367,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         right: 0,
         zIndex: 11,
         background: "colorPalette.2",
+        ...stickyBgOverlap,
       },
       "&[aria-sort]": {
         fontWeight: 600,

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -38,6 +38,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           position: "sticky",
           right: 0,
           zIndex: 3,
+          backgroundColor: "bg",
           "& [data-slot='nimbus-table-cell-pin-button']": {
             opacity: 0,
           },
@@ -48,6 +49,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         "& .data-table-sticky-cell": {
           position: "sticky",
           left: 0,
+          backgroundColor: "bg",
         },
         "& [data-slot='drag']": {
           zIndex: 11,
@@ -302,6 +304,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         position: "sticky",
         left: 0,
         zIndex: 13,
+        background: "colorPalette.2",
       },
       "&.drag-column-header": {
         cursor: "default",
@@ -309,6 +312,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         position: "sticky",
         left: 0,
         zIndex: 13,
+        background: "colorPalette.2",
       },
       "&.expand-column-header": {
         cursor: "default",
@@ -316,6 +320,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         position: "sticky",
         left: 0, // Default position when no selection column
         zIndex: 12,
+        background: "colorPalette.2",
       },
       // When drag column is present, offset selection and expand columns
       "&.drag-column-header + &.selection-column-header": {
@@ -340,6 +345,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         position: "sticky",
         right: 0,
         zIndex: 11,
+        background: "colorPalette.2",
       },
       "&[aria-sort]": {
         fontWeight: 600,
@@ -395,7 +401,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       paddingBottom: "400",
       paddingLeft: "600",
       paddingRight: "600",
-      color: "neutral.11",
+      color: "neutral.12",
       focusVisibleRing: "inside",
       hyphens: "auto",
       // td height:auto is not "definite" per CSS spec, so child height:100%

--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -44,6 +44,8 @@ import {
   initialVisibleColumns,
   managerRows,
   initialHiddenColumns,
+  alignDemoColumns,
+  alignDemoRows,
 } from "./data-table.test-data";
 
 import { useDragAndDrop, createArrayHandlers } from "@commercetools/nimbus";
@@ -4973,5 +4975,119 @@ export const DragAndDropRows: Story = {
         );
       }
     );
+  },
+};
+
+export const ColumnAlignment: Story = {
+  render: () => {
+    return <DataTable columns={alignDemoColumns} rows={alignDemoRows} />;
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Table renders with aligned columns", async () => {
+      const table = await canvas.findByRole("grid");
+      expect(table).toBeInTheDocument();
+
+      expect(canvas.getByText("Widget A")).toBeInTheDocument();
+      expect(canvas.getByText("$12.99")).toBeInTheDocument();
+    });
+
+    await step(
+      "Right-aligned numeric cells have text-align: end on the cell",
+      async () => {
+        const priceCell = canvas.getByText("$12.99");
+        const cell = priceCell.closest("td") as HTMLElement;
+        const style = window.getComputedStyle(cell);
+        expect(style.textAlign).toBe("end");
+      }
+    );
+
+    await step(
+      "Center-aligned cells have text-align: center on the cell",
+      async () => {
+        const statusCells = canvas.getAllByText("Active");
+        const cell = statusCells[0].closest("td") as HTMLElement;
+        const style = window.getComputedStyle(cell);
+        expect(style.textAlign).toBe("center");
+      }
+    );
+
+    await step(
+      "Stretch-aligned cells have display: block and width: 100%",
+      async () => {
+        const progressBars = canvasElement.querySelectorAll("[data-truncated]");
+        const stretchWrapper = Array.from(progressBars).find((el) => {
+          const style = window.getComputedStyle(el as HTMLElement);
+          return style.display === "block";
+        }) as HTMLElement;
+        expect(stretchWrapper).toBeTruthy();
+        const style = window.getComputedStyle(stretchWrapper);
+        expect(style.width).not.toBe("0px");
+      }
+    );
+  },
+};
+
+export const StickyColumnBackground: Story = {
+  render: () => {
+    const stickyColumns: DataTableColumnItem[] = [
+      {
+        id: "name",
+        header: "Full Name",
+        accessor: (row) => row.name as React.ReactNode,
+        minWidth: 150,
+      },
+      ...Array.from({ length: 8 }, (_, i) => ({
+        id: `col-${i}`,
+        header: `Column ${i + 1}`,
+        accessor: (row: Record<string, unknown>) =>
+          (row[`col${i}`] || `Value ${i + 1}`) as React.ReactNode,
+        minWidth: 180,
+      })),
+    ];
+
+    const stickyRows: DataTableRowItem[] = Array.from(
+      { length: 15 },
+      (_, i) => ({
+        id: `${i + 1}`,
+        name: `Employee ${i + 1}`,
+        ...Object.fromEntries(
+          Array.from({ length: 8 }, (_, j) => [
+            `col${j}`,
+            `Data R${i + 1}C${j + 1}`,
+          ])
+        ),
+      })
+    );
+
+    return (
+      <Box maxW="600px">
+        <DataTable
+          columns={stickyColumns}
+          rows={stickyRows}
+          maxHeight="300px"
+          selectionMode="multiple"
+          selectionBehavior="toggle"
+        />
+      </Box>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Table renders with sticky elements", async () => {
+      const table = await canvas.findByRole("grid");
+      expect(table).toBeInTheDocument();
+
+      expect(canvas.getByText("Employee 1")).toBeInTheDocument();
+    });
+
+    await step("Sticky cells have opaque background", async () => {
+      const stickyCells = canvasElement.querySelectorAll(
+        ".data-table-sticky-cell"
+      );
+      expect(stickyCells.length).toBeGreaterThan(0);
+    });
   },
 };

--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -5004,11 +5004,31 @@ export const ColumnAlignment: Story = {
     );
 
     await step(
+      "Right-aligned column headers also have text-align: end",
+      async () => {
+        const priceHeader = canvas.getByText("Unit Price");
+        const th = priceHeader.closest("th") as HTMLElement;
+        const style = window.getComputedStyle(th);
+        expect(style.textAlign).toBe("end");
+      }
+    );
+
+    await step(
       "Center-aligned cells have text-align: center on the cell",
       async () => {
         const statusCells = canvas.getAllByText("Active");
         const cell = statusCells[0].closest("td") as HTMLElement;
         const style = window.getComputedStyle(cell);
+        expect(style.textAlign).toBe("center");
+      }
+    );
+
+    await step(
+      "Center-aligned column header also has text-align: center",
+      async () => {
+        const statusHeader = canvas.getByText("Status");
+        const th = statusHeader.closest("th") as HTMLElement;
+        const style = window.getComputedStyle(th);
         expect(style.textAlign).toBe("center");
       }
     );
@@ -5026,6 +5046,19 @@ export const ColumnAlignment: Story = {
         expect(style.width).not.toBe("0px");
       }
     );
+
+    await step("Stretch cells still support truncation class", async () => {
+      const stretchCells = canvasElement.querySelectorAll("[data-truncated]");
+      const stretchBlock = Array.from(stretchCells).find((el) => {
+        const s = window.getComputedStyle(el as HTMLElement);
+        return s.display === "block";
+      }) as HTMLElement;
+      expect(stretchBlock).toBeTruthy();
+      expect(
+        stretchBlock.style.overflow ||
+          window.getComputedStyle(stretchBlock).overflow
+      ).not.toBe("visible");
+    });
   },
 };
 
@@ -5088,6 +5121,35 @@ export const StickyColumnBackground: Story = {
         ".data-table-sticky-cell"
       );
       expect(stickyCells.length).toBeGreaterThan(0);
+
+      const stickyCell = stickyCells[0] as HTMLElement;
+      const bg = window.getComputedStyle(stickyCell).backgroundColor;
+      expect(bg).not.toBe("transparent");
+      expect(bg).not.toBe("rgba(0, 0, 0, 0)");
     });
+
+    await step(
+      "Selected row sticky cells still show selection highlight",
+      async () => {
+        const rows = canvasElement.querySelectorAll("tbody tr");
+        const firstDataRow = rows[0] as HTMLElement;
+        const checkbox = within(firstDataRow).getByRole("checkbox");
+        await userEvent.click(checkbox);
+
+        const selectedRow = canvasElement.querySelector(
+          "tr[aria-selected='true']"
+        );
+        expect(selectedRow).toBeInTheDocument();
+
+        const stickyInSelected = selectedRow?.querySelector(
+          ".data-table-sticky-cell"
+        ) as HTMLElement | null;
+        if (stickyInSelected) {
+          const bg = window.getComputedStyle(stickyInSelected).backgroundColor;
+          expect(bg).not.toBe("transparent");
+          expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+        }
+      }
+    );
   },
 };

--- a/packages/nimbus/src/components/data-table/data-table.test-data.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.test-data.tsx
@@ -9,6 +9,7 @@ import {
   Box,
   RadioInput,
   Badge,
+  ProgressBar,
 } from "@/components";
 import { Info } from "@commercetools/nimbus-icons";
 import { DataTable } from "./data-table";
@@ -1313,5 +1314,90 @@ export const managerRows: DataTableRowItem[] = [
     size: "S",
     color: "Sunset Orange",
     supplier: "Cotton Mills USA",
+  },
+];
+
+export const alignDemoColumns: DataTableColumnItem[] = [
+  {
+    id: "product",
+    header: "Product",
+    accessor: (row) => row.product as React.ReactNode,
+  },
+  {
+    id: "quantity",
+    header: "Quantity",
+    accessor: (row) => row.quantity as React.ReactNode,
+    align: "end",
+  },
+  {
+    id: "price",
+    header: "Unit Price",
+    accessor: (row) => row.price as React.ReactNode,
+    align: "end",
+  },
+  {
+    id: "total",
+    header: "Total",
+    accessor: (row) => row.total as React.ReactNode,
+    align: "end",
+  },
+  {
+    id: "status",
+    header: "Status",
+    accessor: (row) => row.status as React.ReactNode,
+    align: "center",
+  },
+  {
+    id: "progress",
+    header: "Progress",
+    accessor: () => null,
+    align: "stretch",
+    render: ({ row }) => (
+      <ProgressBar
+        value={row.percent as number}
+        size="2xs"
+        aria-label="Progress"
+        isDynamic={false}
+      />
+    ),
+  },
+];
+
+export const alignDemoRows: DataTableRowItem[] = [
+  {
+    id: "1",
+    product: "Widget A",
+    quantity: 150,
+    price: "$12.99",
+    total: "$1,948.50",
+    status: "Active",
+    percent: 75,
+  },
+  {
+    id: "2",
+    product: "Widget B",
+    quantity: 42,
+    price: "$29.99",
+    total: "$1,259.58",
+    status: "Pending",
+    percent: 30,
+  },
+  {
+    id: "3",
+    product: "Widget C",
+    quantity: 300,
+    price: "$5.49",
+    total: "$1,647.00",
+    status: "Active",
+    percent: 100,
+  },
+  {
+    id: "4",
+    product: "Widget D",
+    quantity: 88,
+    price: "$45.00",
+    total: "$3,960.00",
+    status: "Inactive",
+    percent: 0,
   },
 ];

--- a/packages/nimbus/src/components/data-table/data-table.types.ts
+++ b/packages/nimbus/src/components/data-table/data-table.types.ts
@@ -81,6 +81,7 @@ export type DataTableColumnItem<T extends object = Record<string, unknown>> = {
   minWidth?: number | null;
   maxWidth?: number | null;
   sticky?: boolean;
+  align?: "start" | "center" | "end" | "stretch";
   isSortable?: boolean;
   isRowHeader?: boolean;
   headerIcon?: ReactNode;


### PR DESCRIPTION
## Summary

- Added `align` prop (`'start' | 'center' | 'end' | 'stretch'`) to `DataTableColumnItem<T>` for column-level cell alignment — applied to both body cells and column headers
- Changed default body-cell text color from `neutral.11` to `neutral.12` for improved contrast
- Applied opaque backgrounds to sticky header columns (`colorPalette.2`) and sticky body cells (`bg`) so scrolled content no longer shows through
- Fixed Firefox/Safari 1-2px gap at sticky cell edges caused by `border-collapse:collapse` rendering — uses a `::before` pseudo-element with `background: inherit` to extend coverage by 2px on each side

Closes FEC-883

## Test plan
- [ ] Verify `align="end"` right-aligns both column headers and body cells in Storybook `ColumnAlignment` story
- [ ] Verify `align="center"` centers both header and body cell text
- [ ] Verify `align="stretch"` makes ProgressBar fill the full cell width (header defaults to `end` alignment)
- [ ] Verify body cells render with `neutral.12` text color by default
- [ ] Verify sticky header and body cells have opaque backgrounds when scrolling horizontally
- [ ] Verify no 1-2px gap at sticky cell edges in Firefox and Safari
- [ ] Verify hover/selected row states still work correctly on sticky cells (pseudo-element inherits background)
- [ ] Verify stretch cells still support truncation (overflow is not `visible`)
- [ ] Check both light and dark mode for background consistency