### PR TITLE
chore(dependabot): ignore @babel/* major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -91,3 +91,9 @@ updates:
       # Upgrading to @types/node@25+ would add types for APIs not available in our runtime
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # Babel is pinned to 7.x (catalog carets in pnpm-workspace.yaml). Babel 8 is
+      # blocked: @babel/runtime@8 dropped the ./helpers/esm/* export subpaths that
+      # the frozen @emotion/react@11.14 imports, and @preconstruct/cli still pins
+      # @babel/core ^7.7.7. Allow minor/patch within 7.x; suppress the 8.x major PR.
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Stops Dependabot from repeatedly proposing the **Babel 8 major** by adding an `ignore` rule for `@babel/*` `semver-major` updates — mirroring the existing `@types/node` precedent in the same file.

**No dependency, lockfile, or install change.** The catalog carets (`@babel/*: ^7.29.7` in `pnpm-workspace.yaml`) already pin Babel to 7.x; pnpm never resolves 8.x on its own. This PR only silences the recurring Dependabot major PR.

## Why Babel is held at 7

Babel 8 is a hard, external blocker (confirmed empirically, not guessed):

- **`@babel/runtime@8` removed the `./helpers/esm/*` export subpaths.** The frozen `@emotion/react@11.14.0` (a consumer-controlled peer dep) imports `@babel/runtime/helpers/esm/extends` in its ESM build — under a v8 runtime override, esbuild fails with `Could not resolve "@babel/runtime/helpers/esm/extends"` and the postinstall build breaks.
- **`@preconstruct/cli@2.8.13`** (our package build tool, already latest) still declares `@babel/core: ^7.7.7` — no Babel 8 support advertised.

So Babel 8 is gated on upstream (emotion + preconstruct), not on our effort.

## Effect

- ✅ Minor/patch **7.x** Babel updates still proposed (still batched via the existing `babel` group).
- 🚫 The **8.x** major PR is suppressed.

When Babel 8 becomes viable, delete the two added lines to re-open the major.

## Testing

`.github/` config-only change — no build/test impact. `dependabot.yml` validated to parse as well-formed YAML with the expected `ignore` entries.