### PR TITLE
fix(storybook): remove obsolete lazyBarrel:false override

### DIFF
--- a/packages/nimbus/.storybook/main.ts
+++ b/packages/nimbus/.storybook/main.ts
@@ -119,22 +119,6 @@ const config: StorybookConfig = {
                 },
               ],
       },
-      build: {
-        // Disable rolldown's lazy-barrel optimization (default-on since
-        // rolldown 1.1.0, shipped in vite 8.1.0). It drops a still-referenced
-        // binding re-exported through a `sideEffects:false` `export *` barrel —
-        // here the `CodeRoot` binding that `Code` re-exports — so the
-        // production Storybook bundle throws `ReferenceError: CodeRoot is not
-        // defined` at module-eval time, aborting story extraction.
-        // Upstream: rolldown/rolldown#9806, #9964, #9961.
-        // Remove once a fixed rolldown ships (the flag itself is slated for
-        // removal upstream).
-        rolldownOptions: {
-          experimental: {
-            lazyBarrel: false,
-          },
-        },
-      },
     });
   },
 };


### PR DESCRIPTION
> [!NOTE]
> **Removes the `lazyBarrel: false` Storybook override added in #1704.** The prod-Storybook crash it worked around (`ReferenceError: CodeRoot is not defined`) was a rolldown tree-shaking bug, now fixed upstream in **rolldown 1.1.5** — which this repo already ships via `vite@8.1.5`. The workaround is dead weight; removing it re-enables the `lazyBarrel` optimization. One-line change, no source/API/consumer impact.

## Background

#1704 disabled rolldown's `lazyBarrel` optimization to stop the production Storybook build from throwing `ReferenceError: CodeRoot is not defined` at module-eval time (which aborted Chromatic story extraction).

## Root cause (upstream)

Under `sideEffects: ["*.css"]` (every JS module eligible for elimination), `lazyBarrel` dropped the module that _defines_ `CodeRoot` while retaining `export const Code = CodeRoot` — violating the invariant _"keep the use → keep the definition."_ Tracked upstream as three faces of one bug: rolldown [#9806](https://github.com/rolldown/rolldown/issues/9806) / [#9964](https://github.com/rolldown/rolldown/issues/9964) / [#9961](https://github.com/rolldown/rolldown/issues/9961).

Fixed by rolldown [PR #10080](https://github.com/rolldown/rolldown/pull/10080), shipped in **rolldown 1.1.5** (2026-07-08). `vite@8.1.5` now resolves `rolldown@1.1.5`, so the fix is already in our toolchain.

## Change

Remove the `build.rolldownOptions.experimental.lazyBarrel = false` override in `packages/nimbus/.storybook/main.ts`. `lazyBarrel` returns to its default (on), restoring the optimization.

## Verification

Built the prod Storybook with `lazyBarrel` at its default on rolldown 1.1.5, then loaded the former crash victims (`DefaultPage`, `Drawer`, `Dialog`) in a real browser → **0 `ReferenceError`s**, all rendered.

## Related

- Supersedes #1730 (the structural barrel/import refactor) — no longer needed now that the bug is fixed upstream.
- Reverts the workaround from #1704.
