### PR TITLE
fix(test): add explicit waitFor timeouts to flaky dialog close assertions

### DIFF
--- a/packages/nimbus/src/components/dialog/dialog.stories.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.stories.tsx
@@ -120,9 +120,12 @@ export const Default: Story = {
       await userEvent.click(closeButton);
 
       // Wait for dialog to close
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step(
@@ -143,9 +146,12 @@ export const Default: Story = {
         await userEvent.click(cancelButton);
 
         // Wait for dialog to close
-        await waitFor(() => {
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        }, { timeout: 3000 });
+        await waitFor(
+          () => {
+            expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
       }
     );
 
@@ -177,9 +183,12 @@ export const Default: Story = {
 
       // Close with Escape key
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Focus should return to trigger
       await waitFor(
@@ -265,9 +274,12 @@ export const ButtonAsTrigger: Story = {
       await userEvent.click(confirmButton);
 
       // Dialog should close and focus should return to custom trigger
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Wait for focus to be restored to the custom button trigger
       await waitFor(
@@ -507,9 +519,12 @@ export const ScrollBehavior: Story = {
 
       // Close dialog
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Test 'scroll outside' behavior comparison", async () => {
@@ -554,9 +569,12 @@ export const ScrollBehavior: Story = {
 
       // Close dialog
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Test focus restoration after keyboard scrolling", async () => {
@@ -585,9 +603,12 @@ export const ScrollBehavior: Story = {
 
       // Close dialog and verify focus restoration
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify focus restoration (focus should return to original trigger)
       // Note: Focus restoration may vary by test environment
@@ -630,9 +651,12 @@ export const ScrollBehavior: Story = {
       // Close dialog
       const closeButton = canvas.getByRole("button", { name: /close/i });
       await userEvent.click(closeButton);
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };
@@ -915,9 +939,12 @@ export const ComplexDismissalScenarios: Story = {
         .closest('[role="presentation"]');
       if (modalOverlay1) {
         await userEvent.click(modalOverlay1);
-        await waitFor(() => {
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        }, { timeout: 3000 });
+        await waitFor(
+          () => {
+            expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
       }
 
       // Test backdrop disabled, keyboard enabled
@@ -940,9 +967,12 @@ export const ComplexDismissalScenarios: Story = {
 
       // Escape SHOULD close
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Test both disabled
       const trigger3 = canvas.getByRole("button", {
@@ -960,9 +990,12 @@ export const ComplexDismissalScenarios: Story = {
       // Only close button works
       const closeButton = canvas.getByRole("button", { name: "Close" });
       await userEvent.click(closeButton);
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };
@@ -1048,16 +1081,19 @@ export const NestedDialogs: Story = {
       });
       await userEvent.click(secondTrigger);
 
-      await waitFor(() => {
-        // Both dialogs should be present
-        const dialogs = canvas.getAllByRole("dialog");
-        expect(dialogs).toHaveLength(2);
-        expect(
-          canvas.getByText(
-            /This is a nested dialog that should appear above the first/
-          )
-        ).toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          // Both dialogs should be present
+          const dialogs = canvas.getAllByRole("dialog");
+          expect(dialogs).toHaveLength(2);
+          expect(
+            canvas.getByText(
+              /This is a nested dialog that should appear above the first/
+            )
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Close second dialog first (should close in proper order)
       const secondCloseButton = canvas.getByRole("button", {
@@ -1065,13 +1101,16 @@ export const NestedDialogs: Story = {
       });
       await userEvent.click(secondCloseButton);
 
-      await waitFor(() => {
-        const dialogs = canvas.getAllByRole("dialog");
-        expect(dialogs).toHaveLength(1);
-        expect(
-          canvas.getByText("This is the first level dialog.")
-        ).toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          const dialogs = canvas.getAllByRole("dialog");
+          expect(dialogs).toHaveLength(1);
+          expect(
+            canvas.getByText("This is the first level dialog.")
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Close first dialog
       const firstCloseButton = canvas.getByRole("button", {
@@ -1079,9 +1118,12 @@ export const NestedDialogs: Story = {
       });
       await userEvent.click(firstCloseButton);
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify focus restoration to original trigger
       await waitFor(
@@ -1109,28 +1151,37 @@ export const NestedDialogs: Story = {
       });
       await userEvent.click(secondTrigger);
 
-      await waitFor(() => {
-        const dialogs = canvas.getAllByRole("dialog");
-        expect(dialogs).toHaveLength(2);
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          const dialogs = canvas.getAllByRole("dialog");
+          expect(dialogs).toHaveLength(2);
+        },
+        { timeout: 3000 }
+      );
 
       // Escape should close the topmost dialog first
       await userEvent.keyboard("{Escape}");
 
-      await waitFor(() => {
-        const dialogs = canvas.getAllByRole("dialog");
-        expect(dialogs).toHaveLength(1);
-        expect(
-          canvas.getByText("This is the first level dialog.")
-        ).toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          const dialogs = canvas.getAllByRole("dialog");
+          expect(dialogs).toHaveLength(1);
+          expect(
+            canvas.getByText("This is the first level dialog.")
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Another Escape should close the remaining dialog
       await userEvent.keyboard("{Escape}");
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Focus should return to original trigger
       await waitFor(

--- a/packages/nimbus/src/components/dialog/dialog.stories.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.stories.tsx
@@ -122,7 +122,7 @@ export const Default: Story = {
       // Wait for dialog to close
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
 
     await step(
@@ -145,7 +145,7 @@ export const Default: Story = {
         // Wait for dialog to close
         await waitFor(() => {
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        });
+        }, { timeout: 3000 });
       }
     );
 
@@ -179,7 +179,7 @@ export const Default: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Focus should return to trigger
       await waitFor(
@@ -267,7 +267,7 @@ export const ButtonAsTrigger: Story = {
       // Dialog should close and focus should return to custom trigger
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Wait for focus to be restored to the custom button trigger
       await waitFor(
@@ -509,7 +509,7 @@ export const ScrollBehavior: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
 
     await step("Test 'scroll outside' behavior comparison", async () => {
@@ -556,7 +556,7 @@ export const ScrollBehavior: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
 
     await step("Test focus restoration after keyboard scrolling", async () => {
@@ -587,7 +587,7 @@ export const ScrollBehavior: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Verify focus restoration (focus should return to original trigger)
       // Note: Focus restoration may vary by test environment
@@ -632,7 +632,7 @@ export const ScrollBehavior: Story = {
       await userEvent.click(closeButton);
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
   },
 };
@@ -917,7 +917,7 @@ export const ComplexDismissalScenarios: Story = {
         await userEvent.click(modalOverlay1);
         await waitFor(() => {
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        });
+        }, { timeout: 3000 });
       }
 
       // Test backdrop disabled, keyboard enabled
@@ -942,7 +942,7 @@ export const ComplexDismissalScenarios: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Test both disabled
       const trigger3 = canvas.getByRole("button", {
@@ -962,7 +962,7 @@ export const ComplexDismissalScenarios: Story = {
       await userEvent.click(closeButton);
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
   },
 };
@@ -1057,7 +1057,7 @@ export const NestedDialogs: Story = {
             /This is a nested dialog that should appear above the first/
           )
         ).toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Close second dialog first (should close in proper order)
       const secondCloseButton = canvas.getByRole("button", {
@@ -1071,7 +1071,7 @@ export const NestedDialogs: Story = {
         expect(
           canvas.getByText("This is the first level dialog.")
         ).toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Close first dialog
       const firstCloseButton = canvas.getByRole("button", {
@@ -1081,7 +1081,7 @@ export const NestedDialogs: Story = {
 
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Verify focus restoration to original trigger
       await waitFor(
@@ -1112,7 +1112,7 @@ export const NestedDialogs: Story = {
       await waitFor(() => {
         const dialogs = canvas.getAllByRole("dialog");
         expect(dialogs).toHaveLength(2);
-      });
+      }, { timeout: 3000 });
 
       // Escape should close the topmost dialog first
       await userEvent.keyboard("{Escape}");
@@ -1123,14 +1123,14 @@ export const NestedDialogs: Story = {
         expect(
           canvas.getByText("This is the first level dialog.")
         ).toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Another Escape should close the remaining dialog
       await userEvent.keyboard("{Escape}");
 
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
 
       // Focus should return to original trigger
       await waitFor(

--- a/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
+++ b/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
@@ -88,9 +88,12 @@ export const InfoPage: Story = {
       });
       await userEvent.click(backButton);
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };
@@ -408,9 +411,12 @@ export const KeyboardNavigation: Story = {
 
     await step("Escape key closes the modal page", async () => {
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Focus returns to the trigger after close", async () => {
@@ -441,9 +447,12 @@ export const KeyboardNavigation: Story = {
 
       // Close to restore state
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };
@@ -524,30 +533,42 @@ export const StackedModalPages: Story = {
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Edit Product" })
       );
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(1);
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(1);
+        },
+        { timeout: 3000 }
+      );
 
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Add Variant" })
       );
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(2);
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(2);
+        },
+        { timeout: 3000 }
+      );
 
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Select Attribute" })
       );
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(3);
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(3);
+        },
+        { timeout: 3000 }
+      );
 
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Create Attribute" })
       );
-      await waitFor(() => {
-        expect(canvas.getAllByRole("dialog")).toHaveLength(4);
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("dialog")).toHaveLength(4);
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Escape closes only the topmost level", async () => {

--- a/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
+++ b/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
@@ -90,7 +90,7 @@ export const InfoPage: Story = {
 
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
   },
 };
@@ -410,7 +410,7 @@ export const KeyboardNavigation: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
 
     await step("Focus returns to the trigger after close", async () => {
@@ -443,7 +443,7 @@ export const KeyboardNavigation: Story = {
       await userEvent.keyboard("{Escape}");
       await waitFor(() => {
         expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      }, { timeout: 3000 });
     });
   },
 };
@@ -526,28 +526,28 @@ export const StackedModalPages: Story = {
       );
       await waitFor(() => {
         expect(canvas.getAllByRole("dialog")).toHaveLength(1);
-      });
+      }, { timeout: 3000 });
 
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Add Variant" })
       );
       await waitFor(() => {
         expect(canvas.getAllByRole("dialog")).toHaveLength(2);
-      });
+      }, { timeout: 3000 });
 
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Select Attribute" })
       );
       await waitFor(() => {
         expect(canvas.getAllByRole("dialog")).toHaveLength(3);
-      });
+      }, { timeout: 3000 });
 
       await userEvent.click(
         canvas.getByRole("button", { name: "Open Create Attribute" })
       );
       await waitFor(() => {
         expect(canvas.getAllByRole("dialog")).toHaveLength(4);
-      });
+      }, { timeout: 3000 });
     });
 
     await step("Escape closes only the topmost level", async () => {

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
@@ -108,9 +108,10 @@ export const Base: Story = {
 
         await userEvent.click(canvas.getByRole("button", { name: "Cancel" }));
 
-        await waitFor(() =>
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        , { timeout: 3000 });
+        await waitFor(
+          () => expect(canvas.queryByRole("dialog")).not.toBeInTheDocument(),
+          { timeout: 3000 }
+        );
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();
@@ -132,9 +133,10 @@ export const Base: Story = {
         onOpenChange.mockClear();
         await userEvent.click(canvas.getByRole("button", { name: "Save" }));
 
-        await waitFor(() =>
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        , { timeout: 3000 });
+        await waitFor(
+          () => expect(canvas.queryByRole("dialog")).not.toBeInTheDocument(),
+          { timeout: 3000 }
+        );
         expect(onSave).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onCancel).not.toHaveBeenCalled();
@@ -156,9 +158,10 @@ export const Base: Story = {
         onOpenChange.mockClear();
         await userEvent.keyboard("{Escape}");
 
-        await waitFor(() =>
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        , { timeout: 3000 });
+        await waitFor(
+          () => expect(canvas.queryByRole("dialog")).not.toBeInTheDocument(),
+          { timeout: 3000 }
+        );
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();
@@ -182,9 +185,10 @@ export const Base: Story = {
           canvas.getByRole("button", { name: "Close dialog" })
         );
 
-        await waitFor(() =>
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        , { timeout: 3000 });
+        await waitFor(
+          () => expect(canvas.queryByRole("dialog")).not.toBeInTheDocument(),
+          { timeout: 3000 }
+        );
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();
@@ -218,9 +222,10 @@ export const Base: Story = {
           },
         ]);
 
-        await waitFor(() =>
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        , { timeout: 3000 });
+        await waitFor(
+          () => expect(canvas.queryByRole("dialog")).not.toBeInTheDocument(),
+          { timeout: 3000 }
+        );
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();

--- a/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/form-dialog/form-dialog.stories.tsx
@@ -110,7 +110,7 @@ export const Base: Story = {
 
         await waitFor(() =>
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        );
+        , { timeout: 3000 });
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();
@@ -134,7 +134,7 @@ export const Base: Story = {
 
         await waitFor(() =>
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        );
+        , { timeout: 3000 });
         expect(onSave).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onCancel).not.toHaveBeenCalled();
@@ -158,7 +158,7 @@ export const Base: Story = {
 
         await waitFor(() =>
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        );
+        , { timeout: 3000 });
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();
@@ -184,7 +184,7 @@ export const Base: Story = {
 
         await waitFor(() =>
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        );
+        , { timeout: 3000 });
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();
@@ -220,7 +220,7 @@ export const Base: Story = {
 
         await waitFor(() =>
           expect(canvas.queryByRole("dialog")).not.toBeInTheDocument()
-        );
+        , { timeout: 3000 });
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onOpenChange).toHaveBeenCalledWith(false);
         expect(onSave).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Added `{ timeout: 3000 }` to all `waitFor` calls that assert dialog absence or dialog count changes after close actions
- Fixes 13 flaky CI test failures across `dialog.stories.tsx`, `modal-page.stories.tsx`, and `form-dialog.stories.tsx`
- Root cause: dialog exit animations + portal teardown in CI exceed the default 1000ms `waitFor` timeout

## Test plan
- [x] All 25 story tests pass locally (9 dialog + 8 modal-page + 8 form-dialog)
- [ ] CI passes without flaky dialog/modal failures