### PR TITLE
fix(security): resolve dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,6 @@ catalogs:
     dequal:
       specifier: ^2.0.3
       version: 2.0.3
-    dompurify:
-      specifier: ^3.4.12
-      version: 3.4.12
     dotenv:
       specifier: ^17.4.2
       version: 17.4.2
@@ -227,7 +224,8 @@ overrides:
   brace-expansion@2: ~2.0.3
   brace-expansion@>=4.0.0 <5.0.6: '>=5.0.6'
   mdast-util-to-hast: ^13.2.1
-  js-yaml: ^3.14.2
+  js-yaml: ^3.15.0
+  dompurify: ^3.4.12
   qs: '>=6.15.2'
   minimatch@>=3.0.0 <3.1.4: 3.1.4
   svgo: '>=3.3.3'
@@ -387,7 +385,7 @@ importers:
         version: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
       webpack-cli:
         specifier: catalog:tooling
-        version: 7.2.1(js-yaml@3.14.2)(json5@2.2.3)(webpack@5.108.4)
+        version: 7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4)
 
   apps/docs:
     dependencies:
@@ -538,7 +536,7 @@ importers:
         version: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
       webpack-cli:
         specifier: catalog:tooling
-        version: 7.2.1(js-yaml@3.14.2)(json5@2.2.3)(webpack@5.108.4)
+        version: 7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4)
 
   packages/color-tokens:
     dependencies:
@@ -728,7 +726,7 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       dompurify:
-        specifier: catalog:utils
+        specifier: ^3.4.12
         version: 3.4.12
       glob:
         specifier: catalog:tooling
@@ -5449,9 +5447,6 @@ packages:
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
-  dompurify@3.4.5:
-    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
-
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -6424,8 +6419,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   jsdom@29.0.1:
@@ -8835,7 +8830,7 @@ packages:
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
-      js-yaml: ^3.14.2
+      js-yaml: ^3.15.0
       json5: ^2.2.3
       toml: ^3.0.0 || ^4.0.0
       webpack: ^5.101.0
@@ -9543,7 +9538,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -10451,7 +10446,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/dompurify': 2.4.0
-      dompurify: 3.4.5
+      dompurify: 3.4.12
       react: 19.2.0
       react-from-dom: 0.7.5(react@19.2.0)
     transitivePeerDependencies:
@@ -11173,7 +11168,7 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/dompurify': 2.4.0
       '@types/escape-html': 1.0.4
-      dompurify: 3.4.5
+      dompurify: 3.4.12
       downshift: 9.3.3(react@19.2.0)
       escape-html: 1.0.3
       is-hotkey: 0.2.0
@@ -15774,7 +15769,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -15939,10 +15934,6 @@ snapshots:
       domelementtype: 2.3.0
 
   dompurify@3.4.12:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
-  dompurify@3.4.5:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -16593,7 +16584,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -16991,7 +16982,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -18558,7 +18549,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -19824,7 +19815,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-cli@7.2.1(js-yaml@3.14.2)(json5@2.2.3)(webpack@5.108.4):
+  webpack-cli@7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4):
     dependencies:
       '@discoveryjs/json-ext': 1.1.0
       commander: 14.0.3
@@ -19836,7 +19827,7 @@ snapshots:
       webpack: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       json5: 2.2.3
 
   webpack-merge@6.0.1:
@@ -19913,7 +19904,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack-cli: 7.2.1(js-yaml@3.14.2)(json5@2.2.3)(webpack@5.108.4)
+      webpack-cli: 7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,13 @@ overrides:
   "brace-expansion@2": "~2.0.3"
   "brace-expansion@>=4.0.0 <5.0.6": ">=5.0.6"
   mdast-util-to-hast: "^13.2.1"
-  js-yaml: "^3.14.2"
+  # js-yaml 3.x security floor — >=3.15.0 fixes GHSA-h67p-54hq-rp68
+  # (quadratic-complexity DoS in merge-key handling).
+  js-yaml: "^3.15.0"
+  # Force the transitively-pulled dompurify (3.4.5 via @commercetools-uikit/icons
+  # + rich-text-utils) up to the vetted catalog version, clearing the dompurify
+  # GHSA cluster (…-cmwh-pvxp-8882, …-rp9w-3fw7-7cwq, …-76mc-f452-cxcm, etc.).
+  dompurify: "catalog:utils"
   qs: ">=6.15.2"
   "minimatch@>=3.0.0 <3.1.4": "3.1.4"
   svgo: ">=3.3.3"


### PR DESCRIPTION
## Summary

Resolves the open Dependabot alerts by forcing vulnerable **transitive**
dependencies to patched versions via `pnpm-workspace.yaml` overrides — the
repo's established security-override convention. **No published-package
dependency range changes**, so there is no consumer-facing effect: `dompurify`'s
direct dep was already `3.4.12`; only the transitive copy and dev-only `js-yaml`
moved.

## 🔒 Vulnerabilities fixed

All 8 `dompurify` alerts traced to a single transitive copy `dompurify@3.4.5`
pulled by `@commercetools-uikit/icons` + `@commercetools-uikit/rich-text-utils`.
One override unifies every dompurify copy to the vetted catalog version
`^3.4.12` (≥ every patched version, and outside every vulnerable range).

| Alert | Package | Severity | CVE / GHSA | Change |
|-------|---------|----------|------------|--------|
| #143 | dompurify | Medium | GHSA-cmwh-pvxp-8882 | 3.4.5 → 3.4.12 |
| #140 | dompurify | Medium | GHSA-rp9w-3fw7-7cwq | 3.4.5 → 3.4.12 |
| #138 | dompurify | Medium | GHSA-76mc-f452-cxcm | 3.4.5 → 3.4.12 |
| #137 | dompurify | Medium | GHSA-hpcv-96wg-7vj8 | 3.4.5 → 3.4.12 |
| #136 | dompurify | Medium | GHSA-r47g-fvhr-h676 | 3.4.5 → 3.4.12 |
| #135 | js-yaml | Medium | GHSA-h67p-54hq-rp68 | override 3.14.2 → 3.15.0 |
| #142 | dompurify | Low | GHSA-vxr8-fq34-vvx9 | 3.4.5 → 3.4.12 |
| #141 | dompurify | Low | GHSA-gvmj-g25r-r7wr | 3.4.5 → 3.4.12 |
| #139 | dompurify | Low | GHSA-x4vx-rjvf-j5p4 | 3.4.5 → 3.4.12 (out of `<=3.4.6` range) |

### Changes (`pnpm-workspace.yaml` overrides)
- **Add** `dompurify: "catalog:utils"` — pins all copies to `^3.4.12`, removing the transitive `3.4.5`.
- **Update** `js-yaml: "^3.14.2"` → `"^3.15.0"` — bumps the existing 3.x security floor.

## ℹ️ Already resolved (no change needed)

| Alert | Package | Severity | Note |
|-------|---------|----------|------|
| #124 | ws | High (GHSA-96hv-2xvq-fx4p) | Lockfile is already at the patched `8.21.0`; alert is stale and will auto-close. |

## 🧹 Existing overrides audit

Full staleness sweep of all ~40 existing overrides: **all valid, none removed.**
Each entry is either actively resolving a version in the lockfile or a deliberate
proactive security guard (e.g. `happy-dom@<20.8.9` guards an *optional* vitest
peer that isn't currently installed). Per the "a security override that blocks a
vulnerable version is why it's absent" rule, nothing was removed.

## ⚠️ Alerts requiring manual attention

None.

## ✅ Validation

- ✅ `pnpm lint` — 0 errors (1 pre-existing unrelated warning)
- ✅ nimbus typecheck (source) — clean
- ✅ `pnpm test:dev` — **2834 / 2834 tests passed** (224 files)

## 📋 Review checklist

- [ ] Confirm no consumer-facing dependency-range change (published `package.json` unaffected)
- [ ] Confirm the dompurify + js-yaml GHSAs are all addressed
- [ ] Confirm the overrides audit conclusion (no stale removals)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)