### PR TITLE
FEC- 1151  - Chromatic Batch2 (Text Entry Inputs)

### DIFF
--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -333,6 +333,13 @@ call: matrices iterate the 6 `SEMANTIC_COLOR_PALETTES` as the representative set
 the `BRAND` (3) and `SYSTEM` (25) palettes a consumer can also pass run the same
 token machinery and are deliberately not snapshotted.
 
+**An axis the recipe hardcodes isn't an axis.** Full-range applies only to the
+axes the component actually varies. If a recipe pins one to a single value, drop
+it from the grid - MultilineTextInput hardcodes `colorPalette: "neutral"`, so its
+matrix is `state x size x variant` with no palette axis. Different from the
+uniform-transform case above (`disabled` is a real axis folded out for adding no
+signal); a hardcoded palette was never an axis to begin with.
+
 **Cover distinct state-combinations, not just single flags.** When a component
 has multiple boolean states (selected, disabled, invalid, read-only), each
 combination that renders differently needs coverage. Selected-disabled is
@@ -423,6 +430,13 @@ each, independently baselined; count is not a performance concern (it
 parallelizes) and TurboSnap keeps an extra stable story near free. Modes
 (`chromatic.modes`) are for _global_ config only (viewport, theme, locale), so a
 mode is never the answer to two prop-driven surfaces.
+
+**A state with no distinct surface gets no story.** The flip side of the rule
+above: if the recipe has no rule for a state, it renders identically to the
+default and a dedicated story is a redundant baseline, not coverage. Read-only is
+the component-dependent trap - MoneyInput styles it distinctly (`ReadOnlyState`),
+but MultilineTextInput has no `data-readonly` rule, so read-only looks like the
+default and correctly gets no snapshot.
 
 **Snapshot the component, not the harness.** Chromatic photographs the story's
 whole rendered output, so a snapshotted story must render the component
@@ -761,6 +775,9 @@ You MUST validate against these requirements:
       toggles) - every distinct combined look appears in the one snapshot
 - [ ] Axis arrays span the **full supported range** - no trimmed or
       commented-out values; palettes use the 6 `SEMANTIC_COLOR_PALETTES`
+- [ ] Axes the recipe **hardcodes** are dropped from the grid (a pinned
+      `colorPalette` is not a palette axis - MultilineTextInput's neutral-only
+      recipe gives `state x size x variant`)
 - [ ] Distinct **state-combinations** are covered, not just single flags
       (selected-disabled is a separate look from unselected-disabled)
 - [ ] For each state (focus, disabled, read-only, invalid), checked whether the
@@ -768,6 +785,8 @@ You MUST validate against these requirements:
       surface gets its **own** snapshotted story, not a folded gallery frame
       (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`, `DisabledState` +
       `DisabledWithCurrencyLabel`)
+- [ ] A state with **no distinct recipe surface** gets no dedicated story
+      (read-only with no `data-readonly` rule renders like default - no snapshot)
 - [ ] Snapshotted stories render the component **directly** - no debug read-outs,
       value dumps, or demo-wrapper scaffolding in the frame (those stay on the
       un-snapshotted behavioral stories)

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -237,6 +237,27 @@ export const Focused: Story = {
 };
 ```
 
+**Capture the ring on every distinctly-styled focusable sub-element, not just
+the primary one.** A split button's dropdown trigger, an input's clear button or
+stepper, and a date field's calendar toggle each style their own
+`:focus-visible` and each need to be tabbed to and snapshotted - a `Focused`
+story that stops at the first focusable leaves the others untested.
+
+**Text-entry inputs: hide the caret in the `Focused` play function.** Focusing a
+text input paints the browser's blinking caret, which Chromatic can't pause (it's
+neither a CSS nor a JS animation). Set `canvasElement.style.caretColor =
+"transparent"` before tabbing - `caret-color` is inherited, so it cascades to the
+input and the focused snapshot stays deterministic. We scope this to the story
+rather than editing the shared `preview.tsx`. See docs/chromatic-visual-testing.md.
+
+```typescript
+play: async ({ canvasElement }) => {
+  canvasElement.style.caretColor = "transparent"; // deterministic focused snapshot
+  await userEvent.tab();
+  await expect(/* the input */).toHaveFocus();
+},
+```
+
 #### Disabled Story (REQUIRED for interactive components)
 
 ```typescript
@@ -304,6 +325,28 @@ capture it once in a dedicated `Disabled` story (see below) rather than
 multiplying it through the grid. (`:hover` and `:active`/pressed can't be
 captured as static states - see the note under "What Gets Captured".)
 
+**Axes must span the full supported range, not a dev subset.** A trimmed axis
+array is the most common regression-hiding mistake: snapshotting `md/sm` when the
+component supports five sizes, or three palettes when it supports six, leaves
+those cells covered by nothing. A commented-out axis value is a red flag. Scope
+call: matrices iterate the 6 `SEMANTIC_COLOR_PALETTES` as the representative set;
+the `BRAND` (3) and `SYSTEM` (25) palettes a consumer can also pass run the same
+token machinery and are deliberately not snapshotted.
+
+**Cover distinct state-combinations, not just single flags.** When a component
+has multiple boolean states (selected, disabled, invalid, read-only), each
+combination that renders differently needs coverage. Selected-disabled is
+visually distinct from unselected-disabled, so a `Disabled` story showing only
+the unselected case leaves a gap.
+
+**Thin wrappers get no matrix.** A component that only constrains or forwards a
+wrapped component's props (a fixed-shape variant, a field wrapper) re-covers
+nothing by re-rendering the wrapped grid. Snapshot only the axis the wrapper
+introduces, plus `Focused`/`Disabled` if it adds them. FloatingActionButton wraps
+IconButton with a fixed circular shape, so it snapshots only `ColorPalettes` +
+`Focused` + `Disabled`, not a size x variant matrix - those are IconButton's
+states, already covered there.
+
 ```typescript
 export const SmokeTest: Story = {
   tags: ["vrt"],
@@ -365,10 +408,38 @@ whole snapshot, and editing the matrix re-snapshots the entire grid (Chromatic
 can't sub-diff within one image). Reserve standalone snapshots for states that
 need distinct setup or isolated review.
 
+**But a state can render more than one way - one story each, not a gallery
+frame.** Matrix-packing is for axes that _interact_. It is not license to fold
+_independent_ surfaces of a single state into one render. Before assuming a
+single `Focused` / `Disabled` / `ReadOnly` / `Invalid` story covers a state,
+check whether the component renders that state more than one way (mode- or
+variant-driven); if so, each distinct recipe surface gets its own snapshotted
+story. MoneyInput carries `Focused` + `FocusedWithCurrencyLabel` and
+`DisabledState` + `DisabledWithCurrencyLabel` (dropdown vs. `currencies={[]}`
+label mode) rather than one folded frame apiece - independent surfaces don't
+interact, so a shared frame only trades away their independent baselines and
+per-surface triage. Chromatic's idiom is discrete stories, one meaningful state
+each, independently baselined; count is not a performance concern (it
+parallelizes) and TurboSnap keeps an extra stable story near free. Modes
+(`chromatic.modes`) are for _global_ config only (viewport, theme, locale), so a
+mode is never the answer to two prop-driven surfaces.
+
+**Snapshot the component, not the harness.** Chromatic photographs the story's
+whole rendered output, so a snapshotted story must render the component
+**directly** - no debug read-outs, value dumps, or controls scaffolding in the
+frame. A stateful demo wrapper (MoneyInput's `MoneyInputExample` renders a
+`JSON.stringify(value)` panel beside the input) is fine on un-snapshotted
+behavioral stories, but snapshotting one bakes the read-out into the baseline and
+flaps it on every value change. Keep those wrappers on the behavioral stories;
+render the bare component in the ones you snapshot.
+
 **Determinism matters most for snapshots.** A snapshot must render identically
 every run or it diffs on noise: don't bake in live dates or random values, wait
 for async-derived state (image load, data fetch) before the capture, and don't
-leave a stray focus ring on an unrelated story. Some visual states can't be
+leave a stray focus ring on an unrelated story. A focused text input paints the
+browser's blinking caret, which Chromatic can't pause (it's neither a CSS nor a
+JS animation) - hide it in the `Focused` play function with
+`canvasElement.style.caretColor = "transparent"`. Some visual states can't be
 captured statically yet (notably `:hover` and `:active`/pressed); see the
 Chromatic doc for the current gaps.
 
@@ -379,6 +450,17 @@ marks a story as a visual-regression case so tooling can find and select it.
 
 See docs/chromatic-visual-testing.md for the full rationale, CI details, and the
 current hover/pressed limitation.
+
+**When a VRT pattern changes, sync all three canonical docs.** Any change to a
+Chromatic/VRT convention (a new opt-in state, a matrix rule, or a determinism fix
+like `caret-color: transparent` for focused text inputs) must land in all three
+places at once, or they drift:
+
+1. `docs/chromatic-visual-testing.md` — the how/why guide + best practices.
+2. `docs/file-type-guidelines/stories.md` — the "Chromatic Visual Regression
+   Snapshots" section.
+3. `.claude/skills/writing-stories/SKILL.md` (this file) — the `SmokeTest` /
+   `Focused` templates, the "what gets captured" blurb, and the checklist.
 
 ### Step 3: Portal Content Handling
 
@@ -677,11 +759,28 @@ You MUST validate against these requirements:
 - [ ] `SmokeTest` matrix is **exhaustive** over the interacting axes the
       component has (e.g. size x variant x palette, plus selected/unselected for
       toggles) - every distinct combined look appears in the one snapshot
+- [ ] Axis arrays span the **full supported range** - no trimmed or
+      commented-out values; palettes use the 6 `SEMANTIC_COLOR_PALETTES`
+- [ ] Distinct **state-combinations** are covered, not just single flags
+      (selected-disabled is a separate look from unselected-disabled)
+- [ ] For each state (focus, disabled, read-only, invalid), checked whether the
+      component renders it more than one way (mode-/variant-driven); each distinct
+      surface gets its **own** snapshotted story, not a folded gallery frame
+      (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`, `DisabledState` +
+      `DisabledWithCurrencyLabel`)
+- [ ] Snapshotted stories render the component **directly** - no debug read-outs,
+      value dumps, or demo-wrapper scaffolding in the frame (those stay on the
+      un-snapshotted behavioral stories)
 - [ ] Uniform, axis-independent states are captured in a **dedicated** story,
       not folded into the matrix (`disabled` typically resolves to one shared
       style regardless of size/variant/palette → its own `Disabled` snapshot, not
       a grid dimension)
-- [ ] `Focused` story captures the focus ring (`disableSnapshot: false` + `vrt`)
+- [ ] Thin wrappers snapshot only the axis they introduce (+ `Focused`/`Disabled`
+      if added), not a re-rendered copy of the wrapped component's matrix
+- [ ] `Focused` story captures the focus ring (`disableSnapshot: false` + `vrt`);
+      for text-entry inputs the play function hides the blinking caret with
+      `canvasElement.style.caretColor = "transparent"` before tabbing
+      on **every** distinctly-styled focusable sub-element, not just the primary
 - [ ] Visual-state stories opt in via `disableSnapshot: false` + `tags: ["vrt"]`
 - [ ] Only behavior-only stories and stories whose look is already in `SmokeTest`
       left snapshot-off (project default) - never drop a visual state to save cost

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -237,18 +237,13 @@ export const Focused: Story = {
 };
 ```
 
-**Capture the ring on every distinctly-styled focusable sub-element, not just
-the primary one.** A split button's dropdown trigger, an input's clear button or
-stepper, and a date field's calendar toggle each style their own
-`:focus-visible` and each need to be tabbed to and snapshotted - a `Focused`
-story that stops at the first focusable leaves the others untested.
+**Tab to every distinctly-styled focusable sub-element, not just the primary
+one** (a split button's dropdown trigger, an input's stepper/clear button, a date
+field's calendar toggle) - each styles its own `:focus-visible`.
 
-**Text-entry inputs: hide the caret in the `Focused` play function.** Focusing a
-text input paints the browser's blinking caret, which Chromatic can't pause (it's
-neither a CSS nor a JS animation). Set `canvasElement.style.caretColor =
-"transparent"` before tabbing - `caret-color` is inherited, so it cascades to the
-input and the focused snapshot stays deterministic. We scope this to the story
-rather than editing the shared `preview.tsx`. See docs/chromatic-visual-testing.md.
+**Text-entry inputs: hide the caret** so the focused snapshot is deterministic
+(Chromatic can't pause the native caret blink). `caret-color` is inherited, so
+one line on the canvas cascades to the input:
 
 ```typescript
 play: async ({ canvasElement }) => {
@@ -319,40 +314,32 @@ selected/unselected (toggles) apply, covering every combination that produces a
 distinct visual. Content edge cases that change layout (long labels, icon +
 text) can go here too.
 
-Don't fold in an axis that applies a uniform, axis-independent transform. When
-`disabled` resolves to one shared style regardless of palette/size/variant,
-capture it once in a dedicated `Disabled` story (see below) rather than
-multiplying it through the grid. (`:hover` and `:active`/pressed can't be
-captured as static states - see the note under "What Gets Captured".)
+Don't fold in an axis that applies a uniform, axis-independent transform:
+`disabled` resolves to one shared style regardless of palette/size/variant, so
+capture it once in a dedicated `Disabled` story, not multiplied through the grid.
+(`:hover` and `:active`/pressed can't be captured statically - see "What Gets
+Captured".)
 
-**Axes must span the full supported range, not a dev subset.** A trimmed axis
-array is the most common regression-hiding mistake: snapshotting `md/sm` when the
-component supports five sizes, or three palettes when it supports six, leaves
-those cells covered by nothing. A commented-out axis value is a red flag. Scope
-call: matrices iterate the 6 `SEMANTIC_COLOR_PALETTES` as the representative set;
-the `BRAND` (3) and `SYSTEM` (25) palettes a consumer can also pass run the same
-token machinery and are deliberately not snapshotted.
+**Span the full supported range, not a dev subset** - a trimmed or commented-out
+axis (three sizes when the component has five) leaves those cells covered by
+nothing. Palettes iterate the 6 `SEMANTIC_COLOR_PALETTES`; the `BRAND` (3) and
+`SYSTEM` (25) palettes run the same token machinery and aren't snapshotted.
 
-**An axis the recipe hardcodes isn't an axis.** Full-range applies only to the
-axes the component actually varies. If a recipe pins one to a single value, drop
-it from the grid - MultilineTextInput hardcodes `colorPalette: "neutral"`, so its
-matrix is `state x size x variant` with no palette axis. Different from the
-uniform-transform case above (`disabled` is a real axis folded out for adding no
-signal); a hardcoded palette was never an axis to begin with.
+**An axis the recipe hardcodes isn't an axis** - full-range applies only to axes
+the component varies. MultilineTextInput pins `colorPalette: "neutral"`, so its
+matrix is `state x size x variant`, no palette axis. (Distinct from the uniform
+transform above: `disabled` is a real axis folded out; a pinned palette was never
+an axis.)
 
-**Cover distinct state-combinations, not just single flags.** When a component
-has multiple boolean states (selected, disabled, invalid, read-only), each
-combination that renders differently needs coverage. Selected-disabled is
-visually distinct from unselected-disabled, so a `Disabled` story showing only
+**Cover distinct state-combinations, not just single flags** - selected-disabled
+is a separate look from unselected-disabled, so a `Disabled` story showing only
 the unselected case leaves a gap.
 
-**Thin wrappers get no matrix.** A component that only constrains or forwards a
-wrapped component's props (a fixed-shape variant, a field wrapper) re-covers
-nothing by re-rendering the wrapped grid. Snapshot only the axis the wrapper
-introduces, plus `Focused`/`Disabled` if it adds them. FloatingActionButton wraps
-IconButton with a fixed circular shape, so it snapshots only `ColorPalettes` +
-`Focused` + `Disabled`, not a size x variant matrix - those are IconButton's
-states, already covered there.
+**Thin wrappers get no matrix** - a component that only forwards a wrapped
+component's props snapshots only the axis it introduces (+ `Focused`/`Disabled`
+if added), not a re-render of the wrapped grid. FloatingActionButton wraps
+IconButton at a fixed shape, so it snapshots `ColorPalettes` + `Focused` +
+`Disabled` only - size/variant are IconButton's.
 
 ```typescript
 export const SmokeTest: Story = {
@@ -385,85 +372,38 @@ export const SmokeTest: Story = {
 
 ### Chromatic Snapshots: What Gets Captured
 
-This is the **visual snapshot role**. Snapshots are **opt-in**:
-`.storybook/preview.tsx` sets `chromatic: { disableSnapshot: true }` as the
-project default, so Chromatic captures a story only when it sets
-`disableSnapshot: false`.
+The **visual snapshot role**. Snapshots are **opt-in**: `preview.tsx` defaults to
+`disableSnapshot: true`; a story opts in with `disableSnapshot: false` + `tags:
+["vrt"]`. Chromatic reads only `disableSnapshot`; `vrt` is just a label so tooling
+can find snapshot stories. Full rationale, CI details, and the hover/pressed gap
+live in docs/chromatic-visual-testing.md.
 
-**Cover every visual state that can differ.** Anything that changes rendered
-pixels is worth a snapshot: sizes, variants, color palettes,
-selected/unselected, focus rings, disabled/invalid/read-only states, empty vs
-filled content, long text and truncation, icon + text layouts, RTL, and open
-overlays (tooltip/popover/menu). Capture them economically: pack the
-**interacting** axes into one `SmokeTest` matrix (one snapshot for every
-combination that produces a distinct look), and give a dedicated story to each
-state the matrix can't or shouldn't hold (`Focused`, `Disabled`, an open
-popover). Cost is controlled by TurboSnap (unchanged snapshots bill at 1/5) and
-by matrix-packing - **never** by omitting a visual state.
-
-**Leave snapshots off** for stories that add no new visual state: behavior-only
-tests (e.g. `WithRef`, context/DOM-prop assertions) and showcase stories whose
-look is already captured by an on-snapshot story. That's a redundant baseline,
-not missing coverage - but only when the capturing snapshot truly holds every
-state the showcase renders (a `ColorPalettes` story with a disabled column needs
-`Disabled` to cover that column). Verify per component; don't assume.
-
-**Prefer one matrix over many individual snapshots.** A single matrix render is
-one billable snapshot instead of one per combination, and a reviewer spots
-cross-axis regressions in a single image. Tradeoff: a diff in any cell flags the
-whole snapshot, and editing the matrix re-snapshots the entire grid (Chromatic
-can't sub-diff within one image). Reserve standalone snapshots for states that
-need distinct setup or isolated review.
-
-**But a state can render more than one way - one story each, not a gallery
-frame.** Matrix-packing is for axes that _interact_. It is not license to fold
-_independent_ surfaces of a single state into one render. Before assuming a
-single `Focused` / `Disabled` / `ReadOnly` / `Invalid` story covers a state,
-check whether the component renders that state more than one way (mode- or
-variant-driven); if so, each distinct recipe surface gets its own snapshotted
-story. MoneyInput carries `Focused` + `FocusedWithCurrencyLabel` and
-`DisabledState` + `DisabledWithCurrencyLabel` (dropdown vs. `currencies={[]}`
-label mode) rather than one folded frame apiece - independent surfaces don't
-interact, so a shared frame only trades away their independent baselines and
-per-surface triage. Chromatic's idiom is discrete stories, one meaningful state
-each, independently baselined; count is not a performance concern (it
-parallelizes) and TurboSnap keeps an extra stable story near free. Modes
-(`chromatic.modes`) are for _global_ config only (viewport, theme, locale), so a
-mode is never the answer to two prop-driven surfaces.
-
-**A state with no distinct surface gets no story.** The flip side of the rule
-above: if the recipe has no rule for a state, it renders identically to the
-default and a dedicated story is a redundant baseline, not coverage. Read-only is
-the component-dependent trap - MoneyInput styles it distinctly (`ReadOnlyState`),
-but MultilineTextInput has no `data-readonly` rule, so read-only looks like the
-default and correctly gets no snapshot.
-
-**Snapshot the component, not the harness.** Chromatic photographs the story's
-whole rendered output, so a snapshotted story must render the component
-**directly** - no debug read-outs, value dumps, or controls scaffolding in the
-frame. A stateful demo wrapper (MoneyInput's `MoneyInputExample` renders a
-`JSON.stringify(value)` panel beside the input) is fine on un-snapshotted
-behavioral stories, but snapshotting one bakes the read-out into the baseline and
-flaps it on every value change. Keep those wrappers on the behavioral stories;
-render the bare component in the ones you snapshot.
-
-**Determinism matters most for snapshots.** A snapshot must render identically
-every run or it diffs on noise: don't bake in live dates or random values, wait
-for async-derived state (image load, data fetch) before the capture, and don't
-leave a stray focus ring on an unrelated story. A focused text input paints the
-browser's blinking caret, which Chromatic can't pause (it's neither a CSS nor a
-JS animation) - hide it in the `Focused` play function with
-`canvasElement.style.caretColor = "transparent"`. Some visual states can't be
-captured statically yet (notably `:hover` and `:active`/pressed); see the
-Chromatic doc for the current gaps.
-
-The snapshot switch is `disableSnapshot`, not `vrt`. Chromatic captures based on
-`disableSnapshot` alone and never reads `vrt`; the tag is just a **label** that
-marks a story as a visual-regression case so tooling can find and select it.
-`disableSnapshot: false` is what takes the picture.
-
-See docs/chromatic-visual-testing.md for the full rationale, CI details, and the
-current hover/pressed limitation.
+- **Cover every state that changes pixels**, economically: fold the interacting
+  axes into one `SmokeTest`, and give a dedicated story to each state it can't
+  hold (`Focused`, `Disabled`, an open popover). Cost is controlled by TurboSnap
+  and matrix-packing - never by dropping a visual state.
+- **Leave snapshots off** for behavior-only stories (`WithRef`, DOM/context
+  assertions) and any whose look `SmokeTest` already holds - a redundant baseline,
+  not a gap. Verify per component; a `ColorPalettes` story with a disabled column
+  still needs `Disabled`.
+- **One state, multiple distinct surfaces → one story each, not a gallery.** If a
+  component renders a state more than one way (mode-/variant-driven), each surface
+  gets its own snapshot (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`,
+  `DisabledState` + `DisabledWithCurrencyLabel`). Independent surfaces don't
+  interact, so folding them only loses their independent baselines. Modes
+  (`chromatic.modes`) are global config only (viewport/theme/locale), never
+  prop-driven surfaces.
+- **A state with no distinct recipe surface gets no story.** Read-only is the
+  component-dependent trap: MoneyInput styles it (`ReadOnlyState`), but
+  MultilineTextInput / NumberInput / TextInput have no `data-readonly` rule, so it
+  renders like default - no snapshot.
+- **Snapshot the component, not the harness** - render it directly, no debug
+  read-outs or demo wrappers in the frame (those stay on behavioral stories, e.g.
+  MoneyInput's `MoneyInputExample` JSON panel).
+- **Determinism** - identical output every run: no live dates/random values, wait
+  for async-derived state, no stray focus ring. Hide the caret in a `Focused`
+  text-input story. `:hover` and `:active`/pressed can't be captured statically
+  yet.
 
 **When a VRT pattern changes, sync all three canonical docs.** Any change to a
 Chromatic/VRT convention (a new opt-in state, a matrix rule, or a determinism fix
@@ -796,11 +736,10 @@ You MUST validate against these requirements:
       a grid dimension)
 - [ ] Thin wrappers snapshot only the axis they introduce (+ `Focused`/`Disabled`
       if added), not a re-rendered copy of the wrapped component's matrix
-- [ ] `Focused` story captures the focus ring (`disableSnapshot: false` + `vrt`);
-      for text-entry inputs the play function hides the blinking caret with
-      `canvasElement.style.caretColor = "transparent"` before tabbing
-      on **every** distinctly-styled focusable sub-element, not just the primary
-- [ ] Visual-state stories opt in via `disableSnapshot: false` + `tags: ["vrt"]`
+- [ ] `Focused` story opts in (`disableSnapshot: false` + `vrt`) and tabs to
+      **every** distinctly-styled focusable sub-element, not just the primary
+- [ ] Text-entry `Focused` plays hide the caret
+      (`canvasElement.style.caretColor = "transparent"`) before tabbing
 - [ ] Only behavior-only stories and stories whose look is already in `SmokeTest`
       left snapshot-off (project default) - never drop a visual state to save cost
 

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -290,27 +290,19 @@ and keeping the canvas from jumping as you browse. It's independent of
 `disableSnapshot` - not something you opt into per story. `fullscreen` stories
 are exempt because they're meant to touch the edges.
 
-**Cost is controlled by TurboSnap and matrix-packing, not by dropping visual
-states.** TurboSnap bills unchanged snapshots at 1/5 cost, and packing a whole
+**Cost is TurboSnap and matrix-packing, never dropping states.** TurboSnap bills
+unchanged snapshots at 1/5, and folding a
 `colorPalette × size × variant × state` grid into one `SmokeTest` render keeps
-combinatorial coverage down to a single billable snapshot. Those are the levers.
-The `vrt` selection is therefore not "snapshot fewer states" - every visual
-state must still be covered - it's "don't re-snapshot a state an on-snapshot
-already covers." Turning an individual per-axis story's snapshot off loses no
-coverage _when_ its states are already captured elsewhere - by the matrix, or by
-a dedicated story like `Disabled` for the uniform states the matrix omits; the
-per-component audit is what confirms that. Dropping a state no snapshot covers
-does lose coverage. Never trade a visual state away to save cost.
-
-**One matrix beats many individual snapshots for the routine combinations.**
-Folding the size/variant/palette/state grid into a single `SmokeTest` render
-keeps it to one billable snapshot rather than one per combination, and a
-reviewer catches cross-axis regressions in a single image because every state
-sits next to its neighbors. The tradeoff is granularity: a diff in any one cell
-flags the whole snapshot, and editing the matrix re-snapshots the entire grid
-(Chromatic can't sub-diff within one image). So reserve standalone snapshots for
-states that need distinct setup or deserve isolated review (`Focused`,
-`DisabledGroup`, an open menu), not for states that are straight recipe output.
+combinatorial coverage to a single billable snapshot (a reviewer also catches
+cross-axis regressions in one image, every state beside its neighbors). Those
+are the only levers: the `vrt` selection means "don't re-snapshot a state an
+on-snapshot already covers" - turning a per-axis story off loses nothing _when_
+the matrix or a dedicated `Disabled` already holds its states - never "snapshot
+fewer states." The matrix's tradeoff is granularity: a diff in any cell flags
+the whole snapshot, and editing it re-snapshots the whole grid, so reserve
+standalone snapshots for states needing distinct setup or isolated review
+(`Focused`, `DisabledGroup`, an open menu), not straight recipe output. Dropping
+a state no snapshot covers does lose coverage.
 
 **Hover and pressed are a known coverage gap.** They are genuine visual states,
 but neither is currently captured, and it's an infra limitation, not a choice:
@@ -379,33 +371,30 @@ but neither is currently captured, and it's an infra limitation, not a choice:
 - **A single state can render more than one distinct surface - give each its own
   story, don't fold them into a gallery frame.** Before assuming one `Focused` /
   `Disabled` / `ReadOnly` / `Invalid` story covers a state, check whether the
-  component renders that state more than one way (mode- or variant-driven). If
-  it does, each distinct recipe surface gets its own snapshotted story.
-  MoneyInput renders focus and disabled two ways - dropdown mode (a currency
-  Select) and label mode (`currencies={[]}`, a static currency label with its
-  own `currencyLabel[data-disabled] { opacity: 0.5 }` rule) - so it carries
+  component renders it more than one way (mode-/variant-driven); if so, each
+  distinct recipe surface gets its own snapshotted story. MoneyInput renders
+  focus and disabled two ways - dropdown mode (a currency Select) and label mode
+  (`currencies={[]}`, a static label with its own
+  `currencyLabel[data-disabled] { opacity: 0.5 }` rule) - so it carries
   `Focused`
   - `FocusedWithCurrencyLabel` and `DisabledState` +
-    `DisabledWithCurrencyLabel`, not one folded frame apiece. This is not the
-    `SmokeTest` fold in reverse: the matrix folds axes that _interact_ into one
-    snapshot, but independent surfaces of a single state do **not** interact, so
-    folding them into one "gallery" render only trades away their independent
-    baselines and per-surface triage to save a single snapshot. Chromatic's
-    guidance is discrete stories, one meaningful state each, each independently
-    baselined and approved; snapshot count is not a performance concern
-    (Chromatic parallelizes), and TurboSnap keeps the recurring cost of an extra
-    stable story near zero. Reserve folding for the interacting axes in
-    `SmokeTest`.
+    `DisabledWithCurrencyLabel`. Independent surfaces don't interact the way
+    matrix axes do, so folding them into one gallery render only trades away
+    their independent baselines and per-surface triage. Snapshot count isn't a
+    performance concern (Chromatic parallelizes; TurboSnap keeps a stable extra
+    story near free); reserve folding for the interacting axes in `SmokeTest`.
 - **A state that renders identically to the default gets no snapshot at all.**
   The flip side of the rule above: before adding a `ReadOnly` / `Disabled` /
   `Invalid` story, confirm the recipe actually renders that state distinctly. If
   there's no rule for it, it looks exactly like the default, and a dedicated
   snapshot is a redundant baseline, not coverage. Read-only is the common trap
   because the call is component-dependent: MoneyInput styles read-only
-  distinctly so it carries `ReadOnlyState`, but MultilineTextInput has no
-  `data-readonly` recipe rule - read-only renders identically to default - so it
-  correctly has no read-only snapshot. Same state, opposite call, decided purely
-  by whether a distinct recipe surface exists.
+  distinctly (it disables the currency Select) so it carries `ReadOnlyState`,
+  but MultilineTextInput / NumberInput / TextInput have no `data-readonly`
+  recipe rule
+  - read-only renders identically to default - so they correctly have no
+    read-only snapshot. Same state, opposite call, decided purely by whether a
+    distinct recipe surface exists.
 - **Modes are for global config, not component props.** Chromatic
   [modes](https://www.chromatic.com/docs/modes/) (`chromatic.modes`) capture the
   same story under different _global_ settings applied through Storybook
@@ -451,30 +440,21 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   animations/transitions, videos, GIFs, but not JS animations. Worth remembering
   if any button state animates via JS.
 - **Hide the blinking text caret on a focused input.** A `Focused` snapshot of a
-  text-entry input (MoneyInput, TextInput, NumberInput, etc.) captures the
-  keyboard focus ring, but focusing the input also paints the browser's blinking
-  caret. That blink is not a snapshot Chromatic can stabilize: Chromatic's
+  text-entry input captures the focus ring, but focusing also paints the
+  browser's native caret - which Chromatic can't stabilize (its
   [animations docs](https://www.chromatic.com/docs/animations/) cover only CSS
-  animations (auto-paused at their last frame) and JS animations (disable via
-  `isChromatic()`), and the native caret is neither, so a focused-input snapshot
-  would diff on whichever blink phase the capture lands on. Hide it in the
-  `Focused` story's play function - `caret-color` is inherited, so one line on
-  the story canvas cascades to the input:
+  and JS animations; the native caret is neither), so the snapshot would diff on
+  whichever blink phase it lands on. Hide it in the `Focused` play function;
+  `caret-color` is inherited, so one line on the canvas cascades to the input.
+  We scope it to the story rather than editing the shared `preview.tsx`:
 
   ```typescript
   play: async ({ canvasElement }) => {
-    // Deterministic focused snapshot: the caret blink is browser-native, so
-    // Chromatic can't pause it.
-    canvasElement.style.caretColor = "transparent";
+    canvasElement.style.caretColor = "transparent"; // native caret can't be paused
     await userEvent.tab();
-    // ...focus the input, assert the ring
+    // ...assert the ring
   },
   ```
-
-  We scope this to the `Focused` story rather than hiding the caret globally in
-  `preview.tsx`, keeping the shared config untouched. The one-liner repeats once
-  per text-entry component's `Focused` story - a deliberate trade for not
-  editing a file every story depends on.
 
 - **Fonts/async loading can shift tooltips/menus** - relevant to IconButton's
   `ColorPalettes` story (it wraps each button in a `Tooltip`). Preload fonts or

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -354,6 +354,16 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   palette/size/variant, so a `Disabled`/`DisabledGroup` story captures it once
   instead of the matrix re-rendering every cell at half opacity for no new
   coverage.
+- **An axis the recipe hardcodes is not a matrix axis.** The
+  `size × variant × colorPalette` grid only spans the axes the component
+  actually varies. When a recipe pins one of them to a single value, that axis
+  drops out entirely - MultilineTextInput hardcodes `colorPalette: "neutral"`,
+  so its matrix is `state × size × variant` with no palette axis at all. This is
+  distinct from the uniform-transform case above: `disabled` is a real axis
+  folded out because it multiplies cells without adding signal; a hardcoded
+  palette was never an axis to begin with. Don't force the full
+  `SEMANTIC_COLOR_PALETTES` sweep onto a component whose recipe can only ever
+  render one.
 - **Cover distinct state-combinations, not just single flags.** When a component
   has multiple boolean states (selected, disabled, invalid, read-only), each
   combination that renders differently needs its own coverage. Selected-disabled
@@ -379,6 +389,16 @@ but neither is currently captured, and it's an infra limitation, not a choice:
     (Chromatic parallelizes), and TurboSnap keeps the recurring cost of an extra
     stable story near zero. Reserve folding for the interacting axes in
     `SmokeTest`.
+- **A state that renders identically to the default gets no snapshot at all.**
+  The flip side of the rule above: before adding a `ReadOnly` / `Disabled` /
+  `Invalid` story, confirm the recipe actually renders that state distinctly. If
+  there's no rule for it, it looks exactly like the default, and a dedicated
+  snapshot is a redundant baseline, not coverage. Read-only is the common trap
+  because the call is component-dependent: MoneyInput styles read-only
+  distinctly so it carries `ReadOnlyState`, but MultilineTextInput has no
+  `data-readonly` recipe rule - read-only renders identically to default - so it
+  correctly has no read-only snapshot. Same state, opposite call, decided purely
+  by whether a distinct recipe surface exists.
 - **Modes are for global config, not component props.** Chromatic
   [modes](https://www.chromatic.com/docs/modes/) (`chromatic.modes`) capture the
   same story under different _global_ settings applied through Storybook

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -336,7 +336,16 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   any state the matrix can't render in one static image (focus ring,
   disabled-but-focusable, open tooltip/popover, special layouts) gets its own
   snapshotted story. Coverage is the target; the matrix is just the most
-  efficient container for the interacting axes.
+  efficient container for the interacting axes. A single-axis showcase story
+  varies one axis with the rest at defaults, so a cross-axis cell like
+  `size="2xs" variant="ghost" colorPalette="critical"` is captured by
+  **nothing** but the matrix - and that is exactly where recipe regressions
+  hide. Axis arrays must span the **full supported range** - a trimmed or
+  commented-out value (snapshotting three sizes when the component supports
+  five) leaves those cells covered by nothing. Scope call: matrices iterate the
+  6 `SEMANTIC_COLOR_PALETTES`; the `BRAND` (3) and `SYSTEM` (25) palettes a
+  consumer can also pass run the same token machinery and are deliberately not
+  snapshotted.
 - **Fold an axis into the matrix only if it interacts.** An axis whose
   combination with the others yields a distinct visual belongs in the grid; one
   that applies a **uniform, axis-independent transform** does not. `disabled` is
@@ -345,6 +354,58 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   palette/size/variant, so a `Disabled`/`DisabledGroup` story captures it once
   instead of the matrix re-rendering every cell at half opacity for no new
   coverage.
+- **Cover distinct state-combinations, not just single flags.** When a component
+  has multiple boolean states (selected, disabled, invalid, read-only), each
+  combination that renders differently needs its own coverage. Selected-disabled
+  is visually distinct from unselected-disabled, so a `Disabled` story showing
+  only the unselected case leaves a gap.
+- **A single state can render more than one distinct surface - give each its own
+  story, don't fold them into a gallery frame.** Before assuming one `Focused` /
+  `Disabled` / `ReadOnly` / `Invalid` story covers a state, check whether the
+  component renders that state more than one way (mode- or variant-driven). If
+  it does, each distinct recipe surface gets its own snapshotted story.
+  MoneyInput renders focus and disabled two ways - dropdown mode (a currency
+  Select) and label mode (`currencies={[]}`, a static currency label with its
+  own `currencyLabel[data-disabled] { opacity: 0.5 }` rule) - so it carries
+  `Focused`
+  - `FocusedWithCurrencyLabel` and `DisabledState` +
+    `DisabledWithCurrencyLabel`, not one folded frame apiece. This is not the
+    `SmokeTest` fold in reverse: the matrix folds axes that _interact_ into one
+    snapshot, but independent surfaces of a single state do **not** interact, so
+    folding them into one "gallery" render only trades away their independent
+    baselines and per-surface triage to save a single snapshot. Chromatic's
+    guidance is discrete stories, one meaningful state each, each independently
+    baselined and approved; snapshot count is not a performance concern
+    (Chromatic parallelizes), and TurboSnap keeps the recurring cost of an extra
+    stable story near zero. Reserve folding for the interacting axes in
+    `SmokeTest`.
+- **Modes are for global config, not component props.** Chromatic
+  [modes](https://www.chromatic.com/docs/modes/) (`chromatic.modes`) capture the
+  same story under different _global_ settings applied through Storybook
+  globals/decorators - viewport, theme, locale - each as an independently
+  baselined snapshot. They are not a mechanism for prop-driven variations: a
+  difference you produce by passing different props (MoneyInput's dropdown vs.
+  label mode is `currencies={[...]}` vs. `currencies={[]}`) is a separate
+  **story**, not a mode. We don't use modes at launch (single desktop viewport,
+  light theme only); they're the tool if/when dark-mode or multi-viewport
+  coverage lands.
+- **Snapshot the component, not the harness.** Chromatic photographs the story's
+  entire rendered output, so anything in the render tree lands in the baseline.
+  A snapshotted story must render the component **directly** - no debug
+  read-outs, value dumps, or controls scaffolding in the frame. Those authoring
+  aids are fine on the un-snapshotted behavioral stories (MoneyInput's
+  `MoneyInputExample` wrapper renders a `JSON.stringify(value)` panel next to
+  the input, useful for clicking through in Storybook), but a snapshot of one
+  would bake the read-out into the baseline and flap on every value change. So
+  the state/matrix stories render `<MoneyInput>` directly and leave the wrapper
+  to `BasicExample` and the other behavioral stories.
+- **Thin wrappers get no matrix.** A component that only constrains or forwards
+  a wrapped component's props re-covers nothing by re-rendering the wrapped
+  grid. FloatingActionButton wraps IconButton with a fixed circular shape, so it
+  snapshots only `ColorPalettes` + `Focused` + `Disabled`, not a size × variant
+  matrix - those are IconButton's states, already covered there. (Distinct from
+  the independent-axes case below: there the axes don't interact; here the
+  wrapper delegates them wholesale to a component that already snapshots them.)
 - **Not every component needs a `SmokeTest` matrix.** A matrix earns its place
   only when the axes _interact_. When they're independent (Avatar's `size` /
   `colorPalette` / content mode don't combine into novel visuals), skip the
@@ -352,11 +413,42 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   family of near-identical or purely behavioral stories into one labeled
   snapshot (Avatar's `AllFallbacks`) when it aids review without losing
   coverage.
+- **Capture the focus ring on every distinctly-styled focusable sub-element.** A
+  split button's dropdown trigger, an input's clear button or stepper, and a
+  date field's calendar toggle each style their own `:focus-visible`; a
+  `Focused` story that tabs only to the primary element leaves the rest
+  untested.
 - **Use `play` for functional testing alongside visual** - the two aren't in
   tension; a story can both assert behavior and be snapshotted.
 - **Pause JS-driven animations manually** - Chromatic auto-pauses CSS
   animations/transitions, videos, GIFs, but not JS animations. Worth remembering
   if any button state animates via JS.
+- **Hide the blinking text caret on a focused input.** A `Focused` snapshot of a
+  text-entry input (MoneyInput, TextInput, NumberInput, etc.) captures the
+  keyboard focus ring, but focusing the input also paints the browser's blinking
+  caret. That blink is not a snapshot Chromatic can stabilize: Chromatic's
+  [animations docs](https://www.chromatic.com/docs/animations/) cover only CSS
+  animations (auto-paused at their last frame) and JS animations (disable via
+  `isChromatic()`), and the native caret is neither, so a focused-input snapshot
+  would diff on whichever blink phase the capture lands on. Hide it in the
+  `Focused` story's play function - `caret-color` is inherited, so one line on
+  the story canvas cascades to the input:
+
+  ```typescript
+  play: async ({ canvasElement }) => {
+    // Deterministic focused snapshot: the caret blink is browser-native, so
+    // Chromatic can't pause it.
+    canvasElement.style.caretColor = "transparent";
+    await userEvent.tab();
+    // ...focus the input, assert the ring
+  },
+  ```
+
+  We scope this to the `Focused` story rather than hiding the caret globally in
+  `preview.tsx`, keeping the shared config untouched. The one-liner repeats once
+  per text-entry component's `Focused` story - a deliberate trade for not
+  editing a file every story depends on.
+
 - **Fonts/async loading can shift tooltips/menus** - relevant to IconButton's
   `ColorPalettes` story (it wraps each button in a `Tooltip`). Preload fonts or
   add a delay if those snapshots turn out flaky.
@@ -376,3 +468,4 @@ but neither is currently captured, and it's an infra limitation, not a choice:
 - [Interaction tests](https://www.chromatic.com/docs/interactions/)
 - [Disable snapshots](https://www.chromatic.com/docs/disable-snapshots/)
 - [TurboSnap](https://www.chromatic.com/docs/turbosnap/)
+- [Modes](https://www.chromatic.com/docs/modes/)

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -324,8 +324,15 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   Aria's `[data-hovered]` attribute - an addon forces one convention, so the
   recipes have to converge on it. Track this as a cross-cutting foundation task,
   not per-component work.
-- **Pressed** needs nothing: no button-family recipe styles `:active`/pressed,
-  so there is no visual state to capture.
+- **Pressed** needs nothing _for the button family_: none of its recipes style
+  `:active`/pressed (Button sets a `data-pressed` attribute, but no recipe rule
+  paints it), so there's no visual to capture there. Don't generalize that to
+  every component - some non-button recipes do style pressed. NumberInput's
+  steppers set `_active` (`bg: neutral.4`), a real pressed visual, so for
+  components like it pressed is a genuine uncaptured state deferred alongside
+  hover (a held-down frame isn't deterministically snapshottable today, same
+  infra family). Check the recipe rather than assuming pressed is always a
+  no-op.
 
 ### Broader best practices
 

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -180,6 +180,28 @@ disabled-but-focusable, an open tooltip/popover); a showcase story whose look a
 snapshot already covers stays snapshot-off. Never drop a visual state to save
 cost.
 
+**One state can be more than one surface - one story each, no gallery frame.**
+Before assuming a single `Focused` / `Disabled` / `ReadOnly` / `Invalid` story
+covers a state, check whether the component renders it more than one way (mode-
+or variant-driven). If it does, each distinct recipe surface gets its own
+snapshotted story - MoneyInput's `Focused` + `FocusedWithCurrencyLabel` and
+`DisabledState` + `DisabledWithCurrencyLabel` (dropdown vs. `currencies={[]}`
+label mode). Don't fold those into a single "gallery" render to save a snapshot:
+independent surfaces don't interact the way matrix axes do, so a shared frame
+only costs you their independent baselines and per-surface triage. Folding is
+for the interacting axes in `SmokeTest`. (Chromatic modes are for _global_
+config - viewport, theme, locale - not prop-driven variations, so a mode is
+never the answer to two prop-driven surfaces.)
+
+**Snapshot the component, not the harness.** Chromatic photographs the story's
+whole rendered output, so a snapshotted story must render the component
+**directly** - no debug read-outs, value dumps, or controls scaffolding in the
+frame. A stateful demo wrapper (MoneyInput's `MoneyInputExample` renders a
+`JSON.stringify(value)` panel beside the input) is fine on un-snapshotted
+behavioral stories, but snapshotting one bakes the read-out into the baseline
+and flaps it on every value change. Keep such wrappers on the behavioral
+stories; render the bare component in the ones you snapshot.
+
 **A `Focused` story keeps its ring for free.** Nothing blurs the focused element
 after a play function, so a story whose final state legitimately keeps focus (a
 `Focused` story, or an open combobox) snapshots the ring as-is - no extra
@@ -202,9 +224,31 @@ export const Focused: Story = {
 };
 ```
 
+**Tab to every distinctly-styled focusable sub-element.** A split button's
+dropdown trigger, an input's clear button or stepper, and a date field's
+calendar toggle each style their own `:focus-visible`, so a `Focused` story that
+stops at the first focusable leaves the rest untested.
+
 **Crop padding is global.** A `preview.tsx` decorator wraps every
 non-`fullscreen` story in `1rem` so focus and selection rings don't clip at
 Chromatic's content crop. You don't opt into it.
+
+**Hide the caret in a text-input `Focused` story.** Focusing a text-entry input
+snapshots the focus ring, but also paints the browser's blinking caret - which
+Chromatic can't stabilize (it's neither a CSS nor a JS animation). Hide it in
+the play function; `caret-color` is inherited, so one line on the canvas
+cascades to the input:
+
+```typescript
+play: async ({ canvasElement }) => {
+  canvasElement.style.caretColor = "transparent"; // deterministic focused snapshot
+  await userEvent.tab();
+  // ...assert focus
+},
+```
+
+We scope this to the story instead of touching `preview.tsx`. See
+[Chromatic Visual Testing](../chromatic-visual-testing.md).
 
 **Prefer local images, and wait for image-driven state.** Serve images from
 `public/` via `staticDirs`, not a remote URL (a remote image is a flaky network
@@ -224,9 +268,11 @@ play: async ({ canvasElement }) => {
 },
 ```
 
-For the matrix-vs-individual tradeoff, the fold-an-axis rule, the hover/pressed
-coverage gap, CI triggers, baselines, and TurboSnap, see
-[Chromatic Visual Testing](../chromatic-visual-testing.md).
+For the matrix-vs-individual tradeoff, the fold-an-axis rule, full-range axis
+exhaustiveness (and the `SEMANTIC_COLOR_PALETTES` scope), distinct
+state-combinations, one-state-many-surfaces, why modes are global-only,
+thin-wrapper coverage, the hover/pressed coverage gap, CI triggers, baselines,
+and TurboSnap, see [Chromatic Visual Testing](../chromatic-visual-testing.md).
 
 ## File Structure
 

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -158,9 +158,9 @@ graph TD
 ## Chromatic Visual Regression Snapshots
 
 Stories double as Chromatic's visual-regression cases, but snapshots are
-**opt-in**: `.storybook/preview.tsx` sets `chromatic: { disableSnapshot: true }`
-as the project default, so a story is captured only when it turns snapshots back
-on:
+**opt-in**: `.storybook/preview.tsx` defaults to
+`chromatic: { disableSnapshot: true }`, so a story is captured only when it
+turns snapshots back on:
 
 ```typescript
 export const SmokeTest: Story = {
@@ -170,59 +170,45 @@ export const SmokeTest: Story = {
 };
 ```
 
-`disableSnapshot: false` is what takes the picture; Chromatic never reads the
-`vrt` tag. `vrt` is our own label for spotting and selecting snapshotted
-stories, so keep the two together.
+`disableSnapshot: false` takes the picture; Chromatic never reads `vrt` (our own
+label for finding snapshot stories - keep the two together).
 
-**What to snapshot:** cover every prop-driven visual state. Any state the matrix
-can't render in one static image gets its own snapshotted story (`Focused`,
-disabled-but-focusable, an open tooltip/popover); a showcase story whose look a
-snapshot already covers stays snapshot-off. Never drop a visual state to save
-cost.
+**What to snapshot:** every prop-driven visual state. Fold the interacting axes
+into one `SmokeTest` matrix; any state it can't render in one static image gets
+its own story (`Focused`, disabled-but-focusable, an open tooltip/popover). A
+showcase whose look a snapshot already covers stays snapshot-off. Never drop a
+visual state to save cost.
 
-**One state can be more than one surface - one story each, no gallery frame.**
-Before assuming a single `Focused` / `Disabled` / `ReadOnly` / `Invalid` story
-covers a state, check whether the component renders it more than one way (mode-
-or variant-driven). If it does, each distinct recipe surface gets its own
-snapshotted story - MoneyInput's `Focused` + `FocusedWithCurrencyLabel` and
-`DisabledState` + `DisabledWithCurrencyLabel` (dropdown vs. `currencies={[]}`
-label mode). Don't fold those into a single "gallery" render to save a snapshot:
-independent surfaces don't interact the way matrix axes do, so a shared frame
-only costs you their independent baselines and per-surface triage. Folding is
-for the interacting axes in `SmokeTest`. (Chromatic modes are for _global_
-config - viewport, theme, locale - not prop-driven variations, so a mode is
-never the answer to two prop-driven surfaces.)
+**One state, multiple distinct surfaces → one story each, not a gallery frame.**
+If a component renders a state more than one way (mode-/variant-driven), each
+surface gets its own snapshot - MoneyInput's `Focused` +
+`FocusedWithCurrencyLabel` and `DisabledState` + `DisabledWithCurrencyLabel`
+(dropdown vs. `currencies={[]}` label mode). Folding is only for the interacting
+axes in `SmokeTest`.
 
-**A state with no distinct recipe surface gets no story.** The flip side: before
-adding a `ReadOnly` / `Disabled` / `Invalid` story, confirm the recipe renders
-that state differently from the default. Read-only is the trap because the call
-is component-dependent - MoneyInput styles read-only distinctly (it carries
-`ReadOnlyState`), but MultilineTextInput has no `data-readonly` rule, so
-read-only renders identically to default and correctly gets no snapshot. Same
-state, opposite call, decided by whether a distinct surface exists.
+**A state with no distinct recipe surface gets no story.** Confirm the recipe
+renders the state differently from default first. Read-only is the
+component-dependent trap: MoneyInput styles it (`ReadOnlyState`), but
+MultilineTextInput / NumberInput / TextInput have no `data-readonly` rule, so it
+renders like default and correctly gets no snapshot.
 
-**Snapshot the component, not the harness.** Chromatic photographs the story's
-whole rendered output, so a snapshotted story must render the component
-**directly** - no debug read-outs, value dumps, or controls scaffolding in the
-frame. A stateful demo wrapper (MoneyInput's `MoneyInputExample` renders a
-`JSON.stringify(value)` panel beside the input) is fine on un-snapshotted
-behavioral stories, but snapshotting one bakes the read-out into the baseline
-and flaps it on every value change. Keep such wrappers on the behavioral
-stories; render the bare component in the ones you snapshot.
+**Snapshot the component, not the harness.** A snapshotted story renders the
+component directly - no debug read-outs or demo wrappers in the frame
+(MoneyInput's `MoneyInputExample` JSON panel is fine on behavioral stories, but
+would flap a snapshot on every value change). Keep wrappers on the behavioral
+stories.
 
-**A `Focused` story keeps its ring for free.** Nothing blurs the focused element
-after a play function, so a story whose final state legitimately keeps focus (a
-`Focused` story, or an open combobox) snapshots the ring as-is - no extra
-parameter needed. The flip side: a behavior story that leaves a stray ring it
-doesn't want in the snapshot should blur in its own play function, or better, be
-split so the snapshotted visual story doesn't end focused:
+**A `Focused` story keeps its ring for free** - nothing blurs the focused
+element after a play function, so a story that legitimately ends focused
+snapshots the ring as-is. Conversely, a behavior story that leaves a stray ring
+should blur (or be split so the snapshotted story doesn't end focused). Tab to
+**every** distinctly-styled focusable sub-element (a split button's trigger, an
+input's stepper/clear button), not just the first.
 
 ```typescript
 export const Focused: Story = {
   tags: ["vrt"],
-  parameters: {
-    chromatic: { disableSnapshot: false },
-  },
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {/* minimal render */},
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -232,20 +218,8 @@ export const Focused: Story = {
 };
 ```
 
-**Tab to every distinctly-styled focusable sub-element.** A split button's
-dropdown trigger, an input's clear button or stepper, and a date field's
-calendar toggle each style their own `:focus-visible`, so a `Focused` story that
-stops at the first focusable leaves the rest untested.
-
-**Crop padding is global.** A `preview.tsx` decorator wraps every
-non-`fullscreen` story in `1rem` so focus and selection rings don't clip at
-Chromatic's content crop. You don't opt into it.
-
-**Hide the caret in a text-input `Focused` story.** Focusing a text-entry input
-snapshots the focus ring, but also paints the browser's blinking caret - which
-Chromatic can't stabilize (it's neither a CSS nor a JS animation). Hide it in
-the play function; `caret-color` is inherited, so one line on the canvas
-cascades to the input:
+**Text-input `Focused`: hide the caret** so the snapshot is deterministic
+(Chromatic can't pause the native caret blink). `caret-color` is inherited:
 
 ```typescript
 play: async ({ canvasElement }) => {
@@ -255,19 +229,17 @@ play: async ({ canvasElement }) => {
 },
 ```
 
-We scope this to the story instead of touching `preview.tsx`. See
-[Chromatic Visual Testing](../chromatic-visual-testing.md).
+**Crop padding is global** - a `preview.tsx` decorator wraps every
+non-`fullscreen` story in `1rem` so focus/selection rings don't clip at
+Chromatic's crop. Not opt-in.
 
-**Prefer local images, and wait for image-driven state.** Serve images from
-`public/` via `staticDirs`, not a remote URL (a remote image is a flaky network
-dependency that can fail the play function before capture). Chromatic waits for
-images to load but not for state your component _derives_ from that load (Avatar
-hides its `<img>` until `onLoad` and swaps to a fallback on error), so a story
-snapshotting a post-load or post-error state must wait for it:
+**Prefer local images, and wait for image-derived state.** Serve images from
+`public/` via `staticDirs` (a remote URL is a flaky network dependency).
+Chromatic waits for images to load but not for state your component _derives_
+from the load (Avatar hides its `<img>` until `onLoad`, swaps to a fallback on
+error), so wait for that state before the snapshot:
 
 ```typescript
-// Wait for the state the component derives from the load (here, the <img>
-// hidden behind its fallback) before the snapshot is captured.
 play: async ({ canvasElement }) => {
   const img = canvasElement.querySelector("img");
   await waitFor(() => expect(img).toHaveStyle("display: none"), {
@@ -276,11 +248,10 @@ play: async ({ canvasElement }) => {
 },
 ```
 
-For the matrix-vs-individual tradeoff, the fold-an-axis rule, full-range axis
-exhaustiveness (and the `SEMANTIC_COLOR_PALETTES` scope), distinct
-state-combinations, one-state-many-surfaces, why modes are global-only,
-thin-wrapper coverage, the hover/pressed coverage gap, CI triggers, baselines,
-and TurboSnap, see [Chromatic Visual Testing](../chromatic-visual-testing.md).
+Full rationale - matrix tradeoffs, the fold-an-axis and hardcoded-axis rules,
+`SEMANTIC_COLOR_PALETTES` scope, thin-wrapper coverage, why modes are
+global-only, the hover/pressed gap, CI, baselines, TurboSnap - is in
+[Chromatic Visual Testing](../chromatic-visual-testing.md).
 
 ## File Structure
 

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -193,6 +193,14 @@ for the interacting axes in `SmokeTest`. (Chromatic modes are for _global_
 config - viewport, theme, locale - not prop-driven variations, so a mode is
 never the answer to two prop-driven surfaces.)
 
+**A state with no distinct recipe surface gets no story.** The flip side: before
+adding a `ReadOnly` / `Disabled` / `Invalid` story, confirm the recipe renders
+that state differently from the default. Read-only is the trap because the call
+is component-dependent - MoneyInput styles read-only distinctly (it carries
+`ReadOnlyState`), but MultilineTextInput has no `data-readonly` rule, so
+read-only renders identically to default and correctly gets no snapshot. Same
+state, opposite call, decided by whether a distinct surface exists.
+
 **Snapshot the component, not the harness.** Chromatic photographs the story's
 whole rendered output, so a snapshotted story must render the component
 **directly** - no debug read-outs, value dumps, or controls scaffolding in the

--- a/packages/nimbus/src/components/money-input/money-input.stories.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.stories.tsx
@@ -219,11 +219,6 @@ export const HighPrecisionExample: Story = {
   },
 };
 
-/**
- * Disabled in dropdown mode: the amount input and the currency Select are both
- * disabled. The label-mode dimming rule is a distinct recipe surface, captured
- * separately by DisabledWithCurrencyLabel.
- */
 export const DisabledState: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -248,11 +243,8 @@ export const DisabledState: Story = {
 };
 
 /**
- * Disabled in label mode: with no currencies supplied the static currency label
- * dims via money-input's own `currencyLabel[data-disabled] { opacity: 0.5 }`
- * recipe rule, which renders nowhere else. Distinct recipe surface from the
- * dropdown-mode DisabledState above, so it gets its own snapshot (mirrors the
- * Focused / FocusedWithCurrencyLabel split).
+ * Label mode (no currencies): the static currency label dims via its own recipe
+ * rule - a distinct surface from DisabledState.
  */
 export const DisabledWithCurrencyLabel: Story = {
   tags: ["vrt"],
@@ -321,11 +313,6 @@ export const ErrorState: Story = {
   },
 };
 
-/**
- * Captures the keyboard-focus ring on the amount input, the state no other
- * snapshot renders. See docs/chromatic-visual-testing.md for why the caret is
- * hidden here.
- */
 export const Focused: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -340,13 +327,10 @@ export const Focused: Story = {
     const canvas = within(canvasElement);
     const amountInput = canvas.getByRole("textbox", { name: /Amount/i });
 
-    // Hide the blinking text caret so the focused snapshot is deterministic.
-    // The caret blink is browser-native (not a CSS/JS animation Chromatic can
-    // pause); caret-color is inherited, so this cascades to the input.
+    // Hide the native caret (Chromatic can't pause its blink); caret-color inherits.
     canvasElement.style.caretColor = "transparent";
 
-    // Tab past the currency selector (first focusable) to the amount input so
-    // its keyboard focus ring renders.
+    // Two tabs: past the currency selector (first focusable) to the amount input.
     await userEvent.tab();
     await userEvent.tab();
     await expect(amountInput).toHaveFocus();
@@ -354,12 +338,8 @@ export const Focused: Story = {
 };
 
 /**
- * Label-mode focus: with no currencies supplied the currency renders as a static
- * label, and focusing the amount input draws a single continuous outline around
- * the label + input together. This is money-input's own recipe styling, distinct
- * from the dropdown-mode focus ring above, so it needs its own snapshot. Caret
- * hidden for determinism, same as Focused. A two-decimal value keeps it out of
- * high precision so the amount input is the only focusable element (single tab).
+ * Label mode (no currencies): focus draws one continuous outline around label +
+ * input - a distinct surface from Focused. Two-decimal value = single tab.
  */
 export const FocusedWithCurrencyLabel: Story = {
   tags: ["vrt"],
@@ -450,9 +430,7 @@ export const ConsistentFormattingAcrossCurrencies: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Every currency renders 1,234.567 identically: comma thousands separator,
-    // period decimal separator, and the same high-precision badge (3 decimals
-    // exceeds the 2-decimal standard for USD/EUR/GBP).
+    // All three format 1,234.567 identically and show the high-precision badge.
     const badges = canvas.getAllByLabelText(/High precision price/i);
     expect(badges).toHaveLength(3);
 
@@ -608,8 +586,7 @@ export const EULocaleFormattingExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // All three exceed their currency's standard fraction digits, so each shows
-    // the high-precision badge.
+    // All three exceed their currency's fraction digits, so each shows the badge.
     const highPrecisionLabel = getMessage("highPrecisionPrice", "de");
     const badges = canvas.getAllByLabelText(highPrecisionLabel);
     expect(badges).toHaveLength(3);
@@ -1179,11 +1156,8 @@ export const ModernApiTest: Story = {
 };
 
 /**
- * Packs the interacting visual axes into one snapshot: size (`md`/`sm`) x
- * currency chrome (dropdown vs. static label when no currencies are supplied).
- * Each cell holds a high-precision value so the badge and value alignment are
- * captured too. Uniform states (disabled/read-only/invalid/focus) live in their
- * own dedicated snapshotted stories, not this matrix.
+ * Matrix: size x currency chrome (dropdown vs. static label). High-precision
+ * values so the badge is captured; other states have dedicated stories.
  */
 export const SmokeTest: Story = {
   tags: ["vrt"],

--- a/packages/nimbus/src/components/money-input/money-input.stories.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.stories.tsx
@@ -213,72 +213,172 @@ export const HighPrecisionExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Verify that the high precision badge appears for the initial value
-    // Initial value "42.12345" EUR should show high precision (5 > 2 decimal places)
+    // "42.12345" EUR has 5 fraction digits, past EUR's 2, so the badge shows.
     const highPrecisionBadge = canvas.getByLabelText(/High Precision Price/i);
     expect(highPrecisionBadge).toBeInTheDocument();
-
-    // With consistent formatting, all currencies now use the same decimal separator
-    // EUR and USD both use periods for decimals, no more German locale issues
   },
 };
 
+/**
+ * Disabled in dropdown mode: the amount input and the currency Select are both
+ * disabled. The label-mode dimming rule is a distinct recipe surface, captured
+ * separately by DisabledWithCurrencyLabel.
+ */
 export const DisabledState: Story = {
-  render: (args) => (
-    <MoneyInputExample
-      initialValue={{ amount: "100.005", currencyCode: "USD" }}
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MoneyInput
+      value={{ amount: "100.005", currencyCode: "USD" }}
+      currencies={DEFAULT_CURRENCIES}
+      isDisabled
+      hasHighPrecisionBadge
       aria-label="Money input example"
-      {...args}
     />
   ),
-  args: {
-    isDisabled: true,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const amountInput = canvas.getByRole("textbox", { name: /Amount/i });
+    expect(amountInput).toBeDisabled();
+
+    const currencySelect = canvas.getByRole("button", { name: /Currency/i });
+    expect(currencySelect).toHaveAttribute("data-disabled", "true");
   },
+};
+
+/**
+ * Disabled in label mode: with no currencies supplied the static currency label
+ * dims via money-input's own `currencyLabel[data-disabled] { opacity: 0.5 }`
+ * recipe rule, which renders nowhere else. Distinct recipe surface from the
+ * dropdown-mode DisabledState above, so it gets its own snapshot (mirrors the
+ * Focused / FocusedWithCurrencyLabel split).
+ */
+export const DisabledWithCurrencyLabel: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MoneyInput
+      value={{ amount: "100.005", currencyCode: "USD" }}
+      currencies={[]}
+      isDisabled
+      hasHighPrecisionBadge
+      aria-label="Money input example"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const amountInput = canvas.getByRole("textbox", { name: /Amount/i });
+    expect(amountInput).toBeDisabled();
+
+    const currencyLabel = canvasElement.querySelector(
+      "label[data-disabled='true']"
+    );
+    expect(currencyLabel).toBeInTheDocument();
+  },
+};
+
+export const ReadOnlyState: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MoneyInput
+      value={{ amount: "250.75", currencyCode: "GBP" }}
+      currencies={DEFAULT_CURRENCIES}
+      isReadOnly
+      aria-label="Money input example"
+    />
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     const amountInput = canvas.getByRole("textbox", {
       name: /Amount/i,
     });
-    const currencySelect = canvas.getByRole("button", { name: /Currency/i });
-
-    expect(amountInput).toBeDisabled();
-    // Check that the Select component is disabled (may use different attributes)
-    expect(currencySelect).toHaveAttribute("data-disabled", "true");
-  },
-};
-
-export const ReadOnlyState: Story = {
-  render: (args) => (
-    <MoneyInputExample
-      initialValue={{ amount: "250.75", currencyCode: "GBP" }}
-      aria-label="Money input example"
-      {...args}
-    />
-  ),
-  args: {
-    isReadOnly: true,
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const amountInput = canvas.getByRole("textbox", {
-      name: "Amount",
-    });
     expect(amountInput).toHaveAttribute("readonly");
   },
 };
 
 export const ErrorState: Story = {
-  render: (args) => (
-    <MoneyInputExample
-      initialValue={{ amount: "invalid", currencyCode: "EUR" }}
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MoneyInput
+      value={{ amount: "1234.56", currencyCode: "EUR" }}
+      currencies={DEFAULT_CURRENCIES}
+      isInvalid
       aria-label="Money input example"
-      {...args}
     />
   ),
-  args: {
-    isInvalid: true,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const amountInput = canvas.getByRole("textbox", {
+      name: /Amount/i,
+    });
+    expect(amountInput).toHaveAttribute("data-invalid", "true");
+  },
+};
+
+/**
+ * Captures the keyboard-focus ring on the amount input, the state no other
+ * snapshot renders. See docs/chromatic-visual-testing.md for why the caret is
+ * hidden here.
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MoneyInput
+      value={{ amount: "1234.56", currencyCode: "EUR" }}
+      currencies={DEFAULT_CURRENCIES}
+      aria-label="Money input example"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const amountInput = canvas.getByRole("textbox", { name: /Amount/i });
+
+    // Hide the blinking text caret so the focused snapshot is deterministic.
+    // The caret blink is browser-native (not a CSS/JS animation Chromatic can
+    // pause); caret-color is inherited, so this cascades to the input.
+    canvasElement.style.caretColor = "transparent";
+
+    // Tab past the currency selector (first focusable) to the amount input so
+    // its keyboard focus ring renders.
+    await userEvent.tab();
+    await userEvent.tab();
+    await expect(amountInput).toHaveFocus();
+  },
+};
+
+/**
+ * Label-mode focus: with no currencies supplied the currency renders as a static
+ * label, and focusing the amount input draws a single continuous outline around
+ * the label + input together. This is money-input's own recipe styling, distinct
+ * from the dropdown-mode focus ring above, so it needs its own snapshot. Caret
+ * hidden for determinism, same as Focused. A two-decimal value keeps it out of
+ * high precision so the amount input is the only focusable element (single tab).
+ */
+export const FocusedWithCurrencyLabel: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MoneyInput
+      value={{ amount: "1234.56", currencyCode: "USD" }}
+      currencies={[]}
+      aria-label="Money input example"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const amountInput = canvas.getByRole("textbox");
+
+    canvasElement.style.caretColor = "transparent";
+
+    await userEvent.tab();
+    await expect(amountInput).toHaveFocus();
   },
 };
 
@@ -508,10 +608,8 @@ export const EULocaleFormattingExample: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // All should show high precision badges since they exceed standard fraction digits
-    // NOTE: This test will fail locally until locale normalization is implemented
-    // (useLocale() may return "de-DE" but dictionary only has "de", causing fallback to "en")
-    // TODO: FIGURE THIS OUT. Fix locale normalization in component (see PROGRESS_COMPILE_TIME_PARSING.md)
+    // All three exceed their currency's standard fraction digits, so each shows
+    // the high-precision badge.
     const highPrecisionLabel = getMessage("highPrecisionPrice", "de");
     const badges = canvas.getAllByLabelText(highPrecisionLabel);
     expect(badges).toHaveLength(3);
@@ -1078,4 +1176,38 @@ export const ModernApiTest: Story = {
       expect(eventsText).toContain('"currencyCode":"EUR"');
     });
   },
+};
+
+/**
+ * Packs the interacting visual axes into one snapshot: size (`md`/`sm`) x
+ * currency chrome (dropdown vs. static label when no currencies are supplied).
+ * Each cell holds a high-precision value so the badge and value alignment are
+ * captured too. Uniform states (disabled/read-only/invalid/focus) live in their
+ * own dedicated snapshotted stories, not this matrix.
+ */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="600">
+      {inputSize.map((size) => (
+        <Stack key={size} direction="row" gap="400" alignItems="flex-start">
+          <MoneyInput
+            size={size}
+            value={{ amount: "1234.567", currencyCode: "EUR" }}
+            currencies={DEFAULT_CURRENCIES}
+            hasHighPrecisionBadge
+            aria-label={`Money input ${size} with currency dropdown`}
+          />
+          <MoneyInput
+            size={size}
+            value={{ amount: "1234.567", currencyCode: "USD" }}
+            currencies={[]}
+            hasHighPrecisionBadge
+            aria-label={`Money input ${size} with currency label`}
+          />
+        </Stack>
+      ))}
+    </Stack>
+  ),
 };

--- a/packages/nimbus/src/components/money-input/money-input.stories.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.stories.tsx
@@ -450,16 +450,16 @@ export const ConsistentFormattingAcrossCurrencies: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // All currencies should show consistent formatting with periods as decimal separators
-    // and consistent high precision badge behavior
-
-    // Check that all three high precision badges are present
+    // Every currency renders 1,234.567 identically: comma thousands separator,
+    // period decimal separator, and the same high-precision badge (3 decimals
+    // exceeds the 2-decimal standard for USD/EUR/GBP).
     const badges = canvas.getAllByLabelText(/High precision price/i);
     expect(badges).toHaveLength(3);
 
-    // All should show high precision for 1234.567 (3 decimals > 2 standard for USD/EUR/GBP)
-    badges.forEach((badge) => {
-      expect(badge).toBeInTheDocument();
+    const inputs = canvas.getAllByRole("textbox", { name: /Amount/i });
+    expect(inputs).toHaveLength(3);
+    inputs.forEach((input) => {
+      expect(input).toHaveValue("1,234.567");
     });
   },
 };

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.stories.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.stories.tsx
@@ -30,6 +30,9 @@ export const Base: Story = {
     placeholder: "base multiline text input",
     ["aria-label"]: "test-textarea",
   },
+  render: (args) => (
+    <MultilineTextInput {...args} data-testid="base-textarea" />
+  ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const textarea = canvas.getByLabelText("test-textarea");
@@ -40,6 +43,7 @@ export const Base: Story = {
 
     await step("Forwards data- & aria-attributes", async () => {
       await expect(textarea).toHaveAttribute("aria-label", "test-textarea");
+      await expect(textarea).toHaveAttribute("data-testid", "base-textarea");
     });
 
     await step("Is focusable with <tab> key", async () => {
@@ -97,6 +101,8 @@ export const Variants: Story = {
 };
 
 export const LeadingElements: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const examples: Array<{
       label: string;
@@ -283,7 +289,36 @@ export const Invalid: Story = {
   },
 };
 
+/**
+ * Captures the keyboard-focus ring, the state no matrix cell can render (only one
+ * element holds focus at a time). See docs/chromatic-visual-testing.md for why the
+ * caret is hidden here.
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <MultilineTextInput
+      defaultValue="Focused multiline text input"
+      aria-label="focused-textarea"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText("focused-textarea");
+
+    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
+    // caret-color inherits, so hiding it here cascades to the textarea.
+    canvasElement.style.caretColor = "transparent";
+
+    await userEvent.tab();
+    await expect(textarea).toHaveFocus();
+  },
+};
+
 export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     onChange: fn(),
     ["aria-label"]: "test-textarea",
@@ -383,6 +418,8 @@ export const Controlled: Story = {
 };
 
 export const WithRows: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     rows: 5,
     placeholder: "Textarea with 5 rows",
@@ -493,19 +530,21 @@ export const AutoGrow: Story = {
     await step(
       "Auto-shrinks to minimum when all content is deleted",
       async () => {
-        // Clear all content
         await userEvent.clear(autoGrowTextarea);
-
-        // Should shrink to minimal height
-        const emptyHeight = autoGrowTextarea.clientHeight;
-
-        // Add content again
         await userEvent.type(
           autoGrowTextarea,
           "Line 1{enter}Line 2{enter}Line 3{enter}Line 4"
         );
+        const filledHeight = autoGrowTextarea.clientHeight;
 
-        // Should grow again
+        await userEvent.clear(autoGrowTextarea);
+        const emptyHeight = autoGrowTextarea.clientHeight;
+        await expect(emptyHeight).toBeLessThan(filledHeight);
+
+        await userEvent.type(
+          autoGrowTextarea,
+          "Line 1{enter}Line 2{enter}Line 3{enter}Line 4"
+        );
         await expect(autoGrowTextarea.clientHeight).toBeGreaterThan(
           emptyHeight
         );

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.stories.tsx
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.stories.tsx
@@ -289,11 +289,6 @@ export const Invalid: Story = {
   },
 };
 
-/**
- * Captures the keyboard-focus ring, the state no matrix cell can render (only one
- * element holds focus at a time). See docs/chromatic-visual-testing.md for why the
- * caret is hidden here.
- */
 export const Focused: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -307,8 +302,7 @@ export const Focused: Story = {
     const canvas = within(canvasElement);
     const textarea = canvas.getByLabelText("focused-textarea");
 
-    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
-    // caret-color inherits, so hiding it here cascades to the textarea.
+    // Hide the native caret (Chromatic can't pause its blink); caret-color inherits.
     canvasElement.style.caretColor = "transparent";
 
     await userEvent.tab();

--- a/packages/nimbus/src/components/number-input/number-input.stories.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.stories.tsx
@@ -36,6 +36,7 @@ export const Base: Story = {
     placeholder: "123",
     ["aria-label"]: "test-number-input",
   },
+  render: (args) => <NumberInput {...args} data-testid="base-number-input" />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText("test-number-input");
@@ -50,6 +51,7 @@ export const Base: Story = {
 
     await step("Forwards data- & aria-attributes", async () => {
       await expect(input).toHaveAttribute("aria-label", "test-number-input");
+      await expect(input).toHaveAttribute("data-testid", "base-number-input");
     });
 
     await step("Is focusable with <tab> key", async () => {
@@ -187,58 +189,90 @@ export const NumberConstraints: Story = {
   ),
 };
 
-export const AllCombinations: Story = {
+/**
+ * Captures the keyboard-focus ring the matrix can't render (only one element
+ * holds focus at a time). The increment/decrement steppers are excluded from the
+ * tab order, so a single tab lands on the input and draws the `_focusWithin` ring
+ * on the root. See docs/chromatic-visual-testing.md for why the caret is hidden
+ * here.
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
-    <Stack>
-      {inputSize.map((size) => (
-        <Box key={String(size)}>
-          <Text mb={2} fontSize="lg" fontWeight="bold">
-            Size: {String(size)}
-          </Text>
-          <Stack direction="row" wrap="wrap">
-            {inputVariants.map((variant) => (
-              <Box key={String(variant)} minW="200px">
-                <Text mb={1} fontSize="sm" fontWeight="medium">
-                  {String(variant)}
-                </Text>
-                <Stack>
-                  <NumberInput
-                    size={size}
-                    variant={variant}
-                    placeholder="123"
-                    aria-label={`${String(variant)} ${String(size)} default`}
-                  />
-                  <NumberInput
-                    size={size}
-                    variant={variant}
-                    defaultValue={123}
-                    aria-label={`${String(variant)} ${String(size)} with value`}
-                  />
-                  <NumberInput
-                    size={size}
-                    variant={variant}
-                    placeholder="123"
-                    isInvalid
-                    aria-label={`${String(variant)} ${String(size)} invalid`}
-                  />
-                  <NumberInput
-                    size={size}
-                    variant={variant}
-                    placeholder="123"
-                    isDisabled
-                    aria-label={`${String(variant)} ${String(size)} disabled`}
-                  />
-                </Stack>
-              </Box>
+    <NumberInput defaultValue={123} aria-label="focused-number-input" />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("focused-number-input");
+
+    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
+    // caret-color inherits, so hiding it here cascades to the input.
+    canvasElement.style.caretColor = "transparent";
+
+    await userEvent.tab();
+    await expect(input).toHaveFocus();
+  },
+};
+
+/**
+ * Packs the interacting axes into one snapshot: state (default / disabled /
+ * invalid / invalid & disabled) x size (md/sm) x variant (solid/ghost). No
+ * colorPalette axis - the recipe hardcodes `neutral`. Every cell renders the
+ * increment/decrement steppers, so their resting chrome is captured here too.
+ * Focus (its own ring, dedicated `Focused` story) and read-only (no
+ * `data-readonly` recipe rule, so it renders like the default) are deliberately
+ * not in the matrix.
+ */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => {
+    const states = [
+      { label: "Default", props: {} },
+      { label: "Disabled", props: { isDisabled: true } },
+      { label: "Invalid", props: { isInvalid: true } },
+      {
+        label: "Invalid & Disabled",
+        props: { isInvalid: true, isDisabled: true },
+      },
+    ];
+
+    return (
+      <Stack gap="600">
+        {states.map((state) => (
+          <Stack key={state.label} direction="column" gap="400">
+            <Text fontWeight="bold">{state.label}</Text>
+            {inputSize.map((size) => (
+              <Stack
+                key={size as string}
+                direction="row"
+                gap="400"
+                alignItems="flex-start"
+              >
+                {inputVariants.map((variant) => (
+                  <Box key={variant as string}>
+                    <NumberInput
+                      {...state.props}
+                      size={size}
+                      variant={variant}
+                      defaultValue={1234}
+                      aria-label={`${variant} ${size} ${state.label}`}
+                    />
+                  </Box>
+                ))}
+              </Stack>
             ))}
           </Stack>
-        </Box>
-      ))}
-    </Stack>
-  ),
+        ))}
+      </Stack>
+    );
+  },
 };
 
 export const LeadingAndTrailingElements: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const examples: Array<{
       label: string;

--- a/packages/nimbus/src/components/number-input/number-input.stories.tsx
+++ b/packages/nimbus/src/components/number-input/number-input.stories.tsx
@@ -189,13 +189,6 @@ export const NumberConstraints: Story = {
   ),
 };
 
-/**
- * Captures the keyboard-focus ring the matrix can't render (only one element
- * holds focus at a time). The increment/decrement steppers are excluded from the
- * tab order, so a single tab lands on the input and draws the `_focusWithin` ring
- * on the root. See docs/chromatic-visual-testing.md for why the caret is hidden
- * here.
- */
 export const Focused: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -206,8 +199,7 @@ export const Focused: Story = {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText("focused-number-input");
 
-    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
-    // caret-color inherits, so hiding it here cascades to the input.
+    // Hide the native caret (Chromatic can't pause its blink); caret-color inherits.
     canvasElement.style.caretColor = "transparent";
 
     await userEvent.tab();
@@ -216,13 +208,8 @@ export const Focused: Story = {
 };
 
 /**
- * Packs the interacting axes into one snapshot: state (default / disabled /
- * invalid / invalid & disabled) x size (md/sm) x variant (solid/ghost). No
- * colorPalette axis - the recipe hardcodes `neutral`. Every cell renders the
- * increment/decrement steppers, so their resting chrome is captured here too.
- * Focus (its own ring, dedicated `Focused` story) and read-only (no
- * `data-readonly` recipe rule, so it renders like the default) are deliberately
- * not in the matrix.
+ * Matrix: state x size x variant. No colorPalette axis (recipe hardcodes
+ * neutral); the steppers render in every cell.
  */
 export const SmokeTest: Story = {
   tags: ["vrt"],

--- a/packages/nimbus/src/components/password-input/password-input.stories.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.stories.tsx
@@ -35,8 +35,7 @@ export const Base: Story = {
       "Toggle is reachable by tab and operable with Enter/Space",
       async () => {
         const toggleButton = canvas.getByRole("button");
-        // Anchor focus on the input, then tab to prove the toggle is in the tab
-        // order (not force-focused), before exercising Enter/Space activation.
+        // Tab from the input to prove the toggle is in the tab order (not force-focused).
         input.focus();
         await userEvent.tab();
         await expect(toggleButton).toHaveFocus();
@@ -183,13 +182,9 @@ export const Controlled: Story = {
 };
 
 /**
- * PasswordInput is a thin wrapper over TextInput, so its size/variant/state chrome
- * and the input focus ring are TextInput's coverage. What's unique here is the
- * masked value and the trailing visibility toggle, whose size tracks the input
- * (md -> xs, sm -> 2xs). This matrix captures both at both sizes; variant is not
- * an axis (the toggle is always ghost/primary and the input chrome is
- * TextInput's), so it adds no password-specific signal. The revealed state
- * (plaintext + hide icon) needs an interaction, so it lives in `Revealed`.
+ * Thin wrapper over TextInput, so it snapshots only what it adds: the masked
+ * value + visibility toggle, at both sizes (the toggle tracks input size). Chrome
+ * is TextInput's coverage; variant isn't an axis. Revealed state is `Revealed`.
  */
 export const SmokeTest: Story = {
   tags: ["vrt"],
@@ -209,10 +204,8 @@ export const SmokeTest: Story = {
 };
 
 /**
- * The revealed state: clicking the toggle swaps type=password -> text (dots ->
- * plaintext) and the show icon -> hide icon. The play clicks the toggle, then
- * blurs so the toggle's focus ring (IconButton's own coverage) stays out of the
- * frame - this snapshot is only the unmasked value + hide icon.
+ * Revealed state (plaintext + hide icon). The play blurs after toggling so the
+ * toggle's focus ring (IconButton's coverage) stays out of the frame.
  */
 export const Revealed: Story = {
   tags: ["vrt"],

--- a/packages/nimbus/src/components/password-input/password-input.stories.tsx
+++ b/packages/nimbus/src/components/password-input/password-input.stories.tsx
@@ -31,14 +31,21 @@ export const Base: Story = {
       await userEvent.click(toggleButton);
       await expect(input).toHaveAttribute("type", "password");
     });
-    await step("Can toggle with keyboard (Enter/Space)", async () => {
-      const toggleButton = canvas.getByRole("button");
-      toggleButton.focus();
-      await userEvent.keyboard("{enter}");
-      await expect(input).toHaveAttribute("type", "text");
-      await userEvent.keyboard(" ");
-      await expect(input).toHaveAttribute("type", "password");
-    });
+    await step(
+      "Toggle is reachable by tab and operable with Enter/Space",
+      async () => {
+        const toggleButton = canvas.getByRole("button");
+        // Anchor focus on the input, then tab to prove the toggle is in the tab
+        // order (not force-focused), before exercising Enter/Space activation.
+        input.focus();
+        await userEvent.tab();
+        await expect(toggleButton).toHaveFocus();
+        await userEvent.keyboard("{enter}");
+        await expect(input).toHaveAttribute("type", "text");
+        await userEvent.keyboard(" ");
+        await expect(input).toHaveAttribute("type", "password");
+      }
+    );
   },
 };
 
@@ -172,5 +179,55 @@ export const Controlled: Story = {
       await expect(input).toHaveValue("");
       await expect(valueDisplay).toHaveTextContent("Current value:");
     });
+  },
+};
+
+/**
+ * PasswordInput is a thin wrapper over TextInput, so its size/variant/state chrome
+ * and the input focus ring are TextInput's coverage. What's unique here is the
+ * masked value and the trailing visibility toggle, whose size tracks the input
+ * (md -> xs, sm -> 2xs). This matrix captures both at both sizes; variant is not
+ * an axis (the toggle is always ghost/primary and the input chrome is
+ * TextInput's), so it adds no password-specific signal. The revealed state
+ * (plaintext + hide icon) needs an interaction, so it lives in `Revealed`.
+ */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack gap="600" align="flex-start">
+      {(["sm", "md"] as const).map((size) => (
+        <PasswordInput
+          key={size}
+          size={size}
+          defaultValue="hunter2"
+          aria-label={`password ${size}`}
+        />
+      ))}
+    </Stack>
+  ),
+};
+
+/**
+ * The revealed state: clicking the toggle swaps type=password -> text (dots ->
+ * plaintext) and the show icon -> hide icon. The play clicks the toggle, then
+ * blurs so the toggle's focus ring (IconButton's own coverage) stays out of the
+ * frame - this snapshot is only the unmasked value + hide icon.
+ */
+export const Revealed: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <PasswordInput defaultValue="hunter2" aria-label="revealed password" />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("revealed password");
+    const toggleButton = canvas.getByRole("button");
+
+    await userEvent.click(toggleButton);
+    await expect(input).toHaveAttribute("type", "text");
+
+    await userEvent.click(document.body);
   },
 };

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -207,12 +207,6 @@ export const Invalid: Story = {
   },
 };
 
-/**
- * Captures the keyboard-focus ring the matrix can't render (only one element
- * holds focus at a time). A bare TextInput has no trailing control, so one tab
- * lands on the input and draws the `_focusWithin` ring. See
- * docs/chromatic-visual-testing.md for why the caret is hidden here.
- */
 export const Focused: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -223,8 +217,7 @@ export const Focused: Story = {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText("focused-input");
 
-    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
-    // caret-color inherits, so hiding it here cascades to the input.
+    // Hide the native caret (Chromatic can't pause its blink); caret-color inherits.
     canvasElement.style.caretColor = "transparent";
 
     await userEvent.tab();
@@ -233,11 +226,8 @@ export const Focused: Story = {
 };
 
 /**
- * Packs the interacting axes into one snapshot: state (default / disabled /
- * invalid / invalid & disabled) x size (md/sm) x variant (solid/ghost). No
- * colorPalette axis - the recipe styles fixed semantic tokens, not a palette
- * variant. Focus (its own ring, `Focused`) and read-only (no `data-readonly`
- * rule, so it renders like the default) are deliberately not in the matrix.
+ * Matrix: state x size x variant. No colorPalette axis (recipe styles fixed
+ * semantic tokens, not a palette variant).
  */
 export const SmokeTest: Story = {
   tags: ["vrt"],
@@ -446,9 +436,8 @@ export const LeadingAndTrailingElements: Story = {
 };
 
 /**
- * RTL mirrors the leading/trailing adornment layout (icons swap sides), a
- * distinct visual captured nowhere else. `dir="rtl"` is set on a wrapping Box
- * (prop-driven), so this is a story rather than a Chromatic mode.
+ * RTL mirrors the adornment layout (icons swap sides) - a distinct visual,
+ * prop-driven so a story not a mode.
  */
 export const RTLSupport: Story = {
   tags: ["vrt"],

--- a/packages/nimbus/src/components/text-input/text-input.stories.tsx
+++ b/packages/nimbus/src/components/text-input/text-input.stories.tsx
@@ -35,6 +35,7 @@ export const Base: Story = {
     placeholder: "base text input",
     ["aria-label"]: "test-input",
   },
+  render: (args) => <TextInput {...args} data-testid="base-input" />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByLabelText("test-input");
@@ -45,6 +46,7 @@ export const Base: Story = {
 
     await step("Forwards data- & aria-attributes", async () => {
       await expect(input).toHaveAttribute("aria-label", "test-input");
+      await expect(input).toHaveAttribute("data-testid", "base-input");
     });
 
     await step("Is focusable with <tab> key", async () => {
@@ -205,7 +207,41 @@ export const Invalid: Story = {
   },
 };
 
+/**
+ * Captures the keyboard-focus ring the matrix can't render (only one element
+ * holds focus at a time). A bare TextInput has no trailing control, so one tab
+ * lands on the input and draws the `_focusWithin` ring. See
+ * docs/chromatic-visual-testing.md for why the caret is hidden here.
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <TextInput defaultValue="Focused text input" aria-label="focused-input" />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("focused-input");
+
+    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
+    // caret-color inherits, so hiding it here cascades to the input.
+    canvasElement.style.caretColor = "transparent";
+
+    await userEvent.tab();
+    await expect(input).toHaveFocus();
+  },
+};
+
+/**
+ * Packs the interacting axes into one snapshot: state (default / disabled /
+ * invalid / invalid & disabled) x size (md/sm) x variant (solid/ghost). No
+ * colorPalette axis - the recipe styles fixed semantic tokens, not a palette
+ * variant. Focus (its own ring, `Focused`) and read-only (no `data-readonly`
+ * rule, so it renders like the default) are deliberately not in the matrix.
+ */
 export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     onChange: fn(),
     ["aria-label"]: "test-input",
@@ -302,6 +338,8 @@ export const Controlled: Story = {
 };
 
 export const LeadingAndTrailingElements: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const examples: Array<{
       label: string;
@@ -407,7 +445,14 @@ export const LeadingAndTrailingElements: Story = {
   },
 };
 
+/**
+ * RTL mirrors the leading/trailing adornment layout (icons swap sides), a
+ * distinct visual captured nowhere else. `dir="rtl"` is set on a wrapping Box
+ * (prop-driven), so this is a story rather than a Chromatic mode.
+ */
 export const RTLSupport: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack direction="column" gap="400">


### PR DESCRIPTION
[P1 Nimbus - Batch 2 Audit - Text-entry inputs ](https://commercetools.atlassian.net/browse/FEC-1151)
Relates to: https://github.com/commercetools/nimbus/pull/1782 & https://github.com/commercetools/nimbus/pull/1695

**VRT components audited & tagged** (text-entry inputs)
  - MoneyInput (the reference/blueprint for the batch)
  - MultilineTextInput
  - NumberInput
  - PasswordInput
  - TextInput

  Each opts its `SmokeTest` matrix & a dedicated `Focused` story into snapshots, plus adornment/state stories where they add a distinct visual. Everything else stays behavioral (verified by play functions, not pixels).

  **Test-integrity fixes** to play functions so they assert what their labels claim (data-/aria forwarding, `MoneyInput` cross-currency formatting, `PasswordInput` keyboard toggle now tabs to the control instead of force-focusing).

  **Docs**: updated the VRT guidance (`chromatic-visual-testing.md`, `stories.md`, `writing-stories` skill) with three patterns this batch surfaced, a hardcoded/absent `colorPalette` axis, the read-only "renders identically → no
snapshot" case & non-button components that style pressed.

No changeset: all changes are in stories/docs, nothing consumer-facing ships.