### PR TITLE
vc/ relocate `FlotingActionButton` component to patterns

### DIFF
--- a/packages/nimbus/src/docs/patterns-buttons.mdx
+++ b/packages/nimbus/src/docs/patterns-buttons.mdx
@@ -1,0 +1,24 @@
+---
+id: Patterns-Buttons
+title: Buttons
+description: Pre-styled button patterns for prominent, single-purpose actions
+order: 5
+menu:
+  - Patterns
+  - Buttons
+tags:
+  - patterns
+  - buttons
+  - actions
+icon: SmartButton
+---
+
+# Buttons
+
+Button pattern components wrap the base button components in small, opinionated APIs for common, high-visibility actions. Use them to get consistent styling and placement without re-deriving the defaults each time.
+
+## Available button patterns
+
+<CategoryOverview variant="list" />
+</content>
+</invoke>

--- a/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.dev.mdx
+++ b/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.dev.mdx
@@ -1,5 +1,5 @@
 ---
-title: Floating action button component
+title: Floating action button pattern
 tab-title: Implementation
 tab-order: 3
 ---
@@ -160,6 +160,6 @@ integration and application-specific logic.
 
 ## Resources
 
-- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-buttons-floatingactionbutton--docs)
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/patterns-buttons-floatingactionbutton--docs)
 - [React Aria Button](https://react-spectrum.adobe.com/react-aria/Button.html)
 - [ARIA Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)

--- a/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.mdx
+++ b/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.mdx
@@ -1,16 +1,17 @@
 ---
-id: Components-FloatingActionButton
+id: Patterns-FloatingActionButton
 title: Floating action button
 exportName: FloatingActionButton
 description: A circular, icon-only floating button for prominent single actions, such as opening a chat panel or triggering a primary workflow.
 lifecycleState: Stable
 order: 999
 menu:
-  - Components
+  - Patterns
   - Buttons
   - Floating action button
 tags:
   - component
+  - pattern
   - buttons
   - actions
   - floating

--- a/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.stories.tsx
+++ b/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.stories.tsx
@@ -12,7 +12,7 @@ import { SEMANTIC_COLOR_PALETTES } from "@/constants/color-palettes";
  * cover what the FAB itself adds: that it renders and its visual identity.
  */
 const meta: Meta<typeof FloatingActionButton> = {
-  title: "Components/Buttons/FloatingActionButton",
+  title: "patterns/buttons/FloatingActionButton",
   component: FloatingActionButton,
   tags: ["autodocs"],
   parameters: { layout: "centered" },

--- a/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.tsx
+++ b/packages/nimbus/src/patterns/buttons/floating-action-button/floating-action-button.tsx
@@ -28,7 +28,7 @@ FloatingActionButtonComponent.displayName = "FloatingActionButton";
  * Placement is the consumer's responsibility via standard style props
  * (`position="fixed"`, `insetBlockEnd`, `insetInlineEnd`, …).
  *
- * @see {@link https://nimbus-documentation.vercel.app/components/inputs/floating-action-button}
+ * @see {@link https://nimbus-documentation.vercel.app/patterns/buttons/floating-action-button}
  */
 export const FloatingActionButton: typeof FloatingActionButtonComponent =
   FloatingActionButtonComponent;


### PR DESCRIPTION
FAB is structurally a pattern (lives in `src/patterns/buttons/`, thin wrapper around **IconButton,** no recipe/slots/React Aria, props type is just IconButtonProps), but its frontmatter declared it a Component, so it showed under Components → Buttons in the docs & Storybook.

This PR just updates it to be grouped with Patterns.

No changeset needed, docs-only recategorization. 