### PR TITLE
feat(item): add Item and ItemGroup row components

### DIFF
--- a/.changeset/add-item-component.md
+++ b/.changeset/add-item-component.md
@@ -5,18 +5,16 @@
 `Item`: new compound component for a horizontal content row — `Item.Root` with
 `.Header`, `.Media`, `.Content` (wrapping `.Title` and `.Description`),
 `.Actions`, and `.Footer`. Use it for settings rows, notification entries, and
-file/resource rows; it complements `Card` (a vertical container) and
-`List`/`Menu` (interactive, selectable collections).
+file/resource rows.
 
-- Presentational by default. Pass an `href` to `Item.Root` and the whole row
-  becomes an accessible link (keyboard-focusable, router-aware). Action controls
-  placed in `Item.Actions` stay independently operable and never trigger row
-  navigation.
-- `variant` (`plain` | `outline` | `subtle`) and `size` (`xs` | `sm` | `md`)
-  control the row's treatment and density. `Item.Media` has its own `variant`
+- Presentational by default. Pass an `href` to `Item.Root` to turn the whole row
+  into an accessible, router-aware link; controls in `Item.Actions` stay
+  independently operable and never trigger row navigation.
+- `variant` (`plain` | `outline` | `subtle`) and `size` (`xs` | `sm` | `md`) set
+  the row's treatment and density. `Item.Media` takes its own `variant`
   (`default` | `icon` | `image`) for icons, avatars, or thumbnails.
 
-`ItemGroup`: new component that stacks `Item` rows into a group —
+`ItemGroup`: new compound component that stacks `Item` rows into a group —
 `ItemGroup.Root` with `.Separator` for dividers between rows.
 
 Both components are **Beta**.

--- a/.changeset/add-item-component.md
+++ b/.changeset/add-item-component.md
@@ -1,0 +1,22 @@
+---
+"@commercetools/nimbus": minor
+---
+
+`Item`: new compound component for a horizontal content row — `Item.Root` with
+`.Header`, `.Media`, `.Content` (wrapping `.Title` and `.Description`),
+`.Actions`, and `.Footer`. Use it for settings rows, notification entries, and
+file/resource rows; it complements `Card` (a vertical container) and
+`List`/`Menu` (interactive, selectable collections).
+
+- Presentational by default. Pass an `href` to `Item.Root` and the whole row
+  becomes an accessible link (keyboard-focusable, router-aware). Action controls
+  placed in `Item.Actions` stay independently operable and never trigger row
+  navigation.
+- `variant` (`plain` | `outline` | `subtle`) and `size` (`xs` | `sm` | `md`)
+  control the row's treatment and density. `Item.Media` has its own `variant`
+  (`default` | `icon` | `image`) for icons, avatars, or thumbnails.
+
+`ItemGroup`: new component that stacks `Item` rows into a group —
+`ItemGroup.Root` with `.Separator` for dividers between rows.
+
+Both components are **Experimental**.

--- a/.changeset/add-item-component.md
+++ b/.changeset/add-item-component.md
@@ -19,4 +19,4 @@ file/resource rows; it complements `Card` (a vertical container) and
 `ItemGroup`: new component that stacks `Item` rows into a group —
 `ItemGroup.Root` with `.Separator` for dividers between rows.
 
-Both components are **Experimental**.
+Both components are **Beta**.

--- a/docs/file-type-guidelines/compound-components.md
+++ b/docs/file-type-guidelines/compound-components.md
@@ -236,6 +236,16 @@ AlertRoot.displayName = 'Alert.Root';
 This ensures consistent behavior across the design system and proper prop
 forwarding.
 
+> **Slot-context shortcut:** When a Root component renders _only_ a slot
+> component (no React Aria wrapper, no custom context provider), the
+> `withProvider` slot already owns the recipe context and handles variant
+> extraction internally. In that case the explicit `useSlotRecipe` /
+> `splitVariantProps` / `extractStyleProps` calls may be omitted — the slot
+> component does the work. `Item.Root` and `ItemGroup.Root` use this simplified
+> pattern. Prefer the full pattern when the Root wraps a React Aria component or
+> a custom context provider, since variant and style props must be split before
+> reaching those wrappers.
+
 ### Sub-Component Implementation
 
 Sub-components should support flexible composition and avoid hardcoding content:

--- a/openspec/changes/add-item-component/.openspec.yaml
+++ b/openspec/changes/add-item-component/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/add-item-component/design.md
+++ b/openspec/changes/add-item-component/design.md
@@ -1,0 +1,142 @@
+# Design: Item
+
+## Context
+
+`Item` is a **Tier 3 presentational compound** — layout, styling, and
+accessibility, with no data or runtime concerns. It fills the one container
+shape Nimbus lacks: a **horizontal content row** (leading media, a
+title/description column, trailing actions), as opposed to `Card` (a vertical
+content container) and `List`/`Menu` (interactive, selectable collections).
+
+The anatomy and the interactivity model are lifted from shadcn's **React Aria**
+`Item` variant and retrofitted to Nimbus conventions. The single most important
+decision it carries over is _restraint_: the row is presentational and only
+upgrades to a link — never a button, never a selection target.
+
+## Where Item sits among Nimbus containers
+
+```mermaid
+flowchart TB
+    Card["Card — vertical content container<br/>Root · Header · Body · Footer"]
+    Item["Item — horizontal content row<br/>Media · Content(Title/Description) · Actions"]
+    ListMenu["List / Menu — interactive, selectable collections"]
+    Card -. "different axis, not a replacement" .- Item
+    Item -. "not selectable; hand off to" .-> ListMenu
+```
+
+`Item` complements rather than competes: reach for `Card` when content stacks
+vertically as a self-contained block, for `Item` when it reads as a row in a
+set, and for `List`/`Menu` when rows must be selectable or navigable as a
+managed collection.
+
+## The crux: link-upgrade, and why not a button
+
+shadcn's React Aria `Item` integrates the framework in exactly one place:
+
+```tsx
+const Element = "href" in props ? LinkPrimitive : "div";
+```
+
+Nimbus adopts the same polymorphism, but sources the behavior from the `useLink`
+**hook** (`react-aria`) — the identical primitive `Nimbus`'s own `Link`
+component uses internally — rather than importing `react-aria-components`'
+`Link`, and rather than wrapping the row in Nimbus `<Link>`.
+
+```mermaid
+flowchart TD
+    A["Item.Root props"] --> B{"href present?"}
+    B -->|no| C["render &lt;div&gt;<br/>(pure presentational row)"]
+    B -->|yes| D["render &lt;a&gt; via useLink<br/>keyboard · press · focus-visible"]
+    D --> E["Item recipe stays authoritative on appearance"]
+```
+
+Two things this must NOT do, and why:
+
+- **No button / `onPress`-as-button mode.** A `<button>` wrapping the
+  title+description+media subtree announces the whole thing as one control, and
+  it makes the nested `Item.Actions` buttons invalid (`<button>` inside
+  `<button>`). Real actions are `Button`/`IconButton` placed in `Item.Actions`,
+  which keep an **independent focus order** from the row link. A link containing
+  action buttons is the tolerable, common composition; a button containing them
+  is not.
+- **No wrap in Nimbus `<Link>`.** The `Link` recipe carries link-specific
+  appearance (font color, underline) that would fight Item's recipe. Reusing the
+  `useLink` hook gives us the accessible link behavior while Item's own recipe
+  governs how the row looks.
+
+## Responsibilities & seams
+
+### `Item.Root` — the row envelope (compound provider)
+
+- **Owns:** the `nimbusItem` slot-recipe context every part reads; the flex row
+  layout (media · content · actions), plus optional header/footer bands; the
+  `variant`/`size` axes; the div↔`<a>` polymorphism and, in link mode, the
+  `useLink` behavior + focus-visible ring.
+- **Refuses to own:** the content of each part (crosses the seam as `children`);
+  selection state; the semantics of a _collection_ (that is the peer
+  `ItemGroup`, below).
+
+### The parts
+
+- **`Item.Media`** — a fixed, non-shrinking leading slot with its own `variant`
+  (`default | icon | image`) to size/shape icon vs avatar vs image content.
+  Decorative by default.
+- **`Item.Content` / `Item.Title` / `Item.Description`** — the vertical text
+  column; `Content` is the flex-growing middle, `Title` primary, `Description`
+  secondary.
+- **`Item.Actions`** — trailing slot for interactive controls; independent focus
+  order; the _only_ sanctioned home for row actions.
+- **`Item.Header` / `Item.Footer`** — optional full-width bands above/below the
+  row (shadcn parity).
+
+### `ItemGroup` — the standalone peer (separate component/folder)
+
+`ItemGroup` wraps `Item.Root` rows; it is a **parent** of the row, so it cannot
+be a `withContext` slot of `nimbusItem` (a context slot must live under the
+`Item.Root` provider). It is therefore its own component with its own
+`nimbusItemGroup` recipe:
+
+- **`ItemGroup.Root`** — a plain vertical stack container. It deliberately does
+  **not** set `role="list"`: a list role requires `listitem` children and
+  forbids separator children (`aria-required-children`), which free composition
+  can't guarantee.
+- **`ItemGroup.Separator`** — a horizontal divider (`role="separator"`, not a
+  focus stop) between rows.
+
+## Styling
+
+One `defineSlotRecipe` keyed `nimbusItem`, className `nimbus-item`, one slot per
+part, **design tokens only**. Registered in `src/theme/slot-recipes/index.ts`.
+
+- Root: `variant` = `plain | outline | subtle` (default `plain`); `size` =
+  `xs | sm | md` (default `md`, controlling padding/gap density).
+- Media: `variant` = `default | icon | image`.
+
+`outline`/`subtle` deliberately match the Nimbus-wide variant vocabulary
+(`button`, `avatar`, `code`, `toast`); `Card`'s `outlined`/`muted` is the
+outlier and is not touched here.
+
+## Accessibility (WCAG 2.1 AA)
+
+- Link-mode `Item.Root` is a genuine `<a>`: keyboard focusable, activates on
+  Enter, shows a recipe-driven focus-visible ring; navigation integrates with
+  the app router via `useLink`.
+- Row link and `Item.Actions` controls occupy distinct, independently reachable
+  focus stops — no nested-interactive trap. A capture-phase guard on the link
+  root cancels navigation when a click originates inside `Item.Actions`, so
+  nested controls (whose own React Aria press handling stops event propagation)
+  remain operable without navigating the row.
+- `Item.Media` is decorative unless the consumer names it.
+- `ItemGroup.Root` is a plain container (no `role="list"`, see above);
+  `ItemGroup.Separator` is `role="separator"` and not a focus stop.
+- Variant/size never encode meaning by color alone.
+
+## Usage notes
+
+- **Clickable row** → put `href` on `Item.Root`; do not also make the whole row
+  a button. Secondary per-row actions go in `Item.Actions`.
+- **List of rows** → wrap in `ItemGroup.Root` and interleave
+  `ItemGroup.Separator`.
+- **Selectable / navigable collection** → that is not `Item`; use `List`/`Menu`.
+- **Media** → supply your own `Icon`/`Avatar`/`Image` as `Item.Media` children;
+  set its `variant` to match.

--- a/openspec/changes/add-item-component/proposal.md
+++ b/openspec/changes/add-item-component/proposal.md
@@ -1,0 +1,149 @@
+# Change: Add the Item component
+
+## Why
+
+Nimbus has containers for **vertical** content (`Card`) and for **interactive,
+selectable** collections (`List`, `Menu`), but no primitive for the most common
+shape in dense product UI: a **horizontal content row** — leading media, a
+title/description column, and trailing actions. Consumers rebuild this layout ad
+hoc (settings rows, notification entries, file/resource rows, summary rows),
+each with slightly different spacing and alignment.
+
+shadcn's React Aria `Item` is a well-shaped reference for exactly this row
+primitive. Its React Aria variant integrates the framework in a single, precise
+way: the row is a plain `<div>` and **upgrades to an accessible link only when an
+`href` is present** (`const Element = "href" in props ? Link : "div"`). It never
+becomes a button and never owns selection — those concerns belong to nested
+`Button`s and to `List`/`Menu` respectively. That restraint is the right model
+for Nimbus and is the crux of this proposal.
+
+We adopt the shadcn anatomy in full (10 parts) and retrofit it to Nimbus
+conventions: a Chakra v3 slot recipe, the `useLink` react-aria hook (the same
+primitive Nimbus's own `Link` uses), and the compound `Item.*` namespace API
+that mirrors `Card`.
+
+## What Changes
+
+**Component:** `Item` (Tier 3 compound).
+**Package:** `@commercetools/nimbus`.
+**Category:** Layout / Data display.
+
+### 1. Compound anatomy — two peer components
+
+shadcn's parts split cleanly along a structural line: the parts that live
+*inside* a row share a styling context and belong to a compound `Item`; the
+parts that *wrap* rows (`ItemGroup`, `ItemSeparator`) are parents of the row and
+cannot share its context, so they are a separate peer component `ItemGroup`.
+This mirrors the Nimbus convention (e.g. `ChatMessage` vs `ChatMessageList`) and
+the documented compound-component rules.
+
+`Item` publishes a slot-recipe styling context that every in-row part reads,
+mirroring `Card`'s compound (dot-notation) form:
+
+```tsx
+<ItemGroup.Root>
+  <Item.Root href="/settings/profile">
+    <Item.Media variant="icon"><PersonIcon /></Item.Media>
+    <Item.Content>
+      <Item.Title>Profile</Item.Title>
+      <Item.Description>Name, avatar, and contact details</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton aria-label="Open"><ChevronRightIcon /></IconButton>
+    </Item.Actions>
+  </Item.Root>
+  <ItemGroup.Separator />
+  <Item.Root>…</Item.Root>
+</ItemGroup.Root>
+```
+
+- **`Item`** parts (share the row context): `Item.Root`, `Item.Header`,
+  `Item.Media`, `Item.Content`, `Item.Title`, `Item.Description`,
+  `Item.Actions`, `Item.Footer`. `Header`/`Footer` are optional bands
+  above/below the media+content+actions row.
+- **`ItemGroup`** (standalone peer that wraps rows): `ItemGroup.Root` (vertical
+  stack) and `ItemGroup.Separator` (divider between rows).
+
+### 2. Interactivity — link-upgrade only
+
+`Item.Root` renders a `<div>` by default. When `href` (plus optional link props:
+`target`, `rel`, routing props, `onPress`/`onClick`) is passed, it renders as an
+`<a>` whose accessible link behavior comes from the **`useLink` hook** from
+`react-aria` — the same primitive `Nimbus`'s `Link` uses internally. Item is
+**not** wrapped in Nimbus `<Link>` (whose own recipe would fight Item's);
+Item's recipe stays authoritative on appearance while `useLink` supplies
+keyboard, focus, and press semantics. Hover / focus-visible states are driven by
+the recipe.
+
+There is deliberately **no** button (`onPress`-as-button) mode and **no**
+selectable mode:
+
+- A row-as-button is semantically wrong (it announces the entire title +
+  description + media subtree as one control) and **invalidates the nested
+  action buttons** the component is designed to hold (`<button>` inside
+  `<button>`). Real actions live as `Button`/`IconButton` in `Item.Actions`.
+- Selection is `List`/`Menu`'s responsibility; duplicating it here would fork
+  that logic.
+
+### 3. Styling — one slot recipe, tokens only
+
+A single Chakra `defineSlotRecipe` keyed `nimbusItem` (className `nimbus-item`)
+with a slot per part. Design tokens only (spacing, colors, radii, typography) —
+no hard-coded values. Registered as `nimbusItem` in
+`src/theme/slot-recipes/index.ts`.
+
+- **`Item.Root`** axes: `variant` = `plain | outline | subtle` (default `plain`);
+  `size` = `xs | sm | md` (default `md`).
+- **`Item.Media`** axis: `variant` = `default | icon | image`.
+
+Naming note: `outline` and `subtle` are used deliberately. They match the
+Nimbus-wide variant vocabulary (`button`, `avatar`, `code`, `toast` all use
+`subtle`); `Card`'s `outlined`/`muted` spelling is the outlier and is **not**
+changed by this proposal.
+
+### 4. Accessibility (WCAG 2.1 AA)
+
+`Item.Group` exposes `role="list"` (and rows read as its items); a link-mode
+`Item.Root` is a real, keyboard-focusable `<a>` with a recipe-driven
+focus-visible ring; `Item.Media` is treated as decorative unless the consumer
+names it; nested action buttons retain an independent focus order distinct from
+the row link.
+
+## Out of scope
+
+- **Button / pressable row mode** and **selectable / multi-select rows** —
+  intentionally excluded (see §2); served by nested `Button`s and by
+  `List`/`Menu`.
+- **Changing `Card`'s `outlined`/`muted` variant names** to match `outline`/
+  `subtle` — separate scope.
+- **A batteries-included icon/avatar inside `Item.Media`** — `Media` is a layout
+  slot; the consumer supplies the `Icon`/`Avatar`/`Image`.
+
+## Rejected alternatives
+
+- **`onPress` button mode on `Item.Root`** — rejected: semantically wrong for a
+  multi-part content row and invalidates the nested `Item.Actions` buttons.
+- **Wrapping the row in Nimbus `<Link>`** — rejected: the `Link` recipe
+  (font color, underline) would conflict with Item's recipe; reusing the
+  `useLink` hook keeps Item's styling authoritative.
+- **Dropping `Header`/`Footer` for a leaner surface** — rejected: the user chose
+  full shadcn parity so consumers can add per-row header/footer bands.
+
+## Impact
+
+- **Two new capabilities: `nimbus-item` and `nimbus-item-group`.**
+- **New component** `packages/nimbus/src/components/item/` — namespace object,
+  per-part files under `components/`, types, recipe, slots, stories, docs.
+- **New component** `packages/nimbus/src/components/item-group/` — the standalone
+  `ItemGroup` peer (Root + Separator), its own types, recipe, slots, stories,
+  docs.
+- **Recipes** registered as `nimbusItem` and `nimbusItemGroup` in the theme.
+  `nimbusItem`: `variant` (`plain`/`outline`/`subtle`) + `size`
+  (`xs`/`sm`/`md`) on the root, media `variant` (`default`/`icon`/`image`) via a
+  `data-variant` attribute. `nimbusItemGroup`: `root` + `separator` slots.
+- **Barrel exports** `Item`, `ItemGroup`, and their public types from
+  `@commercetools/nimbus`.
+- Lifecycle **Experimental**; noted in the changeset.
+- Figma Code Connect deferred (no Figma design source; designed from the shadcn
+  React Aria reference).
+- No tokens-package changes.

--- a/openspec/changes/add-item-component/proposal.md
+++ b/openspec/changes/add-item-component/proposal.md
@@ -143,7 +143,7 @@ the row link.
   `data-variant` attribute. `nimbusItemGroup`: `root` + `separator` slots.
 - **Barrel exports** `Item`, `ItemGroup`, and their public types from
   `@commercetools/nimbus`.
-- Lifecycle **Experimental**; noted in the changeset.
+- Lifecycle **Beta**; noted in the changeset.
 - Figma Code Connect deferred (no Figma design source; designed from the shadcn
   React Aria reference).
 - No tokens-package changes.

--- a/openspec/changes/add-item-component/specs/nimbus-item-group/spec.md
+++ b/openspec/changes/add-item-component/specs/nimbus-item-group/spec.md
@@ -1,0 +1,76 @@
+# Specification: ItemGroup
+
+## Overview
+
+`ItemGroup` is a standalone presentational compound that lays a set of `Item`
+rows out as a vertical stack, with optional dividers between them. It is a
+**peer** of `Item` (it wraps `Item.Root` rows rather than nesting inside one),
+so it is its own component with its own recipe, not an `Item.*` part.
+
+Parts: `ItemGroup.Root` (the stack container) and `ItemGroup.Separator` (a
+horizontal divider between rows).
+
+**Component:** `ItemGroup`
+**Package:** `@commercetools/nimbus`
+**Category:** Layout / Data display
+
+## ADDED Requirements
+
+### Requirement: Group container
+
+`ItemGroup.Root` SHALL render a container that lays its child `Item` rows out as
+a full-width vertical stack, establishing the `nimbusItemGroup` styling context.
+
+#### Scenario: Wraps rows as a vertical stack
+
+- **WHEN** multiple `Item.Root` rows are wrapped in `ItemGroup.Root`
+- **THEN** the group SHALL render them stacked vertically at full width
+
+#### Scenario: No invalid list semantics
+
+- **WHEN** `ItemGroup.Root` is rendered
+- **THEN** it SHALL NOT assign `role="list"`, because a list role would require
+  every child to be a `listitem` and would forbid separator children
+  (`aria-required-children`), which the free-composition API cannot guarantee
+
+### Requirement: Group separator
+
+`ItemGroup.Separator` SHALL render a horizontal divider intended to sit between
+rows in an `ItemGroup.Root`, exposing `role="separator"` and not being a focus
+stop.
+
+#### Scenario: Divider between rows
+
+- **WHEN** `ItemGroup.Separator` is placed between two rows in an
+  `ItemGroup.Root`
+- **THEN** it SHALL render a full-width horizontal divider with
+  `role="separator"`
+- **AND** it SHALL NOT be a keyboard focus stop
+
+### Requirement: Grouped link rows
+
+`ItemGroup` SHALL support rows that are themselves links, so a group can present
+a set of navigable rows.
+
+#### Scenario: Group of link rows
+
+- **WHEN** an `ItemGroup.Root` contains multiple `Item.Root` rows each given an
+  `href`
+- **THEN** each row SHALL render as an independent accessible link within the
+  group
+
+### Requirement: Component registration and theming
+
+The component SHALL follow Nimbus structure, styling, and export conventions.
+
+#### Scenario: Slot recipe registration
+
+- **WHEN** the theme is assembled
+- **THEN** the component SHALL register a slot recipe as `nimbusItemGroup`
+  (slots `root` and `separator`)
+
+#### Scenario: Barrel export
+
+- **WHEN** consumers import from `@commercetools/nimbus`
+- **THEN** the package SHALL export `ItemGroup` and its public types from the
+  barrel

--- a/openspec/changes/add-item-component/specs/nimbus-item/spec.md
+++ b/openspec/changes/add-item-component/specs/nimbus-item/spec.md
@@ -1,0 +1,164 @@
+# Specification: Item
+
+## Overview
+
+`Item` is a Tier 3 presentational compound that lays out a **horizontal content
+row**: `Item.Root` (establishes the styling context and the row layout) plus
+`.Header`, `.Media`, `.Content` (wrapping `.Title` and `.Description`),
+`.Actions`, and `.Footer`. Laying multiple rows out as a set is the job of the
+separate, peer `ItemGroup` component (see the `nimbus-item-group` capability),
+not an `Item.*` part.
+
+`Item.Root` is presentational by default (`<div>`) and **upgrades to an
+accessible link** (`<a>` via the `react-aria` `useLink` hook) when an `href` is
+present. It has no button mode and no selection state; row actions live as
+nested controls in `.Actions`, and selectable/navigable collections are the
+responsibility of `List`/`Menu`. `variant` (`plain | outline | subtle`) and
+`size` (`xs | sm | md`) axes control the row's visual treatment and density;
+`Item.Media` carries its own `variant` (`default | icon | image`).
+
+**Component:** `Item` **Package:** `@commercetools/nimbus` **Category:** Layout
+/ Data display
+
+## ADDED Requirements
+
+### Requirement: Compound row layout
+
+The component SHALL expose a compound API — `Item.Root`, `Item.Header`,
+`Item.Media`, `Item.Content`, `Item.Title`, `Item.Description`, `Item.Actions`,
+`Item.Footer` — that lays out a single content row. `Item.Root` SHALL establish
+the `nimbusItem` styling context every part reads, and SHALL arrange media
+leading, the content column in the middle, and actions trailing, with optional
+header/footer bands above/below the row.
+
+#### Scenario: Render a row with all core parts
+
+- **WHEN** an `Item.Root` contains `Item.Media`, an `Item.Content` with
+  `Item.Title` and `Item.Description`, and an `Item.Actions`
+- **THEN** it SHALL render the media leading, the title above the description in
+  the middle column, and the actions trailing on the same row
+
+#### Scenario: Optional header and footer bands
+
+- **WHEN** an `Item.Root` includes `Item.Header` and/or `Item.Footer`
+- **THEN** the header SHALL render as a full-width band above the
+  media+content+actions row and the footer as a full-width band below it
+
+#### Scenario: Parts read the Root context
+
+- **WHEN** a part is rendered inside `Item.Root`
+- **THEN** it SHALL derive its styling from the `variant`/`size` published by
+  `Item.Root` without consumer prop-drilling
+
+### Requirement: Link-upgrade interactivity
+
+`Item.Root` SHALL render a non-interactive `<div>` by default, and SHALL render
+an accessible link (`<a>`) when an `href` is provided. Link behavior SHALL be
+supplied by the `useLink` hook from `react-aria` (the same primitive Nimbus's
+`Link` uses), while `Item`'s own recipe remains authoritative for appearance.
+`Item.Root` SHALL NOT provide a button/pressable-row mode and SHALL NOT own
+selection state.
+
+#### Scenario: Presentational by default
+
+- **WHEN** `Item.Root` is rendered without an `href`
+- **THEN** it SHALL render a `<div>` with no link/button role and no interactive
+  tab stop introduced by `Item.Root` itself
+
+#### Scenario: Upgrades to a link with href
+
+- **WHEN** `Item.Root` is given an `href`
+- **THEN** it SHALL render an `<a>` that is keyboard focusable, activates on
+  Enter, and shows a recipe-driven focus-visible ring
+- **AND** it SHALL forward link props (`target`, `rel`, `onPress`/`onClick`,
+  router props) to the underlying link
+
+#### Scenario: Actions remain independently operable inside a link row
+
+- **WHEN** an `Item.Root` with an `href` contains `Item.Actions` holding a
+  `Button`/`IconButton`
+- **THEN** the action control SHALL be a focus stop independent of the row link
+  and SHALL be operable without triggering row navigation
+
+#### Scenario: No row-as-button mode
+
+- **WHEN** a consumer needs the row to perform an action rather than navigate
+- **THEN** the component SHALL NOT offer a button role on `Item.Root`; the
+  action SHALL be expressed as a `Button`/`IconButton` inside `Item.Actions`
+
+### Requirement: Root variant and size
+
+`Item.Root` SHALL accept a `variant` of `"plain"` (default), `"outline"`, or
+`"subtle"`, and a `size` of `"xs"`, `"sm"`, or `"md"` (default `"md"`)
+controlling padding and gap density.
+
+#### Scenario: Visual variants
+
+- **WHEN** `variant="outline"` is set
+- **THEN** the row SHALL render a token-based border
+- **AND WHEN** `variant="subtle"` is set
+- **THEN** the row SHALL render a token-based subtle surface background
+- **AND WHEN** `variant="plain"` (default) is set
+- **THEN** the row SHALL render with no border and no filled surface
+
+#### Scenario: Density sizes
+
+- **WHEN** `size` is `"xs"`, `"sm"`, or `"md"`
+- **THEN** the row SHALL scale its padding and gap by the corresponding
+  token-based density step, with `"md"` as the default
+
+### Requirement: Media variants
+
+`Item.Media` SHALL accept a `variant` of `"default"`, `"icon"`, or `"image"`
+sizing and shaping its leading content, and SHALL be a fixed, non-shrinking
+slot.
+
+#### Scenario: Media content types
+
+- **WHEN** `Item.Media` is given `variant="icon"` with an icon child
+- **THEN** it SHALL size the icon for an inline row glyph
+- **AND WHEN** `variant="image"` is set with an image child
+- **THEN** it SHALL constrain the image to the row's media box
+- **AND** in all cases the media slot SHALL NOT shrink when the content column
+  grows
+
+### Requirement: Accessibility (WCAG 2.1 AA)
+
+The component SHALL be accessible by default. A link-mode row SHALL be a genuine
+accessible link; `Item.Media` SHALL be decorative unless named; and interactive
+affordances SHALL never be conveyed by color alone.
+
+#### Scenario: Decorative media not mislabelled
+
+- **WHEN** `Item.Media` contains a decorative glyph with no consumer-provided
+  name
+- **THEN** it SHALL be treated as decorative (`aria-hidden`) and SHALL NOT
+  inject a misleading generic label into the accessibility tree
+- **AND WHEN** the consumer provides an accessible name
+- **THEN** the media SHALL expose that name
+
+#### Scenario: Link affordance not color-only
+
+- **WHEN** an `Item.Root` is in link mode
+- **THEN** its interactive state (focus) SHALL be conveyed by a visible
+  focus-visible indicator, not by color change alone
+
+### Requirement: Component registration and theming
+
+The component SHALL follow Nimbus structure, styling, and export conventions.
+
+#### Scenario: Slot recipe registration
+
+- **WHEN** the theme is assembled
+- **THEN** the component SHALL register a slot recipe as `nimbusItem` (slots for
+  `root`, `header`, `media`, `content`, `title`, `description`, `actions`,
+  `footer`) with `variant` (`plain`/`outline`/`subtle`) and `size`
+  (`xs`/`sm`/`md`) on the root
+- **AND** `Item.Media`'s `variant` (`default`/`icon`/`image`) SHALL be applied
+  via a `data-variant` attribute the media slot targets, since it is independent
+  of the root's shared-context `variant`
+
+#### Scenario: Barrel export
+
+- **WHEN** consumers import from `@commercetools/nimbus`
+- **THEN** the package SHALL export `Item` and its public types from the barrel

--- a/openspec/changes/add-item-component/tasks.md
+++ b/openspec/changes/add-item-component/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Add the Item and ItemGroup components
+
+> **API note:** This change delivers **two peer components**:
+>
+> - **`Item`** (compound) — `Item.Root` (publishes the `nimbusItem` context) +
+>   `.Header`, `.Media`, `.Content` (wrapping `.Title` / `.Description`),
+>   `.Actions`, `.Footer`. Interactivity is **link-upgrade only**: `Item.Root`
+>   is a `<div>` that becomes an `<a>` (via the `react-aria` `useLink` hook)
+>   when `href` is present. No button mode, no selection; row actions are nested
+>   `Button`s in `.Actions`, and a capture-phase guard on the link root stops an
+>   action click from navigating the row.
+> - **`ItemGroup`** (compound, standalone peer) — `ItemGroup.Root` (vertical
+>   stack of rows) + `ItemGroup.Separator`. It wraps `Item.Root` rows (it is a
+>   parent, not a child), so it is its own component/folder, not `Item.Group`.
+
+## 1. Scaffold the `item/` component — DONE
+
+- [x] 1.1 Create `packages/nimbus/src/components/item/` mirroring `card/`.
+- [x] 1.2 `item.tsx` compound namespace `Item` (Root/Header/Media/Content/Title/
+      Description/Actions/Footer) + JSDoc + underscore raw exports.
+- [x] 1.3 Per-part files under `components/` + `components/index.ts`.
+- [x] 1.4 Barrel `index.ts`; exported from `components/index.ts` → package barrel.
+
+## 2. Failing Storybook tests first (TDD) — DONE
+
+- [x] 2.1–2.4 Authored `item.stories.tsx` play functions (static row; header/
+      footer; variant×size; media variants; link-mode `<a>` + keyboard; actions
+      independently operable without navigation).
+- [x] 2.5 Confirmed red against the shells before implementing.
+
+## 3–6. Implement `item/` — DONE
+
+- [x] 3. Types (`item.types.ts`) — slot + public props; Root link surface;
+      Media `variant`.
+- [x] 4. Recipe (`item.recipe.ts`) — `defineSlotRecipe` `nimbusItem`, 8 slots,
+      `variant` (`plain`/`outline`/`subtle`) + `size` (`xs`/`sm`/`md`) on root,
+      media `variant` via `data-variant`; registered in
+      `theme/slot-recipes/index.ts`; theme typings regenerated.
+- [x] 5. Slots (`item.slots.tsx`) — `withProvider` root, `withContext` rest.
+- [x] 6. Parts + link-upgrade (`item.root.tsx`) — `useLink` on `href`; static
+      `<div>` otherwise; capture-phase guard stops action-click navigation.
+
+## 7. Scaffold + implement the `item-group/` component — DONE
+
+- [x] 7.1 Create `packages/nimbus/src/components/item-group/` (own folder).
+- [x] 7.2 `item-group.tsx` compound namespace `ItemGroup` (Root/Separator) +
+      raw exports; `item-group.types.ts`; `item-group.slots.tsx`
+      (`withProvider` root, `withContext` separator).
+- [x] 7.3 Recipe `item-group.recipe.ts` — `defineSlotRecipe` `nimbusItemGroup`
+      (slots `root`, `separator`); `ItemGroup.Root` is a plain stack (no
+      `role="list"`); `ItemGroup.Separator` renders `role="separator"`.
+      Registered as `nimbusItemGroup`; theme typings regenerated.
+- [x] 7.4 `item-group.stories.tsx` play functions (grouped rows + separators;
+      grouped link rows); barrel + package-barrel export.
+
+## 8. Documentation — DONE
+
+- [x] 8.1 `item/` docs: `item.mdx`, `item.dev.mdx`, `item.a11y.mdx`,
+      `item.guidelines.mdx`, `item.docs.spec.tsx`.
+- [x] 8.2 `item-group/` docs: `item-group.mdx`, `item-group.dev.mdx`,
+      `item-group.a11y.mdx`, `item-group.guidelines.mdx`,
+      `item-group.docs.spec.tsx`.
+
+## 9. Figma Code Connect — DEFERRED
+
+- [ ] 9.1 `*.figma.tsx` deferred until a Figma design source exists (these
+      components were designed from the shadcn React Aria reference, not Figma).
+
+## 10. Verification
+
+- [x] 10.1 `typecheck:dev` — 0 errors.
+- [x] 10.2 `item` story tests pass (7/7) against source; `item-group` (2/2);
+      automatic axe checks pass; browser-stable across repeated runs.
+- [x] 10.3 `pnpm lint` (eslint) on both folders incl. docs — no errors.
+- [x] 10.4 Built-surface check: `pnpm --filter @commercetools/nimbus build`
+      succeeded; `pnpm test:storybook` passed against `dist` (item 7/7,
+      item-group 2/2); `item.docs.spec`/`item-group.docs.spec` pass (9 total).
+- [x] 10.5 Changeset added (`.changeset/add-item-component.md`, lifecycle
+      **Experimental**) describing `Item` and `ItemGroup` for consumers.

--- a/openspec/changes/add-item-component/tasks.md
+++ b/openspec/changes/add-item-component/tasks.md
@@ -76,4 +76,4 @@
       succeeded; `pnpm test:storybook` passed against `dist` (item 7/7,
       item-group 2/2); `item.docs.spec`/`item-group.docs.spec` pass (9 total).
 - [x] 10.5 Changeset added (`.changeset/add-item-component.md`, lifecycle
-      **Experimental**) describing `Item` and `ItemGroup` for consumers.
+      **Beta**) describing `Item` and `ItemGroup` for consumers.

--- a/packages/nimbus/src/components/index.ts
+++ b/packages/nimbus/src/components/index.ts
@@ -48,6 +48,8 @@ export * from "./card";
 export * from "./chat-message";
 export * from "./chat-message-list";
 export * from "./form-field";
+export * from "./item";
+export * from "./item-group";
 export * from "./icon";
 export * from "./inline-svg";
 export * from "./loading-spinner";

--- a/packages/nimbus/src/components/item-group/components/index.ts
+++ b/packages/nimbus/src/components/item-group/components/index.ts
@@ -1,0 +1,2 @@
+export { ItemGroupRoot } from "./item-group.root";
+export { ItemGroupSeparator } from "./item-group.separator";

--- a/packages/nimbus/src/components/item-group/components/item-group.root.tsx
+++ b/packages/nimbus/src/components/item-group/components/item-group.root.tsx
@@ -7,9 +7,14 @@ import type { ItemGroupRootProps } from "../item-group.types";
  * its own component rather than as an `Item.*` part and does not share the
  * row's styling context.
  *
- * No `role="list"` is applied: a list role would require every child to be a
- * `listitem` and forbid separator children, which free composition can't
- * guarantee.
+ * Exposes the grouping to assistive technology with `role="group"` rather than
+ * `role="list"`: a list role would require every child to be a `listitem` and
+ * forbid separator children, which free composition can't guarantee, whereas
+ * `group` signals that the rows belong together without constraining what they
+ * are. Give the group an accessible name with `aria-label`/`aria-labelledby`
+ * when the grouping isn't obvious from surrounding context — both pass
+ * straight through. The role is an overridable default; pass your own `role`
+ * to replace it.
  *
  * @supportsStyleProps
  */
@@ -17,7 +22,7 @@ export const ItemGroupRoot = (props: ItemGroupRootProps) => {
   const { ref: forwardedRef, children, ...restProps } = props;
 
   return (
-    <ItemGroupRootSlot ref={forwardedRef} {...restProps}>
+    <ItemGroupRootSlot ref={forwardedRef} role="group" {...restProps}>
       {children}
     </ItemGroupRootSlot>
   );

--- a/packages/nimbus/src/components/item-group/components/item-group.root.tsx
+++ b/packages/nimbus/src/components/item-group/components/item-group.root.tsx
@@ -1,0 +1,26 @@
+import { ItemGroupRootSlot } from "../item-group.slots";
+import type { ItemGroupRootProps } from "../item-group.types";
+
+/**
+ * ItemGroup.Root - A container that visually groups a set of `Item` rows into a
+ * vertical stack. It is a parent of `Item.Root` (not a child), so it lives in
+ * its own component rather than as an `Item.*` part and does not share the
+ * row's styling context.
+ *
+ * No `role="list"` is applied: a list role would require every child to be a
+ * `listitem` and forbid separator children, which free composition can't
+ * guarantee.
+ *
+ * @supportsStyleProps
+ */
+export const ItemGroupRoot = (props: ItemGroupRootProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemGroupRootSlot ref={forwardedRef} {...restProps}>
+      {children}
+    </ItemGroupRootSlot>
+  );
+};
+
+ItemGroupRoot.displayName = "ItemGroup.Root";

--- a/packages/nimbus/src/components/item-group/components/item-group.separator.tsx
+++ b/packages/nimbus/src/components/item-group/components/item-group.separator.tsx
@@ -1,0 +1,23 @@
+import { ItemGroupSeparatorSlot } from "../item-group.slots";
+import type { ItemGroupSeparatorProps } from "../item-group.types";
+
+/**
+ * ItemGroup.Separator - A horizontal divider between rows in an
+ * `ItemGroup.Root`. Exposes `role="separator"` and is not a focus stop.
+ *
+ * @supportsStyleProps
+ */
+export const ItemGroupSeparator = (props: ItemGroupSeparatorProps) => {
+  const { ref: forwardedRef, ...restProps } = props;
+
+  return (
+    <ItemGroupSeparatorSlot
+      ref={forwardedRef}
+      role="separator"
+      aria-orientation="horizontal"
+      {...restProps}
+    />
+  );
+};
+
+ItemGroupSeparator.displayName = "ItemGroup.Separator";

--- a/packages/nimbus/src/components/item-group/index.ts
+++ b/packages/nimbus/src/components/item-group/index.ts
@@ -1,0 +1,2 @@
+export * from "./item-group";
+export * from "./item-group.types";

--- a/packages/nimbus/src/components/item-group/index.ts
+++ b/packages/nimbus/src/components/item-group/index.ts
@@ -1,2 +1,2 @@
 export * from "./item-group";
-export * from "./item-group.types";
+export type * from "./item-group.types";

--- a/packages/nimbus/src/components/item-group/item-group.a11y.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.a11y.mdx
@@ -1,0 +1,74 @@
+---
+tab-title: Accessibility
+tab-order: 4
+---
+
+## Accessibility
+
+Accessibility ensures that digital content and functionality are usable by
+everyone, including people with disabilities, by addressing visual, auditory,
+cognitive, and physical limitations.
+
+### Why no `role="list"`
+
+The ARIA `list` role carries an `aria-required-children` constraint: every
+child must be a `listitem`, and no other content is permitted. `ItemGroup.Root`
+cannot guarantee that constraint — it composes freely with any mix of
+`Item.Root` rows and `ItemGroup.Separator` dividers — so applying
+`role="list"` would produce an invalid accessibility tree the moment a
+separator (or anything else) sits between rows. `ItemGroup.Root` therefore
+renders a plain, roleless `<div>`; each `Item.Root` keeps its own semantics (a
+plain row, or a link when given `href`) unaffected by the wrapper.
+
+```jsx live
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root href="#profile">
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root href="#settings">
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+);
+```
+
+### The separator is not a focus stop
+
+`ItemGroup.Separator` sets `role="separator"` and
+`aria-orientation="horizontal"`. It is a purely visual, static divider — it
+does not receive `tabIndex` and is not part of the focus order. This matches
+the [WAI-ARIA `separator` role](https://www.w3.org/TR/wai-aria-1.2/#separator):
+a separator is only focusable when it is also used to resize adjacent panes,
+which `ItemGroup.Separator` does not do here.
+
+### If you need a listbox instead
+
+If the rows are actually selectable options rather than a purely visual
+grouping, `ItemGroup` is not the right primitive — reach for a
+selection-aware component (e.g. `List`, `Menu`) that manages
+`listitem`/`option` semantics and keyboard navigation for you.
+
+### Accessibility standards
+
+- **Info and relationships:** `ItemGroup.Root` imposes no
+  `aria-required-children` constraint, so a mix of rows and separators stays a
+  valid accessibility tree.
+- **Name, role, value:** `ItemGroup.Separator` exposes `role="separator"` with
+  `aria-orientation="horizontal"`; it carries no accessible name because it
+  conveys no information beyond the visual divide.
+- **Focus order:** neither `ItemGroup.Root` nor `ItemGroup.Separator` is a
+  focus stop; keyboard focus moves directly between the interactive content
+  inside each `Item.Root` (or the row itself, when it is a link).
+- **Semantic HTML:** each `Item.Root` keeps its own role — a plain container,
+  or an `<a>` when given `href` — unaffected by the group.
+
+### Resources
+
+- [WAI-ARIA: `list` role](https://www.w3.org/TR/wai-aria-1.2/#list)
+- [WAI-ARIA: `separator` role](https://www.w3.org/TR/wai-aria-1.2/#separator)

--- a/packages/nimbus/src/components/item-group/item-group.a11y.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.a11y.mdx
@@ -9,20 +9,26 @@ Accessibility ensures that digital content and functionality are usable by
 everyone, including people with disabilities, by addressing visual, auditory,
 cognitive, and physical limitations.
 
-### Why no `role="list"`
+### Grouping role: `group`, not `list`
 
-The ARIA `list` role carries an `aria-required-children` constraint: every
-child must be a `listitem`, and no other content is permitted. `ItemGroup.Root`
-cannot guarantee that constraint — it composes freely with any mix of
-`Item.Root` rows and `ItemGroup.Separator` dividers — so applying
-`role="list"` would produce an invalid accessibility tree the moment a
-separator (or anything else) sits between rows. `ItemGroup.Root` therefore
-renders a plain, roleless `<div>`; each `Item.Root` keeps its own semantics (a
-plain row, or a link when given `href`) unaffected by the wrapper.
+`ItemGroup.Root` exposes its contents to assistive technology with
+`role="group"`, which signals that the rows belong together. It deliberately
+does **not** use `role="list"`: the ARIA `list` role carries an
+`aria-required-children` constraint — every child must be a `listitem`, and no
+other content is permitted — which `ItemGroup.Root` cannot guarantee, because
+it composes freely with any mix of `Item.Root` rows and `ItemGroup.Separator`
+dividers. `role="list"` would produce an invalid accessibility tree the moment
+a separator (or anything else) sits between rows; `role="group"` carries no
+such constraint, so each `Item.Root` keeps its own semantics (a plain row, or a
+link when given `href`) unaffected by the wrapper.
+
+Give the group an accessible name with `aria-label` or `aria-labelledby` when
+the grouping isn't clear from surrounding context. The role is an overridable
+default — pass your own `role` to replace it.
 
 ```jsx live
 const App = () => (
-  <ItemGroup.Root>
+  <ItemGroup.Root aria-label="Account">
     <Item.Root href="#profile">
       <Item.Content>
         <Item.Title>Profile</Item.Title>
@@ -56,11 +62,13 @@ selection-aware component (e.g. `List`, `Menu`) that manages
 
 ### Accessibility standards
 
-- **Info and relationships:** `ItemGroup.Root` imposes no
-  `aria-required-children` constraint, so a mix of rows and separators stays a
-  valid accessibility tree.
-- **Name, role, value:** `ItemGroup.Separator` exposes `role="separator"` with
-  `aria-orientation="horizontal"`; it carries no accessible name because it
+- **Info and relationships:** `ItemGroup.Root` exposes `role="group"` to tie
+  its rows together without an `aria-required-children` constraint, so a mix of
+  rows and separators stays a valid accessibility tree.
+- **Name, role, value:** `ItemGroup.Root` is a `group`; give it an accessible
+  name with `aria-label`/`aria-labelledby` when the grouping isn't clear from
+  context. `ItemGroup.Separator` exposes `role="separator"` with
+  `aria-orientation="horizontal"` and carries no accessible name, because it
   conveys no information beyond the visual divide.
 - **Focus order:** neither `ItemGroup.Root` nor `ItemGroup.Separator` is a
   focus stop; keyboard focus moves directly between the interactive content
@@ -70,5 +78,6 @@ selection-aware component (e.g. `List`, `Menu`) that manages
 
 ### Resources
 
+- [WAI-ARIA: `group` role](https://www.w3.org/TR/wai-aria-1.2/#group)
 - [WAI-ARIA: `list` role](https://www.w3.org/TR/wai-aria-1.2/#list)
 - [WAI-ARIA: `separator` role](https://www.w3.org/TR/wai-aria-1.2/#separator)

--- a/packages/nimbus/src/components/item-group/item-group.dev.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.dev.mdx
@@ -1,0 +1,140 @@
+---
+title: Item group component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import { Item, ItemGroup } from '@commercetools/nimbus';
+```
+
+### Basic usage
+
+`ItemGroup` is a compound component: wrap `Item.Root` rows in
+`ItemGroup.Root`, and place `ItemGroup.Separator` between the rows that should
+be visually divided.
+
+```jsx live-dev
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root>
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+)
+```
+
+## Usage examples
+
+### Rows with media and separators
+
+`ItemGroup.Root` does not restyle the rows it wraps — each `Item.Root` keeps
+its own `variant`/`size`. Use `ItemGroup.Separator` only between rows, never
+before the first or after the last.
+
+```jsx live-dev
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+        <Item.Description>Name, avatar, and contact details</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Notifications />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Notifications</Item.Title>
+        <Item.Description>Email and push preferences</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Settings />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+        <Item.Description>Workspace configuration</Item.Description>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+)
+```
+
+### Grouped link rows
+
+Give `Item.Root` an `href` to upgrade a row to an accessible link;
+`ItemGroup` composes with link rows the same way it composes with
+presentational ones.
+
+```jsx live-dev
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root href="#profile">
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root href="#settings">
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+)
+```
+
+## Component requirements
+
+- Place `ItemGroup.Separator` only _between_ `Item.Root` rows — never before
+  the first row or after the last.
+- `ItemGroup.Root` renders a plain `<div>` with no implicit `role`. It does not
+  set `role="list"` — see Accessibility for why — so it never constrains what
+  you place inside it.
+- `ItemGroup.Root` only affects layout (a vertical stack); it does not read or
+  override each row's own `variant`/`size`.
+
+## Accessibility
+
+`ItemGroup.Root` deliberately does not set `role="list"`: that role requires
+every child to be a `listitem` and forbids other content, such as a separator,
+which the free-composition API here can't guarantee. `ItemGroup.Separator`
+sets `role="separator"` and `aria-orientation="horizontal"`; it is a static,
+non-focusable divider. See the **Accessibility tab** for the full rationale.
+
+## API reference
+
+<PropsTable id="ItemGroup" />
+
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using
+ItemGroup within your application. As the component's internal functionality
+is already tested by Nimbus, these patterns help you verify your integration
+and application-specific logic.
+
+{{docs-tests: item-group.docs.spec.tsx}}
+
+## Resources
+
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-itemgroup--docs)

--- a/packages/nimbus/src/components/item-group/item-group.dev.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.dev.mdx
@@ -108,19 +108,22 @@ const App = () => (
 
 - Place `ItemGroup.Separator` only _between_ `Item.Root` rows — never before
   the first row or after the last.
-- `ItemGroup.Root` renders a plain `<div>` with no implicit `role`. It does not
-  set `role="list"` — see Accessibility for why — so it never constrains what
-  you place inside it.
+- `ItemGroup.Root` exposes its rows as a `role="group"` (an overridable
+  default). It does not set `role="list"` — see Accessibility for why — so it
+  never constrains what you place inside it.
 - `ItemGroup.Root` only affects layout (a vertical stack); it does not read or
   override each row's own `variant`/`size`.
 
 ## Accessibility
 
-`ItemGroup.Root` deliberately does not set `role="list"`: that role requires
-every child to be a `listitem` and forbids other content, such as a separator,
-which the free-composition API here can't guarantee. `ItemGroup.Separator`
-sets `role="separator"` and `aria-orientation="horizontal"`; it is a static,
-non-focusable divider. See the **Accessibility tab** for the full rationale.
+`ItemGroup.Root` exposes `role="group"` so assistive tech announces the rows as
+belonging together; give it a name with `aria-label`/`aria-labelledby` when the
+grouping isn't clear from context. It deliberately does not use `role="list"`:
+that role requires every child to be a `listitem` and forbids other content,
+such as a separator, which the free-composition API here can't guarantee.
+`ItemGroup.Separator` sets `role="separator"` and `aria-orientation="horizontal"`;
+it is a static, non-focusable divider. See the **Accessibility tab** for the
+full rationale.
 
 ## API reference
 

--- a/packages/nimbus/src/components/item-group/item-group.docs.spec.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.docs.spec.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Item, ItemGroup, NimbusProvider } from "@commercetools/nimbus";
+
+/**
+ * @docs-section basic-rendering
+ * @docs-title Basic Rendering Tests
+ * @docs-description Verify a group renders its rows and the separators between them
+ * @docs-order 1
+ */
+describe("ItemGroup - Basic rendering", () => {
+  it("renders each row's content", () => {
+    render(
+      <NimbusProvider>
+        <ItemGroup.Root>
+          <Item.Root>
+            <Item.Content>
+              <Item.Title>Profile</Item.Title>
+              <Item.Description>
+                Name, avatar, and contact details
+              </Item.Description>
+            </Item.Content>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root>
+            <Item.Content>
+              <Item.Title>Notifications</Item.Title>
+              <Item.Description>Email and push preferences</Item.Description>
+            </Item.Content>
+          </Item.Root>
+        </ItemGroup.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+  });
+
+  it("renders a separator between rows", () => {
+    render(
+      <NimbusProvider>
+        <ItemGroup.Root>
+          <Item.Root>
+            <Item.Content>
+              <Item.Title>Profile</Item.Title>
+            </Item.Content>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root>
+            <Item.Content>
+              <Item.Title>Settings</Item.Title>
+            </Item.Content>
+          </Item.Root>
+        </ItemGroup.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+
+  it("renders no implicit role on the group container", () => {
+    render(
+      <NimbusProvider>
+        <ItemGroup.Root data-testid="group">
+          <Item.Root>
+            <Item.Content>
+              <Item.Title>Profile</Item.Title>
+            </Item.Content>
+          </Item.Root>
+        </ItemGroup.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByTestId("group")).not.toHaveAttribute("role");
+  });
+});
+
+/**
+ * @docs-section grouped-link-rows
+ * @docs-title Grouped Link Rows
+ * @docs-description Item rows upgrade to accessible links when given an href, and ItemGroup composes with them the same way
+ * @docs-order 2
+ */
+describe("ItemGroup - Grouped link rows", () => {
+  it("renders each linked row as an accessible link", () => {
+    render(
+      <NimbusProvider>
+        <ItemGroup.Root>
+          <Item.Root href="#profile">
+            <Item.Content>
+              <Item.Title>Profile</Item.Title>
+            </Item.Content>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root href="#settings">
+            <Item.Content>
+              <Item.Title>Settings</Item.Title>
+            </Item.Content>
+          </Item.Root>
+        </ItemGroup.Root>
+      </NimbusProvider>
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", "#profile");
+    expect(links[1]).toHaveAttribute("href", "#settings");
+  });
+});

--- a/packages/nimbus/src/components/item-group/item-group.docs.spec.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.docs.spec.tsx
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
+import { Fragment, useEffect, useState } from "react";
 import { render, screen } from "@testing-library/react";
-import { Item, ItemGroup, NimbusProvider } from "@commercetools/nimbus";
+import userEvent from "@testing-library/user-event";
+import {
+  Item,
+  ItemGroup,
+  IconButton,
+  NimbusProvider,
+} from "@commercetools/nimbus";
+import { Delete } from "@commercetools/nimbus-icons";
 
 /**
  * @docs-section basic-rendering
@@ -57,22 +65,6 @@ describe("ItemGroup - Basic rendering", () => {
 
     expect(screen.getByRole("separator")).toBeInTheDocument();
   });
-
-  it("renders no implicit role on the group container", () => {
-    render(
-      <NimbusProvider>
-        <ItemGroup.Root data-testid="group">
-          <Item.Root>
-            <Item.Content>
-              <Item.Title>Profile</Item.Title>
-            </Item.Content>
-          </Item.Root>
-        </ItemGroup.Root>
-      </NimbusProvider>
-    );
-
-    expect(screen.getByTestId("group")).not.toHaveAttribute("role");
-  });
 });
 
 /**
@@ -105,5 +97,89 @@ describe("ItemGroup - Grouped link rows", () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute("href", "#profile");
     expect(links[1]).toHaveAttribute("href", "#settings");
+  });
+});
+
+/**
+ * @docs-section async-data
+ * @docs-title Async Data & State Management
+ * @docs-description Populate a group from data fetched after mount, interleave separators between rows, and update the group from a row action
+ * @docs-order 3
+ */
+describe("ItemGroup - Async data and state management", () => {
+  it("renders rows once data resolves and removes one via a row action", async () => {
+    const user = userEvent.setup();
+
+    type Resource = { id: string; title: string; description: string };
+
+    const fetchResources = (): Promise<Resource[]> =>
+      Promise.resolve([
+        { id: "spec", title: "Design spec", description: "PDF · 2.4 MB" },
+        { id: "assets", title: "Brand assets", description: "ZIP · 18 MB" },
+      ]);
+
+    const FileGroup = () => {
+      const [resources, setResources] = useState<Resource[] | null>(null);
+
+      useEffect(() => {
+        let active = true;
+        void fetchResources().then((data) => {
+          if (active) setResources(data);
+        });
+        return () => {
+          active = false;
+        };
+      }, []);
+
+      if (!resources) return <span>Loading files…</span>;
+
+      return (
+        <ItemGroup.Root aria-label="Files">
+          {resources.map((resource, index) => (
+            <Fragment key={resource.id}>
+              {index > 0 && <ItemGroup.Separator />}
+              <Item.Root>
+                <Item.Content>
+                  <Item.Title>{resource.title}</Item.Title>
+                  <Item.Description>{resource.description}</Item.Description>
+                </Item.Content>
+                <Item.Actions>
+                  <IconButton
+                    aria-label={`Remove ${resource.title}`}
+                    size="xs"
+                    variant="ghost"
+                    onPress={() =>
+                      setResources((prev) =>
+                        (prev ?? []).filter((item) => item.id !== resource.id)
+                      )
+                    }
+                  >
+                    <Delete />
+                  </IconButton>
+                </Item.Actions>
+              </Item.Root>
+            </Fragment>
+          ))}
+        </ItemGroup.Root>
+      );
+    };
+
+    render(
+      <NimbusProvider>
+        <FileGroup />
+      </NimbusProvider>
+    );
+
+    // Rows appear only after the async fetch resolves.
+    expect(await screen.findByText("Design spec")).toBeInTheDocument();
+    expect(screen.getByText("Brand assets")).toBeInTheDocument();
+
+    // A per-row action updates the group's state.
+    await user.click(
+      screen.getByRole("button", { name: "Remove Design spec" })
+    );
+
+    expect(screen.queryByText("Design spec")).not.toBeInTheDocument();
+    expect(screen.getByText("Brand assets")).toBeInTheDocument();
   });
 });

--- a/packages/nimbus/src/components/item-group/item-group.docs.spec.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.docs.spec.tsx
@@ -11,100 +11,10 @@ import {
 import { Delete } from "@commercetools/nimbus-icons";
 
 /**
- * @docs-section basic-rendering
- * @docs-title Basic Rendering Tests
- * @docs-description Verify a group renders its rows and the separators between them
- * @docs-order 1
- */
-describe("ItemGroup - Basic rendering", () => {
-  it("renders each row's content", () => {
-    render(
-      <NimbusProvider>
-        <ItemGroup.Root>
-          <Item.Root>
-            <Item.Content>
-              <Item.Title>Profile</Item.Title>
-              <Item.Description>
-                Name, avatar, and contact details
-              </Item.Description>
-            </Item.Content>
-          </Item.Root>
-          <ItemGroup.Separator />
-          <Item.Root>
-            <Item.Content>
-              <Item.Title>Notifications</Item.Title>
-              <Item.Description>Email and push preferences</Item.Description>
-            </Item.Content>
-          </Item.Root>
-        </ItemGroup.Root>
-      </NimbusProvider>
-    );
-
-    expect(screen.getByText("Profile")).toBeInTheDocument();
-    expect(screen.getByText("Notifications")).toBeInTheDocument();
-  });
-
-  it("renders a separator between rows", () => {
-    render(
-      <NimbusProvider>
-        <ItemGroup.Root>
-          <Item.Root>
-            <Item.Content>
-              <Item.Title>Profile</Item.Title>
-            </Item.Content>
-          </Item.Root>
-          <ItemGroup.Separator />
-          <Item.Root>
-            <Item.Content>
-              <Item.Title>Settings</Item.Title>
-            </Item.Content>
-          </Item.Root>
-        </ItemGroup.Root>
-      </NimbusProvider>
-    );
-
-    expect(screen.getByRole("separator")).toBeInTheDocument();
-  });
-});
-
-/**
- * @docs-section grouped-link-rows
- * @docs-title Grouped Link Rows
- * @docs-description Item rows upgrade to accessible links when given an href, and ItemGroup composes with them the same way
- * @docs-order 2
- */
-describe("ItemGroup - Grouped link rows", () => {
-  it("renders each linked row as an accessible link", () => {
-    render(
-      <NimbusProvider>
-        <ItemGroup.Root>
-          <Item.Root href="#profile">
-            <Item.Content>
-              <Item.Title>Profile</Item.Title>
-            </Item.Content>
-          </Item.Root>
-          <ItemGroup.Separator />
-          <Item.Root href="#settings">
-            <Item.Content>
-              <Item.Title>Settings</Item.Title>
-            </Item.Content>
-          </Item.Root>
-        </ItemGroup.Root>
-      </NimbusProvider>
-    );
-
-    const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(2);
-    expect(links[0]).toHaveAttribute("href", "#profile");
-    expect(links[1]).toHaveAttribute("href", "#settings");
-  });
-});
-
-/**
  * @docs-section async-data
  * @docs-title Async Data & State Management
  * @docs-description Populate a group from data fetched after mount, interleave separators between rows, and update the group from a row action
- * @docs-order 3
+ * @docs-order 1
  */
 describe("ItemGroup - Async data and state management", () => {
   it("renders rows once data resolves and removes one via a row action", async () => {

--- a/packages/nimbus/src/components/item-group/item-group.guidelines.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.guidelines.mdx
@@ -1,0 +1,107 @@
+---
+title: ItemGroup
+tab-title: Guidelines
+tab-order: 2
+---
+
+## Guidelines
+
+`ItemGroup` guidelines focus on using visual grouping and separators to signal
+that a set of `Item` rows belong to the same category, without changing how
+each row behaves on its own.
+
+### Best practices
+
+- **Group related rows only:** Put rows in the same `ItemGroup.Root` because
+  they belong to the same category or section — not simply because they sit
+  next to each other on the page.
+- **Use separators sparingly:** A separator signals a boundary between
+  subsections within the group. Don't add one between every row if the whole
+  group is already a single category.
+- **Don't restyle individual rows to compensate:** `ItemGroup.Root` only
+  stacks rows vertically; each `Item.Root` keeps its own `variant` and `size`.
+  Pick a consistent `variant`/`size` across the rows in a group rather than
+  varying it row-by-row.
+- **Keep rows self-contained:** Each `Item.Root` should make sense read on its
+  own — a group is a visual convenience, not a shared sentence split across
+  rows.
+
+### Usage
+
+> [!TIP]\
+> When to use
+
+- **A settings or preferences list:** A vertical stack of related,
+  individually navigable rows (Profile, Notifications, Settings…).
+- **A short list of linked resources:** Rows that each navigate elsewhere,
+  optionally divided into sections by separators.
+- **A summary list of key-value rows:** Presentational rows (no interaction)
+  that belong together, such as an order's line items.
+
+> [!CAUTION]\
+> When not to use
+
+- **Selectable options:** If a user needs to select one or more rows (a
+  listbox, a menu), use a selection-aware component instead — `ItemGroup` has
+  no selection state or keyboard navigation of its own.
+- **A single row:** If there's only one row, skip the group — it adds a
+  wrapper with no visual benefit.
+- **Unrelated content:** Don't reach for `ItemGroup` just to stack arbitrary
+  content vertically; use `Stack` for that and reserve `ItemGroup` for a set
+  of `Item` rows.
+
+```jsx live
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+        <Item.Description>Name, avatar, and contact details</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Notifications />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Notifications</Item.Title>
+        <Item.Description>Email and push preferences</Item.Description>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+);
+```
+
+### Composition
+
+Separators divide rows from each other — they don't set the group apart from
+its surroundings.
+
+> [!CAUTION]\
+> **Don't**
+>
+> - Don't lead or trail the group with a separator.
+> - Don't place two separators back-to-back — there's no row between them to
+>   divide.
+
+```jsx live
+const App = () => (
+  <ItemGroup.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root>
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+);
+```

--- a/packages/nimbus/src/components/item-group/item-group.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.mdx
@@ -5,7 +5,7 @@ exportName: ItemGroup
 description:
   A container that groups a set of Item rows into a vertical stack, with
   optional dividers between them.
-lifecycleState: Experimental
+lifecycleState: Beta
 order: 999
 menu:
   - Components

--- a/packages/nimbus/src/components/item-group/item-group.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.mdx
@@ -34,13 +34,15 @@ as its own component instead of an `Item.*` part.
 - `ItemGroup.Separator` — a horizontal divider placed between rows.
 
 Grouping is purely visual: `ItemGroup.Root` does not impose a list semantic on
-its children, so any mix of presentational and linked `Item.Root` rows —
-divided by as many or as few separators as needed — is valid. See the
-**Accessibility tab** for why no `role="list"` is applied.
+its children, so any mix of presentational and linked `Item.Root` rows — divided
+by as many or as few separators as needed — is valid. See the **Accessibility
+tab** for why no `role="list"` is applied.
 
 ### Resources
 
 Deep dive into implementation details and access the Nimbus design library.
+
+[Figma library](https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?m=dev)
 
 ## Variables
 

--- a/packages/nimbus/src/components/item-group/item-group.mdx
+++ b/packages/nimbus/src/components/item-group/item-group.mdx
@@ -1,0 +1,111 @@
+---
+id: Components-ItemGroup
+title: Item group
+exportName: ItemGroup
+description:
+  A container that groups a set of Item rows into a vertical stack, with
+  optional dividers between them.
+lifecycleState: Experimental
+order: 999
+menu:
+  - Components
+  - Data Display
+  - Item group
+tags:
+  - component
+  - item-group
+  - group
+  - list
+  - container
+  - rows
+  - separator
+---
+
+## Overview
+
+`ItemGroup` visually groups a set of `Item` rows into a single vertical stack,
+with an optional divider between rows. It is a **peer** of `Item` — it wraps
+`Item.Root` rows from the outside rather than nesting inside one — so it ships
+as its own component instead of an `Item.*` part.
+
+- `ItemGroup.Root` — the container. Lays its children out as a vertical stack;
+  it does not add spacing or a border of its own beyond the rows placed inside
+  it.
+- `ItemGroup.Separator` — a horizontal divider placed between rows.
+
+Grouping is purely visual: `ItemGroup.Root` does not impose a list semantic on
+its children, so any mix of presentational and linked `Item.Root` rows —
+divided by as many or as few separators as needed — is valid. See the
+**Accessibility tab** for why no `role="list"` is applied.
+
+### Resources
+
+Deep dive into implementation details and access the Nimbus design library.
+
+## Variables
+
+Get familiar with the features.
+
+### Rows with separators
+
+Place `ItemGroup.Separator` between rows to divide related but distinct pieces
+of information within the group.
+
+```jsx live
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+        <Item.Description>Name, avatar, and contact details</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Notifications />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Notifications</Item.Title>
+        <Item.Description>Email and push preferences</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root>
+      <Item.Media variant="icon">
+        <Icons.Settings />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+        <Item.Description>Workspace configuration</Item.Description>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+);
+```
+
+### Grouped navigation rows
+
+Rows can be links (`Item.Root href="..."`) just as easily as static rows; the
+group divides them the same way either way.
+
+```jsx live
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root href="#profile">
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root href="#settings">
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+);
+```

--- a/packages/nimbus/src/components/item-group/item-group.recipe.ts
+++ b/packages/nimbus/src/components/item-group/item-group.recipe.ts
@@ -4,11 +4,11 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * Recipe configuration for the ItemGroup component.
  *
  * `ItemGroup.Root` lays a set of `Item` rows out as a vertical stack;
- * `ItemGroup.Separator` is a horizontal divider between rows. The group is a
- * plain container and deliberately does **not** assign `role="list"` — a list
- * role would require every child to be a `listitem` and would forbid separator
- * children (`aria-required-children`), which the free-composition API cannot
- * guarantee.
+ * `ItemGroup.Separator` is a horizontal divider between rows. The group carries
+ * `role="group"` (set in the component, not here) and deliberately does **not**
+ * assign `role="list"` — a list role would require every child to be a
+ * `listitem` and would forbid separator children (`aria-required-children`),
+ * which the free-composition API cannot guarantee.
  */
 export const itemGroupSlotRecipe = defineSlotRecipe({
   slots: ["root", "separator"],

--- a/packages/nimbus/src/components/item-group/item-group.recipe.ts
+++ b/packages/nimbus/src/components/item-group/item-group.recipe.ts
@@ -1,0 +1,35 @@
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
+
+/**
+ * Recipe configuration for the ItemGroup component.
+ *
+ * `ItemGroup.Root` lays a set of `Item` rows out as a vertical stack;
+ * `ItemGroup.Separator` is a horizontal divider between rows. The group is a
+ * plain container and deliberately does **not** assign `role="list"` — a list
+ * role would require every child to be a `listitem` and would forbid separator
+ * children (`aria-required-children`), which the free-composition API cannot
+ * guarantee.
+ */
+export const itemGroupSlotRecipe = defineSlotRecipe({
+  slots: ["root", "separator"],
+
+  className: "nimbus-item-group",
+
+  base: {
+    root: {
+      display: "flex",
+      flexDirection: "column",
+      width: "100%",
+    },
+    // Mirrors the Nimbus Separator's horizontal treatment so grouped dividers
+    // read identically to standalone ones.
+    separator: {
+      colorPalette: "neutral",
+      border: "0",
+      flexShrink: "0",
+      width: "100%",
+      height: "25",
+      backgroundColor: "colorPalette.6",
+    },
+  },
+});

--- a/packages/nimbus/src/components/item-group/item-group.slots.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.slots.tsx
@@ -1,0 +1,30 @@
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "../../type-utils/slot-types";
+import type {
+  ItemGroupRootSlotProps,
+  ItemGroupSeparatorSlotProps,
+} from "./item-group.types";
+
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusItemGroup",
+});
+
+/**
+ * Root slot — provides the `nimbusItemGroup` styling context and lays the
+ * grouped rows out as a vertical stack.
+ */
+export const ItemGroupRootSlot: SlotComponent<
+  HTMLDivElement,
+  ItemGroupRootSlotProps
+> = withProvider<HTMLDivElement, ItemGroupRootSlotProps>("div", "root");
+
+/**
+ * Separator slot — a horizontal divider between grouped rows.
+ */
+export const ItemGroupSeparatorSlot: SlotComponent<
+  HTMLDivElement,
+  ItemGroupSeparatorSlotProps
+> = withContext<HTMLDivElement, ItemGroupSeparatorSlotProps>(
+  "div",
+  "separator"
+);

--- a/packages/nimbus/src/components/item-group/item-group.stories.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Item, ItemGroup } from "@commercetools/nimbus";
+import { Person, Settings, Notifications } from "@commercetools/nimbus-icons";
+import { within, expect } from "storybook/test";
+
+const meta: Meta<typeof ItemGroup.Root> = {
+  title: "Components/ItemGroup",
+  component: ItemGroup.Root,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ItemGroup.Root>;
+
+/**
+ * Base — a group of Item rows divided by separators.
+ */
+export const Base: Story = {
+  render: () => (
+    <ItemGroup.Root data-testid="group">
+      <Item.Root>
+        <Item.Media variant="icon">
+          <Person />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Profile</Item.Title>
+          <Item.Description>Name, avatar, and contact details</Item.Description>
+        </Item.Content>
+      </Item.Root>
+      <ItemGroup.Separator />
+      <Item.Root>
+        <Item.Media variant="icon">
+          <Notifications />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Notifications</Item.Title>
+          <Item.Description>Email and push preferences</Item.Description>
+        </Item.Content>
+      </Item.Root>
+      <ItemGroup.Separator />
+      <Item.Root>
+        <Item.Media variant="icon">
+          <Settings />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Settings</Item.Title>
+          <Item.Description>Workspace configuration</Item.Description>
+        </Item.Content>
+      </Item.Root>
+    </ItemGroup.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Group wraps all its rows", async () => {
+      const group = canvas.getByTestId("group");
+      await expect(group).toBeInTheDocument();
+      await expect(within(group).getByText("Profile")).toBeInTheDocument();
+      await expect(
+        within(group).getByText("Notifications")
+      ).toBeInTheDocument();
+      await expect(within(group).getByText("Settings")).toBeInTheDocument();
+    });
+
+    await step("Renders separators between rows", async () => {
+      await expect(canvas.getAllByRole("separator")).toHaveLength(2);
+    });
+  },
+};
+
+/**
+ * Grouped link rows — each row navigates; the group divides them.
+ */
+export const LinkRows: Story = {
+  render: () => (
+    <ItemGroup.Root data-testid="group">
+      <Item.Root href="#profile">
+        <Item.Content>
+          <Item.Title>Profile</Item.Title>
+        </Item.Content>
+      </Item.Root>
+      <ItemGroup.Separator />
+      <Item.Root href="#settings">
+        <Item.Content>
+          <Item.Title>Settings</Item.Title>
+        </Item.Content>
+      </Item.Root>
+    </ItemGroup.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Each row is an accessible link", async () => {
+      const links = canvas.getAllByRole("link");
+      await expect(links).toHaveLength(2);
+      await expect(links[0]).toHaveAttribute("href", "#profile");
+      await expect(links[1]).toHaveAttribute("href", "#settings");
+    });
+  },
+};

--- a/packages/nimbus/src/components/item-group/item-group.stories.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.stories.tsx
@@ -4,7 +4,7 @@ import { Person, Settings, Notifications } from "@commercetools/nimbus-icons";
 import { within, expect } from "storybook/test";
 
 const meta: Meta<typeof ItemGroup.Root> = {
-  title: "Components/ItemGroup",
+  title: "Components/Item/ItemGroup",
   component: ItemGroup.Root,
 };
 

--- a/packages/nimbus/src/components/item-group/item-group.stories.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof ItemGroup.Root>;
  */
 export const Base: Story = {
   render: () => (
-    <ItemGroup.Root data-testid="group">
+    <ItemGroup.Root data-testid="group" aria-label="Account">
       <Item.Root>
         <Item.Media variant="icon">
           <Person />
@@ -60,6 +60,13 @@ export const Base: Story = {
         within(group).getByText("Notifications")
       ).toBeInTheDocument();
       await expect(within(group).getByText("Settings")).toBeInTheDocument();
+    });
+
+    await step("Exposes the rows as a named group to AT", async () => {
+      // role="group" gives assistive tech a grouping signal without imposing
+      // listitem requirements; aria-label passes straight through as its name.
+      const group = canvas.getByRole("group", { name: "Account" });
+      await expect(group).toBe(canvas.getByTestId("group"));
     });
 
     await step("Renders separators between rows", async () => {

--- a/packages/nimbus/src/components/item-group/item-group.stories.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.stories.tsx
@@ -16,8 +16,9 @@ type Story = StoryObj<typeof ItemGroup.Root>;
  * Base — a group of Item rows divided by separators.
  */
 export const Base: Story = {
+  tags: ["vrt"],
   render: () => (
-    <ItemGroup.Root data-testid="group" aria-label="Account">
+    <ItemGroup.Root aria-label="Account">
       <Item.Root>
         <Item.Media variant="icon">
           <Person />
@@ -53,7 +54,7 @@ export const Base: Story = {
     const canvas = within(canvasElement);
 
     await step("Group wraps all its rows", async () => {
-      const group = canvas.getByTestId("group");
+      const group = canvas.getByRole("group", { name: "Account" });
       await expect(group).toBeInTheDocument();
       await expect(within(group).getByText("Profile")).toBeInTheDocument();
       await expect(
@@ -66,7 +67,7 @@ export const Base: Story = {
       // role="group" gives assistive tech a grouping signal without imposing
       // listitem requirements; aria-label passes straight through as its name.
       const group = canvas.getByRole("group", { name: "Account" });
-      await expect(group).toBe(canvas.getByTestId("group"));
+      await expect(group).toBeInTheDocument();
     });
 
     await step("Renders separators between rows", async () => {
@@ -80,7 +81,7 @@ export const Base: Story = {
  */
 export const LinkRows: Story = {
   render: () => (
-    <ItemGroup.Root data-testid="group">
+    <ItemGroup.Root>
       <Item.Root href="#profile">
         <Item.Content>
           <Item.Title>Profile</Item.Title>

--- a/packages/nimbus/src/components/item-group/item-group.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.tsx
@@ -1,0 +1,40 @@
+import { ItemGroupRoot, ItemGroupSeparator } from "./components";
+
+/**
+ * ItemGroup
+ * ============================================================
+ * A standalone container that groups a set of `Item` rows into a vertical
+ * stack, with optional dividers between them. It is a **peer** of `Item` (it
+ * wraps `Item.Root` rows rather than nesting inside one), so it is its own
+ * component rather than an `Item.*` part.
+ *
+ * @see {@link https://nimbus-documentation.vercel.app/components/data-display/item-group}
+ *
+ * @example
+ * ```tsx
+ * <ItemGroup.Root>
+ *   <Item.Root>…</Item.Root>
+ *   <ItemGroup.Separator />
+ *   <Item.Root>…</Item.Root>
+ * </ItemGroup.Root>
+ * ```
+ */
+export const ItemGroup = {
+  /**
+   * # ItemGroup.Root
+   *
+   * The container that lays grouped `Item` rows out as a vertical stack.
+   */
+  Root: ItemGroupRoot,
+  /**
+   * # ItemGroup.Separator
+   *
+   * A horizontal divider placed between rows in an `ItemGroup.Root`.
+   */
+  Separator: ItemGroupSeparator,
+};
+
+export {
+  ItemGroupRoot as _ItemGroupRoot,
+  ItemGroupSeparator as _ItemGroupSeparator,
+};

--- a/packages/nimbus/src/components/item-group/item-group.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.tsx
@@ -24,12 +24,33 @@ export const ItemGroup = {
    * # ItemGroup.Root
    *
    * The container that lays grouped `Item` rows out as a vertical stack.
+   * Exposes the grouping to assistive technology with `role="group"`; give it
+   * an accessible name with `aria-label`/`aria-labelledby` when the grouping
+   * isn't obvious from surrounding context.
+   *
+   * @example
+   * ```tsx
+   * <ItemGroup.Root aria-label="Account settings">
+   *   <Item.Root>…</Item.Root>
+   *   <ItemGroup.Separator />
+   *   <Item.Root>…</Item.Root>
+   * </ItemGroup.Root>
+   * ```
    */
   Root: ItemGroupRoot,
   /**
    * # ItemGroup.Separator
    *
    * A horizontal divider placed between rows in an `ItemGroup.Root`.
+   *
+   * @example
+   * ```tsx
+   * <ItemGroup.Root>
+   *   <Item.Root>…</Item.Root>
+   *   <ItemGroup.Separator />
+   *   <Item.Root>…</Item.Root>
+   * </ItemGroup.Root>
+   * ```
    */
   Separator: ItemGroupSeparator,
 };

--- a/packages/nimbus/src/components/item-group/item-group.types.ts
+++ b/packages/nimbus/src/components/item-group/item-group.types.ts
@@ -1,0 +1,26 @@
+import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type { HTMLChakraProps } from "@chakra-ui/react/styled-system";
+
+// ============================================================
+// SLOT PROPS
+// ============================================================
+
+export type ItemGroupRootSlotProps = HTMLChakraProps<"div">;
+export type ItemGroupSeparatorSlotProps = HTMLChakraProps<"div">;
+
+// ============================================================
+// MAIN PROPS
+// ============================================================
+
+/** Props for the `ItemGroup.Root` component. */
+export type ItemGroupRootProps = OmitInternalProps<ItemGroupRootSlotProps> & {
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+  [key: `data-${string}`]: unknown;
+};
+
+/** Props for the `ItemGroup.Separator` component. */
+export type ItemGroupSeparatorProps =
+  OmitInternalProps<ItemGroupSeparatorSlotProps> & {
+    ref?: React.Ref<HTMLDivElement>;
+  };

--- a/packages/nimbus/src/components/item/components/index.ts
+++ b/packages/nimbus/src/components/item/components/index.ts
@@ -1,0 +1,8 @@
+export { ItemRoot } from "./item.root";
+export { ItemHeader } from "./item.header";
+export { ItemMedia } from "./item.media";
+export { ItemContent } from "./item.content";
+export { ItemTitle } from "./item.title";
+export { ItemDescription } from "./item.description";
+export { ItemActions } from "./item.actions";
+export { ItemFooter } from "./item.footer";

--- a/packages/nimbus/src/components/item/components/item.actions.tsx
+++ b/packages/nimbus/src/components/item/components/item.actions.tsx
@@ -1,0 +1,23 @@
+import { ItemActionsSlot } from "../item.slots";
+import type { ItemActionsProps } from "../item.types";
+
+/**
+ * Item.Actions - Trailing slot for interactive controls (Button, IconButton).
+ *
+ * Controls placed here keep a focus order independent of a link-mode
+ * `Item.Root`, and — via the `data-item-actions` marker that a link-mode root
+ * watches for — activate without triggering row navigation.
+ *
+ * @supportsStyleProps
+ */
+export const ItemActions = (props: ItemActionsProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemActionsSlot ref={forwardedRef} data-item-actions="" {...restProps}>
+      {children}
+    </ItemActionsSlot>
+  );
+};
+
+ItemActions.displayName = "Item.Actions";

--- a/packages/nimbus/src/components/item/components/item.content.tsx
+++ b/packages/nimbus/src/components/item/components/item.content.tsx
@@ -1,0 +1,20 @@
+import { ItemContentSlot } from "../item.slots";
+import type { ItemContentProps } from "../item.types";
+
+/**
+ * Item.Content - The growing middle column that wraps Item.Title and
+ * Item.Description.
+ *
+ * @supportsStyleProps
+ */
+export const ItemContent = (props: ItemContentProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemContentSlot ref={forwardedRef} {...restProps}>
+      {children}
+    </ItemContentSlot>
+  );
+};
+
+ItemContent.displayName = "Item.Content";

--- a/packages/nimbus/src/components/item/components/item.description.tsx
+++ b/packages/nimbus/src/components/item/components/item.description.tsx
@@ -1,0 +1,19 @@
+import { ItemDescriptionSlot } from "../item.slots";
+import type { ItemDescriptionProps } from "../item.types";
+
+/**
+ * Item.Description - Secondary text below the title.
+ *
+ * @supportsStyleProps
+ */
+export const ItemDescription = (props: ItemDescriptionProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemDescriptionSlot ref={forwardedRef} {...restProps}>
+      {children}
+    </ItemDescriptionSlot>
+  );
+};
+
+ItemDescription.displayName = "Item.Description";

--- a/packages/nimbus/src/components/item/components/item.footer.tsx
+++ b/packages/nimbus/src/components/item/components/item.footer.tsx
@@ -1,0 +1,19 @@
+import { ItemFooterSlot } from "../item.slots";
+import type { ItemFooterProps } from "../item.types";
+
+/**
+ * Item.Footer - Optional full-width band rendered below the row.
+ *
+ * @supportsStyleProps
+ */
+export const ItemFooter = (props: ItemFooterProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemFooterSlot ref={forwardedRef} {...restProps}>
+      {children}
+    </ItemFooterSlot>
+  );
+};
+
+ItemFooter.displayName = "Item.Footer";

--- a/packages/nimbus/src/components/item/components/item.header.tsx
+++ b/packages/nimbus/src/components/item/components/item.header.tsx
@@ -1,0 +1,19 @@
+import { ItemHeaderSlot } from "../item.slots";
+import type { ItemHeaderProps } from "../item.types";
+
+/**
+ * Item.Header - Optional full-width band rendered above the row.
+ *
+ * @supportsStyleProps
+ */
+export const ItemHeader = (props: ItemHeaderProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemHeaderSlot ref={forwardedRef} {...restProps}>
+      {children}
+    </ItemHeaderSlot>
+  );
+};
+
+ItemHeader.displayName = "Item.Header";

--- a/packages/nimbus/src/components/item/components/item.media.tsx
+++ b/packages/nimbus/src/components/item/components/item.media.tsx
@@ -1,0 +1,32 @@
+import { ItemMediaSlot } from "../item.slots";
+import type { ItemMediaProps } from "../item.types";
+
+/**
+ * Item.Media - Fixed, non-shrinking leading slot for an icon, avatar, or image.
+ *
+ * `variant` (`default | icon | image`) sizes and shapes the media independently
+ * of `Item.Root`'s `variant`; it is applied via a `data-variant` attribute that
+ * the recipe's media slot targets.
+ *
+ * Media is presentation only — it injects no accessible name of its own. Pass a
+ * decorative icon (hidden by its own `aria-hidden`) or supply an explicit name
+ * on the child when the media is meaningful.
+ *
+ * @supportsStyleProps
+ */
+export const ItemMedia = (props: ItemMediaProps) => {
+  const {
+    ref: forwardedRef,
+    children,
+    variant = "default",
+    ...restProps
+  } = props;
+
+  return (
+    <ItemMediaSlot ref={forwardedRef} data-variant={variant} {...restProps}>
+      {children}
+    </ItemMediaSlot>
+  );
+};
+
+ItemMedia.displayName = "Item.Media";

--- a/packages/nimbus/src/components/item/components/item.root.tsx
+++ b/packages/nimbus/src/components/item/components/item.root.tsx
@@ -66,8 +66,11 @@ const ItemRootLink = ({
     <ItemRootSlot
       as="a"
       ref={ref as React.Ref<HTMLDivElement>}
-      onClickCapture={handleClickCapture}
-      {...mergeProps(rest, linkProps)}
+      // Fold the guard into `mergeProps` (rather than passing it as a bare prop
+      // before the spread) so it *chains* with any consumer-supplied
+      // `onClickCapture` — react-aria composes `on*` handlers — instead of being
+      // silently overwritten by the spread.
+      {...mergeProps(rest, linkProps, { onClickCapture: handleClickCapture })}
     >
       {children}
     </ItemRootSlot>

--- a/packages/nimbus/src/components/item/components/item.root.tsx
+++ b/packages/nimbus/src/components/item/components/item.root.tsx
@@ -1,0 +1,112 @@
+import { useRef } from "react";
+import type { MouseEvent } from "react";
+import { useLink, useObjectRef, mergeProps } from "react-aria";
+import { mergeRefs } from "@/utils";
+import { ItemRootSlot } from "../item.slots";
+import type { ItemRootProps } from "../item.types";
+
+/**
+ * Internal: link-mode root.
+ *
+ * Renders the root slot as an `<a>` and applies the `useLink` hook (the same
+ * primitive Nimbus's `Link` uses) so the whole row is an accessible link —
+ * keyboard focusable, activatable with Enter, router-aware. The Item recipe
+ * remains authoritative for appearance; `useLink` only supplies interaction.
+ *
+ * Only the React Aria link options are handed to `useLink`; the remaining
+ * (styling / DOM) props are spread straight onto the slot.
+ */
+const ItemRootLink = ({
+  ref: forwardedRef,
+  children,
+  href,
+  target,
+  rel,
+  download,
+  ping,
+  referrerPolicy,
+  routerOptions,
+  onPress,
+  ...rest
+}: ItemRootProps) => {
+  const localRef = useRef<HTMLAnchorElement>(null);
+  const ref = useObjectRef<HTMLAnchorElement>(
+    mergeRefs<HTMLAnchorElement>(
+      localRef,
+      forwardedRef as React.Ref<HTMLAnchorElement>
+    )
+  );
+  const { linkProps } = useLink(
+    {
+      href,
+      target,
+      rel,
+      download,
+      ping,
+      referrerPolicy,
+      routerOptions,
+      onPress,
+      elementType: "a",
+    },
+    ref
+  );
+
+  // Guard against nested-interactive navigation: a click originating inside
+  // `Item.Actions` must not navigate the row. Runs in the capture phase (before
+  // the action's own handlers) so it only cancels the anchor's default/managed
+  // navigation, while the action control still receives and handles the event.
+  const handleClickCapture = (e: MouseEvent<HTMLDivElement>) => {
+    const target = e.target as Element | null;
+    if (target?.closest?.("[data-item-actions]")) {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <ItemRootSlot
+      as="a"
+      ref={ref as React.Ref<HTMLDivElement>}
+      onClickCapture={handleClickCapture}
+      {...mergeProps(rest, linkProps)}
+    >
+      {children}
+    </ItemRootSlot>
+  );
+};
+
+/**
+ * Internal: presentational (default) root — a plain `<div>` with no link or
+ * button semantics and no interactive tab stop of its own.
+ */
+const ItemRootStatic = ({
+  ref: forwardedRef,
+  children,
+  ...rest
+}: ItemRootProps) => (
+  <ItemRootSlot ref={forwardedRef} {...rest}>
+    {children}
+  </ItemRootSlot>
+);
+
+/**
+ * Item.Root - The row container and styling-context provider for all Item
+ * parts.
+ *
+ * Presentational by default (`<div>`). When `href` is provided it upgrades to
+ * an accessible link (`<a>`) via `useLink`. There is intentionally no
+ * button/pressable-row mode — row actions belong in `Item.Actions` as nested
+ * `Button`/`IconButton` controls, which keep an independent focus order.
+ *
+ * @supportsStyleProps
+ */
+export const ItemRoot = ({ href, ...props }: ItemRootProps) => {
+  // Split into two components so the `useLink` hook is only ever called on the
+  // link path (hooks cannot be called conditionally within one component).
+  return href != null ? (
+    <ItemRootLink href={href} {...props} />
+  ) : (
+    <ItemRootStatic {...props} />
+  );
+};
+
+ItemRoot.displayName = "Item.Root";

--- a/packages/nimbus/src/components/item/components/item.title.tsx
+++ b/packages/nimbus/src/components/item/components/item.title.tsx
@@ -1,0 +1,19 @@
+import { ItemTitleSlot } from "../item.slots";
+import type { ItemTitleProps } from "../item.types";
+
+/**
+ * Item.Title - The primary label of the row.
+ *
+ * @supportsStyleProps
+ */
+export const ItemTitle = (props: ItemTitleProps) => {
+  const { ref: forwardedRef, children, ...restProps } = props;
+
+  return (
+    <ItemTitleSlot ref={forwardedRef} {...restProps}>
+      {children}
+    </ItemTitleSlot>
+  );
+};
+
+ItemTitle.displayName = "Item.Title";

--- a/packages/nimbus/src/components/item/index.ts
+++ b/packages/nimbus/src/components/item/index.ts
@@ -1,0 +1,2 @@
+export * from "./item";
+export * from "./item.types";

--- a/packages/nimbus/src/components/item/index.ts
+++ b/packages/nimbus/src/components/item/index.ts
@@ -1,2 +1,2 @@
 export * from "./item";
-export * from "./item.types";
+export type * from "./item.types";

--- a/packages/nimbus/src/components/item/item.a11y.mdx
+++ b/packages/nimbus/src/components/item/item.a11y.mdx
@@ -1,0 +1,131 @@
+---
+tab-title: Accessibility
+tab-order: 4
+---
+
+## Accessibility
+
+Accessibility ensures that digital content and functionality are usable by
+everyone, including people with disabilities, by addressing visual, auditory,
+cognitive, and physical limitations.
+
+### Presentational by default
+
+`Item.Root` renders a plain `<div>` when no `href` is provided — no role, no
+accessible name, and no focus stop of its own. Nothing in the row is announced
+as interactive unless you either pass `href` or nest real interactive controls
+in `Item.Actions`.
+
+```jsx live
+const App = () => (
+  <Item.Root variant="outline" data-testid="static-row">
+    <Item.Media variant="icon" aria-hidden>
+      <Icons.Person />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Profile</Item.Title>
+      <Item.Description>Name, avatar, and contact details</Item.Description>
+    </Item.Content>
+  </Item.Root>
+);
+```
+
+### Link-mode accessible name
+
+When `href` upgrades `Item.Root` to an `<a>`, its accessible name is computed
+the standard way for a link: from its visible text content — the title, the
+description, and anything else rendered inside the row. `Item` does not wire
+up `aria-labelledby`/`aria-describedby` slots the way `Card` does, so a long
+description becomes part of a long announced name. If that verbosity is
+undesirable, override it explicitly with `aria-label` or `aria-labelledby`.
+
+```jsx live
+const App = () => (
+  <Item.Root
+    href="#settings"
+    variant="outline"
+    aria-label="Open account settings"
+  >
+    <Item.Media variant="icon" aria-hidden>
+      <Icons.Settings />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Settings</Item.Title>
+      <Item.Description>
+        Manage your profile, notifications, and connected accounts
+      </Item.Description>
+    </Item.Content>
+  </Item.Root>
+);
+```
+
+### Media is decorative unless you name it
+
+`Item.Media` injects no accessible name of its own — it is a layout slot, not
+a labeling one. Mark purely decorative media `aria-hidden` (as in the examples
+above) so it doesn't add an unlabeled node to the accessibility tree. Only give
+media its own name when it conveys information the title and description
+don't already state.
+
+### Actions keep an independent focus order
+
+Controls placed in `Item.Actions` are always their own focusable, operable
+stops — this holds whether `Item.Root` is a plain `<div>` or a link. When the
+row is a link, activating a control inside `Item.Actions` (by click, `Enter`,
+or `Space`) does **not** also activate the row's navigation: a capture-phase
+guard on the link cancels the row's own navigation whenever the originating
+event comes from inside `Item.Actions`, while the action's own handler still
+runs.
+
+```jsx live
+const App = () => (
+  <Item.Root href="#item-target" variant="outline">
+    <Item.Content>
+      <Item.Title>Report Q3</Item.Title>
+      <Item.Description>Opens the report</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton aria-label="Delete" size="xs" variant="ghost">
+        <Icons.Delete />
+      </IconButton>
+    </Item.Actions>
+  </Item.Root>
+);
+```
+
+### No row-as-button mode
+
+`Item.Root` intentionally offers no button/pressable-row mode. Rendering the
+whole row as a single button would announce the entire title, description,
+and media subtree as one control and would make every nested `Item.Actions`
+control an invalid button-inside-button. When a row needs to perform an
+action rather than navigate, put that action in `Item.Actions` as a
+`Button`/`IconButton` — don't attach a press handler to `Item.Root` itself.
+
+### Stacking rows
+
+`Item` lays out a single row and has no opinion about the list that contains
+it. To stack multiple rows, use the separate `ItemGroup` component — see its
+own accessibility documentation for how it composes rows into a group.
+
+### Accessibility standards
+
+- **Name, role, value:** A link-mode `Item.Root` is a genuine `<a>` with a
+  computed or explicit accessible name; a non-link `Item.Root` has none, which
+  is correct for presentational content.
+- **Info and relationships:** `Item.Media`, `Item.Title`, and
+  `Item.Description` are plain, unrelated `<div>`s — nothing but visible
+  layout ties them together, so don't depend on assistive technology inferring
+  a relationship beyond DOM order.
+- **Use of color:** `variant` (`plain`/`outline`/`subtle`) and `colorPalette`
+  are visual cues only; don't use color alone to signal that a row is
+  interactive or to distinguish one row's meaning from another's — pair it
+  with visible text.
+- **Non-text content:** Keep decorative media `aria-hidden`; give meaningful
+  media (an avatar that identifies a specific person, for example) its own
+  name.
+- **Focus order / no keyboard trap:** Controls in `Item.Actions` are always
+  independent focus stops, never captured by or hidden behind the row's link.
+- **Target size:** Size interactive controls placed in `Item.Actions` (for
+  example `IconButton`) per your target-size requirements — `Item` does not
+  enforce a minimum hit area on nested controls.

--- a/packages/nimbus/src/components/item/item.a11y.mdx
+++ b/packages/nimbus/src/components/item/item.a11y.mdx
@@ -93,6 +93,38 @@ const App = () => (
 );
 ```
 
+### Interactive controls in a link row are a content-model tradeoff
+
+Combining an `href` on `Item.Root` with an interactive control in
+`Item.Actions` nests that control inside the row's `<a>`. The HTML content
+model disallows interactive content inside an `<a>`, so this arrangement is
+technically invalid — the same reason a whole row can't be a single button
+(see below).
+
+Nimbus supports it anyway as the way to pair navigation with a row action: it
+is a common, well-understood pattern, the capture-phase guard above keeps the
+click behavior correct, and the nested control remains a first-class focus
+stop. Two things to keep in mind about the tradeoff:
+
+- **Automated a11y checks won't flag it, and that's expected.** `axe`'s
+  `nested-interactive` rule only applies to elements whose role makes their
+  children presentational (for example `button`); it does **not** apply to
+  links, so a control inside a link row passes the a11y test suite. The absence
+  of a violation here is not evidence that the markup is valid.
+- **If strict content-model validity matters** in your context, don't give a
+  single row both an `href` and interactive `Item.Actions`. Make the row
+  presentational (a `<div>`) and let its controls stand on their own, or let
+  the whole row navigate with no competing actions.
+
+### `Item.Actions` is for controls, not links
+
+Place JS-activated controls — `Button`, `IconButton` — in `Item.Actions`. Do
+**not** put a navigating `<a href>` there inside a link row: the row's
+capture-phase guard cancels navigation for anything originating in
+`Item.Actions`, so the inner link would silently do nothing. If a row needs a
+second destination, express it as a control the guard leaves alone (an
+`onPress` that routes), or restructure so the destinations aren't nested.
+
 ### No row-as-button mode
 
 `Item.Root` intentionally offers no button/pressable-row mode. Rendering the

--- a/packages/nimbus/src/components/item/item.dev.mdx
+++ b/packages/nimbus/src/components/item/item.dev.mdx
@@ -1,0 +1,309 @@
+---
+title: Item Component
+tab-title: Implementation
+tab-order: 3
+---
+
+## Getting started
+
+### Import
+
+```tsx
+import { Item, type ItemRootProps } from '@commercetools/nimbus';
+```
+
+### Basic usage
+
+`Item` is a compound component. Wrap `Item.Media`, `Item.Content` (itself
+wrapping `Item.Title` and `Item.Description`), and `Item.Actions` inside
+`Item.Root`. `Item.Root` renders a plain `<div>` unless you pass `href`.
+
+```jsx live-dev
+const App = () => (
+  <Item.Root variant="outline">
+    <Item.Media variant="icon">
+      <Icons.Person />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Profile</Item.Title>
+      <Item.Description>Name, avatar, and contact details</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton aria-label="Settings" size="xs" variant="ghost">
+        <Icons.Settings />
+      </IconButton>
+    </Item.Actions>
+  </Item.Root>
+);
+```
+
+## Usage examples
+
+### Sizes
+
+The `size` prop (`xs`, `sm`, `md`) scales the row's padding and gap via the
+`nimbusItem` recipe's density tokens. `md` is the default.
+
+```jsx live-dev
+const App = () => (
+  <Stack gap="400">
+    <Item.Root size="xs" variant="outline">
+      <Item.Media variant="icon"><Icons.Person /></Item.Media>
+      <Item.Content>
+        <Item.Title>Extra small</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root size="sm" variant="outline">
+      <Item.Media variant="icon"><Icons.Person /></Item.Media>
+      <Item.Content>
+        <Item.Title>Small</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root size="md" variant="outline">
+      <Item.Media variant="icon"><Icons.Person /></Item.Media>
+      <Item.Content>
+        <Item.Title>Medium (default)</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </Stack>
+);
+```
+
+### Variants
+
+`variant` (`plain`, `outline`, `subtle`) controls the row's border and fill.
+`plain` is the default.
+
+```jsx live-dev
+const App = () => (
+  <Stack gap="400">
+    <Item.Root variant="plain">
+      <Item.Content><Item.Title>Plain (default)</Item.Title></Item.Content>
+    </Item.Root>
+    <Item.Root variant="outline">
+      <Item.Content><Item.Title>Outline</Item.Title></Item.Content>
+    </Item.Root>
+    <Item.Root variant="subtle">
+      <Item.Content><Item.Title>Subtle</Item.Title></Item.Content>
+    </Item.Root>
+  </Stack>
+);
+```
+
+### Media variants
+
+`Item.Media` carries its own `variant` (`default`, `icon`, `image`), applied
+via a `data-variant` attribute rather than the shared recipe context — this
+keeps it independent of `Item.Root`'s `variant` prop. `default` applies no
+sizing, so use it when you need to size the media yourself (for example a
+custom avatar component).
+
+```jsx live-dev
+const App = () => (
+  <Stack gap="400">
+    <Item.Root variant="outline">
+      <Item.Media variant="icon">
+        <Icons.Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Icon media</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root variant="outline">
+      <Item.Media variant="image">
+        <img
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+          alt="Placeholder thumbnail"
+        />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Image media</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </Stack>
+);
+```
+
+### Header and footer bands
+
+`Item.Header` and `Item.Footer` set `flex-basis: 100%` inside the row's
+`flex-wrap` layout, so they occupy their own full-width band above or below
+the media·content·actions line.
+
+```jsx live-dev
+const App = () => (
+  <Item.Root variant="outline">
+    <Item.Header>
+      <Text fontWeight="600">Header band</Text>
+    </Item.Header>
+    <Item.Media variant="icon">
+      <Icons.Person />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>With header and footer</Item.Title>
+      <Item.Description>Both bands span the full row width.</Item.Description>
+    </Item.Content>
+    <Item.Footer>
+      <Text textStyle="sm">Footer band</Text>
+    </Item.Footer>
+  </Item.Root>
+);
+```
+
+### Link-upgrade
+
+Passing `href` (plus optional `target`, `rel`, `download`, `ping`,
+`referrerPolicy`, `routerOptions`, `onPress`) switches `Item.Root`'s rendered
+element from `<div>` to `<a>` and wires it up with React Aria's `useLink` —
+the same hook Nimbus's own `Link` uses internally. `Item`'s recipe stays
+authoritative on appearance; `useLink` only supplies keyboard, focus, and
+press behavior.
+
+```jsx live-dev
+const App = () => (
+  <Item.Root href="#item-target" variant="outline">
+    <Item.Media variant="icon">
+      <Icons.Settings />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Settings</Item.Title>
+      <Item.Description>Navigate to settings</Item.Description>
+    </Item.Content>
+  </Item.Root>
+);
+```
+
+### Actions inside a link row
+
+`Item.Actions` controls remain independently operable even when `Item.Root`
+is a link: an internal capture-phase guard on the link cancels the row's own
+navigation whenever the originating click comes from inside `Item.Actions`,
+while the action's own handler still runs normally. There is no button mode
+for `Item.Root` itself — a row rendered as a `<button>` would make every
+nested `Item.Actions` control an invalid button-inside-button, so real
+actions always live in `Item.Actions`.
+
+```jsx live-dev
+const App = () => (
+  <Item.Root href="#item-target" variant="outline">
+    <Item.Content>
+      <Item.Title>Report Q3</Item.Title>
+      <Item.Description>Opens the report</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton
+        aria-label="Delete"
+        size="xs"
+        variant="ghost"
+        onPress={() => console.log("delete")}
+      >
+        <Icons.Delete />
+      </IconButton>
+    </Item.Actions>
+  </Item.Root>
+);
+```
+
+### Color palette
+
+The row inherits the `slate` color palette by default (media, title, and
+description colors, plus the `subtle`/`outline` variant surfaces all read from
+`colorPalette.*` tokens). Override `colorPalette` like any other Chakra style
+prop to tint a row semantically, for example a destructive row.
+
+```jsx live-dev
+const App = () => (
+  <Item.Root variant="subtle" colorPalette="critical">
+    <Item.Media variant="icon">
+      <Icons.Delete />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Delete account</Item.Title>
+      <Item.Description>This action cannot be undone.</Item.Description>
+    </Item.Content>
+  </Item.Root>
+);
+```
+
+### Stacking rows with ItemGroup
+
+`Item` only lays out a single row. To stack several rows into a list, with
+optional dividers between them, wrap `Item.Root` rows in the separate
+`ItemGroup` component rather than nesting them inside one `Item.Root`.
+
+```jsx live-dev
+const App = () => (
+  <ItemGroup.Root>
+    <Item.Root href="#profile">
+      <Item.Content><Item.Title>Profile</Item.Title></Item.Content>
+    </Item.Root>
+    <ItemGroup.Separator />
+    <Item.Root href="#billing">
+      <Item.Content><Item.Title>Billing</Item.Title></Item.Content>
+    </Item.Root>
+  </ItemGroup.Root>
+);
+```
+
+## Component requirements
+
+- Nest `Item.Media`, `Item.Content`, and `Item.Actions` as direct children of
+  `Item.Root`; wrap `Item.Title` and `Item.Description` inside `Item.Content`.
+- `Item.Header` and `Item.Footer` are optional and render as full-width bands;
+  place them as direct children of `Item.Root` alongside the other parts.
+- Passing `href` is the only thing that changes `Item.Root`'s rendered
+  element and interaction model — every other prop behaves the same on the
+  `<div>` and `<a>` paths.
+- `Item.Root` does not accept `as`/`asChild`; it is not polymorphic.
+
+### Accessibility
+
+`Item.Root` renders a plain, unlabeled `<div>` by default — no role or
+accessible name is implied. When it upgrades to a link, its accessible name is
+computed the standard way, from its visible text content (title, description,
+and any other text inside the row), unless you override it with `aria-label`
+or `aria-labelledby`. `Item.Media` injects no accessible name of its own: mark
+decorative media `aria-hidden` (as shown in the link-upgrade example above) or
+give it an explicit name when the media conveys information the title doesn't
+already state.
+
+If your use case requires tracking and analytics for this component, it is
+good practice to add a **persistent**, **unique** id to the component:
+
+```tsx
+const PERSISTENT_ID = "settings-item-row";
+
+export const Example = () => (
+  <Item.Root id={PERSISTENT_ID} href="/settings">
+    <Item.Content>
+      <Item.Title>Settings</Item.Title>
+    </Item.Content>
+  </Item.Root>
+);
+```
+
+#### Keyboard navigation
+
+- `Tab`: When `href` is set, the row is one focusable stop, like any link;
+  controls inside `Item.Actions` are additional, independent focusable stops.
+  Without `href`, `Item.Root` introduces no focusable stop of its own.
+- `Enter`: Activates the row's link.
+- Activating a control inside `Item.Actions` (by click, `Enter`, or `Space`)
+  does not activate the row's link, even when the row is a link.
+
+## API reference
+
+<PropsTable id="Item" />
+
+## Testing your implementation
+
+These examples demonstrate how to test your implementation when using Item
+within your application. As the component's internal functionality is already
+tested by Nimbus, these patterns help you verify your integration and
+application-specific logic.
+
+{{docs-tests: item.docs.spec.tsx}}
+
+## Resources
+
+- [Storybook](https://nimbus-storybook.vercel.app/?path=/docs/components-item--docs)

--- a/packages/nimbus/src/components/item/item.docs.spec.tsx
+++ b/packages/nimbus/src/components/item/item.docs.spec.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Item, IconButton, NimbusProvider } from "@commercetools/nimbus";
@@ -129,5 +130,78 @@ describe("Item - Row with actions", () => {
     // The row link is still present and the location was never navigated.
     expect(screen.getByRole("link", { name: /Report Q3/ })).toBeInTheDocument();
     expect(window.location.hash).not.toBe("#report");
+  });
+});
+
+/**
+ * @docs-section state-management
+ * @docs-title State Management
+ * @docs-description Drive a list of Item rows from application state and toggle a row's state from its own action, without navigating the row
+ * @docs-order 4
+ */
+describe("Item - State management", () => {
+  it("toggles a row's pinned state from its action while leaving the link intact", async () => {
+    const user = userEvent.setup();
+
+    type Row = { id: string; title: string; pinned: boolean };
+
+    const PinnableList = () => {
+      const [rows, setRows] = useState<Row[]>([
+        { id: "profile", title: "Profile", pinned: false },
+        { id: "billing", title: "Billing", pinned: true },
+      ]);
+
+      const togglePinned = (id: string) =>
+        setRows((prev) =>
+          prev.map((row) =>
+            row.id === id ? { ...row, pinned: !row.pinned } : row
+          )
+        );
+
+      return (
+        <div>
+          {rows.map((row) => (
+            <Item.Root key={row.id} href={`#${row.id}`} variant="outline">
+              <Item.Media variant="icon">
+                <Person />
+              </Item.Media>
+              <Item.Content>
+                <Item.Title>{row.title}</Item.Title>
+                <Item.Description>
+                  {row.pinned ? "Pinned" : "Not pinned"}
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions>
+                <IconButton
+                  aria-label={`${row.pinned ? "Unpin" : "Pin"} ${row.title}`}
+                  size="xs"
+                  variant="ghost"
+                  onPress={() => togglePinned(row.id)}
+                >
+                  <Settings />
+                </IconButton>
+              </Item.Actions>
+            </Item.Root>
+          ))}
+        </div>
+      );
+    };
+
+    render(
+      <NimbusProvider>
+        <PinnableList />
+      </NimbusProvider>
+    );
+
+    // Each row is a link, and each row's action is a separate control.
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+
+    // Activating a row action updates state without navigating the row.
+    await user.click(screen.getByRole("button", { name: "Pin Profile" }));
+    expect(
+      screen.getByRole("button", { name: "Unpin Profile" })
+    ).toBeInTheDocument();
+    // The row link is still present — the action did not navigate away.
+    expect(screen.getByRole("link", { name: /Profile/ })).toBeInTheDocument();
   });
 });

--- a/packages/nimbus/src/components/item/item.docs.spec.tsx
+++ b/packages/nimbus/src/components/item/item.docs.spec.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Item, IconButton, NimbusProvider } from "@commercetools/nimbus";
+import { Person, Settings, Delete } from "@commercetools/nimbus-icons";
+
+/**
+ * @docs-section basic-rendering
+ * @docs-title Basic Rendering Tests
+ * @docs-description Compose a static row from media, title, and description
+ * @docs-order 1
+ */
+describe("Item - Basic rendering", () => {
+  it("renders a static row as a plain div", () => {
+    render(
+      <NimbusProvider>
+        <Item.Root variant="outline" data-testid="item">
+          <Item.Media variant="icon">
+            <Person />
+          </Item.Media>
+          <Item.Content>
+            <Item.Title>Profile</Item.Title>
+            <Item.Description>
+              Name, avatar, and contact details
+            </Item.Description>
+          </Item.Content>
+        </Item.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByTestId("item").tagName).toBe("DIV");
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(
+      screen.getByText("Name, avatar, and contact details")
+    ).toBeInTheDocument();
+  });
+
+  it("renders header and footer bands", () => {
+    render(
+      <NimbusProvider>
+        <Item.Root variant="outline">
+          <Item.Header>Header band</Item.Header>
+          <Item.Content>
+            <Item.Title>With header and footer</Item.Title>
+          </Item.Content>
+          <Item.Footer>Footer band</Item.Footer>
+        </Item.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.getByText("Header band")).toBeInTheDocument();
+    expect(screen.getByText("Footer band")).toBeInTheDocument();
+  });
+});
+
+/**
+ * @docs-section link-row
+ * @docs-title Link Row Tests
+ * @docs-description Passing href upgrades Item.Root to an accessible link
+ * @docs-order 2
+ */
+describe("Item - Link row", () => {
+  it("upgrades to an <a> with href", () => {
+    render(
+      <NimbusProvider>
+        <Item.Root href="/settings" variant="outline">
+          <Item.Media variant="icon">
+            <Settings />
+          </Item.Media>
+          <Item.Content>
+            <Item.Title>Settings</Item.Title>
+            <Item.Description>Navigate to settings</Item.Description>
+          </Item.Content>
+        </Item.Root>
+      </NimbusProvider>
+    );
+
+    const link = screen.getByRole("link", { name: /Settings/ });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/settings");
+  });
+
+  it("renders as a plain div when href is omitted", () => {
+    render(
+      <NimbusProvider>
+        <Item.Root variant="outline" data-testid="item">
+          <Item.Content>
+            <Item.Title>Settings</Item.Title>
+          </Item.Content>
+        </Item.Root>
+      </NimbusProvider>
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByTestId("item").tagName).toBe("DIV");
+  });
+});
+
+/**
+ * @docs-section row-with-actions
+ * @docs-title Row With Actions Tests
+ * @docs-description Actions inside Item.Actions stay independently operable, even inside a link row
+ * @docs-order 3
+ */
+describe("Item - Row with actions", () => {
+  it("fires the action handler without navigating the row", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+
+    render(
+      <NimbusProvider>
+        <Item.Root href="#report" variant="outline">
+          <Item.Content>
+            <Item.Title>Report Q3</Item.Title>
+            <Item.Description>Opens the report</Item.Description>
+          </Item.Content>
+          <Item.Actions>
+            <IconButton aria-label="Delete" size="xs" onPress={onDelete}>
+              <Delete />
+            </IconButton>
+          </Item.Actions>
+        </Item.Root>
+      </NimbusProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    // The row link is still present and the location was never navigated.
+    expect(screen.getByRole("link", { name: /Report Q3/ })).toBeInTheDocument();
+    expect(window.location.hash).not.toBe("#report");
+  });
+});

--- a/packages/nimbus/src/components/item/item.docs.spec.tsx
+++ b/packages/nimbus/src/components/item/item.docs.spec.tsx
@@ -1,143 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Item, IconButton, NimbusProvider } from "@commercetools/nimbus";
-import { Person, Settings, Delete } from "@commercetools/nimbus-icons";
-
-/**
- * @docs-section basic-rendering
- * @docs-title Basic Rendering Tests
- * @docs-description Compose a static row from media, title, and description
- * @docs-order 1
- */
-describe("Item - Basic rendering", () => {
-  it("renders a static row as a plain div", () => {
-    render(
-      <NimbusProvider>
-        <Item.Root variant="outline" data-testid="item">
-          <Item.Media variant="icon">
-            <Person />
-          </Item.Media>
-          <Item.Content>
-            <Item.Title>Profile</Item.Title>
-            <Item.Description>
-              Name, avatar, and contact details
-            </Item.Description>
-          </Item.Content>
-        </Item.Root>
-      </NimbusProvider>
-    );
-
-    expect(screen.getByTestId("item").tagName).toBe("DIV");
-    expect(screen.getByText("Profile")).toBeInTheDocument();
-    expect(
-      screen.getByText("Name, avatar, and contact details")
-    ).toBeInTheDocument();
-  });
-
-  it("renders header and footer bands", () => {
-    render(
-      <NimbusProvider>
-        <Item.Root variant="outline">
-          <Item.Header>Header band</Item.Header>
-          <Item.Content>
-            <Item.Title>With header and footer</Item.Title>
-          </Item.Content>
-          <Item.Footer>Footer band</Item.Footer>
-        </Item.Root>
-      </NimbusProvider>
-    );
-
-    expect(screen.getByText("Header band")).toBeInTheDocument();
-    expect(screen.getByText("Footer band")).toBeInTheDocument();
-  });
-});
-
-/**
- * @docs-section link-row
- * @docs-title Link Row Tests
- * @docs-description Passing href upgrades Item.Root to an accessible link
- * @docs-order 2
- */
-describe("Item - Link row", () => {
-  it("upgrades to an <a> with href", () => {
-    render(
-      <NimbusProvider>
-        <Item.Root href="/settings" variant="outline">
-          <Item.Media variant="icon">
-            <Settings />
-          </Item.Media>
-          <Item.Content>
-            <Item.Title>Settings</Item.Title>
-            <Item.Description>Navigate to settings</Item.Description>
-          </Item.Content>
-        </Item.Root>
-      </NimbusProvider>
-    );
-
-    const link = screen.getByRole("link", { name: /Settings/ });
-    expect(link.tagName).toBe("A");
-    expect(link).toHaveAttribute("href", "/settings");
-  });
-
-  it("renders as a plain div when href is omitted", () => {
-    render(
-      <NimbusProvider>
-        <Item.Root variant="outline" data-testid="item">
-          <Item.Content>
-            <Item.Title>Settings</Item.Title>
-          </Item.Content>
-        </Item.Root>
-      </NimbusProvider>
-    );
-
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-    expect(screen.getByTestId("item").tagName).toBe("DIV");
-  });
-});
-
-/**
- * @docs-section row-with-actions
- * @docs-title Row With Actions Tests
- * @docs-description Actions inside Item.Actions stay independently operable, even inside a link row
- * @docs-order 3
- */
-describe("Item - Row with actions", () => {
-  it("fires the action handler without navigating the row", async () => {
-    const user = userEvent.setup();
-    const onDelete = vi.fn();
-
-    render(
-      <NimbusProvider>
-        <Item.Root href="#report" variant="outline">
-          <Item.Content>
-            <Item.Title>Report Q3</Item.Title>
-            <Item.Description>Opens the report</Item.Description>
-          </Item.Content>
-          <Item.Actions>
-            <IconButton aria-label="Delete" size="xs" onPress={onDelete}>
-              <Delete />
-            </IconButton>
-          </Item.Actions>
-        </Item.Root>
-      </NimbusProvider>
-    );
-
-    await user.click(screen.getByRole("button", { name: "Delete" }));
-
-    expect(onDelete).toHaveBeenCalledTimes(1);
-    // The row link is still present and the location was never navigated.
-    expect(screen.getByRole("link", { name: /Report Q3/ })).toBeInTheDocument();
-    expect(window.location.hash).not.toBe("#report");
-  });
-});
+import { Person, Settings } from "@commercetools/nimbus-icons";
 
 /**
  * @docs-section state-management
  * @docs-title State Management
  * @docs-description Drive a list of Item rows from application state and toggle a row's state from its own action, without navigating the row
- * @docs-order 4
+ * @docs-order 1
  */
 describe("Item - State management", () => {
   it("toggles a row's pinned state from its action while leaving the link intact", async () => {

--- a/packages/nimbus/src/components/item/item.guidelines.mdx
+++ b/packages/nimbus/src/components/item/item.guidelines.mdx
@@ -1,0 +1,187 @@
+---
+title: Item
+tab-title: Guidelines
+tab-order: 2
+---
+
+## Guidelines
+
+Item guidelines focus on keeping a single content row scannable, restrained,
+and predictable, so a page built from many rows stays easy to read and use.
+
+### Best practices
+
+- **One row, one subject:** Keep each row focused on a single item — a
+  setting, a notification, a file. Don't merge two unrelated things into one
+  row's title and description.
+- **Concise title and description:** The title should read as a short label;
+  push supporting detail into the description rather than lengthening the
+  title itself.
+- **Limited, obvious actions:** Place only the actions a row actually needs in
+  `Item.Actions`. A row crowded with icon buttons is harder to scan and harder
+  to hit accurately.
+- **Consistent rows within a group:** When several rows sit together (via
+  `ItemGroup`), keep their structure consistent — if one row has media and
+  actions, give its siblings the same shape, even if a slot is empty.
+- **Choose one interaction model per row:** A row either navigates (`href`) or
+  hosts actions (`Item.Actions`), or both together — it never behaves like a
+  button in its own right. Don't design a row that expects a whole-row click
+  to trigger something other than navigation.
+- **Match density to context:** Use `size="xs"` or `size="sm"` for dense
+  lists with many rows, and `size="md"` for standalone or spacious rows.
+
+### Usage
+
+`Item` is the shape behind the horizontal rows that make up settings screens,
+notification lists, and resource/file browsers — content that is naturally a
+sequence of similar, scannable lines rather than a single detailed view.
+
+> [!TIP]\
+> When to use
+
+- **Settings and preference rows:** A label, a short description, and a
+  control or a link to a detail page.
+- **Notifications and activity entries:** An icon or avatar, a short message,
+  and optional actions like dismiss or mark-as-read.
+- **File or resource rows:** A thumbnail or type icon, a name and metadata,
+  and actions like download or delete.
+- **Navigational rows:** A row that exists purely to link somewhere else, with
+  a leading icon and a trailing chevron as the visual cue.
+
+> [!CAUTION]\
+> When not to use
+
+- **A single, detailed item:** When you need to present a lot of information
+  about one specific thing, use `Card` or a dedicated page instead of forcing
+  it into one row.
+- **Selectable or multi-select collections:** `Item` has no selection state.
+  If users need to select one or more rows, reach for `Menu` or a purpose-built
+  selectable list instead.
+- **A row that should act like a button:** If activating the whole row should
+  trigger an action rather than navigate, don't attach a press handler to
+  `Item.Root` — put a `Button`/`IconButton` in `Item.Actions` instead.
+- **Comparing structured data across many attributes:** When rows would need
+  many aligned columns to be useful, a table communicates that better than a
+  row layout.
+
+### Content
+
+Keep a row's text short enough to scan at a glance. The title carries the
+subject; the description adds just enough context to disambiguate it from
+its neighbors.
+
+> [!TIP]\
+> **Do**
+>
+> - Write titles as short, specific labels ("Two-factor authentication", not
+>   "Settings related to your account security").
+> - Use the description for one supporting detail, not a second paragraph.
+
+```jsx live
+const App = () => (
+  <Item.Root variant="outline" width="384px">
+    <Item.Media variant="icon">
+      <Icons.Security />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Two-factor authentication</Item.Title>
+      <Item.Description>Adds a second step when you sign in.</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <Button size="xs" variant="outline">Enable</Button>
+    </Item.Actions>
+  </Item.Root>
+);
+```
+
+> [!CAUTION]\
+> **Don't**
+>
+> - Don't stack multiple unrelated facts into the title.
+> - Don't let the description grow into a paragraph — a link-mode row's
+>   accessible name is built from that same text, so a long description makes
+>   for a long, awkward announcement.
+
+```jsx live
+const App = () => (
+  <Item.Root variant="outline" width="384px">
+    <Item.Content>
+      <Item.Title>Two-factor authentication and password and email</Item.Title>
+      <Item.Description>
+        Adds a second step when you sign in, also lets you change your
+        password, and also shows your current recovery email address plus a
+        button to change it if you no longer have access to it.
+      </Item.Description>
+    </Item.Content>
+  </Item.Root>
+);
+```
+
+### Actions
+
+Keep the trailing actions short, obvious, and limited to what that specific
+row needs — a row is meant to be scanned quickly, not studied.
+
+> [!TIP]\
+> **Do**
+>
+> - Use one primary action per row, and reach for an icon button only when its
+>   meaning is unambiguous (a trash icon for delete).
+> - When a row also links somewhere, keep any action clearly separated from
+>   the row's own navigation — for example a trailing chevron for "go to
+>   details" versus a distinct trash icon for "delete this".
+
+```jsx live
+const App = () => (
+  <Item.Root href="#report" variant="outline" width="384px">
+    <Item.Media variant="icon">
+      <Icons.Description />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Q3 report</Item.Title>
+      <Item.Description>Updated 2 days ago</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton aria-label="Delete report" size="xs" variant="ghost">
+        <Icons.Delete />
+      </IconButton>
+    </Item.Actions>
+  </Item.Root>
+);
+```
+
+> [!CAUTION]\
+> **Don't**
+>
+> - Don't crowd a row with many actions — split them into a menu behind a
+>   single overflow control instead.
+> - Don't rely on a whole-row click to do something a visible action should do
+>   instead; nested actions must stay independently operable.
+
+```jsx live
+const App = () => (
+  <Item.Root href="#report" variant="outline" width="384px">
+    <Item.Media variant="icon">
+      <Icons.Description />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Q3 report</Item.Title>
+      <Item.Description>Updated 2 days ago</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton aria-label="Share" size="xs" variant="ghost">
+        <Icons.Share />
+      </IconButton>
+      <IconButton aria-label="Rename" size="xs" variant="ghost">
+        <Icons.Edit />
+      </IconButton>
+      <IconButton aria-label="Archive" size="xs" variant="ghost">
+        <Icons.Archive />
+      </IconButton>
+      <IconButton aria-label="Delete report" size="xs" variant="ghost">
+        <Icons.Delete />
+      </IconButton>
+    </Item.Actions>
+  </Item.Root>
+);
+```

--- a/packages/nimbus/src/components/item/item.mdx
+++ b/packages/nimbus/src/components/item/item.mdx
@@ -2,7 +2,9 @@
 id: Components-Item
 title: Item
 exportName: Item
-description: A horizontal content row with leading media, a title and description, and trailing actions — for settings, notification, and resource rows.
+description:
+  A horizontal content row with leading media, a title and description, and
+  trailing actions — for settings, notification, and resource rows.
 lifecycleState: Beta
 order: 999
 menu:
@@ -27,8 +29,8 @@ hoc with slightly different spacing every time.
 
 `Item` is deliberately restrained. It is presentational by default and only
 becomes interactive in one way: passing `href` upgrades the entire row to an
-accessible link. There is no button mode and no built-in selection state —
-real actions live as `Button`/`IconButton` controls inside `Item.Actions`, and
+accessible link. There is no button mode and no built-in selection state — real
+actions live as `Button`/`IconButton` controls inside `Item.Actions`, and
 selectable, navigable collections stay the job of `Menu`. `Item` complements
 `Card`, which composes vertical containers, the same way it complements those
 interactive collections: each owns a different shape.
@@ -40,17 +42,18 @@ the separate `ItemGroup` component.
 
 Deep dive into implementation details and access the Nimbus design library.
 
+[Figma library](https://www.figma.com/design/gHbAJGfcrCv7f2bgzUQgHq/NIMBUS-Guidelines?m=dev)
+
 ## Variables
 
 Get familiar with the features.
 
 ### Media
 
-`Item.Media` is a fixed, non-shrinking slot for an icon, avatar, or image.
-Its `variant` sizes and shapes the content independently of the row's own
-`variant`: `default` imposes no sizing (use it for a custom-sized avatar),
-`icon` sizes an inline glyph, and `image` constrains a thumbnail into a
-rounded box.
+`Item.Media` is a fixed, non-shrinking slot for an icon, avatar, or image. Its
+`variant` sizes and shapes the content independently of the row's own `variant`:
+`default` imposes no sizing (use it for a custom-sized avatar), `icon` sizes an
+inline glyph, and `image` constrains a thumbnail into a rounded box.
 
 ```jsx live
 const App = () => (
@@ -65,10 +68,7 @@ const App = () => (
     </Item.Root>
     <Item.Root variant="outline">
       <Item.Media variant="image">
-        <img
-          src="/images/card/card-discount-template.png"
-          alt=""
-        />
+        <img src="/images/card/card-discount-template.png" alt="" />
       </Item.Media>
       <Item.Content>
         <Item.Title>Image media</Item.Title>
@@ -107,9 +107,9 @@ const App = () => (
 
 ### Variant
 
-The `variant` prop controls the row's visual treatment: `plain` (default) has
-no border or fill, `outline` adds a token-based border, and `subtle` fills the
-row with a muted surface color.
+The `variant` prop controls the row's visual treatment: `plain` (default) has no
+border or fill, `outline` adds a token-based border, and `subtle` fills the row
+with a muted surface color.
 
 ```jsx live
 const App = () => (
@@ -138,9 +138,9 @@ const App = () => (
 
 ### Header and footer
 
-`Item.Header` and `Item.Footer` are optional full-width bands rendered above
-and below the media·content·actions row — useful for a category label or a
-timestamp that shouldn't compete with the title for horizontal space.
+`Item.Header` and `Item.Footer` are optional full-width bands rendered above and
+below the media·content·actions row — useful for a category label or a timestamp
+that shouldn't compete with the title for horizontal space.
 
 ```jsx live
 const App = () => (
@@ -156,7 +156,9 @@ const App = () => (
       <Item.Description>Summarizes activity across your team.</Item.Description>
     </Item.Content>
     <Item.Footer>
-      <Text textStyle="sm" color="neutral.11">Sent Monday at 9:00am</Text>
+      <Text textStyle="sm" color="neutral.11">
+        Sent Monday at 9:00am
+      </Text>
     </Item.Footer>
   </Item.Root>
 );

--- a/packages/nimbus/src/components/item/item.mdx
+++ b/packages/nimbus/src/components/item/item.mdx
@@ -1,0 +1,189 @@
+---
+id: Components-Item
+title: Item
+exportName: Item
+description: A horizontal content row with leading media, a title and description, and trailing actions — for settings, notification, and resource rows.
+lifecycleState: Experimental
+order: 999
+menu:
+  - Components
+  - Data Display
+  - Item
+tags:
+  - component
+  - item
+  - row
+  - list
+  - content
+---
+
+## Overview
+
+`Item` lays out **one horizontal content row**: leading media, a title and
+description column, and trailing actions, with optional full-width bands above
+and below. It is the shape behind settings rows, notification entries,
+file/resource rows, and summary rows — the pattern teams otherwise rebuild ad
+hoc with slightly different spacing every time.
+
+`Item` is deliberately restrained. It is presentational by default and only
+becomes interactive in one way: passing `href` upgrades the entire row to an
+accessible link. There is no button mode and no built-in selection state —
+real actions live as `Button`/`IconButton` controls inside `Item.Actions`, and
+selectable, navigable collections stay the job of `Menu`. `Item` complements
+`Card`, which composes vertical containers, the same way it complements those
+interactive collections: each owns a different shape.
+
+To stack several rows into a list with dividers between them, pair `Item` with
+the separate `ItemGroup` component.
+
+### Resources
+
+Deep dive into implementation details and access the Nimbus design library.
+
+## Variables
+
+Get familiar with the features.
+
+### Media
+
+`Item.Media` is a fixed, non-shrinking slot for an icon, avatar, or image.
+Its `variant` sizes and shapes the content independently of the row's own
+`variant`: `default` imposes no sizing (use it for a custom-sized avatar),
+`icon` sizes an inline glyph, and `image` constrains a thumbnail into a
+rounded box.
+
+```jsx live
+const App = () => (
+  <Stack gap="400">
+    <Item.Root variant="outline">
+      <Item.Media variant="icon">
+        <Icons.Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Icon media</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root variant="outline">
+      <Item.Media variant="image">
+        <img
+          src="/images/card/card-discount-template.png"
+          alt=""
+        />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Image media</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </Stack>
+);
+```
+
+### Size
+
+The `size` prop scales the row's padding and gap. Use `xs` and `sm` for dense
+lists of rows, and `md` (the default) for standalone or spacious layouts.
+
+```jsx live
+const App = () => (
+  <Stack gap="400">
+    <Item.Root size="xs" variant="outline">
+      <Item.Content>
+        <Item.Title>Extra small</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root size="sm" variant="outline">
+      <Item.Content>
+        <Item.Title>Small</Item.Title>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root size="md" variant="outline">
+      <Item.Content>
+        <Item.Title>Medium (default)</Item.Title>
+      </Item.Content>
+    </Item.Root>
+  </Stack>
+);
+```
+
+### Variant
+
+The `variant` prop controls the row's visual treatment: `plain` (default) has
+no border or fill, `outline` adds a token-based border, and `subtle` fills the
+row with a muted surface color.
+
+```jsx live
+const App = () => (
+  <Stack gap="400">
+    <Item.Root variant="plain">
+      <Item.Content>
+        <Item.Title>Plain</Item.Title>
+        <Item.Description>No border, no fill.</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root variant="outline">
+      <Item.Content>
+        <Item.Title>Outline</Item.Title>
+        <Item.Description>A token-based border.</Item.Description>
+      </Item.Content>
+    </Item.Root>
+    <Item.Root variant="subtle">
+      <Item.Content>
+        <Item.Title>Subtle</Item.Title>
+        <Item.Description>A muted surface fill.</Item.Description>
+      </Item.Content>
+    </Item.Root>
+  </Stack>
+);
+```
+
+### Header and footer
+
+`Item.Header` and `Item.Footer` are optional full-width bands rendered above
+and below the media·content·actions row — useful for a category label or a
+timestamp that shouldn't compete with the title for horizontal space.
+
+```jsx live
+const App = () => (
+  <Item.Root variant="outline">
+    <Item.Header>
+      <Text fontWeight="600">This week</Text>
+    </Item.Header>
+    <Item.Media variant="icon">
+      <Icons.Person />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Weekly digest</Item.Title>
+      <Item.Description>Summarizes activity across your team.</Item.Description>
+    </Item.Content>
+    <Item.Footer>
+      <Text textStyle="sm" color="neutral.11">Sent Monday at 9:00am</Text>
+    </Item.Footer>
+  </Item.Root>
+);
+```
+
+### Link rows and actions
+
+Passing `href` upgrades the row to an accessible link — the whole row is
+keyboard focusable and navigable. Controls placed in `Item.Actions` stay
+independently operable: pressing one fires its own handler without triggering
+the row's navigation.
+
+```jsx live
+const App = () => (
+  <Item.Root href="#settings" variant="outline">
+    <Item.Media variant="icon">
+      <Icons.Settings />
+    </Item.Media>
+    <Item.Content>
+      <Item.Title>Settings</Item.Title>
+      <Item.Description>Navigate to your account settings</Item.Description>
+    </Item.Content>
+    <Item.Actions>
+      <IconButton aria-label="Remove shortcut" size="xs" variant="ghost">
+        <Icons.Delete />
+      </IconButton>
+    </Item.Actions>
+  </Item.Root>
+);
+```

--- a/packages/nimbus/src/components/item/item.mdx
+++ b/packages/nimbus/src/components/item/item.mdx
@@ -3,7 +3,7 @@ id: Components-Item
 title: Item
 exportName: Item
 description: A horizontal content row with leading media, a title and description, and trailing actions — for settings, notification, and resource rows.
-lifecycleState: Experimental
+lifecycleState: Beta
 order: 999
 menu:
   - Components

--- a/packages/nimbus/src/components/item/item.recipe.ts
+++ b/packages/nimbus/src/components/item/item.recipe.ts
@@ -1,0 +1,184 @@
+import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
+
+/**
+ * Recipe configuration for the Item component.
+ *
+ * A single slot recipe drives all Item parts. The root is laid out as one
+ * `flex-wrap` row so that `header` and `footer` (which set `flex-basis: 100%`)
+ * occupy their own full-width bands above/below the media·content·actions row.
+ *
+ * `Item.Media` needs a `variant` (`default | icon | image`) that is independent
+ * of the root's `variant`, so it is driven by a `data-variant` attribute on the
+ * media slot rather than a recipe variant (which would collide with the root's
+ * `variant` prop across the shared slot-recipe context).
+ */
+export const itemRecipe = defineSlotRecipe({
+  // Only the parts that live *inside* the row share the recipe context.
+  // `Item.Group` wraps rows (it is a parent of `Item.Root`, not a child), and
+  // `Item.Separator` reuses the standalone Nimbus `Separator`, so neither is a
+  // context slot here — they style themselves.
+  slots: [
+    "root",
+    "header",
+    "media",
+    "content",
+    "title",
+    "description",
+    "actions",
+    "footer",
+  ],
+
+  className: "nimbus-item",
+
+  base: {
+    root: {
+      colorPalette: "slate",
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: "var(--item-gap)",
+      p: "var(--item-padding)",
+      width: "100%",
+      borderRadius: "300",
+      // Link-mode defaults: keep the anchor visually identical to the div and
+      // let the recipe (not the browser) own its appearance. A plain <div>
+      // ignores these; they only take visible effect once the root is an <a>.
+      color: "inherit",
+      textDecoration: "none",
+      textAlign: "start",
+      outline: "none",
+      _focusVisible: {
+        focusRing: "outside",
+      },
+      "&:is(a)": {
+        cursor: "pointer",
+        transitionProperty: "background-color, border-color",
+        transitionDuration: "fast",
+        _hover: {
+          backgroundColor: "colorPalette.2",
+        },
+      },
+    },
+
+    // Full-width band above the row.
+    header: {
+      flexBasis: "100%",
+      display: "flex",
+      alignItems: "center",
+      minWidth: 0,
+    },
+
+    // Fixed, non-shrinking leading slot.
+    media: {
+      display: "flex",
+      flexShrink: 0,
+      alignItems: "center",
+      justifyContent: "center",
+      color: "colorPalette.11",
+      "& svg": {
+        pointerEvents: "none",
+      },
+      "&[data-variant='icon']": {
+        boxSize: "600",
+        "& svg": {
+          boxSize: "500",
+        },
+      },
+      "&[data-variant='image']": {
+        boxSize: "1000",
+        borderRadius: "200",
+        overflow: "hidden",
+        "& img": {
+          boxSize: "100%",
+          objectFit: "cover",
+        },
+      },
+    },
+
+    // Growing middle column.
+    content: {
+      display: "flex",
+      flex: "1",
+      flexDirection: "column",
+      gap: "spacing.50",
+      // Allow long titles/descriptions to wrap/truncate instead of forcing the
+      // row wider than its container.
+      minWidth: 0,
+    },
+
+    title: {
+      textStyle: "sm",
+      fontWeight: "500",
+      color: "colorPalette.12",
+    },
+
+    description: {
+      textStyle: "sm",
+      color: "colorPalette.11",
+    },
+
+    // Trailing slot for interactive controls.
+    actions: {
+      display: "flex",
+      flexShrink: 0,
+      alignItems: "center",
+      gap: "spacing.100",
+      marginInlineStart: "auto",
+    },
+
+    // Full-width band below the row.
+    footer: {
+      flexBasis: "100%",
+      display: "flex",
+      alignItems: "center",
+      minWidth: 0,
+    },
+  },
+
+  variants: {
+    size: {
+      xs: {
+        root: {
+          "--item-gap": "spacing.200",
+          "--item-padding": "spacing.200",
+        },
+      },
+      sm: {
+        root: {
+          "--item-gap": "spacing.300",
+          "--item-padding": "spacing.300",
+        },
+      },
+      md: {
+        root: {
+          "--item-gap": "spacing.400",
+          "--item-padding": "spacing.400",
+        },
+      },
+    },
+
+    variant: {
+      plain: {
+        root: {
+          backgroundColor: "transparent",
+        },
+      },
+      outline: {
+        root: {
+          border: "solid-25",
+          borderColor: "colorPalette.6",
+        },
+      },
+      subtle: {
+        root: {
+          backgroundColor: "colorPalette.2",
+        },
+      },
+    },
+  },
+
+  defaultVariants: {
+    size: "md",
+    variant: "plain",
+  },
+});

--- a/packages/nimbus/src/components/item/item.recipe.ts
+++ b/packages/nimbus/src/components/item/item.recipe.ts
@@ -12,7 +12,7 @@ import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
  * media slot rather than a recipe variant (which would collide with the root's
  * `variant` prop across the shared slot-recipe context).
  */
-export const itemRecipe = defineSlotRecipe({
+export const itemSlotRecipe = defineSlotRecipe({
   // Only the parts that live *inside* the row share the recipe context.
   // `Item.Group` wraps rows (it is a parent of `Item.Root`, not a child), and
   // `Item.Separator` reuses the standalone Nimbus `Separator`, so neither is a

--- a/packages/nimbus/src/components/item/item.slots.tsx
+++ b/packages/nimbus/src/components/item/item.slots.tsx
@@ -1,0 +1,55 @@
+import { createSlotRecipeContext } from "@chakra-ui/react/styled-system";
+import type { SlotComponent } from "../../type-utils/slot-types";
+import type {
+  ItemActionsSlotProps,
+  ItemContentSlotProps,
+  ItemDescriptionSlotProps,
+  ItemFooterSlotProps,
+  ItemHeaderSlotProps,
+  ItemMediaSlotProps,
+  ItemRootSlotProps,
+  ItemTitleSlotProps,
+} from "./item.types";
+
+const { withProvider, withContext } = createSlotRecipeContext({
+  key: "nimbusItem",
+});
+
+/**
+ * Root slot — provides the `nimbusItem` styling context for all Item parts.
+ * Rendered as a `<div>` by default; `Item.Root` swaps it to an `<a>` (via
+ * `as="a"`) when the row upgrades to a link.
+ */
+export const ItemRootSlot: SlotComponent<HTMLDivElement, ItemRootSlotProps> =
+  withProvider<HTMLDivElement, ItemRootSlotProps>("div", "root");
+
+export const ItemHeaderSlot: SlotComponent<
+  HTMLDivElement,
+  ItemHeaderSlotProps
+> = withContext<HTMLDivElement, ItemHeaderSlotProps>("div", "header");
+
+export const ItemMediaSlot: SlotComponent<HTMLDivElement, ItemMediaSlotProps> =
+  withContext<HTMLDivElement, ItemMediaSlotProps>("div", "media");
+
+export const ItemContentSlot: SlotComponent<
+  HTMLDivElement,
+  ItemContentSlotProps
+> = withContext<HTMLDivElement, ItemContentSlotProps>("div", "content");
+
+export const ItemTitleSlot: SlotComponent<HTMLDivElement, ItemTitleSlotProps> =
+  withContext<HTMLDivElement, ItemTitleSlotProps>("div", "title");
+
+export const ItemDescriptionSlot: SlotComponent<
+  HTMLDivElement,
+  ItemDescriptionSlotProps
+> = withContext<HTMLDivElement, ItemDescriptionSlotProps>("div", "description");
+
+export const ItemActionsSlot: SlotComponent<
+  HTMLDivElement,
+  ItemActionsSlotProps
+> = withContext<HTMLDivElement, ItemActionsSlotProps>("div", "actions");
+
+export const ItemFooterSlot: SlotComponent<
+  HTMLDivElement,
+  ItemFooterSlotProps
+> = withContext<HTMLDivElement, ItemFooterSlotProps>("div", "footer");

--- a/packages/nimbus/src/components/item/item.stories.tsx
+++ b/packages/nimbus/src/components/item/item.stories.tsx
@@ -297,10 +297,19 @@ export const AsLink: Story = {
  * is operable without triggering row navigation.
  */
 const onDeleteAction = fn();
+const onRootClickCapture = fn();
 
 export const LinkWithActions: Story = {
   render: () => (
-    <Item.Root href="#item-target" variant="outline" data-testid="item">
+    <Item.Root
+      href="#item-target"
+      variant="outline"
+      data-testid="item"
+      // A consumer-supplied capture handler must coexist with the row's own
+      // navigation guard, not replace it (regression guard for the guard being
+      // merged rather than passed as a bare prop before the spread).
+      onClickCapture={onRootClickCapture}
+    >
       <Item.Content>
         <Item.Title>Report Q3</Item.Title>
         <Item.Description>Opens the report</Item.Description>
@@ -321,6 +330,7 @@ export const LinkWithActions: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     onDeleteAction.mockClear();
+    onRootClickCapture.mockClear();
 
     await step("Row link and action are both present", async () => {
       await expect(
@@ -340,6 +350,9 @@ export const LinkWithActions: Story = {
 
       // The action handler fired...
       await expect(onDeleteAction).toHaveBeenCalledTimes(1);
+      // ...the consumer's own onClickCapture on the row also fired (the guard
+      // is chained via mergeProps, not clobbered by the consumer handler)...
+      await expect(onRootClickCapture).toHaveBeenCalledTimes(1);
       // ...and the click did NOT navigate the row link (still mounted; the
       // location hash never became the row's href target).
       await expect(

--- a/packages/nimbus/src/components/item/item.stories.tsx
+++ b/packages/nimbus/src/components/item/item.stories.tsx
@@ -1,0 +1,302 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Item,
+  type ItemRootProps,
+  Stack,
+  Text,
+  IconButton,
+} from "@commercetools/nimbus";
+import {
+  Person,
+  Settings,
+  ChevronRight,
+  Delete,
+} from "@commercetools/nimbus-icons";
+import { within, expect, userEvent, fn } from "storybook/test";
+
+const sizes: ItemRootProps["size"][] = ["xs", "sm", "md"];
+const variants: ItemRootProps["variant"][] = ["plain", "outline", "subtle"];
+
+const meta: Meta<typeof Item.Root> = {
+  title: "Components/Item",
+  component: Item.Root,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Item.Root>;
+
+/**
+ * Base story — a static (presentational) row with media, content, and actions.
+ */
+export const Base: Story = {
+  render: () => (
+    <Item.Root variant="outline" data-testid="item">
+      <Item.Media variant="icon">
+        <Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Profile</Item.Title>
+        <Item.Description>Name, avatar, and contact details</Item.Description>
+      </Item.Content>
+      <Item.Actions>
+        <IconButton aria-label="Settings" size="xs" variant="ghost">
+          <Settings />
+        </IconButton>
+      </Item.Actions>
+    </Item.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const item = canvas.getByTestId("item");
+
+    await step("Renders a <div> by default (presentational)", async () => {
+      await expect(item.tagName).toBe("DIV");
+    });
+
+    await step("Displays title and description", async () => {
+      await expect(canvas.getByText("Profile")).toBeInTheDocument();
+      await expect(
+        canvas.getByText("Name, avatar, and contact details")
+      ).toBeInTheDocument();
+    });
+
+    await step("Renders the action control", async () => {
+      await expect(
+        canvas.getByRole("button", { name: "Settings" })
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Sizes — xs, sm, md density steps.
+ */
+export const Sizes: Story = {
+  render: () => (
+    <Stack gap="400">
+      {sizes.map((size) => (
+        <Item.Root
+          key={size as string}
+          size={size}
+          variant="outline"
+          data-testid={`item-size-${size as string}`}
+        >
+          <Item.Media variant="icon">
+            <Person />
+          </Item.Media>
+          <Item.Content>
+            <Item.Title>Size: {size as string}</Item.Title>
+            <Item.Description>Density scales padding and gap.</Item.Description>
+          </Item.Content>
+        </Item.Root>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("Renders each size", async () => {
+      for (const size of sizes) {
+        await expect(
+          canvas.getByTestId(`item-size-${size as string}`)
+        ).toBeInTheDocument();
+      }
+    });
+  },
+};
+
+/**
+ * Variants — plain, outline, subtle.
+ */
+export const Variants: Story = {
+  render: () => (
+    <Stack gap="400">
+      {variants.map((variant) => (
+        <Item.Root
+          key={variant as string}
+          variant={variant}
+          data-testid={`item-variant-${variant as string}`}
+        >
+          <Item.Content>
+            <Item.Title>Variant: {variant as string}</Item.Title>
+          </Item.Content>
+        </Item.Root>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("Renders each variant", async () => {
+      for (const variant of variants) {
+        await expect(
+          canvas.getByTestId(`item-variant-${variant as string}`)
+        ).toBeInTheDocument();
+      }
+    });
+  },
+};
+
+/**
+ * Media variants — default, icon, image.
+ */
+export const MediaVariants: Story = {
+  render: () => (
+    <Stack gap="400">
+      <Item.Root variant="outline" data-testid="media-icon">
+        <Item.Media variant="icon" data-testid="media-icon-slot">
+          <Person />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Icon media</Item.Title>
+        </Item.Content>
+      </Item.Root>
+      <Item.Root variant="outline" data-testid="media-image">
+        <Item.Media variant="image" data-testid="media-image-slot">
+          <img
+            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+            alt="Placeholder thumbnail"
+          />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Image media</Item.Title>
+        </Item.Content>
+      </Item.Root>
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("Media slot carries its data-variant", async () => {
+      await expect(canvas.getByTestId("media-icon-slot")).toHaveAttribute(
+        "data-variant",
+        "icon"
+      );
+      await expect(canvas.getByTestId("media-image-slot")).toHaveAttribute(
+        "data-variant",
+        "image"
+      );
+    });
+  },
+};
+
+/**
+ * Header and footer bands.
+ */
+export const WithHeaderAndFooter: Story = {
+  render: () => (
+    <Item.Root variant="outline" data-testid="item">
+      <Item.Header>
+        <Text fontWeight="600">Header band</Text>
+      </Item.Header>
+      <Item.Media variant="icon">
+        <Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>With header and footer</Item.Title>
+        <Item.Description>Both bands span the full row width.</Item.Description>
+      </Item.Content>
+      <Item.Footer>
+        <Text textStyle="sm">Footer band</Text>
+      </Item.Footer>
+    </Item.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("Renders header and footer content", async () => {
+      await expect(canvas.getByText("Header band")).toBeInTheDocument();
+      await expect(canvas.getByText("Footer band")).toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Link-upgrade — passing href renders the row as an accessible <a>.
+ */
+export const AsLink: Story = {
+  render: () => (
+    <Item.Root href="#item-target" variant="outline" data-testid="item">
+      <Item.Media variant="icon">
+        <Settings />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Settings</Item.Title>
+        <Item.Description>Navigate to settings</Item.Description>
+      </Item.Content>
+      <Item.Media aria-hidden>
+        <ChevronRight />
+      </Item.Media>
+    </Item.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Upgrades to an <a> with href", async () => {
+      const link = canvas.getByRole("link", { name: /Settings/ });
+      await expect(link.tagName).toBe("A");
+      await expect(link).toHaveAttribute("href", "#item-target");
+    });
+
+    await step("Is keyboard focusable", async () => {
+      const link = canvas.getByRole("link", { name: /Settings/ });
+      await userEvent.tab();
+      await expect(link).toHaveFocus();
+    });
+  },
+};
+
+/**
+ * Link row with actions — the action control is an independent focus stop and
+ * is operable without triggering row navigation.
+ */
+const onDeleteAction = fn();
+
+export const LinkWithActions: Story = {
+  render: () => (
+    <Item.Root href="#item-target" variant="outline" data-testid="item">
+      <Item.Content>
+        <Item.Title>Report Q3</Item.Title>
+        <Item.Description>Opens the report</Item.Description>
+      </Item.Content>
+      <Item.Actions>
+        <IconButton
+          aria-label="Delete"
+          size="xs"
+          variant="ghost"
+          onPress={onDeleteAction}
+          data-testid="delete-action"
+        >
+          <Delete />
+        </IconButton>
+      </Item.Actions>
+    </Item.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    onDeleteAction.mockClear();
+
+    await step("Row link and action are both present", async () => {
+      await expect(
+        canvas.getByRole("link", { name: /Report Q3/ })
+      ).toBeInTheDocument();
+      await expect(
+        canvas.getByRole("button", { name: "Delete" })
+      ).toBeInTheDocument();
+    });
+
+    await step("Action activates without navigating the row", async () => {
+      const action = canvas.getByRole("button", { name: "Delete" });
+      action.focus();
+      await expect(action).toHaveFocus();
+
+      await userEvent.click(action);
+
+      // The action handler fired...
+      await expect(onDeleteAction).toHaveBeenCalledTimes(1);
+      // ...and the click did NOT navigate the row link (still mounted; the
+      // location hash never became the row's href target).
+      await expect(
+        canvas.getByRole("link", { name: /Report Q3/ })
+      ).toBeInTheDocument();
+      await expect(window.location.hash).not.toBe("#item-target");
+    });
+  },
+};

--- a/packages/nimbus/src/components/item/item.stories.tsx
+++ b/packages/nimbus/src/components/item/item.stories.tsx
@@ -146,7 +146,7 @@ export const Variants: Story = {
 export const MediaVariants: Story = {
   render: () => (
     <Stack gap="400">
-      <Item.Root variant="outline" data-testid="media-icon">
+      <Item.Root variant="outline">
         <Item.Media variant="icon" data-testid="media-icon-slot">
           <Person />
         </Item.Media>
@@ -154,7 +154,7 @@ export const MediaVariants: Story = {
           <Item.Title>Icon media</Item.Title>
         </Item.Content>
       </Item.Root>
-      <Item.Root variant="outline" data-testid="media-image">
+      <Item.Root variant="outline">
         <Item.Media variant="image" data-testid="media-image-slot">
           <Image
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
@@ -248,7 +248,7 @@ export const WithButtonActions: Story = {
 
     await step("Action is operable", async () => {
       const action = canvas.getByRole("button", { name: "Manage" });
-      action.focus();
+      await userEvent.tab();
       await expect(action).toHaveFocus();
 
       await userEvent.click(action);
@@ -262,7 +262,7 @@ export const WithButtonActions: Story = {
  */
 export const AsLink: Story = {
   render: () => (
-    <Item.Root href="#item-target" variant="outline" data-testid="item">
+    <Item.Root href="#item-target" variant="outline">
       <Item.Media variant="icon">
         <Settings />
       </Item.Media>
@@ -304,7 +304,6 @@ export const LinkWithActions: Story = {
     <Item.Root
       href="#item-target"
       variant="outline"
-      data-testid="item"
       // A consumer-supplied capture handler must coexist with the row's own
       // navigation guard, not replace it (regression guard for the guard being
       // merged rather than passed as a bare prop before the spread).
@@ -320,7 +319,6 @@ export const LinkWithActions: Story = {
           size="xs"
           variant="ghost"
           onPress={onDeleteAction}
-          data-testid="delete-action"
         >
           <Delete />
         </IconButton>
@@ -343,7 +341,9 @@ export const LinkWithActions: Story = {
 
     await step("Action activates without navigating the row", async () => {
       const action = canvas.getByRole("button", { name: "Delete" });
-      action.focus();
+      // Tab past the row link to reach the action control (both are tab stops).
+      await userEvent.tab();
+      await userEvent.tab();
       await expect(action).toHaveFocus();
 
       await userEvent.click(action);
@@ -393,14 +393,14 @@ const onMemberSettings = fn();
 
 export const Showcase: Story = {
   render: () => (
-    <Stack gap="800" maxWidth="640px" data-testid="showcase">
+    <Stack gap="800" maxWidth="640px">
       <Text textStyle="lg" fontWeight="700">
         Item &amp; ItemGroup — full showcase
       </Text>
 
       {/* Standalone card: a full-width banner image in the Header, a thumbnail
           in the Media slot, a Button action, and a Footer band. */}
-      <Item.Root variant="outline" data-testid="hero-card">
+      <Item.Root variant="outline">
         <Item.Header>
           <Image
             src="https://picsum.photos/seed/hero/640/200"

--- a/packages/nimbus/src/components/item/item.stories.tsx
+++ b/packages/nimbus/src/components/item/item.stories.tsx
@@ -2,13 +2,17 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   Item,
   type ItemRootProps,
+  ItemGroup,
   Stack,
   Text,
+  Button,
   IconButton,
+  Image,
 } from "@commercetools/nimbus";
 import {
   Person,
   Settings,
+  Notifications,
   ChevronRight,
   Delete,
 } from "@commercetools/nimbus-icons";
@@ -18,7 +22,7 @@ const sizes: ItemRootProps["size"][] = ["xs", "sm", "md"];
 const variants: ItemRootProps["variant"][] = ["plain", "outline", "subtle"];
 
 const meta: Meta<typeof Item.Root> = {
-  title: "Components/Item",
+  title: "Components/Item/Item",
   component: Item.Root,
 };
 
@@ -152,7 +156,7 @@ export const MediaVariants: Story = {
       </Item.Root>
       <Item.Root variant="outline" data-testid="media-image">
         <Item.Media variant="image" data-testid="media-image-slot">
-          <img
+          <Image
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
             alt="Placeholder thumbnail"
           />
@@ -204,6 +208,51 @@ export const WithHeaderAndFooter: Story = {
     await step("Renders header and footer content", async () => {
       await expect(canvas.getByText("Header band")).toBeInTheDocument();
       await expect(canvas.getByText("Footer band")).toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Actions with a full Button — `Item.Actions` accepts a regular `Button`, not
+ * only an `IconButton`. The action keeps an independent focus order from the
+ * row and is operable on its own.
+ */
+const onManageAction = fn();
+
+export const WithButtonActions: Story = {
+  render: () => (
+    <Item.Root variant="outline" data-testid="item">
+      <Item.Media variant="icon">
+        <Person />
+      </Item.Media>
+      <Item.Content>
+        <Item.Title>Team members</Item.Title>
+        <Item.Description>Invite and manage who has access</Item.Description>
+      </Item.Content>
+      <Item.Actions>
+        <Button size="xs" variant="outline" onPress={onManageAction}>
+          Manage
+        </Button>
+      </Item.Actions>
+    </Item.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    onManageAction.mockClear();
+
+    await step("Renders a text Button action", async () => {
+      await expect(
+        canvas.getByRole("button", { name: "Manage" })
+      ).toBeInTheDocument();
+    });
+
+    await step("Action is operable", async () => {
+      const action = canvas.getByRole("button", { name: "Manage" });
+      action.focus();
+      await expect(action).toHaveFocus();
+
+      await userEvent.click(action);
+      await expect(onManageAction).toHaveBeenCalledTimes(1);
     });
   },
 };
@@ -299,4 +348,396 @@ export const LinkWithActions: Story = {
       await expect(window.location.hash).not.toBe("#item-target");
     });
   },
+};
+
+/**
+ * Showcase — one story that exercises the entire Item + ItemGroup surface in a
+ * single page. It is deliberately a kitchen sink, not a realistic layout: the
+ * point is coverage, not product sense. In one render it uses —
+ *
+ * - **Parts:** `Item.Header`, `Item.Media`, `Item.Content` (`Item.Title` /
+ *   `Item.Description`), `Item.Actions`, and `Item.Footer`.
+ * - **Root variants** `plain` · `outline` · `subtle` and **sizes** `md` · `sm`
+ *   · `xs`.
+ * - **Media variants** `icon`, `image`, and `default`, plus style-prop
+ *   overrides on the media slot for **avatars** (`borderRadius="full"`),
+ *   **thumbnails** (default image box), and **large images** (a widened media
+ *   box and a full-width banner in `Item.Header`).
+ * - **Imagery** via the Nimbus `Image` component sourced from picsum.photos
+ *   with fixed `seed`s, so every picture is deterministic.
+ * - **Link-upgrade** rows (`href` → `<a>`), including a link row whose trailing
+ *   `Item.Actions` control stays operable without navigating the row.
+ * - **Actions** as both a `Button` (solid / outline / ghost) and an
+ *   `IconButton`.
+ * - **`ItemGroup.Root` + `ItemGroup.Separator`** for grouped sections, and a
+ *   standalone `Item.Root` outside any group.
+ *
+ * Not VRT-snapshotted (the network imagery would flake, and `SmokeTest` already
+ * owns visual coverage with an offline image); the play function asserts
+ * behavior and the deterministic image `src`.
+ */
+const onMemberSettings = fn();
+
+export const Showcase: Story = {
+  render: () => (
+    <Stack gap="800" maxWidth="640px" data-testid="showcase">
+      <Text textStyle="lg" fontWeight="700">
+        Item &amp; ItemGroup — full showcase
+      </Text>
+
+      {/* Standalone card: a full-width banner image in the Header, a thumbnail
+          in the Media slot, a Button action, and a Footer band. */}
+      <Item.Root variant="outline" data-testid="hero-card">
+        <Item.Header>
+          <Image
+            src="https://picsum.photos/seed/hero/640/200"
+            alt=""
+            width="100%"
+            height="160px"
+            borderRadius="200"
+            objectFit="cover"
+          />
+        </Item.Header>
+        <Item.Media variant="image">
+          <Image
+            src="https://picsum.photos/seed/report/96/96"
+            alt="Report thumbnail"
+          />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Quarterly report</Item.Title>
+          <Item.Description>
+            Header banner, thumbnail media, and a footer band on one Item.
+          </Item.Description>
+        </Item.Content>
+        <Item.Actions>
+          <Button size="xs" variant="solid">
+            Open
+          </Button>
+        </Item.Actions>
+        <Item.Footer>
+          <Text textStyle="sm">Updated 3 days ago · 12 contributors</Text>
+        </Item.Footer>
+      </Item.Root>
+
+      {/* Members — avatars (rounded image media), a link row with an operable
+          trailing action, and Button actions, divided by separators. */}
+      <Stack gap="300">
+        <Text textStyle="sm" fontWeight="600">
+          Members
+        </Text>
+        <ItemGroup.Root>
+          <Item.Root href="#member-alex" data-testid="member-link">
+            <Item.Media variant="image" borderRadius="full">
+              <Image
+                src="https://picsum.photos/seed/alex/96/96"
+                alt="Alex Rivera"
+              />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Alex Rivera</Item.Title>
+              <Item.Description>Owner · alex@acme.com</Item.Description>
+            </Item.Content>
+            <Item.Actions>
+              <IconButton
+                aria-label="Member settings"
+                size="xs"
+                variant="ghost"
+                onPress={onMemberSettings}
+              >
+                <Settings />
+              </IconButton>
+            </Item.Actions>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root>
+            <Item.Media variant="image" borderRadius="full">
+              <Image
+                src="https://picsum.photos/seed/jordan/96/96"
+                alt="Jordan Lee"
+              />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Jordan Lee</Item.Title>
+              <Item.Description>Editor · jordan@acme.com</Item.Description>
+            </Item.Content>
+            <Item.Actions>
+              <Button size="xs" variant="outline">
+                Manage
+              </Button>
+            </Item.Actions>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root>
+            <Item.Media variant="icon">
+              <Person />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Pat Morgan</Item.Title>
+              <Item.Description>Viewer · pat@acme.com</Item.Description>
+            </Item.Content>
+            <Item.Actions>
+              <Button size="xs" variant="ghost">
+                Change role
+              </Button>
+            </Item.Actions>
+          </Item.Root>
+        </ItemGroup.Root>
+      </Stack>
+
+      {/* Gallery — large image media via a widened media box. */}
+      <Stack gap="300">
+        <Text textStyle="sm" fontWeight="600">
+          Gallery
+        </Text>
+        <ItemGroup.Root>
+          <Item.Root>
+            <Item.Media
+              variant="image"
+              width="120px"
+              height="80px"
+              borderRadius="200"
+            >
+              <Image
+                src="https://picsum.photos/seed/mountain/240/160"
+                alt="Mountains at dusk"
+              />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Mountains at dusk</Item.Title>
+              <Item.Description>Large 120×80 media override</Item.Description>
+            </Item.Content>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root>
+            <Item.Media
+              variant="image"
+              width="120px"
+              height="80px"
+              borderRadius="200"
+            >
+              <Image
+                src="https://picsum.photos/seed/ocean/240/160"
+                alt="Open water"
+              />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Open water</Item.Title>
+              <Item.Description>Another landscape thumbnail</Item.Description>
+            </Item.Content>
+          </Item.Root>
+        </ItemGroup.Root>
+      </Stack>
+
+      {/* Recent activity — dense rows (size sm), subtle variant, default media. */}
+      <Stack gap="300">
+        <Text textStyle="sm" fontWeight="600">
+          Recent activity
+        </Text>
+        <ItemGroup.Root>
+          <Item.Root size="sm" variant="subtle">
+            <Item.Media variant="icon">
+              <Notifications />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Deployment succeeded</Item.Title>
+              <Item.Description>2 minutes ago</Item.Description>
+            </Item.Content>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root size="sm" variant="subtle">
+            <Item.Media variant="default">
+              <Person />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>New member joined</Item.Title>
+              <Item.Description>Yesterday</Item.Description>
+            </Item.Content>
+          </Item.Root>
+        </ItemGroup.Root>
+      </Stack>
+
+      {/* Quick links — compact (size xs) link rows with a trailing chevron. */}
+      <Stack gap="300">
+        <Text textStyle="sm" fontWeight="600">
+          Quick links
+        </Text>
+        <ItemGroup.Root>
+          <Item.Root href="#docs" size="xs">
+            <Item.Media variant="icon">
+              <Settings />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Documentation</Item.Title>
+            </Item.Content>
+            <Item.Media aria-hidden>
+              <ChevronRight />
+            </Item.Media>
+          </Item.Root>
+          <ItemGroup.Separator />
+          <Item.Root href="#support" size="xs">
+            <Item.Media variant="icon">
+              <Person />
+            </Item.Media>
+            <Item.Content>
+              <Item.Title>Contact support</Item.Title>
+            </Item.Content>
+            <Item.Media aria-hidden>
+              <ChevronRight />
+            </Item.Media>
+          </Item.Root>
+        </ItemGroup.Root>
+      </Stack>
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    onMemberSettings.mockClear();
+
+    await step("Renders every section and the standalone card", async () => {
+      await expect(canvas.getByText("Quarterly report")).toBeInTheDocument();
+      await expect(
+        canvas.getByText("Updated 3 days ago · 12 contributors")
+      ).toBeInTheDocument();
+      await expect(canvas.getByText("Members")).toBeInTheDocument();
+      await expect(canvas.getByText("Gallery")).toBeInTheDocument();
+      await expect(canvas.getByText("Recent activity")).toBeInTheDocument();
+      await expect(canvas.getByText("Quick links")).toBeInTheDocument();
+    });
+
+    await step("Rows with href upgrade to accessible links", async () => {
+      const memberLink = canvas.getByTestId("member-link");
+      await expect(memberLink.tagName).toBe("A");
+      await expect(memberLink).toHaveAttribute("href", "#member-alex");
+      await expect(
+        canvas.getByRole("link", { name: /Documentation/ })
+      ).toHaveAttribute("href", "#docs");
+    });
+
+    await step(
+      "A trailing action in a link row fires without navigating",
+      async () => {
+        await userEvent.click(
+          canvas.getByRole("button", { name: "Member settings" })
+        );
+        await expect(onMemberSettings).toHaveBeenCalledTimes(1);
+        await expect(window.location.hash).not.toBe("#member-alex");
+      }
+    );
+
+    await step("Image media uses the deterministic seeded source", async () => {
+      await expect(
+        canvas.getByRole("img", { name: "Jordan Lee" })
+      ).toHaveAttribute("src", "https://picsum.photos/seed/jordan/96/96");
+    });
+
+    await step("Separators divide the grouped sections", async () => {
+      // Members (2) + Gallery (1) + Recent activity (1) + Quick links (1) = 5
+      await expect(canvas.getAllByRole("separator")).toHaveLength(5);
+    });
+  },
+};
+
+/**
+ * SmokeTest — the full `variant × size` grid plus the media variants, a link
+ * row, and header/footer bands, packed into a single render. This is the story
+ * Chromatic snapshots (`tags: ["vrt"]`); it keeps combinatorial visual coverage
+ * to one billable image. No play function — it exists purely for visual
+ * regression.
+ */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack gap="800">
+      {variants.map((variant) => (
+        <Stack key={variant as string} direction="column" gap="400">
+          {sizes.map((size) => (
+            <Item.Root key={size as string} variant={variant} size={size}>
+              <Item.Media variant="icon">
+                <Person />
+              </Item.Media>
+              <Item.Content>
+                <Item.Title>
+                  {variant as string} · {size as string}
+                </Item.Title>
+                <Item.Description>
+                  Media, content, and a trailing action.
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions>
+                <IconButton aria-label="Settings" size="xs" variant="ghost">
+                  <Settings />
+                </IconButton>
+              </Item.Actions>
+            </Item.Root>
+          ))}
+        </Stack>
+      ))}
+
+      {/* Media variants */}
+      <Stack direction="column" gap="400">
+        <Item.Root variant="outline">
+          <Item.Media variant="default">
+            <Person />
+          </Item.Media>
+          <Item.Content>
+            <Item.Title>Media: default</Item.Title>
+          </Item.Content>
+        </Item.Root>
+        <Item.Root variant="outline">
+          <Item.Media variant="icon">
+            <Person />
+          </Item.Media>
+          <Item.Content>
+            <Item.Title>Media: icon</Item.Title>
+          </Item.Content>
+        </Item.Root>
+        <Item.Root variant="outline">
+          <Item.Media variant="image">
+            <Image
+              src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+              alt="Placeholder thumbnail"
+            />
+          </Item.Media>
+          <Item.Content>
+            <Item.Title>Media: image</Item.Title>
+          </Item.Content>
+        </Item.Root>
+      </Stack>
+
+      {/* Link row */}
+      <Item.Root href="#smoke-target" variant="outline">
+        <Item.Media variant="icon">
+          <Settings />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>Link row</Item.Title>
+          <Item.Description>Renders as an accessible anchor</Item.Description>
+        </Item.Content>
+        <Item.Media aria-hidden>
+          <ChevronRight />
+        </Item.Media>
+      </Item.Root>
+
+      {/* Header + footer bands */}
+      <Item.Root variant="outline">
+        <Item.Header>
+          <Text fontWeight="600">Header band</Text>
+        </Item.Header>
+        <Item.Media variant="icon">
+          <Person />
+        </Item.Media>
+        <Item.Content>
+          <Item.Title>With header and footer</Item.Title>
+          <Item.Description>
+            Both bands span the full row width.
+          </Item.Description>
+        </Item.Content>
+        <Item.Footer>
+          <Text textStyle="sm">Footer band</Text>
+        </Item.Footer>
+      </Item.Root>
+    </Stack>
+  ),
 };

--- a/packages/nimbus/src/components/item/item.tsx
+++ b/packages/nimbus/src/components/item/item.tsx
@@ -47,12 +47,31 @@ export const Item = {
    * Renders a `<div>` by default and upgrades to an `<a>` (via React Aria's
    * `useLink`) when an `href` is provided. Accepts `variant`
    * (`plain`/`outline`/`subtle`) and `size` (`xs`/`sm`/`md`) props.
+   *
+   * @example
+   * ```tsx
+   * <Item.Root variant="outline" size="md" href="/settings/profile">
+   *   <Item.Content>
+   *     <Item.Title>Profile</Item.Title>
+   *   </Item.Content>
+   * </Item.Root>
+   * ```
    */
   Root: ItemRoot,
   /**
    * # Item.Header
    *
    * Optional full-width band rendered above the media·content·actions row.
+   *
+   * @example
+   * ```tsx
+   * <Item.Root>
+   *   <Item.Header>Shared with your team</Item.Header>
+   *   <Item.Content>
+   *     <Item.Title>Design spec</Item.Title>
+   *   </Item.Content>
+   * </Item.Root>
+   * ```
    */
   Header: ItemHeader,
   /**
@@ -60,24 +79,54 @@ export const Item = {
    *
    * Fixed, non-shrinking leading slot for an icon, avatar, or image. Its own
    * `variant` (`default`/`icon`/`image`) sizes and shapes the media.
+   *
+   * @example
+   * ```tsx
+   * <Item.Media variant="icon">
+   *   <PersonIcon />
+   * </Item.Media>
+   * ```
    */
   Media: ItemMedia,
   /**
    * # Item.Content
    *
    * The growing middle column that wraps `Item.Title` and `Item.Description`.
+   *
+   * @example
+   * ```tsx
+   * <Item.Content>
+   *   <Item.Title>Profile</Item.Title>
+   *   <Item.Description>Name, avatar, and contact details</Item.Description>
+   * </Item.Content>
+   * ```
    */
   Content: ItemContent,
   /**
    * # Item.Title
    *
    * The primary label of the row.
+   *
+   * @example
+   * ```tsx
+   * <Item.Content>
+   *   <Item.Title>Notifications</Item.Title>
+   * </Item.Content>
+   * ```
    */
   Title: ItemTitle,
   /**
    * # Item.Description
    *
    * Secondary text below the title.
+   *
+   * @example
+   * ```tsx
+   * <Item.Content>
+   *   <Item.Title>Notifications</Item.Title>
+   *   <Item.Description>Email and push preferences</Item.Description>
+   * </Item.Content>
+   * ```
    */
   Description: ItemDescription,
   /**
@@ -85,12 +134,29 @@ export const Item = {
    *
    * Trailing slot for interactive controls (`Button`, `IconButton`). Controls
    * here keep a focus order independent of a link-mode `Item.Root`.
+   *
+   * @example
+   * ```tsx
+   * <Item.Actions>
+   *   <IconButton aria-label="Open"><ChevronRightIcon /></IconButton>
+   * </Item.Actions>
+   * ```
    */
   Actions: ItemActions,
   /**
    * # Item.Footer
    *
    * Optional full-width band rendered below the row.
+   *
+   * @example
+   * ```tsx
+   * <Item.Root>
+   *   <Item.Content>
+   *     <Item.Title>Design spec</Item.Title>
+   *   </Item.Content>
+   *   <Item.Footer>Updated 3 days ago</Item.Footer>
+   * </Item.Root>
+   * ```
    */
   Footer: ItemFooter,
 };

--- a/packages/nimbus/src/components/item/item.tsx
+++ b/packages/nimbus/src/components/item/item.tsx
@@ -1,0 +1,107 @@
+import {
+  ItemRoot,
+  ItemHeader,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+  ItemActions,
+  ItemFooter,
+} from "./components";
+
+/**
+ * Item
+ * ============================================================
+ * A horizontal content-row primitive: leading media, a title/description
+ * column, and trailing actions. Complements `Card` (a vertical container) and
+ * `List`/`Menu` (interactive, selectable collections).
+ *
+ * Presentational by default; `Item.Root` upgrades to an accessible link when
+ * given an `href`. Row actions live as nested controls in `Item.Actions`.
+ *
+ * @see {@link https://nimbus-documentation.vercel.app/components/data-display/item}
+ *
+ * @example
+ * ```tsx
+ * <ItemGroup>
+ *   <Item.Root href="/settings/profile">
+ *     <Item.Media variant="icon"><PersonIcon /></Item.Media>
+ *     <Item.Content>
+ *       <Item.Title>Profile</Item.Title>
+ *       <Item.Description>Name, avatar, and contact details</Item.Description>
+ *     </Item.Content>
+ *     <Item.Actions>
+ *       <IconButton aria-label="Open"><ChevronRightIcon /></IconButton>
+ *     </Item.Actions>
+ *   </Item.Root>
+ *   <ItemGroup.Separator />
+ *   <Item.Root>…</Item.Root>
+ * </ItemGroup>
+ * ```
+ */
+export const Item = {
+  /**
+   * # Item.Root
+   *
+   * The row container and styling-context provider for all Item parts.
+   * Renders a `<div>` by default and upgrades to an `<a>` (via React Aria's
+   * `useLink`) when an `href` is provided. Accepts `variant`
+   * (`plain`/`outline`/`subtle`) and `size` (`xs`/`sm`/`md`) props.
+   */
+  Root: ItemRoot,
+  /**
+   * # Item.Header
+   *
+   * Optional full-width band rendered above the media·content·actions row.
+   */
+  Header: ItemHeader,
+  /**
+   * # Item.Media
+   *
+   * Fixed, non-shrinking leading slot for an icon, avatar, or image. Its own
+   * `variant` (`default`/`icon`/`image`) sizes and shapes the media.
+   */
+  Media: ItemMedia,
+  /**
+   * # Item.Content
+   *
+   * The growing middle column that wraps `Item.Title` and `Item.Description`.
+   */
+  Content: ItemContent,
+  /**
+   * # Item.Title
+   *
+   * The primary label of the row.
+   */
+  Title: ItemTitle,
+  /**
+   * # Item.Description
+   *
+   * Secondary text below the title.
+   */
+  Description: ItemDescription,
+  /**
+   * # Item.Actions
+   *
+   * Trailing slot for interactive controls (`Button`, `IconButton`). Controls
+   * here keep a focus order independent of a link-mode `Item.Root`.
+   */
+  Actions: ItemActions,
+  /**
+   * # Item.Footer
+   *
+   * Optional full-width band rendered below the row.
+   */
+  Footer: ItemFooter,
+};
+
+export {
+  ItemRoot as _ItemRoot,
+  ItemHeader as _ItemHeader,
+  ItemMedia as _ItemMedia,
+  ItemContent as _ItemContent,
+  ItemTitle as _ItemTitle,
+  ItemDescription as _ItemDescription,
+  ItemActions as _ItemActions,
+  ItemFooter as _ItemFooter,
+};

--- a/packages/nimbus/src/components/item/item.types.ts
+++ b/packages/nimbus/src/components/item/item.types.ts
@@ -64,7 +64,12 @@ export type ItemLinkProps = Partial<
 export type ItemRootProps = OmitInternalProps<ItemRootSlotProps> &
   ItemLinkProps & {
     children?: React.ReactNode;
-    ref?: React.Ref<HTMLDivElement & HTMLAnchorElement>;
+    /**
+     * Ref to the root element. `Item.Root` renders a `<div>` by default and an
+     * `<a>` in link mode, so the ref is typed to the default element; in link
+     * mode it resolves to the underlying `HTMLAnchorElement` at runtime.
+     */
+    ref?: React.Ref<HTMLDivElement>;
     [key: `data-${string}`]: unknown;
   };
 

--- a/packages/nimbus/src/components/item/item.types.ts
+++ b/packages/nimbus/src/components/item/item.types.ts
@@ -1,0 +1,121 @@
+import type { OmitInternalProps } from "../../type-utils/omit-props";
+import type {
+  HTMLChakraProps,
+  SlotRecipeProps,
+  UnstyledProp,
+} from "@chakra-ui/react/styled-system";
+import type { AriaLinkOptions } from "react-aria";
+
+// ============================================================
+// RECIPE PROPS
+// ============================================================
+
+type ItemRecipeProps = {
+  /** Controls padding and gap density. */
+  size?: SlotRecipeProps<"nimbusItem">["size"];
+  /** Controls visual treatment (border / subtle surface). */
+  variant?: SlotRecipeProps<"nimbusItem">["variant"];
+} & UnstyledProp;
+
+// ============================================================
+// SLOT PROPS
+// ============================================================
+
+export type ItemRootSlotProps = HTMLChakraProps<"div", ItemRecipeProps>;
+export type ItemHeaderSlotProps = HTMLChakraProps<"div">;
+export type ItemMediaSlotProps = HTMLChakraProps<"div">;
+export type ItemContentSlotProps = HTMLChakraProps<"div">;
+export type ItemTitleSlotProps = HTMLChakraProps<"div">;
+export type ItemDescriptionSlotProps = HTMLChakraProps<"div">;
+export type ItemActionsSlotProps = HTMLChakraProps<"div">;
+export type ItemFooterSlotProps = HTMLChakraProps<"div">;
+
+// ============================================================
+// HELPER TYPES
+// ============================================================
+
+/**
+ * The subset of React Aria's link options that `Item.Root` forwards to the
+ * `useLink` hook when it upgrades from a `<div>` to an `<a>`. Presence of
+ * `href` is what triggers the upgrade.
+ */
+export type ItemLinkProps = Partial<
+  Pick<
+    AriaLinkOptions,
+    | "href"
+    | "target"
+    | "rel"
+    | "download"
+    | "ping"
+    | "referrerPolicy"
+    | "routerOptions"
+    | "onPress"
+  >
+>;
+
+// ============================================================
+// MAIN PROPS
+// ============================================================
+
+/**
+ * Props for the `Item.Root` component. Presentational by default; passing
+ * `href` upgrades the root to an accessible link (see `ItemLinkProps`).
+ */
+export type ItemRootProps = OmitInternalProps<ItemRootSlotProps> &
+  ItemLinkProps & {
+    children?: React.ReactNode;
+    ref?: React.Ref<HTMLDivElement & HTMLAnchorElement>;
+    [key: `data-${string}`]: unknown;
+  };
+
+/** Props for the `Item.Header` component. */
+export type ItemHeaderProps = OmitInternalProps<ItemHeaderSlotProps> & {
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+/** Media presentation variant for `Item.Media`. */
+export type ItemMediaVariant = "default" | "icon" | "image";
+
+/** Props for the `Item.Media` component. */
+export type ItemMediaProps = OmitInternalProps<ItemMediaSlotProps> & {
+  /**
+   * How the leading media is sized/shaped. Independent of `Item.Root`'s
+   * `variant`; applied via a `data-variant` attribute on the media slot.
+   * @default "default"
+   */
+  variant?: ItemMediaVariant;
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+/** Props for the `Item.Content` component. */
+export type ItemContentProps = OmitInternalProps<ItemContentSlotProps> & {
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+/** Props for the `Item.Title` component. */
+export type ItemTitleProps = OmitInternalProps<ItemTitleSlotProps> & {
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+/** Props for the `Item.Description` component. */
+export type ItemDescriptionProps =
+  OmitInternalProps<ItemDescriptionSlotProps> & {
+    children?: React.ReactNode;
+    ref?: React.Ref<HTMLDivElement>;
+  };
+
+/** Props for the `Item.Actions` component. */
+export type ItemActionsProps = OmitInternalProps<ItemActionsSlotProps> & {
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+/** Props for the `Item.Footer` component. */
+export type ItemFooterProps = OmitInternalProps<ItemFooterSlotProps> & {
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+};

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -19,6 +19,8 @@ import { draggableListSlotRecipe } from "@/components/draggable-list/draggable-l
 import { drawerSlotRecipe } from "@/components/drawer/drawer.recipe";
 import { fieldErrorsRecipe } from "@/components/field-errors/field-errors.recipe";
 import { formFieldRecipe } from "@/components/form-field/form-field.recipe";
+import { itemRecipe } from "@/components/item/item.recipe";
+import { itemGroupSlotRecipe } from "@/components/item-group/item-group.recipe";
 import { listSlotRecipe } from "@/components/list/list.recipe";
 import { localizedFieldSlotRecipe } from "@/components/localized-field/localized-field.recipe";
 import { menuSlotRecipe } from "@/components/menu/menu.recipe";
@@ -95,6 +97,8 @@ export const slotRecipes = {
   nimbusDrawer: drawerSlotRecipe,
   nimbusFieldErrors: fieldErrorsRecipe,
   nimbusFormField: formFieldRecipe,
+  nimbusItem: itemRecipe,
+  nimbusItemGroup: itemGroupSlotRecipe,
   nimbusList: listSlotRecipe,
   nimbusLocalizedField: localizedFieldSlotRecipe,
   nimbusMenu: menuSlotRecipe,

--- a/packages/nimbus/src/theme/slot-recipes/index.ts
+++ b/packages/nimbus/src/theme/slot-recipes/index.ts
@@ -19,7 +19,7 @@ import { draggableListSlotRecipe } from "@/components/draggable-list/draggable-l
 import { drawerSlotRecipe } from "@/components/drawer/drawer.recipe";
 import { fieldErrorsRecipe } from "@/components/field-errors/field-errors.recipe";
 import { formFieldRecipe } from "@/components/form-field/form-field.recipe";
-import { itemRecipe } from "@/components/item/item.recipe";
+import { itemSlotRecipe } from "@/components/item/item.recipe";
 import { itemGroupSlotRecipe } from "@/components/item-group/item-group.recipe";
 import { listSlotRecipe } from "@/components/list/list.recipe";
 import { localizedFieldSlotRecipe } from "@/components/localized-field/localized-field.recipe";
@@ -97,7 +97,7 @@ export const slotRecipes = {
   nimbusDrawer: drawerSlotRecipe,
   nimbusFieldErrors: fieldErrorsRecipe,
   nimbusFormField: formFieldRecipe,
-  nimbusItem: itemRecipe,
+  nimbusItem: itemSlotRecipe,
   nimbusItemGroup: itemGroupSlotRecipe,
   nimbusList: listSlotRecipe,
   nimbusLocalizedField: localizedFieldSlotRecipe,


### PR DESCRIPTION
## Summary

Adds two new Nimbus components — **`Item`** (a horizontal
content-row compound) and **`ItemGroup`** (a standalone container that stacks
`Item` rows) — adapted from shadcn's React Aria `Item` and retrofitted to Nimbus
conventions (Chakra slot recipes, `useLink`, compound namespaces). They fill the
one container shape Nimbus lacked: a dense row of leading media + title/
description + trailing actions, complementing `Card` (vertical) and `List`/
`Menu` (interactive/selectable collections).

<img width="709" height="1174" alt="image" src="https://github.com/user-attachments/assets/fcbdaa8e-74a1-4019-b7ad-23845c758470" />


## Motivation

Product surfaces (settings rows, notification entries, file/resource rows)
repeatedly rebuild the same media·content·actions row by hand. `Item` gives them
one accessible, tokenized primitive. `FEC-988` — `Item` is the successor of the
originally planned component.

## What changed

- **`Item`** (`packages/nimbus/src/components/item/`) — compound namespace:
  `Item.Root`, `.Header`, `.Media`, `.Content`, `.Title`, `.Description`,
  `.Actions`, `.Footer`. Recipe `nimbusItem`: `variant` (`plain`/`outline`/
  `subtle`) × `size` (`xs`/`sm`/`md`); `Item.Media` carries its own `variant`
  (`default`/`icon`/`image`) via a `data-variant` attribute.
- **`ItemGroup`** (`packages/nimbus/src/components/item-group/`) — standalone
  peer: `ItemGroup.Root` (vertical stack) + `ItemGroup.Separator`. Recipe
  `nimbusItemGroup`.
- Recipes registered in the theme; both components exported from the package
  barrel.
- Full docs per component (designer `.mdx`, engineering `.dev.mdx`, `.a11y.mdx`,
  `.guidelines.mdx`) + consumer `.docs.spec.tsx`, a changeset, and the OpenSpec
  change (`nimbus-item` + `nimbus-item-group`).

## How it works

- **Link-upgrade, not a button.** `Item.Root` renders a `<div>` by default and
  upgrades to an accessible `<a>` via `react-aria`'s `useLink` when given an
  `href` (the same primitive Nimbus `Link` uses; Item's own recipe stays
  authoritative on appearance). There is deliberately **no** button/pressable
  mode — a row-as-button is semantically wrong and would invalidate nested
  action buttons. Real actions live in `Item.Actions`.
- **Actions don't hijack navigation.** In a link row, a capture-phase guard on
  the anchor cancels navigation when a click originates inside `Item.Actions`,
  so nested `Button`/`IconButton` controls stay independently operable. (React
  Aria's button stops propagation _below_ a container handler, so the guard runs
  in the capture phase.)
- **`ItemGroup` omits `role="list"`** on purpose: a list role requires
  `listitem` children and forbids the separator children this API composes, so
  it would fail axe's `aria-required-children`. The group is a plain stack;
  `ItemGroup.Separator` is `role="separator"`.

Two real defects were caught by the test discipline during development (an
action click navigating a link row; the invalid `role="list"` + separator) and
fixed as described above.

## Test plan

- [x] `typecheck:dev` — 0 errors
- [x] Storybook play functions (source): `item` 7/7, `item-group` 2/2 — incl.
      link-mode `<a>`, keyboard focus, action-without-navigation, media
      variants, grouped rows/separators; automatic axe checks pass
- [x] Consumer `docs.spec` (JSDOM): 2/2 (consumer-integration scenarios only;
      internal-behavior sections removed per testing-strategy guidelines)
- [x] `eslint` clean on both folders (incl. docs)
- [x] **Built-surface (CI gate):** `build` succeeded; `test:storybook` against
      `dist` — `item` 7/7, `item-group` 2/2
- [x] ItemGroup Base story tagged `vrt` for Chromatic visual regression

## Screenshots / recordings

<!-- Not attached. Visual states are exercised by the play functions and
verified by Chromatic in CI; a reviewer can view stories under
Components/Item and Components/ItemGroup. -->

## Feedback wanted

- **Variant naming:** `Item` uses `outline`/`subtle` (matching the wider Nimbus
  vocabulary — `button`, `avatar`, `code`, `toast`), which differs from `Card`'s
  `outlined`/`muted`. Kept intentionally; is that the right call, or should Card
  be aligned separately?
- **Actions in link rows:** the capture-phase navigation guard supports
  "clickable row + trailing action." Is that the behavior we want, or should
  link rows disallow interactive actions entirely?
- **`ItemGroup` a11y:** dropping `role="list"` (for axe compliance with
  separators) vs. investing in `listitem` semantics — acceptable for v1?

## AI assistance disclosure

Generated with assistance from Claude Code. Human review checklist:

- [ ] Logic verified against intent
- [ ] No fabricated APIs / functions / imports
- [ ] Tests reflect actual behavior, not assumed behavior

Closes FEC-988