### PR TITLE
feat(mcp): add get_docs_page tool for full page content retrieval

### DIFF
--- a/.changeset/add-get-docs-page-tool.md
+++ b/.changeset/add-get-docs-page-tool.md
@@ -1,0 +1,9 @@
+---
+"@commercetools/nimbus-mcp": minor
+---
+
+**get_docs_page**: new MCP tool that returns the full content of a Nimbus
+documentation page by its route path. Accepts an optional `section` parameter to
+retrieve a single tab view (e.g. "dev", "guidelines", "a11y") from tabbed pages.
+Use `search_docs` first to discover page paths, then `get_docs_page` to read the
+full content.

--- a/packages/nimbus-mcp/src/server.ts
+++ b/packages/nimbus-mcp/src/server.ts
@@ -4,6 +4,7 @@ import { registerGetTokens } from "./tools/get-tokens.js";
 import { registerListComponents } from "./tools/list-components.js";
 import { registerSearchDocs } from "./tools/search-docs.js";
 import { registerSearchIcons } from "./tools/search-icons.js";
+import { registerGetDocsPage } from "./tools/get-docs-page.js";
 import { registerMigrateFromUiKit } from "./tools/migrate-from-uikit.js";
 
 /**
@@ -28,6 +29,7 @@ export function createServer(): McpServer {
 
   // Register all tools
   registerGetComponent(server);
+  registerGetDocsPage(server);
   registerGetTokens(server);
   registerListComponents(server);
   registerSearchDocs(server);

--- a/packages/nimbus-mcp/src/tools/get-component.ts
+++ b/packages/nimbus-mcp/src/tools/get-component.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.js";
 import { stripMarkdown } from "../utils/markdown.js";
 import { fuzzyResolveName } from "../utils/relevance.js";
+import { routePathToSlug as pathToSlug } from "../utils/route.js";
 
 // ---------------------------------------------------------------------------
 // Section definitions
@@ -206,12 +207,6 @@ async function resolveComponent(
     if (r.exportName) names.push(r.exportName);
     return names;
   });
-}
-
-/** Derives the route data slug from a manifest entry's path. */
-function pathToSlug(path: string): string {
-  // "/components/buttons/button" → "components-buttons-button"
-  return path.replace(/^\//, "").replace(/\//g, "-");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/nimbus-mcp/src/tools/get-docs-page.spec.ts
+++ b/packages/nimbus-mcp/src/tools/get-docs-page.spec.ts
@@ -91,6 +91,35 @@ describe("get_docs_page — tabbed page", () => {
   });
 });
 
+describe("get_docs_page — path normalization", () => {
+  it("handles leading slash in path", async () => {
+    const { result } = await callGetDocsPage({
+      path: "/home/getting-started/installation",
+    });
+    expect(result).toBeDefined();
+    expect(result!.title).toBe("Installation");
+  });
+
+  it("handles trailing slash in path", async () => {
+    const { result } = await callGetDocsPage({
+      path: "home/getting-started/installation/",
+    });
+    expect(result).toBeDefined();
+    expect(result!.title).toBe("Installation");
+  });
+});
+
+describe("get_docs_page — case-insensitive sections", () => {
+  it("matches section regardless of case", async () => {
+    const { result } = await callGetDocsPage({
+      path: "components/buttons/button",
+      section: "Overview",
+    });
+    expect(result).toBeDefined();
+    expect(result!.content.length).toBeGreaterThan(0);
+  });
+});
+
 describe("get_docs_page — error handling", () => {
   it("returns helpful error for unknown route", async () => {
     const { error, isError } = await callGetDocsPage({

--- a/packages/nimbus-mcp/src/tools/get-docs-page.spec.ts
+++ b/packages/nimbus-mcp/src/tools/get-docs-page.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createTestClient } from "../test-utils.js";
+import type { DocsPageResult } from "../types.js";
+
+let client: Client;
+let close: () => Promise<void>;
+
+beforeAll(async () => {
+  const ctx = createTestClient();
+  await ctx.connect();
+  client = ctx.client;
+  close = ctx.close;
+});
+
+afterAll(() => close());
+
+async function callGetDocsPage(args: {
+  path: string;
+  section?: string;
+}): Promise<{ result?: DocsPageResult; error?: string; isError?: boolean }> {
+  const result = await client.callTool({
+    name: "get_docs_page",
+    arguments: args,
+  });
+  const text = (result.content as Array<{ type: string; text: string }>).find(
+    (c) => c.type === "text"
+  )?.text;
+
+  if (result.isError) {
+    return { error: text, isError: true };
+  }
+  return { result: JSON.parse(text!) as DocsPageResult };
+}
+
+describe("get_docs_page — single page (no tabs)", () => {
+  it("returns full content for a known route", async () => {
+    const { result } = await callGetDocsPage({
+      path: "home/getting-started/installation",
+    });
+    expect(result).toBeDefined();
+    expect(result!.title).toBe("Installation");
+    expect(result!.description).toBeTruthy();
+    expect(result!.path).toBe("home/getting-started/installation");
+    expect(result!.content.length).toBeGreaterThan(100);
+  });
+
+  it("includes sections list in metadata", async () => {
+    const { result } = await callGetDocsPage({
+      path: "home/getting-started/installation",
+    });
+    expect(result!.sections).toBeDefined();
+    expect(Array.isArray(result!.sections)).toBe(true);
+    expect(result!.sections.length).toBeGreaterThan(0);
+  });
+});
+
+describe("get_docs_page — tabbed page", () => {
+  it("returns all views concatenated when no section specified", async () => {
+    const { result } = await callGetDocsPage({
+      path: "components/buttons/button",
+    });
+    expect(result).toBeDefined();
+    expect(result!.title).toBe("Button");
+    expect(result!.sections.length).toBeGreaterThan(1);
+    expect(result!.content.length).toBeGreaterThan(100);
+  });
+
+  it("returns a specific section when requested", async () => {
+    const allViews = await callGetDocsPage({
+      path: "components/buttons/button",
+    });
+    const single = await callGetDocsPage({
+      path: "components/buttons/button",
+      section: "overview",
+    });
+    expect(single.result).toBeDefined();
+    expect(single.result!.content.length).toBeGreaterThan(0);
+    expect(single.result!.content.length).toBeLessThan(
+      allViews.result!.content.length
+    );
+  });
+
+  it("returns error for unknown section", async () => {
+    const { error, isError } = await callGetDocsPage({
+      path: "components/buttons/button",
+      section: "nonexistent",
+    });
+    expect(isError).toBe(true);
+    expect(error).toContain("nonexistent");
+  });
+});
+
+describe("get_docs_page — error handling", () => {
+  it("returns helpful error for unknown route", async () => {
+    const { error, isError } = await callGetDocsPage({
+      path: "this/does/not/exist",
+    });
+    expect(isError).toBe(true);
+    expect(error).toContain("search_docs");
+  });
+});

--- a/packages/nimbus-mcp/src/tools/get-docs-page.ts
+++ b/packages/nimbus-mcp/src/tools/get-docs-page.ts
@@ -3,6 +3,18 @@ import { z } from "zod";
 import { getRouteData } from "../data-loader.js";
 import type { DocsPageResult } from "../types.js";
 import { stripMarkdown } from "../utils/markdown.js";
+import { routePathToSlug } from "../utils/route.js";
+
+const viewContentCache = new WeakMap<object, string>();
+
+function getCachedStripped(viewObj: { mdx: string }): string {
+  let cached = viewContentCache.get(viewObj);
+  if (!cached) {
+    cached = stripMarkdown(viewObj.mdx);
+    viewContentCache.set(viewObj, cached);
+  }
+  return cached;
+}
 
 export function registerGetDocsPage(server: McpServer): void {
   server.registerTool(
@@ -28,40 +40,63 @@ export function registerGetDocsPage(server: McpServer): void {
       },
     },
     async ({ path, section }) => {
-      const slug = path.replace(/\//g, "-");
-
-      let routeData;
       try {
-        routeData = await getRouteData(slug);
-      } catch {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Page not found for path "${path}". Use search_docs to find valid page paths.`,
-            },
-          ],
-          isError: true,
-        };
-      }
+        const slug = routePathToSlug(path);
 
-      const { meta } = routeData;
-      const availableSections = routeData.views
-        ? Object.keys(routeData.views)
-        : [];
-
-      if (section) {
-        const view = routeData.views?.[section];
-        if (!view) {
+        let routeData;
+        try {
+          routeData = await getRouteData(slug);
+        } catch {
           return {
             content: [
               {
                 type: "text" as const,
-                text: `Section "${section}" not found for "${meta.title}". Available sections: ${availableSections.join(", ") || "none (single-page content)"}`,
+                text: `Page not found for path "${path}". Use search_docs to find valid page paths.`,
               },
             ],
             isError: true,
           };
+        }
+
+        const { meta } = routeData;
+        const availableSections = Object.keys(routeData.views ?? {});
+
+        const normalizedSection = section?.toLowerCase();
+        if (normalizedSection) {
+          const view = routeData.views?.[normalizedSection];
+          if (!view) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Section "${section}" not found for "${meta.title}". Available sections: ${availableSections.join(", ") || "none (single-page content)"}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const result: DocsPageResult = {
+            title: meta.title,
+            description: meta.description,
+            path: meta.route,
+            sections: availableSections,
+            content: getCachedStripped(view),
+          };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result) }],
+          };
+        }
+
+        let content: string;
+        if (availableSections.length > 0 && routeData.views) {
+          content = Object.entries(routeData.views)
+            .map(([key, view]) => `--- ${key} ---\n${getCachedStripped(view)}`)
+            .join("\n\n");
+        } else if (routeData.mdx) {
+          content = stripMarkdown(routeData.mdx);
+        } else {
+          content = meta.description;
         }
 
         const result: DocsPageResult = {
@@ -69,34 +104,22 @@ export function registerGetDocsPage(server: McpServer): void {
           description: meta.description,
           path: meta.route,
           sections: availableSections,
-          content: stripMarkdown(view.mdx),
+          content,
         };
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result) }],
         };
+      } catch {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Docs data is not available in this environment.",
+            },
+          ],
+          isError: true,
+        };
       }
-
-      let content: string;
-      if (routeData.views) {
-        content = Object.entries(routeData.views)
-          .map(([key, view]) => `--- ${key} ---\n${stripMarkdown(view.mdx)}`)
-          .join("\n\n");
-      } else if (routeData.mdx) {
-        content = stripMarkdown(routeData.mdx);
-      } else {
-        content = meta.description;
-      }
-
-      const result: DocsPageResult = {
-        title: meta.title,
-        description: meta.description,
-        path: meta.route,
-        sections: availableSections,
-        content,
-      };
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(result) }],
-      };
     }
   );
 }

--- a/packages/nimbus-mcp/src/tools/get-docs-page.ts
+++ b/packages/nimbus-mcp/src/tools/get-docs-page.ts
@@ -1,0 +1,102 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getRouteData } from "../data-loader.js";
+import type { DocsPageResult } from "../types.js";
+import { stripMarkdown } from "../utils/markdown.js";
+
+export function registerGetDocsPage(server: McpServer): void {
+  server.registerTool(
+    "get_docs_page",
+    {
+      title: "Get Docs Page",
+      description:
+        "Returns the full content of a Nimbus documentation page by its route path (as returned by search_docs). " +
+        "For tabbed pages, optionally specify a section to retrieve a single view. " +
+        "Use search_docs first to find the page path.",
+      inputSchema: {
+        path: z
+          .string()
+          .describe(
+            'Route path from search_docs results, e.g. "home/getting-started/installation".'
+          ),
+        section: z
+          .string()
+          .optional()
+          .describe(
+            'For tabbed pages, which view to return (e.g. "overview", "dev", "guidelines", "a11y"). Omit to get all views concatenated.'
+          ),
+      },
+    },
+    async ({ path, section }) => {
+      const slug = path.replace(/\//g, "-");
+
+      let routeData;
+      try {
+        routeData = await getRouteData(slug);
+      } catch {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Page not found for path "${path}". Use search_docs to find valid page paths.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const { meta } = routeData;
+      const availableSections = routeData.views
+        ? Object.keys(routeData.views)
+        : [];
+
+      if (section) {
+        const view = routeData.views?.[section];
+        if (!view) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Section "${section}" not found for "${meta.title}". Available sections: ${availableSections.join(", ") || "none (single-page content)"}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const result: DocsPageResult = {
+          title: meta.title,
+          description: meta.description,
+          path: meta.route,
+          sections: availableSections,
+          content: stripMarkdown(view.mdx),
+        };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+        };
+      }
+
+      let content: string;
+      if (routeData.views) {
+        content = Object.entries(routeData.views)
+          .map(([key, view]) => `--- ${key} ---\n${stripMarkdown(view.mdx)}`)
+          .join("\n\n");
+      } else if (routeData.mdx) {
+        content = stripMarkdown(routeData.mdx);
+      } else {
+        content = meta.description;
+      }
+
+      const result: DocsPageResult = {
+        title: meta.title,
+        description: meta.description,
+        path: meta.route,
+        sections: availableSections,
+        content,
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    }
+  );
+}

--- a/packages/nimbus-mcp/src/tools/search-docs.spec.ts
+++ b/packages/nimbus-mcp/src/tools/search-docs.spec.ts
@@ -102,6 +102,26 @@ describe("search_docs — relevance ordering", () => {
   });
 });
 
+describe("search_docs — toolHint coverage", () => {
+  it("every result includes a toolHint", async () => {
+    const results = await callSearchDocs({ query: "installation" });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.toolHint).toBeDefined();
+      expect(typeof r.toolHint).toBe("string");
+    }
+  });
+
+  it("returns get_docs_page hint for non-component/token/icon pages", async () => {
+    const results = await callSearchDocs({ query: "installation" });
+    const installPage = results.find((r) =>
+      r.path.includes("getting-started/installation")
+    );
+    expect(installPage).toBeDefined();
+    expect(installPage!.toolHint).toBe("get_docs_page");
+  });
+});
+
 describe("search_docs — deep content search (phase 2)", () => {
   it("finds content from dev views (import paths, props)", async () => {
     const results = await callSearchDocs({ query: "ButtonProps" });

--- a/packages/nimbus-mcp/src/tools/search-docs.ts
+++ b/packages/nimbus-mcp/src/tools/search-docs.ts
@@ -20,13 +20,13 @@ import { stripMarkdown } from "../utils/markdown.js";
 
 const MAX_RESULTS = 10;
 
-/** Maps a route to the most useful follow-up tool, if any. */
-function deriveToolHint(route: string): string | undefined {
+/** Maps a route to the most useful follow-up tool. */
+function deriveToolHint(route: string): string {
   if (route.includes("design-tokens")) return "get_tokens";
   if (route.startsWith("components/") || route.startsWith("patterns/"))
     return "get_component";
   if (route.startsWith("icons")) return "search_icons";
-  return undefined;
+  return "get_docs_page";
 }
 const SNIPPET_LENGTH = 200;
 /** Characters of context shown before the matched token in a snippet. */
@@ -437,7 +437,7 @@ export function registerSearchDocs(server: McpServer): void {
               snippet: viewMatch
                 ? extractSnippet(viewMatch.content, tokens)
                 : extractSnippet(stripMarkdown(entry.content), tokens),
-              ...(toolHint ? { toolHint } : {}),
+              toolHint,
             };
           });
 

--- a/packages/nimbus-mcp/src/tools/search-docs.ts
+++ b/packages/nimbus-mcp/src/tools/search-docs.ts
@@ -17,6 +17,7 @@ import {
   scorePreLowered,
 } from "../utils/relevance.js";
 import { stripMarkdown } from "../utils/markdown.js";
+import { routePathToSlug as routeToSlug } from "../utils/route.js";
 
 const MAX_RESULTS = 10;
 
@@ -115,11 +116,6 @@ function extractSnippet(content: string, tokens: string[]): string {
   if (end < content.length) snippet = snippet + "…";
 
   return snippet;
-}
-
-/** Convert a route slug to the file name format (route slashes → dashes). */
-function routeToSlug(route: string): string {
-  return route.replace(/\//g, "-");
 }
 
 const viewContentCache = new WeakMap<object, CachedViewContent>();
@@ -351,7 +347,7 @@ export function registerSearchDocs(server: McpServer): void {
       description:
         "Search all Nimbus docs (components, patterns, hooks, icons, tokens) including guidelines and accessibility views. " +
         "Returns matching pages with content snippets. Props are not searchable here — use get_component with section='props' for prop details. " +
-        "Results include a toolHint field indicating which tool to call for deeper info (e.g. get_component, get_tokens, search_icons).",
+        "Results include a toolHint field indicating which tool to call for deeper info (e.g. get_component, get_tokens, search_icons, get_docs_page).",
       inputSchema: {
         query: z
           .string()

--- a/packages/nimbus-mcp/src/types.ts
+++ b/packages/nimbus-mcp/src/types.ts
@@ -45,7 +45,7 @@ export interface DocSearchResult {
   /** Content snippet highlighting the match. */
   snippet: string;
   /** Suggested tool to call for deeper info on this result. */
-  toolHint?: string;
+  toolHint: string;
 }
 
 /** Result returned by MCP tool handlers. */

--- a/packages/nimbus-mcp/src/types.ts
+++ b/packages/nimbus-mcp/src/types.ts
@@ -475,3 +475,16 @@ export interface MigrateCompoundResult {
   note: string;
   mappings: MigrateComponentResult[];
 }
+
+// ---------------------------------------------------------------------------
+// Docs page tool types (used by tools/get-docs-page)
+// ---------------------------------------------------------------------------
+
+/** Response from the get_docs_page tool. */
+export interface DocsPageResult {
+  title: string;
+  description: string;
+  path: string;
+  sections: string[];
+  content: string;
+}

--- a/packages/nimbus-mcp/src/utils/route.ts
+++ b/packages/nimbus-mcp/src/utils/route.ts
@@ -1,0 +1,4 @@
+/** Normalize a route path and convert to the docs data slug format. */
+export function routePathToSlug(path: string): string {
+  return path.replace(/^\/+|\/+$/g, "").replace(/\//g, "-");
+}


### PR DESCRIPTION
## Why this matters

Before this PR, `search_docs` returned snippets — short excerpts around the matched term. For component pages, agents could follow the `toolHint` to `get_component` and retrieve structured, section-based content. But for the 57 non-component pages (installation guides, style props, ADRs, design token docs, hooks, contribution guides), there was no follow-up tool. The snippet was all an agent got, and it often lacked the context needed to answer the user's actual question.

`get_docs_page` closes that gap. It's the escape hatch for when a `search_docs` snippet isn't enough: the agent calls `get_docs_page` with the route path and gets the full page content. For tabbed pages, the `section` parameter lets the agent retrieve just the view it needs.

The non-component pages this tool serves are small (median 1.5KB, max 12.5KB) — well within context budget. Component pages (50-85KB) are intentionally routed to `get_component` via `toolHint` instead, where they benefit from structured section-based retrieval.

By making `toolHint` always present (no more `undefined` for non-component pages), every `search_docs` result now tells the agent exactly which tool to call next — completing the discovery-to-detail pipeline across all doc types.

## Summary
- Adds new `get_docs_page` MCP tool that retrieves full documentation page content by route path (from `search_docs` results)
- Supports optional `section` parameter for tabbed pages (e.g. `overview`, `dev`, `guidelines`, `a11y`)
- Returns page metadata (title, description, available sections) alongside content
- Updates `deriveToolHint` in `search_docs` to always return a hint — no more `undefined` toolHint for 55+ non-component pages
- Adds `DocsPageResult` type to `types.ts`
- Extracts shared `routePathToSlug` utility, replacing 3 divergent slug implementations
- Adds WeakMap-based `stripMarkdown` caching for repeated page access
- Case-insensitive section matching and leading/trailing slash normalization

Closes FEC-1128

## Test plan
- [x] `get_docs_page` returns full content for single-page routes (e.g. installation)
- [x] `get_docs_page` returns all views concatenated for tabbed pages when no section specified
- [x] `get_docs_page` returns specific section content when section param provided
- [x] `get_docs_page` returns error with `search_docs` suggestion for unknown routes
- [x] `get_docs_page` returns error for unknown section on tabbed pages
- [x] `search_docs` results always include a `toolHint` (no more `undefined`)
- [x] Non-component/token/icon pages get `get_docs_page` as their toolHint
- [x] Path normalization handles leading/trailing slashes
- [x] Section matching is case-insensitive
- [x] All existing nimbus-mcp tests pass