### PR TITLE
feat(mcp): add suggestions for unmapped components in migrate_from_uikit

### DIFF
--- a/.changeset/mcp-unmapped-suggestions.md
+++ b/.changeset/mcp-unmapped-suggestions.md
@@ -1,0 +1,12 @@
+---
+"@commercetools/nimbus-mcp": minor
+---
+
+**migrate_from_uikit**: unmapped components now include catalog suggestions.
+
+When a UI Kit component has no explicit migration rule, the tool searches the
+Nimbus component catalog and returns a `suggestion` with the likely Nimbus
+equivalent and a confidence level (`high` or `medium`). The `unmapped` array in
+file-mode responses changes from `string[]` to `UnmappedComponent[]` objects. In
+component-name mode, unrecognized names now return a suggestion result instead
+of an error when a catalog match is found.

--- a/packages/nimbus-mcp/src/tools/list-components.ts
+++ b/packages/nimbus-mcp/src/tools/list-components.ts
@@ -9,6 +9,7 @@ import type {
 import {
   filterAndRankPreLowered,
   fuzzyScorePreLowered,
+  toLoweredRouteFields,
 } from "../utils/relevance.js";
 
 /** Normalises a route entry into a sparse ComponentSummary. */
@@ -28,20 +29,6 @@ function toSummary(route: RouteManifestEntry): ComponentSummary {
   if (route.tags.length > 0) summary.tags = route.tags;
 
   return summary;
-}
-
-/** Build pre-lowered fields for a route entry. */
-function toLowered(r: RouteManifestEntry): LoweredRelevanceFields {
-  const title = r.title.toLowerCase();
-  const description = r.description.toLowerCase();
-  const tags = [...r.tags, r.exportName ?? ""].join(" ").toLowerCase();
-  return {
-    title,
-    description,
-    tags,
-    content: "",
-    combined: title + " " + description + " " + tags,
-  };
 }
 
 /**
@@ -99,7 +86,7 @@ export function registerListComponents(server: McpServer): void {
             LoweredRelevanceFields
           >();
           for (const r of routes) {
-            loweredMap.set(r, toLowered(r));
+            loweredMap.set(r, toLoweredRouteFields(r));
           }
 
           // Pass 1: exact substring match, ranked by field-weighted relevance.

--- a/packages/nimbus-mcp/src/tools/migrate-from-uikit.spec.ts
+++ b/packages/nimbus-mcp/src/tools/migrate-from-uikit.spec.ts
@@ -142,7 +142,7 @@ describe("migrate_from_uikit — componentName mode", () => {
     expect(getText(result)).toContain("NonExistentComponent");
   });
 
-  it("includes a suggestion when unknown component has a close Nimbus match", async () => {
+  it("includes a high-confidence suggestion when unknown component has a close Nimbus match", async () => {
     const result = await callMigrate({
       componentName: "SearchTextInput",
     });
@@ -152,8 +152,36 @@ describe("migrate_from_uikit — componentName mode", () => {
     expect(data.uiKitName).toBe("SearchTextInput");
     expect(data.suggestion).toBeDefined();
     expect(data.suggestion.name).toBe("SearchInput");
-    expect(data.suggestion.confidence).toMatch(/^(high|medium)$/);
+    expect(data.suggestion.confidence).toBe("high");
     expect(data.hint).toContain("get_component");
+  });
+
+  it("includes a medium-confidence suggestion via fuzzy match", async () => {
+    // "Acordion" is a typo of "Accordion" — no exact substring match,
+    // but within Levenshtein distance 1 of the Nimbus component name.
+    const result = await callMigrate({
+      componentName: "Acordion",
+    });
+    const data = JSON.parse(getText(result));
+
+    expect(result.isError).toBeUndefined();
+    expect(data.uiKitName).toBe("Acordion");
+    expect(data.suggestion).toBeDefined();
+    expect(data.suggestion.name).toBe("Accordion");
+    expect(data.suggestion.confidence).toBe("medium");
+  });
+
+  it("does not return high-confidence suggestions for all-generic-word names", async () => {
+    // "TextButton" is composed entirely of generic UI words — any match
+    // should be medium confidence at best, not high.
+    const result = await callMigrate({
+      componentName: "TextButton",
+    });
+
+    if (!result.isError) {
+      const data = JSON.parse(getText(result));
+      expect(data.suggestion?.confidence).not.toBe("high");
+    }
   });
 
   it("returns error with no suggestion for truly unknown component", async () => {
@@ -358,7 +386,7 @@ export const MyComponent = () => <div />;
     expect(data.unmapped[0].name).toBe("SearchTextInput");
     expect(data.unmapped[0].suggestion).toBeDefined();
     expect(data.unmapped[0].suggestion.name).toBe("SearchInput");
-    expect(data.unmapped[0].suggestion.confidence).toMatch(/^(high|medium)$/);
+    expect(data.unmapped[0].suggestion.confidence).toBe("high");
   });
 
   it("returns error for non-existent file", async () => {

--- a/packages/nimbus-mcp/src/tools/migrate-from-uikit.spec.ts
+++ b/packages/nimbus-mcp/src/tools/migrate-from-uikit.spec.ts
@@ -141,6 +141,27 @@ describe("migrate_from_uikit — componentName mode", () => {
     expect(result.isError).toBe(true);
     expect(getText(result)).toContain("NonExistentComponent");
   });
+
+  it("includes a suggestion when unknown component has a close Nimbus match", async () => {
+    const result = await callMigrate({
+      componentName: "SearchTextInput",
+    });
+    const data = JSON.parse(getText(result));
+
+    expect(result.isError).toBeUndefined();
+    expect(data.uiKitName).toBe("SearchTextInput");
+    expect(data.suggestion).toBeDefined();
+    expect(data.suggestion.name).toBe("SearchInput");
+    expect(data.suggestion.confidence).toMatch(/^(high|medium)$/);
+    expect(data.hint).toContain("get_component");
+  });
+
+  it("returns error with no suggestion for truly unknown component", async () => {
+    const result = await callMigrate({
+      componentName: "ZzzNonExistentWidget",
+    });
+    expect(result.isError).toBe(true);
+  });
 });
 
 describe("migrate_from_uikit — filePath mode", () => {
@@ -216,8 +237,9 @@ export const MyComponent = () => (
     expect(names).toContain("Text.Body");
     expect(names).not.toContain("Text.Headline");
     // The root names themselves should not appear as unmapped
-    expect(data.unmapped).not.toContain("Spacings");
-    expect(data.unmapped).not.toContain("Text");
+    const unmappedNames = data.unmapped.map((u: { name: string }) => u.name);
+    expect(unmappedNames).not.toContain("Spacings");
+    expect(unmappedNames).not.toContain("Text");
   });
 
   it("returns all sub-components when none are explicitly used in the file", async () => {
@@ -304,8 +326,39 @@ export const MyComponent = () => <div />;
     expect(names).toContain("FieldErrors");
     expect(names).toContain("CollapsiblePanel");
     // Type-only named imports should not appear
-    expect(data.unmapped).not.toContain("TFieldErrors");
-    expect(data.unmapped).not.toContain("TFieldErrorsProps");
+    const unmappedNames = data.unmapped.map((u: { name: string }) => u.name);
+    expect(unmappedNames).not.toContain("TFieldErrors");
+    expect(unmappedNames).not.toContain("TFieldErrorsProps");
+  });
+
+  it("returns unmapped components as objects with suggestions when available", async () => {
+    const suggestionFile = join(tmpDir, "suggestion-test.tsx");
+    await writeFile(
+      suggestionFile,
+      `
+import SearchTextInput from '@commercetools-uikit/search-text-input';
+import { PrimaryButton } from '@commercetools-uikit/buttons';
+
+export const MyComponent = () => <div />;
+`
+    );
+
+    const result = await callMigrate({ filePath: suggestionFile });
+    const data = JSON.parse(getText(result));
+
+    // PrimaryButton should be in mappings (it has a migration rule)
+    const mappedNames = data.mappings.map(
+      (m: { uiKitName: string }) => m.uiKitName
+    );
+    expect(mappedNames).toContain("PrimaryButton");
+
+    // SearchTextInput should be unmapped with a suggestion
+    expect(data.unmapped).toBeInstanceOf(Array);
+    expect(data.unmapped.length).toBe(1);
+    expect(data.unmapped[0].name).toBe("SearchTextInput");
+    expect(data.unmapped[0].suggestion).toBeDefined();
+    expect(data.unmapped[0].suggestion.name).toBe("SearchInput");
+    expect(data.unmapped[0].suggestion.confidence).toMatch(/^(high|medium)$/);
   });
 
   it("returns error for non-existent file", async () => {

--- a/packages/nimbus-mcp/src/tools/migrate-from-uikit.ts
+++ b/packages/nimbus-mcp/src/tools/migrate-from-uikit.ts
@@ -20,6 +20,8 @@ import type {
 import {
   filterAndRankPreLowered,
   fuzzyScorePreLowered,
+  toLoweredRouteFields,
+  WEIGHTS,
 } from "../utils/relevance.js";
 
 // ---------------------------------------------------------------------------
@@ -284,28 +286,41 @@ function splitPascalCase(name: string): string[] {
   return name.replace(/([a-z])([A-Z])/g, "$1 $2").split(/\s+/);
 }
 
-function toLowered(r: RouteManifestEntry): LoweredRelevanceFields {
-  const title = r.title.toLowerCase();
-  const description = r.description.toLowerCase();
-  const tags = [...r.tags, r.exportName ?? ""].join(" ").toLowerCase();
-  return {
-    title,
-    description,
-    tags,
-    content: "",
-    combined: title + " " + description + " " + tags,
-  };
+// Module-level cache for the component catalog and pre-lowered fields.
+let _componentRoutes: RouteManifestEntry[] | undefined;
+let _componentLowered:
+  | Map<RouteManifestEntry, LoweredRelevanceFields>
+  | undefined;
+
+async function getComponentCatalog(): Promise<{
+  routes: RouteManifestEntry[];
+  lowered: Map<RouteManifestEntry, LoweredRelevanceFields>;
+}> {
+  if (!_componentRoutes || !_componentLowered) {
+    const manifest = await getRouteManifest();
+    _componentRoutes = manifest.routes.filter(
+      (r) => r.category === "Components" && r.menu.length === 3
+    );
+    _componentLowered = new Map();
+    for (const r of _componentRoutes) {
+      _componentLowered.set(r, toLoweredRouteFields(r));
+    }
+  }
+  return { routes: _componentRoutes, lowered: _componentLowered };
 }
 
+/**
+ * Returns the candidate with the highest word-overlap ratio against the
+ * query words, or null if no candidate has any overlap (prevents confidently
+ * wrong matches when only generic UI words are in play).
+ */
 function pickClosestByWordOverlap(
   candidates: RouteManifestEntry[],
   uiKitWords: string[]
-): RouteManifestEntry {
-  if (candidates.length === 1) return candidates[0];
-
+): RouteManifestEntry | null {
   const wordSet = new Set(uiKitWords);
-  let best = candidates[0];
-  let bestRatio = -1;
+  let best: RouteManifestEntry | null = null;
+  let bestRatio = 0;
 
   for (const c of candidates) {
     const exportWords = splitPascalCase(c.exportName ?? c.title).map((w) =>
@@ -325,39 +340,34 @@ function pickClosestByWordOverlap(
 async function findNimbusSuggestion(
   uiKitName: string
 ): Promise<UnmappedSuggestion | null> {
-  const manifest = await getRouteManifest();
-  const routes = manifest.routes.filter(
-    (r) => r.category === "Components" && r.menu.length === 3
-  );
+  const { routes, lowered } = await getComponentCatalog();
 
   const allWords = splitPascalCase(uiKitName).map((w) => w.toLowerCase());
   if (allWords.length === 0) return null;
 
   const distinctive = allWords.filter((w) => !GENERIC_UI_WORDS.has(w));
-  const tokens = distinctive.length > 0 ? distinctive : allWords;
-
-  const loweredMap = new Map<RouteManifestEntry, LoweredRelevanceFields>();
-  for (const r of routes) {
-    loweredMap.set(r, toLowered(r));
-  }
+  const usingGenericFallback = distinctive.length === 0;
+  const tokens = usingGenericFallback ? allWords : distinctive;
 
   const exactMatches = filterAndRankPreLowered(
     routes,
     tokens,
-    (r) => loweredMap.get(r)!
+    (r) => lowered.get(r)!
   );
 
   if (exactMatches.length > 0) {
     const best = pickClosestByWordOverlap(exactMatches, allWords);
+    if (!best) return null;
     return {
       name: best.exportName ?? best.title,
-      confidence: "high",
+      confidence: usingGenericFallback ? "medium" : "high",
     };
   }
 
+  const minFuzzyScore = tokens.length * (WEIGHTS.title / 2);
   const fuzzyScored: Array<{ route: RouteManifestEntry; score: number }> = [];
   for (const r of routes) {
-    const score = fuzzyScorePreLowered(loweredMap.get(r)!, tokens);
+    const score = fuzzyScorePreLowered(lowered.get(r)!, tokens);
     if (score > 0) {
       fuzzyScored.push({ route: r, score });
     }
@@ -366,7 +376,7 @@ async function findNimbusSuggestion(
 
   if (fuzzyScored.length > 0) {
     const best = fuzzyScored[0];
-    if (best.score >= tokens.length * 4) {
+    if (best.score >= minFuzzyScore) {
       return {
         name: best.route.exportName ?? best.route.title,
         confidence: "medium",

--- a/packages/nimbus-mcp/src/tools/migrate-from-uikit.ts
+++ b/packages/nimbus-mcp/src/tools/migrate-from-uikit.ts
@@ -6,11 +6,21 @@ import {
   getUiKitCompoundMigrations,
   getAllUiKitMigrations,
 } from "../data/uikit-migration.js";
+import { getRouteManifest } from "../data-loader.js";
 import type {
   MigrateComponentResult,
   MigrateCompoundResult,
   MigrateFileResult,
+  MigrateSuggestionResult,
+  UnmappedComponent,
+  UnmappedSuggestion,
+  LoweredRelevanceFields,
+  RouteManifestEntry,
 } from "../types.js";
+import {
+  filterAndRankPreLowered,
+  fuzzyScorePreLowered,
+} from "../utils/relevance.js";
 
 // ---------------------------------------------------------------------------
 // Import extraction
@@ -249,6 +259,134 @@ function buildComponentResult(
 }
 
 // ---------------------------------------------------------------------------
+// Nimbus catalog suggestion for unmapped components
+// ---------------------------------------------------------------------------
+
+const GENERIC_UI_WORDS = new Set([
+  "input",
+  "field",
+  "text",
+  "button",
+  "component",
+  "panel",
+  "container",
+  "label",
+  "control",
+  "item",
+  "group",
+  "list",
+  "wrapper",
+  "provider",
+  "manager",
+]);
+
+function splitPascalCase(name: string): string[] {
+  return name.replace(/([a-z])([A-Z])/g, "$1 $2").split(/\s+/);
+}
+
+function toLowered(r: RouteManifestEntry): LoweredRelevanceFields {
+  const title = r.title.toLowerCase();
+  const description = r.description.toLowerCase();
+  const tags = [...r.tags, r.exportName ?? ""].join(" ").toLowerCase();
+  return {
+    title,
+    description,
+    tags,
+    content: "",
+    combined: title + " " + description + " " + tags,
+  };
+}
+
+function pickClosestByWordOverlap(
+  candidates: RouteManifestEntry[],
+  uiKitWords: string[]
+): RouteManifestEntry {
+  if (candidates.length === 1) return candidates[0];
+
+  const wordSet = new Set(uiKitWords);
+  let best = candidates[0];
+  let bestRatio = -1;
+
+  for (const c of candidates) {
+    const exportWords = splitPascalCase(c.exportName ?? c.title).map((w) =>
+      w.toLowerCase()
+    );
+    const overlap = exportWords.filter((w) => wordSet.has(w)).length;
+    const ratio = overlap / exportWords.length;
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      best = c;
+    }
+  }
+
+  return best;
+}
+
+async function findNimbusSuggestion(
+  uiKitName: string
+): Promise<UnmappedSuggestion | null> {
+  const manifest = await getRouteManifest();
+  const routes = manifest.routes.filter(
+    (r) => r.category === "Components" && r.menu.length === 3
+  );
+
+  const allWords = splitPascalCase(uiKitName).map((w) => w.toLowerCase());
+  if (allWords.length === 0) return null;
+
+  const distinctive = allWords.filter((w) => !GENERIC_UI_WORDS.has(w));
+  const tokens = distinctive.length > 0 ? distinctive : allWords;
+
+  const loweredMap = new Map<RouteManifestEntry, LoweredRelevanceFields>();
+  for (const r of routes) {
+    loweredMap.set(r, toLowered(r));
+  }
+
+  const exactMatches = filterAndRankPreLowered(
+    routes,
+    tokens,
+    (r) => loweredMap.get(r)!
+  );
+
+  if (exactMatches.length > 0) {
+    const best = pickClosestByWordOverlap(exactMatches, allWords);
+    return {
+      name: best.exportName ?? best.title,
+      confidence: "high",
+    };
+  }
+
+  const fuzzyScored: Array<{ route: RouteManifestEntry; score: number }> = [];
+  for (const r of routes) {
+    const score = fuzzyScorePreLowered(loweredMap.get(r)!, tokens);
+    if (score > 0) {
+      fuzzyScored.push({ route: r, score });
+    }
+  }
+  fuzzyScored.sort((a, b) => b.score - a.score);
+
+  if (fuzzyScored.length > 0) {
+    const best = fuzzyScored[0];
+    if (best.score >= tokens.length * 4) {
+      return {
+        name: best.route.exportName ?? best.route.title,
+        confidence: "medium",
+      };
+    }
+  }
+
+  return null;
+}
+
+async function buildUnmappedComponent(
+  name: string
+): Promise<UnmappedComponent> {
+  const suggestion = await findNimbusSuggestion(name);
+  const result: UnmappedComponent = { name };
+  if (suggestion) result.suggestion = suggestion;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Tool registration
 // ---------------------------------------------------------------------------
 
@@ -345,6 +483,24 @@ export function registerMigrateFromUiKit(server: McpServer): void {
           };
         }
 
+        // Try suggesting a Nimbus component from the catalog
+        const suggestion = await findNimbusSuggestion(componentName);
+        if (suggestion) {
+          const response: MigrateSuggestionResult = {
+            uiKitName: componentName,
+            suggestion,
+          };
+          response.hint = `Use the get_component tool to see full API docs (e.g. get_component(name: "${suggestion.name}"))`;
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(response),
+              },
+            ],
+          };
+        }
+
         return {
           content: [
             {
@@ -391,7 +547,7 @@ export function registerMigrateFromUiKit(server: McpServer): void {
       }
 
       const mappings: MigrateComponentResult[] = [];
-      const unmapped: string[] = [];
+      const unmappedNames: string[] = [];
 
       for (const name of componentNames) {
         const result = buildComponentResult(name);
@@ -415,8 +571,12 @@ export function registerMigrateFromUiKit(server: McpServer): void {
           }
           continue;
         }
-        unmapped.push(name);
+        unmappedNames.push(name);
       }
+
+      const unmapped: UnmappedComponent[] = await Promise.all(
+        unmappedNames.map(buildUnmappedComponent)
+      );
 
       const response: MigrateFileResult = {
         filePath: filePath!,

--- a/packages/nimbus-mcp/src/types.ts
+++ b/packages/nimbus-mcp/src/types.ts
@@ -417,12 +417,31 @@ export interface MigrateComponentResult {
   hint?: string;
 }
 
+/** A suggested Nimbus component for an unmapped UI Kit component. */
+export interface UnmappedSuggestion {
+  name: string;
+  confidence: "high" | "medium";
+}
+
+/** An unmapped UI Kit component, optionally with a suggested Nimbus equivalent. */
+export interface UnmappedComponent {
+  name: string;
+  suggestion?: UnmappedSuggestion;
+}
+
+/** Result for a componentName lookup that has no migration rule but a catalog suggestion. */
+export interface MigrateSuggestionResult {
+  uiKitName: string;
+  suggestion: UnmappedSuggestion;
+  hint?: string;
+}
+
 /** File-level migration result returned by migrate_from_uikit in filePath mode. */
 export interface MigrateFileResult {
   filePath: string;
   mappings: MigrateComponentResult[];
-  /** Component names found in imports but not in the migration database. */
-  unmapped: string[];
+  /** Components found in imports but not in the migration database. */
+  unmapped: UnmappedComponent[];
 }
 
 /** Response for compound root lookups (e.g. "Spacings" → all Spacings.* sub-components). */

--- a/packages/nimbus-mcp/src/utils/relevance.ts
+++ b/packages/nimbus-mcp/src/utils/relevance.ts
@@ -6,10 +6,44 @@
  * is scored exactly once regardless of list size.
  */
 
-import type { RelevanceFields, LoweredRelevanceFields } from "../types.js";
+import type {
+  RelevanceFields,
+  LoweredRelevanceFields,
+  RouteManifestEntry,
+} from "../types.js";
 
 /** Field weights. Higher = more relevant when a query token matches this field. */
-const WEIGHTS = { title: 8, description: 4, tags: 4, content: 1 } as const;
+export const WEIGHTS = {
+  title: 8,
+  description: 4,
+  tags: 4,
+  content: 1,
+} as const;
+
+/**
+ * Builds pre-lowercased relevance fields for a route manifest entry,
+ * including pre-split words and no-spaces variants for fuzzy matching.
+ */
+export function toLoweredRouteFields(
+  r: RouteManifestEntry
+): LoweredRelevanceFields {
+  const title = r.title.toLowerCase();
+  const description = r.description.toLowerCase();
+  const tags = [...r.tags, r.exportName ?? ""].join(" ").toLowerCase();
+  return {
+    title,
+    description,
+    tags,
+    content: "",
+    combined: title + " " + description + " " + tags,
+    titleNoSpaces: title.replace(/\s+/g, ""),
+    titleWords: title.split(/\s+/).filter(Boolean),
+    descriptionNoSpaces: description.replace(/\s+/g, ""),
+    descriptionWords: description.split(/\s+/).filter(Boolean),
+    tagsNoSpaces: tags.replace(/\s+/g, ""),
+    tagsWords: tags.split(/\s+/).filter(Boolean),
+  };
+}
 
 /**
  * Computes a relevance score for a set of fields against pre-parsed query tokens.


### PR DESCRIPTION
## Summary

- When `migrate_from_uikit` can't find an explicit migration rule for a UI Kit component, it now searches the Nimbus component catalog and returns a `suggestion` with the likely equivalent and confidence level (`high`/`medium`)
- In **file mode**, the `unmapped` array changes from `string[]` to `UnmappedComponent[]` objects — each with a `name` and optional `suggestion`
- In **componentName mode**, unrecognized names return a suggestion result (with a `get_component` hint) instead of an error when a catalog match is found
- Uses distinctive-word filtering (strips generic UI words like "input", "field", "button") to improve search accuracy, with word-overlap tiebreaking for precision

Closes FEC-885

## Test plan

- [x] Existing tests updated for new `unmapped` object shape
- [x] New test: componentName mode returns suggestion for "SearchTextInput" → "SearchInput"
- [x] New test: componentName mode returns error for truly unknown "ZzzNonExistentWidget"
- [x] New test: file mode returns unmapped objects with suggestions
- [x] Full MCP test suite passes (218 tests)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)