### PR TITLE
vc/ resolve canary publishing error

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,7 @@
       "@commercetools/nimbus-mcp"
     ]
   ],
-  "ignore": ["@commercetools/nimbus-i18n", "color-tokens", "blank-app", "docs"],
+  "ignore": ["@commercetools/nimbus-i18n", "@commercetools/nimbus-docs-build", "color-tokens", "blank-app", "docs"],
   "access": "restricted",
   "baseBranch": "main",
   "bumpVersionsWithWorkspaceProtocolOnly": false,

--- a/packages/nimbus-docs-build/README.md
+++ b/packages/nimbus-docs-build/README.md
@@ -1,5 +1,9 @@
 # @commercetools/nimbus-docs-build
 
+> **Internal package.** This is a build-time tool used by `apps/docs` within the
+> Nimbus monorepo. It is not published to npm and is not intended for external
+> consumption.
+
 Documentation build system for the Nimbus design system. This package handles:
 
 - **MDX Parsing**: Extracts frontmatter, generates table of contents, supports multi-view documentation

--- a/packages/nimbus-docs-build/package.json
+++ b/packages/nimbus-docs-build/package.json
@@ -36,10 +36,6 @@
     "typescript": "catalog:tooling"
   },
   "peerDependencies": {},
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/commercetools/nimbus.git",

--- a/packages/nimbus-docs-build/package.json
+++ b/packages/nimbus-docs-build/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@commercetools/nimbus-docs-build",
   "version": "1.1.0",
+  "private": true,
   "description": "Documentation build system for Nimbus design system - handles MDX parsing, TypeScript type extraction, and documentation generation",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Reference:[ Slack thread](https://commercetools.slack.com/archives/C0AF9C6TVKM/p1784292162265059)
[Error examples](https://github.com/commercetools/nimbus/actions/workflows/release.yml?query=is%3Afailure+branch%3Amain)

Currently canary fails on any feature merge & is skipped only when the merge is the VP PR itself.


The canary snapshot step in `release.yml `runs on every non-release merge to main:
`pnpm changeset version --snapshot canary`
`pnpm changeset publish --tag canary`

  - snapshot only re-versions packages that have a pending changeset & `@commercetools/nimbus-docs-build` was publishable (not private, not in ignore, not in the fixed group) but doesn't receive changesets, so it kept its static 1.1.0 while everything else got a fresh timestamped version. 
  
 - changeset publish then tried to republish 1.1.0 → X & `set -euo pipefail` threw an error.
 
It is believed to have been accidentally published in the first place.

The fix
 - Matched the repo's existing convention for internal packages (nimbus-i18n, color-tokens are both private & in ignore):
   - packages/nimbus-docs-build/package.json → added "private"
   - .changeset/config.json → added @commercetools/nimbus-docs-build to ignore 
   
Deemed safe b/c:
 - its only consumer is apps/docs (itself private, via workspace:^)
 - nimbus-mcp only references it in comments/docs, not as a dependency
 - the existing 1.1.0 on npm stays live for anyone who pinned it