### PR TITLE
FEC-1155 - Batch3 - Selection & File Inputs

### DIFF
--- a/.changeset/dropzone-focus-ring.md
+++ b/.changeset/dropzone-focus-ring.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": patch
+---
+
+**DropZone**: the keyboard focus ring now renders on the drop target (WCAG 2.1
+AA focus visibility).

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -237,9 +237,11 @@ export const Focused: Story = {
 };
 ```
 
-**Tab to every distinctly-styled focusable sub-element, not just the primary
-one** (a split button's dropdown trigger, an input's stepper/clear button, a date
-field's calendar toggle) - each styles its own `:focus-visible`.
+**Give each distinctly-styled focusable sub-element its own `Focused` story, not
+just the primary one** (a split button's dropdown trigger, an input's
+stepper/clear button, a date field's calendar toggle) - each styles its own
+`:focus-visible`, and since only one element holds focus per snapshot, one story
+can't capture two rings.
 
 **Text-entry inputs: hide the caret** so the focused snapshot is deterministic
 (Chromatic can't pause the native caret blink). `caret-color` is inherited, so
@@ -378,6 +380,11 @@ The **visual snapshot role**. Snapshots are **opt-in**: `preview.tsx` defaults t
 can find snapshot stories. Full rationale, CI details, and the hover/pressed gap
 live in docs/chromatic-visual-testing.md.
 
+- **Enumerate surfaces from source before deciding opt-ins - never from
+  memory.** List every recipe painting selector, `variant`/`size` key,
+  conditional prop, and ambient axis (RTL, locale, theme), then snapshot their
+  cross-product; diff against sibling components' story sets to catch what you
+  didn't think to list.
 - **Cover every state that changes pixels**, economically: fold the interacting
   axes into one `SmokeTest`, and give a dedicated story to each state it can't
   hold (`Focused`, `Disabled`, an open popover). Cost is controlled by TurboSnap
@@ -739,8 +746,11 @@ You MUST validate against these requirements:
       a grid dimension)
 - [ ] Thin wrappers snapshot only the axis they introduce (+ `Focused`/`Disabled`
       if added), not a re-rendered copy of the wrapped component's matrix
-- [ ] `Focused` story opts in (`disableSnapshot: false` + `vrt`) and tabs to
-      **every** distinctly-styled focusable sub-element, not just the primary
+- [ ] A **separate `Focused` story per independent focus surface** (fused/adjacent
+      controls, or multiple `_focusWithin` regions) - not just the primary, and
+      not one story tabbing through all (only one element holds focus per
+      snapshot, so one story can't capture two rings). Each opts in
+      (`disableSnapshot: false` + `vrt`)
 - [ ] Text-entry `Focused` plays hide the caret
       (`canvasElement.style.caretColor = "transparent"`) before tabbing
 - [ ] Only behavior-only stories and stories whose look is already in `SmokeTest`

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -745,6 +745,11 @@ You MUST validate against these requirements:
       (`canvasElement.style.caretColor = "transparent"`) before tabbing
 - [ ] Only behavior-only stories and stories whose look is already in `SmokeTest`
       left snapshot-off (project default) - never drop a visual state to save cost
+- [ ] Each snapshotted story's **play ends in the state the snapshot is named
+      for** - no stray focus ring, no cleared/mutated value, no left-open overlay
+      unless intended. Chromatic captures the play's final state and nothing
+      blurs it, so a play can be assertion-honest yet still snapshot the wrong
+      picture (blur, reset, or split the story)
 
 #### Play Functions (CRITICAL)
 

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -710,6 +710,9 @@ You MUST validate against these requirements:
 
 #### Chromatic Snapshots
 
+- [ ] Surfaces enumerated from the **recipe + component source** (selectors,
+      variant/size keys, conditional props), and snapshots cover their
+      **cross-product** - not recalled from memory
 - [ ] `SmokeTest` matrix is **exhaustive** over the interacting axes the
       component has (e.g. size x variant x palette, plus selected/unselected for
       toggles) - every distinct combined look appears in the one snapshot
@@ -746,6 +749,10 @@ You MUST validate against these requirements:
 #### Play Functions (CRITICAL)
 
 - [ ] ALL interactive components have play functions
+- [ ] Every `step()` name is **backed by its assertions** - if the name claims a
+      behavior the checks don't prove, strengthen the checks to prove it; only
+      rename/drop the claim when the behavior is genuinely another story's
+      concern (and note where it's covered)
 - [ ] Uses `step()` for test organization
 - [ ] Uses `within()` for scoped queries
 - [ ] Uses `waitFor()` for async operations

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -265,8 +265,13 @@ Two consequences for us:
 
 - IconButton's `Base`, with its six `step()`s, produces exactly one snapshot -
   its final resting state. Nothing blurs the element for you, so whatever state
-  the last step leaves (including a focus ring) is exactly what gets captured;
-  end the play function in the state you want snapshotted.
+  the last step leaves (a stray focus ring, a cleared value, a left-open
+  overlay) is exactly what gets captured; end the play in the state you want
+  snapshotted. This is a separate axis from assertion-honesty: a play can assert
+  exactly what its step names claim yet still leave the wrong picture, so for
+  every snapshotted story confirm its **final rendered state is the visual the
+  story name implies** (it's why an honest-looking `ReadOnly`/`Clearable` can
+  still snapshot a focused or emptied control).
 - If you want a snapshot of an intermediate state, the docs say to break it into
   multiple stories rather than expect mid-play captures. So splitting `Base`
   would only be worth it if you wanted to snapshot a state that isn't its final

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -342,6 +342,12 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   adornments the component always renders. Then **diff against sibling
   components' story sets**: a surface a peer primitive snapshots but yours
   doesn't (e.g. `RTLSupport`) is a gap until you can name why it doesn't apply.
+- **One focus snapshot per reachable focus surface.** A component with multiple
+  independent focus targets - fused/adjacent focusable sub-controls, or
+  `_focusWithin` on more than one region - needs a focus story per target, since
+  each side's ring clears the seam differently. There is no "all focused" state
+  to capture: only one element holds focus at a time, so the per-target stories
+  are the complete set (don't add a combined-ring snapshot).
 - **Cover every visual state/variation** - "the more things we have in
   Storybook, the more coverage we get." This is the governing rule: the
   `SmokeTest` matrix must be **exhaustive** over the axes that _interact_

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -326,6 +326,11 @@ but neither is currently captured, and it's an infra limitation, not a choice:
   infra family). Check the recipe rather than assuming pressed is always a
   no-op.
 
+**If a play can drive the real interaction, snapshot the result and leave it
+settled** - drag-over (`data-drop-target`), option focus (`data-focused`),
+selection (`aria-selected`). The gap is `:hover`/`:active` and `data-hovered`,
+which no play-dispatchable event sets.
+
 ### Broader best practices
 
 - **Enumerate surfaces from source, not memory.** Before deciding what to opt

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -328,6 +328,20 @@ but neither is currently captured, and it's an infra limitation, not a choice:
 
 ### Broader best practices
 
+- **Enumerate surfaces from source, not memory.** Before deciding what to opt
+  in, read the recipe (every painting selector - `_hover`, `_focusWithin`,
+  `_disabled`, `_active`, `data-invalid`, `data-readonly`, ... - and every
+  `variant`/`size` key) and the component (every conditional render or prop,
+  e.g. `isDisabled={x || isReadOnly}`). Coverage is the **cross-product** of
+  recipe states × those conditional branches, not the states alone: a read-only
+  field that stays undimmed but disables its trailing button is a distinct
+  surface even though the field "looks like default." Any "renders like default"
+  decision must name the exact delta you checked. Recipe selectors and props
+  aren't the only axes: also account for **ambient axes** no prop names -
+  RTL/`dir` (mirrored icon/adornment layout), locale, theme - and for built-in
+  adornments the component always renders. Then **diff against sibling
+  components' story sets**: a surface a peer primitive snapshots but yours
+  doesn't (e.g. `RTLSupport`) is a gap until you can name why it doesn't apply.
 - **Cover every visual state/variation** - "the more things we have in
   Storybook, the more coverage we get." This is the governing rule: the
   `SmokeTest` matrix must be **exhaustive** over the axes that _interact_

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -206,9 +206,10 @@ stories.
 **A `Focused` story keeps its ring for free** - nothing blurs the focused
 element after a play function, so a story that legitimately ends focused
 snapshots the ring as-is. Conversely, a behavior story that leaves a stray ring
-should blur (or be split so the snapshotted story doesn't end focused). Tab to
-**every** distinctly-styled focusable sub-element (a split button's trigger, an
-input's stepper/clear button), not just the first.
+should blur (or be split so the snapshotted story doesn't end focused). Give
+**each** distinctly-styled focusable sub-element (a split button's trigger, an
+input's stepper/clear button) its own `Focused` story, not just the first - only
+one element holds focus per snapshot, so one story can't capture two rings.
 
 ```typescript
 export const Focused: Story = {

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -179,6 +179,11 @@ its own story (`Focused`, disabled-but-focusable, an open tooltip/popover). A
 showcase whose look a snapshot already covers stays snapshot-off. Never drop a
 visual state to save cost.
 
+**Enumerate surfaces from the recipe + component source first** (selectors,
+variant/size keys, conditional props, and ambient axes like RTL), then snapshot
+their cross-product - not remembered states. See the full rule in
+[chromatic-visual-testing.md](../chromatic-visual-testing.md).
+
 **One state, multiple distinct surfaces → one story each, not a gallery frame.**
 If a component renders a state more than one way (mode-/variant-driven), each
 surface gets its own snapshot - MoneyInput's `Focused` +
@@ -379,6 +384,12 @@ export const Interactive: Story = {
 - State changes
 - Accessibility features
 - Edge cases and error states
+
+**Every `step()` name must be backed by its assertions.** If a step's name
+claims a behavior the checks don't actually prove (e.g. "button appears" while
+only asserting it's in the DOM), strengthen the checks to prove the claim -
+don't rename the step down to match a weaker assertion. Only drop the claim when
+the behavior is genuinely another story's concern, and note where it's covered.
 
 ### Play Function Structure
 

--- a/packages/nimbus/src/components/drop-zone/drop-zone.recipe.ts
+++ b/packages/nimbus/src/components/drop-zone/drop-zone.recipe.ts
@@ -34,7 +34,9 @@ export const dropZoneRecipe = defineRecipe({
     transitionProperty: "background-color, border-color",
     transitionDuration: "0.15s",
     transitionTimingFunction: "ease-in-smooth",
-    focusRing: "outside",
+    // Focus lands on RA's visually-hidden inner button, not this root, so match
+    // on focus-within (like SearchInput) rather than the root's own :focus-visible.
+    _focusWithin: { layerStyle: "focusRing" },
 
     // Sizes the default icon; consumer-supplied children are unaffected.
     "--drop-zone-icon-size": "{sizes.800}",

--- a/packages/nimbus/src/components/drop-zone/drop-zone.stories.tsx
+++ b/packages/nimbus/src/components/drop-zone/drop-zone.stories.tsx
@@ -330,7 +330,7 @@ export const KeyboardAccessible: Story = {
     const innerButton = root.querySelector("button");
 
     await step(
-      "The drop target is keyboard focusable and shows a focus ring",
+      "The drop target is keyboard focusable and sets data-focus-visible",
       async () => {
         if (!innerButton) throw new Error("Expected an inner button");
         await userEvent.tab();

--- a/packages/nimbus/src/components/drop-zone/drop-zone.stories.tsx
+++ b/packages/nimbus/src/components/drop-zone/drop-zone.stories.tsx
@@ -35,6 +35,8 @@ const makeFile = (name: string, type = "text/plain") =>
 // ============================================================
 
 export const Base: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     "data-testid": "drop-zone-root",
   } as never,
@@ -176,6 +178,28 @@ export const RestrictedDropTypes: Story = {
   },
 };
 
+/**
+ * Drag-over (drop-target) visual: `data-drop-target` switches to a solid primary
+ * border + `colorPalette.3` fill. It's a JS-set attribute (not CSS `:hover`), so
+ * the play fires a dragOver and leaves the state active for the snapshot.
+ */
+export const DropTarget: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: {
+    "data-testid": "drop-zone-root",
+    onDrop: fn(),
+  } as never,
+  play: async ({ canvasElement }) => {
+    const root = getRoot(canvasElement);
+    const dataTransfer = makeFileDataTransfer(makeFile("photo.png"));
+    fireDragOver(root, dataTransfer);
+    await waitFor(() => {
+      expect(root).toHaveAttribute("data-drop-target", "true");
+    });
+  },
+};
+
 // ============================================================
 // Composition (children replace the default) + disabled
 // ============================================================
@@ -214,7 +238,7 @@ export const WithFileTriggerComposition: Story = {
       await expect(button).toBeInTheDocument();
     });
 
-    await step("Opens the native file picker when activated", async () => {
+    await step("Renders a hidden file input for click-to-upload", async () => {
       const input =
         canvasElement.querySelector<HTMLInputElement>('input[type="file"]');
       await expect(input).toBeInTheDocument();
@@ -246,12 +270,14 @@ export const CustomContent: Story = {
 };
 
 export const Disabled: Story = {
+  tags: ["vrt"],
   args: {
     "data-testid": "drop-zone-root",
     isDisabled: true,
     onDrop: fn(),
   } as never,
   parameters: {
+    chromatic: { disableSnapshot: false },
     // The disabled layer style intentionally reduces opacity (per WCAG's
     // exemption for disabled/inactive UI, 1.4.3/1.4.11 do not apply), which
     // trips the automated contrast checker. Matches the precedent in
@@ -294,6 +320,8 @@ export const Disabled: Story = {
 // ============================================================
 
 export const KeyboardAccessible: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     "data-testid": "drop-zone-root",
   } as never,

--- a/packages/nimbus/src/components/file-trigger/file-trigger.stories.tsx
+++ b/packages/nimbus/src/components/file-trigger/file-trigger.stories.tsx
@@ -32,8 +32,13 @@ const makeFile = (name: string, type = "text/plain") =>
 
 /**
  * Base case: a Nimbus Button as the child trigger, single-file selection.
+ *
+ * The only VRT snapshot: a minimal guard baseline. FileTrigger renders no visual
+ * of its own, so the other stories add no unique surface and stay behavioral.
  */
 export const Base: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     onSelect: fn(),
   },

--- a/packages/nimbus/src/components/scoped-search-input/scoped-search-input.stories.tsx
+++ b/packages/nimbus/src/components/scoped-search-input/scoped-search-input.stories.tsx
@@ -71,7 +71,10 @@ export const Default: Story = {
   },
 };
 
+/** Fused chrome (Select + SearchInput seam) at sm and md. */
 export const SizeVariants: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const [valueSm, setValueSm] = useState<ScopedSearchInputValue>({
       text: "",
@@ -124,7 +127,10 @@ export const GroupedOptions: Story = {
   },
 };
 
+/** Composite states: default / disabled / read-only / invalid (invalid is asymmetric - only the search half gets it). */
 export const States: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const [value, setValue] = useState<ScopedSearchInputValue>({
       text: "",
@@ -166,6 +172,71 @@ export const States: Story = {
         />
       </Stack>
     );
+  },
+};
+
+/** Search-half focus ring: the right wrapper's `_focusWithin` zIndex lifts the ring above the seam's left edge. */
+export const SearchFocused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => {
+    const [value, setValue] = useState<ScopedSearchInputValue>({
+      text: "search term",
+      option: "all",
+    });
+
+    return (
+      <ScopedSearchInput
+        value={value}
+        onValueChange={setValue}
+        onSubmit={() => {}}
+        options={defaultOptions}
+        selectPlaceholder="Select field"
+        searchPlaceholder="Search..."
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause.
+    canvasElement.style.caretColor = "transparent";
+
+    const searchInput = canvas.getByRole("searchbox");
+    // Tab past the Select trigger to land keyboard focus on the search half.
+    await userEvent.tab();
+    await userEvent.tab();
+    await expect(searchInput).toHaveFocus();
+  },
+};
+
+/** Select-half focus ring: the left wrapper's `_focusWithin` zIndex lifts the trigger ring above the seam's right edge. */
+export const SelectFocused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => {
+    const [value, setValue] = useState<ScopedSearchInputValue>({
+      text: "",
+      option: "all",
+    });
+
+    return (
+      <ScopedSearchInput
+        value={value}
+        onValueChange={setValue}
+        onSubmit={() => {}}
+        options={defaultOptions}
+        selectPlaceholder="Select field"
+        searchPlaceholder="Search..."
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // First tab lands keyboard focus on the Select trigger (the left half).
+    await userEvent.tab();
+    const selectTrigger = canvas.getByRole("button", { name: /all fields/i });
+    await expect(selectTrigger).toHaveFocus();
   },
 };
 

--- a/packages/nimbus/src/components/search-input/search-input.stories.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.stories.tsx
@@ -35,7 +35,7 @@ export const Base: Story = {
       await expect(input).toHaveAttribute("type", "search");
     });
 
-    await step("Forwards data- & aria-attributes", async () => {
+    await step("Forwards aria-attributes", async () => {
       await expect(input).toHaveAttribute("aria-label", "test-search-input");
     });
 
@@ -66,9 +66,14 @@ export const Base: Story = {
     });
 
     await step("Clear button appears when typing", async () => {
+      const clearButton = canvas.getByRole("button", { hidden: true });
+      await waitFor(() =>
+        expect(window.getComputedStyle(clearButton).opacity).toBe("0")
+      );
       await userEvent.type(input, "test");
-      const clearButton = canvas.getByRole("button");
-      await expect(clearButton).toBeInTheDocument();
+      await waitFor(() =>
+        expect(window.getComputedStyle(clearButton).opacity).toBe("1")
+      );
       await userEvent.clear(input);
     });
   },
@@ -208,7 +213,10 @@ export const Invalid: Story = {
   },
 };
 
+/** Distinct composite: undimmed field (no `data-readonly` rule) + disabled clear button. */
 export const ReadOnly: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     isReadOnly: true,
     defaultValue: "Read-only search",
@@ -236,7 +244,66 @@ export const ReadOnly: Story = {
   },
 };
 
+/** Focus ring (`_focusWithin`) the matrix can't render; caret hidden for determinism. */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <SearchInput defaultValue="Focused search" aria-label="focused-search" />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText("focused-search");
+
+    // Caret blink is browser-native, not a CSS/JS animation Chromatic can pause;
+    // caret-color inherits, so hiding it here cascades to the input.
+    canvasElement.style.caretColor = "transparent";
+
+    await userEvent.tab();
+    await expect(input).toHaveFocus();
+  },
+};
+
+/** Value-driven clear button (absent from the empty matrix): enabled + disabled surfaces. */
+export const WithClearButton: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="row" gap="400" alignItems="center">
+      <SearchInput defaultValue="Search query" aria-label="clear-enabled" />
+      <SearchInput
+        defaultValue="Search query"
+        isDisabled
+        aria-label="clear-disabled"
+      />
+    </Stack>
+  ),
+};
+
+/** RTL mirrors the layout: the leading search icon and trailing clear button swap sides. */
+export const RTLSupport: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="400">
+      <Box>
+        <Text mb="200">LTR direction (left-to-right)</Text>
+        <SearchInput defaultValue="Search query" aria-label="ltr-search" />
+      </Box>
+      <Box dir="rtl" width="100%">
+        <Text mb="200" textAlign="right">
+          RTL direction (right-to-left)
+        </Text>
+        <SearchInput defaultValue="Search query" aria-label="rtl-search" />
+      </Box>
+    </Stack>
+  ),
+};
+
+/** Resting-chrome matrix: state x size x variant, empty. No colorPalette axis (fixed tokens). */
 export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     onChange: fn(),
     ["aria-label"]: "test-search-input",
@@ -482,7 +549,9 @@ export const KeyboardNavigation: Story = {
 
     await step("Clear button is visible but not in tab order", async () => {
       const clearButton = canvas.getByRole("button");
-      await expect(clearButton).toBeInTheDocument();
+      await waitFor(() =>
+        expect(window.getComputedStyle(clearButton).opacity).toBe("1")
+      );
       await expect(clearButton).toHaveAttribute("tabindex", "-1");
     });
 
@@ -519,7 +588,9 @@ export const DefaultValue: Story = {
 
     await step("Clear button visible with default value", async () => {
       const clearButton = canvas.getByRole("button");
-      await expect(clearButton).toBeInTheDocument();
+      await waitFor(() =>
+        expect(window.getComputedStyle(clearButton).opacity).toBe("1")
+      );
     });
 
     await step("Can modify default value", async () => {

--- a/packages/nimbus/src/components/search-input/search-input.stories.tsx
+++ b/packages/nimbus/src/components/search-input/search-input.stories.tsx
@@ -241,6 +241,9 @@ export const ReadOnly: Story = {
       const clearButton = canvas.getByRole("button");
       await expect(clearButton).toBeDisabled();
     });
+
+    // Blur the click-focused input so no stray focus ring lands in the snapshot.
+    input.blur();
   },
 };
 

--- a/packages/nimbus/src/components/select/select.stories.tsx
+++ b/packages/nimbus/src/components/select/select.stories.tsx
@@ -313,8 +313,6 @@ export const Loading: Story = {
  * Demonstrates the isClearable prop which shows a clear button when a value is selected
  */
 export const Clearable: Story = {
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack gap="600">

--- a/packages/nimbus/src/components/select/select.stories.tsx
+++ b/packages/nimbus/src/components/select/select.stories.tsx
@@ -120,7 +120,7 @@ export const Base: Story = {
       await expect(button).toHaveTextContent("Bananas");
     });
 
-    await step("Value can be cleared with keyboard", async () => {
+    await step("Value can be cleared via the clear button", async () => {
       const clearButton = select.querySelectorAll("button")[1];
       await userEvent.click(clearButton);
       await expect(button).toHaveTextContent("Select an item");
@@ -294,11 +294,27 @@ export const AsyncLoading: Story = {
   },
 };
 
+/** isLoading: spinner replaces the chevron and the trigger is disabled; Chromatic pauses the spin for a deterministic frame. */
+export const Loading: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Select.Root isLoading aria-label="Loading select">
+      <Select.Options>
+        <Select.Option>Apples</Select.Option>
+        <Select.Option>Bananas</Select.Option>
+      </Select.Options>
+    </Select.Root>
+  ),
+};
+
 /**
  * Clearable
  * Demonstrates the isClearable prop which shows a clear button when a value is selected
  */
 export const Clearable: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack gap="600">
@@ -439,9 +455,12 @@ export const Disabled: Story = {
       await expect(button).not.toHaveFocus();
     });
 
-    await step("Disabled select cannot be clicked to open", async () => {
-      await expect(button).toHaveStyle({ pointerEvents: "none" });
-    });
+    await step(
+      "Disabled trigger has pointer-events: none, so it cannot be opened",
+      async () => {
+        await expect(button).toHaveStyle({ pointerEvents: "none" });
+      }
+    );
   },
 };
 
@@ -451,6 +470,8 @@ export const Disabled: Story = {
  * @see https://github.com/commercetools/nimbus/issues/1243
  */
 export const DisabledClearButton: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Select.Root
@@ -571,6 +592,26 @@ export const Invalid: Story = {
       await userEvent.click(options[0]);
       await expect(button).toHaveTextContent("Apples");
     });
+  },
+};
+
+/** Trigger keyboard-focus ring (`focusRing: outside`). */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Select.Root aria-label="Focused select" data-testid="select">
+      <Select.Options>
+        <Select.Option>Apples</Select.Option>
+        <Select.Option>Bananas</Select.Option>
+      </Select.Options>
+    </Select.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByTestId("select").querySelector("button");
+    await userEvent.tab();
+    await expect(button).toHaveFocus();
   },
 };
 
@@ -729,6 +770,84 @@ export const WithDescriptions: Story = {
   },
 };
 
+/** Open listbox with all option states in one frame: group headers, descriptions, selected (primary.3), keyboard-focused (primary.2), and disabled. */
+export const OpenPopover: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Select.Root
+      defaultSelectedKey="banana"
+      disabledKeys={["orange"]}
+      aria-label="Open popover"
+      data-testid="select"
+    >
+      <Select.Options>
+        <Select.OptionGroup label="Fruits">
+          <Select.Option id="apple" textValue="Apple">
+            <Text slot="label">Apple</Text>
+            <Text slot="description">A crisp and juicy classic.</Text>
+          </Select.Option>
+          <Select.Option id="banana" textValue="Banana">
+            <Text slot="label">Banana</Text>
+            <Text slot="description">A good source of potassium.</Text>
+          </Select.Option>
+          <Select.Option id="orange" textValue="Orange">
+            <Text slot="label">Orange</Text>
+            <Text slot="description">Rich in vitamin C.</Text>
+          </Select.Option>
+        </Select.OptionGroup>
+        <Select.OptionGroup label="Vegetables">
+          <Select.Option id="carrot" textValue="Carrot">
+            <Text slot="label">Carrot</Text>
+            <Text slot="description">A crunchy root vegetable.</Text>
+          </Select.Option>
+        </Select.OptionGroup>
+      </Select.Options>
+    </Select.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByTestId("select").querySelector("button");
+    await userEvent.click(button!);
+    await waitFor(() => {
+      expect(document.querySelector('[role="listbox"]')).toBeInTheDocument();
+    });
+    // Opening focuses the selected option (banana); move up to Apple so the
+    // selected (primary.3) and focused (primary.2) highlights read distinctly.
+    await userEvent.keyboard("{ArrowUp}");
+    await waitFor(() => {
+      const focused = document.querySelector('[data-focused="true"]');
+      expect(focused).toBeInTheDocument();
+      expect(focused).toHaveTextContent("Apple");
+    });
+  },
+};
+
+/** Open listbox tall enough to hit `maxHeight: 40svh` and scroll - captures the clip + custom thin scrollbar. */
+export const OpenPopoverScrollable: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Select.Root aria-label="Scrollable popover" data-testid="select">
+      <Select.Options>
+        {Array.from({ length: 30 }, (_, i) => (
+          <Select.Option key={i} id={`opt-${i}`}>
+            Option {i + 1}
+          </Select.Option>
+        ))}
+      </Select.Options>
+    </Select.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByTestId("select").querySelector("button");
+    await userEvent.click(button!);
+    await waitFor(() => {
+      expect(document.querySelector('[role="listbox"]')).toBeInTheDocument();
+    });
+  },
+};
+
 /**
  * Custom Widths
  * custom widths for select-trigger button and popover
@@ -865,16 +984,13 @@ export const SuperLongAndComplex: Story = {
  * Variants and Sizes combined
  */
 export const VariantsAndSizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
-    const [isInvalid, setInvalid] = useState(false);
     return (
       <Stack>
         {[{}, { isDisabled: true }, { isInvalid: true }].map((props) => (
-          <Stack
-            key={JSON.stringify({ props })}
-            bg="neutral.2"
-            onClick={() => setInvalid(!isInvalid)}
-          >
+          <Stack key={JSON.stringify({ props })} bg="neutral.2">
             {selectVariants.map((variant) => (
               <Stack alignItems="start" key={JSON.stringify({ variant })}>
                 <Text my="400" fontWeight="600">
@@ -1004,6 +1120,8 @@ export const VariantsAndSizes: Story = {
  * Demonstrates different leadingElement configurations with Select component
  */
 export const LeadingElement: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const examples: Array<{
       label: string;


### PR DESCRIPTION
  **P1 Nimbus - Batch 3 Audit - Selection & file inputs**
  Relates to: #1790 (Batch 2) & #1782 (Batch 1)

VRT components audited & tagged (selection & file inputs)
  - `SearchInput`
  - `ScopedSearchInput`
  - `Select`
  - `DropZone`
  - `FileTrigger`

Each opts its resting-state matrix/showcase & a focus story into snapshots, plus the component-specific chrome (clear button, open popover, drag-over target, fused seam). Everything else stays behavioral (verified by play functions, not pixels).

Test-integrity fixes so play steps assert what their names claim.
Extended the VRT guidance in chromatic-related docs (chromatic-visual-testing.md, stories.md, writing-stories skill)

Bug fix (a11y): DropZone keyboard focus ring now renders in normal mode. focusRing was on the root, but keyboard focus lands on React Aria's inner button, so no ring showed.

Possible bugs flagged, not fixed here (RTL): ScopedSearchInput's fused seam & Select's clear/chevron cluster use physical CSS (borderRightRadius, right) rather than logical properties, so they mislay in RTL.


  