### PR TITLE
docs(mcp): update Claude Code install instructions to use ~/.claude.json

### DIFF
--- a/packages/nimbus-mcp/README.md
+++ b/packages/nimbus-mcp/README.md
@@ -17,7 +17,18 @@ claude mcp add -s user nimbus-mcp npx -- -y @commercetools/nimbus-mcp
 
 This writes the server config to `~/.claude.json` and makes it available in all
 sessions. Alternatively, add a `nimbus` entry to your project's `.mcp.json` so
-every team member on the repo gets the server automatically.
+every team member on the repo gets the server automatically:
+
+```json
+{
+  "mcpServers": {
+    "nimbus": {
+      "command": "npx",
+      "args": ["-y", "@commercetools/nimbus-mcp"]
+    }
+  }
+}
+```
 
 ### With Claude Desktop
 

--- a/packages/nimbus-mcp/README.md
+++ b/packages/nimbus-mcp/README.md
@@ -9,18 +9,15 @@ assistants (Claude, etc.) can call.
 
 ### With Claude Code
 
-Add the server to `~/.claude/mcp.json`:
+The recommended way to add the server is via the CLI:
 
-```json
-{
-  "mcpServers": {
-    "nimbus": {
-      "command": "npx",
-      "args": ["-y", "@commercetools/nimbus-mcp"]
-    }
-  }
-}
+```bash
+claude mcp add -s user nimbus-mcp npx -- -y @commercetools/nimbus-mcp
 ```
+
+This writes the server config to `~/.claude.json` and makes it available in all
+sessions. Alternatively, add a `nimbus` entry to your project's `.mcp.json` so
+every team member on the repo gets the server automatically.
 
 ### With Claude Desktop
 

--- a/packages/nimbus/src/docs/home-mcp-server-overview.mdx
+++ b/packages/nimbus/src/docs/home-mcp-server-overview.mdx
@@ -74,7 +74,7 @@ include:
 
 | Assistant           | Configuration file                               |
 | ------------------- | ------------------------------------------------ |
-| **Claude Code**     | `~/.claude/mcp.json` or project `.mcp.json`      |
+| **Claude Code**     | `~/.claude.json` or project `.mcp.json`           |
 | **Claude Desktop**  | App settings or `claude_desktop_config.json`      |
 | **VS Code Copilot** | `.vscode/mcp.json` in workspace                  |
 | **Cursor**          | `.cursor/mcp.json` in workspace                  |

--- a/packages/nimbus/src/docs/home-mcp-server-setup.mdx
+++ b/packages/nimbus/src/docs/home-mcp-server-setup.mdx
@@ -74,9 +74,17 @@ Each AI assistant reads MCP server configuration from a JSON file. Add the
 
 ### Claude Code
 
-Add to your project's `.mcp.json` so every team member on the repo gets the
-server automatically, or to `~/.claude/mcp.json` to enable it across all your
-projects:
+The recommended way to add the server for all your projects is via the CLI:
+
+```bash
+claude mcp add -s user nimbus-mcp npx -- -y @commercetools/nimbus-mcp
+```
+
+This writes the server config to `~/.claude.json` and makes it available in all
+sessions.
+
+Alternatively, add a `nimbus` entry to your project's `.mcp.json` so every team
+member on the repo gets the server automatically:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Updated nimbus-mcp installation docs to recommend the `claude mcp add` CLI command instead of manually editing `~/.claude/mcp.json`
- The CLI writes to `~/.claude.json`, which is the correct location for user-level MCP server config
- Corrected config path references in README, setup docs, and overview docs

Closes FEC-1021

## Test plan
- [ ] Verify the `claude mcp add` command in the docs works correctly
- [ ] Confirm the docs site renders the updated setup page without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)