### PR TITLE
chore(deps): upgrade dotenv 16 → 17

### DIFF
--- a/.claude/skills/nimbus-code-connect/collect-figma-data.ts
+++ b/.claude/skills/nimbus-code-connect/collect-figma-data.ts
@@ -197,7 +197,9 @@ interface CodeConnectData {
 // ---------------------------------------------------------------------------
 
 function loadEnv() {
-  config({ path: join(ROOT, ".env") });
+  // quiet: dotenv 17 logs an "injected env" line on load by default; suppress it
+  // to keep this script's output clean (behavior matched dotenv 16).
+  config({ path: join(ROOT, ".env"), quiet: true });
   const token = process.env.FIGMA_ACCESS_TOKEN;
   if (!token) {
     console.error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ catalogs:
       specifier: ^3.4.12
       version: 3.4.12
     dotenv:
-      specifier: ^16.6.1
-      version: 16.6.1
+      specifier: ^17.4.2
+      version: 17.4.2
     lodash:
       specifier: ^4.18.1
       version: 4.18.1
@@ -290,7 +290,7 @@ importers:
         version: 2.8.13
       dotenv:
         specifier: catalog:utils
-        version: 16.6.1
+        version: 17.4.2
       eslint:
         specifier: catalog:tooling
         version: 10.7.0
@@ -5464,6 +5464,10 @@ packages:
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dotenv@8.6.0:
@@ -15956,6 +15960,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.2.3: {}
+
+  dotenv@17.4.2: {}
 
   dotenv@8.6.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -176,7 +176,7 @@ catalogs:
     "@internationalized/string-compiler": ^3.4.1
   utils:
     dequal: ^2.0.3
-    dotenv: ^16.6.1
+    dotenv: ^17.4.2
     dompurify: ^3.4.12
     lodash: ^4.18.1
     "@types/lodash": ^4.17.24


### PR DESCRIPTION
## Summary

Upgrades `dotenv` **16.6.1 → 17.4.2** (a major bump), the first of the held-back major updates from the recent housekeeping PR, done on its own branch.

## Why this is low-risk

- `dotenv` is a **zero-dependency devDependency** declared only in the root `package.json`.
- Its **only consumer** is the Figma Code-Connect skill script (`.claude/skills/nimbus-code-connect/collect-figma-data.ts`) — a dev-only data-collection tool.
- It is **not** in any published package, build output, or test path.

## What changed in v17

- **API is unchanged** for our usage: `config({ path })` still returns `{ parsed }` and populates `process.env` (verified with a functional probe against 17.4.2).
- The one behavior change is v17's new default startup log (`◇ injected env … `). Passing **`{ quiet: true }`** in `loadEnv()` restores the prior silent output — the documented v17 migration.

## Verification

- ✅ `pnpm install` clean — no `minimumReleaseAgeExclude` block generated (17.4.2 is well past the 24h age gate)
- ✅ Functional probe: `config({ path })` and `{ quiet: true }` behave as expected on 17.4.2
- ✅ `eslint` clean on the modified skill file
- ✅ `pnpm build:packages` passes
- ℹ️ Full test suite not run locally — `dotenv` is a zero-dep dev leaf outside the build/test dependency graph, so it cannot affect it; CI will run the full suite regardless.