### PR TITLE
fix(security): resolve dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,21 +320,23 @@ overrides:
   react-aria-components: 1.19.0
   react-stately: 3.48.0
   '@react-aria/interactions': 3.28.1
-  brace-expansion@<2: ^2.0.3
-  brace-expansion@2: ~2.0.3
-  brace-expansion@>=4.0.0 <5.0.6: '>=5.0.6'
+  brace-expansion@<2: ^2.1.2
+  brace-expansion@2: ^2.1.2
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
   mdast-util-to-hast: ^13.2.1
   js-yaml: ^3.15.0
   dompurify: ^3.4.12
   qs: '>=6.15.2'
   minimatch@>=3.0.0 <3.1.4: 3.1.4
-  svgo: '>=3.3.3'
-  hono: '>=4.12.21'
+  svgo: '>=4.0.2'
+  hono: '>=4.12.27'
   esbuild: '>=0.28.1'
-  shell-quote: '>=1.8.4'
+  shell-quote: '>=1.9.0'
   '@babel/core': ^7.29.7
   '@hono/node-server': '>=1.19.13'
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=4.1.1'
+  immutable: '>=4.3.9 <5'
+  body-parser@2: '>=2.3.0'
   ip-address: '>=10.1.1'
   postcss: '>=8.5.10'
   lodash@<4.18.0: '>=4.18.0'
@@ -2217,7 +2219,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.21'
+      hono: '>=4.12.27'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4903,8 +4905,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boolbase@1.0.0:
@@ -4914,11 +4916,11 @@ packages:
     resolution: {integrity: sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==}
     engines: {node: '>=10'}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5234,6 +5236,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -5784,8 +5790,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.0.0:
-    resolution: {integrity: sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6078,8 +6084,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
     engines: {node: '>=16.9.0'}
 
   htm@3.1.1:
@@ -6131,8 +6137,8 @@ packages:
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
 
-  immutable@4.3.8:
-    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
+  immutable@4.3.9:
+    resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -7916,8 +7922,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -8205,8 +8211,8 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -8421,6 +8427,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript-eslint@8.64.0:
     resolution: {integrity: sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==}
@@ -10633,7 +10643,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
-      immutable: 4.3.8
+      immutable: 4.3.9
       is-hotkey: 0.2.0
       lodash: 4.18.1
       react: 19.2.0
@@ -11088,7 +11098,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
-      immutable: 4.3.8
+      immutable: 4.3.9
       is-hotkey: 0.2.0
       lodash: 4.18.1
       react: 19.2.0
@@ -11982,9 +11992,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@hono/node-server@1.19.13(hono@4.12.25)':
+  '@hono/node-server@1.19.13(hono@4.12.31)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.31
 
   '@humanfs/core@0.19.1': {}
 
@@ -12537,7 +12547,7 @@ snapshots:
       cors: 2.8.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       shx: 0.3.4
       spawn-rx: 5.1.2
       ws: 8.21.0
@@ -12557,7 +12567,7 @@ snapshots:
       concurrently: 9.2.1
       node-fetch: 3.3.2
       open: 10.2.0
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       spawn-rx: 5.1.2
       ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.9.3)
       zod: 3.25.76
@@ -12577,7 +12587,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.25)
+      '@hono/node-server': 1.19.13(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -12587,7 +12597,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.31
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12599,7 +12609,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.25)
+      '@hono/node-server': 1.19.13(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -12609,7 +12619,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.31
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -13972,7 +13982,7 @@ snapshots:
       '@svgr/core': 8.1.0(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
-      svgo: 4.0.1
+      svgo: 4.0.2
     transitivePeerDependencies:
       - typescript
 
@@ -15186,7 +15196,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.0.0
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15296,17 +15306,17 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
       qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15323,11 +15333,11 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15571,7 +15581,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -15587,6 +15597,8 @@ snapshots:
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@1.9.0: {}
 
@@ -16096,7 +16108,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -16166,7 +16178,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.0.0: {}
+  fast-uri@4.1.1: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -16544,7 +16556,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.25: {}
+  hono@4.12.31: {}
 
   htm@3.1.1: {}
 
@@ -16588,7 +16600,7 @@ snapshots:
 
   immer@9.0.21: {}
 
-  immutable@4.3.8: {}
+  immutable@4.3.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -17543,19 +17555,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -18752,7 +18764,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   shelljs@0.8.5:
     dependencies:
@@ -19089,7 +19101,7 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
@@ -19289,6 +19301,12 @@ snapshots:
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,9 +59,9 @@ overrides:
   react-aria-components: "catalog:react"
   react-stately: "catalog:react"
   "@react-aria/interactions": "catalog:react"
-  "brace-expansion@<2": "^2.0.3"
-  "brace-expansion@2": "~2.0.3"
-  "brace-expansion@>=4.0.0 <5.0.6": ">=5.0.6"
+  "brace-expansion@<2": "^2.1.2"
+  "brace-expansion@2": "^2.1.2"
+  "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7"
   mdast-util-to-hast: "^13.2.1"
   # js-yaml 3.x security floor — >=3.15.0 fixes GHSA-h67p-54hq-rp68
   # (quadratic-complexity DoS in merge-key handling).
@@ -72,13 +72,18 @@ overrides:
   dompurify: "catalog:utils"
   qs: ">=6.15.2"
   "minimatch@>=3.0.0 <3.1.4": "3.1.4"
-  svgo: ">=3.3.3"
-  hono: ">=4.12.21"
+  svgo: ">=4.0.2"
+  hono: ">=4.12.27"
   esbuild: ">=0.28.1"
-  shell-quote: ">=1.8.4"
+  shell-quote: ">=1.9.0"
   "@babel/core": "catalog:tooling"
   "@hono/node-server": ">=1.19.13"
-  fast-uri: ">=3.1.2"
+  fast-uri: ">=4.1.1"
+  # immutable <4.3.9 — GHSA-xvcm-6775-5m9r / GHSA-v56q-mh7h-f735 (hash-collision
+  # algorithmic-complexity DoS in Immutable.Map/Set). Capped <5 to stay within 4.x.
+  immutable: ">=4.3.9 <5"
+  # body-parser 2.0.0–2.2.x DoS fixed in 2.3.0 (Dependabot #147). Scoped to 2.x.
+  "body-parser@2": ">=2.3.0"
   ip-address: ">=10.1.1"
   postcss: ">=8.5.10"
   "lodash@<4.18.0": ">=4.18.0"


### PR DESCRIPTION
## Summary

Resolves **12 of 13** open Dependabot security alerts by bumping stale transitive-dependency override floors in `pnpm-workspace.yaml` (and adding two new overrides). All alerts are transitive; this repo's established fix mechanism is version-floor overrides, and most alerts were firing simply because existing floors had gone stale relative to newer advisories.

Only `pnpm-workspace.yaml` and `pnpm-lock.yaml` change.

## 🔒 Vulnerabilities Fixed

| Package               | Severity | Alert(s) / CVE                                         | Override change                          | Resolved |
| --------------------- | -------- | ------------------------------------------------------ | ---------------------------------------- | -------- |
| fast-uri              | HIGH     | #156 (CVE-2026-16221), #154 (CVE-2026-13676)           | `>=3.1.2` → `>=4.1.1`                    | 4.1.1    |
| svgo                  | HIGH     | #155 (GHSA-2p49-hgcm-8545)                             | `>=3.3.3` → `>=4.0.2`                    | 4.0.2    |
| shell-quote           | HIGH     | #146                                                   | `>=1.8.4` → `>=1.9.0`                    | 1.10.0   |
| immutable             | HIGH     | #153 (GHSA-xvcm-6775-5m9r), #152 (GHSA-v56q-mh7h-f735) | **new** `>=4.3.9 <5`                     | 4.3.9    |
| brace-expansion (2.x) | HIGH     | #145                                                   | `~2.0.3` → `^2.1.2`                      | 2.1.2    |
| brace-expansion (5.x) | HIGH     | #144                                                   | `>=5.0.6` → `>=5.0.7` (selector widened) | 5.0.7    |
| hono                  | MEDIUM   | #149, #150, #151                                       | `>=4.12.21` → `>=4.12.27`                | 4.12.31  |
| body-parser           | LOW      | #147                                                   | **new** `@2 >=2.3.0`                     | 2.3.0    |

New floors for `immutable` and `body-parser` are capped/scoped to avoid crossing a major boundary.

## ⚠️ Requires Manual Attention (not in this PR)

| Package           | Severity      | Reason                                                                                                                                                                                                                                                                          |
| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| @hono/node-server | MEDIUM (#148) | Vulnerable range is `< 2.0.5`; the only fix crosses the **1.x → 2.x** major boundary (potential breaking change for the transitive consumer). Left for a deliberate manual decision — bump `"@hono/node-server": ">=1.19.13"` → `">=2.0.5"` once v2 compatibility is confirmed. |

## ✅ Validation

- `pnpm install` succeeds; the lockfile re-resolves off every fixed vulnerable version.
- The change is **regression-free**: it introduces **zero** new lint or type errors.
- ⚠️ Note for reviewers: local `pnpm lint` / `pnpm typecheck` have **pre-existing** failures (ungenerated Chakra theme typings + committed prettier drift), verified independent of this change by reproducing the identical failures on the base state. CI runs the full lint/typecheck/test gate against a proper build.

## 📋 Review Checklist

- [ ] Confirm no runtime/behavior impact from the transitive bumps (all in-major except the intentionally-capped new floors)
- [ ] Confirm the 12 alerts close once merged to the default branch
- [ ] Decide on the `@hono/node-server` major bump (#148) separately

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
