### PR TITLE
FEC-1151 & 1152 - Chromatic batches 4 & 5

### DIFF
--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -241,7 +241,10 @@ export const Focused: Story = {
 just the primary one** (a split button's dropdown trigger, an input's
 stepper/clear button, a date field's calendar toggle) - each styles its own
 `:focus-visible`, and since only one element holds focus per snapshot, one story
-can't capture two rings.
+can't capture two rings. **Verify the ring actually renders before opting in** -
+if it's styled on a slot that never gets the focus state (a non-focusable
+indicator/track keyed off `data-focus` / `_focusWithin`), the snapshot captures
+nothing (see DropZone).
 
 **Text-entry inputs: hide the caret** so the focused snapshot is deterministic
 (Chromatic can't pause the native caret blink). `caret-color` is inherited, so

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -311,13 +311,23 @@ export const Controlled: Story = {
 };
 ```
 
-#### SmokeTest Story (REQUIRED)
+#### SmokeTest Story (only for interacting axes)
 
 Pack the **interacting** axes your component actually has into one matrix:
 iterate whichever of `sizes`, `variants`, `colorPalettes`, and
 selected/unselected (toggles) apply, covering every combination that produces a
 distinct visual. Content edge cases that change layout (long labels, icon +
 text) can go here too.
+
+**A matrix is only for interacting axes.** Build one only when a cross-cell is a
+visual neither axis produces alone (checked × invalid → a distinct critical
+fill). If the axes are **independent** - no novel cross-cell, one just
+scales/recolors the other (`size × colorPalette`, `size × on/off`) - do **not**
+build a matrix, even a small 2×2; snapshot each axis as its own showcase story
+(`Sizes`, `ColorPalettes`, a states story). The cross-product adds cells, not
+coverage. So not every component has a `SmokeTest` - components with only
+independent axes (Avatar, Badge, Switch) use dedicated showcase snapshots
+instead.
 
 Don't fold in an axis that applies a uniform, axis-independent transform:
 `disabled` resolves to one shared style regardless of palette/size/variant, so
@@ -716,7 +726,7 @@ You MUST validate against these requirements:
 - [ ] Focused story (if component is focusable)
 - [ ] Disabled story (for interactive components)
 - [ ] Controlled story (for stateful components)
-- [ ] SmokeTest story (MUST be last)
+- [ ] SmokeTest story if the component has interacting axes (MUST be last); independent axes use dedicated showcase stories instead
 
 #### Chromatic Snapshots
 

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -460,13 +460,15 @@ which no play-dispatchable event sets.
   matrix - those are IconButton's states, already covered there. (Distinct from
   the independent-axes case below: there the axes don't interact; here the
   wrapper delegates them wholesale to a component that already snapshots them.)
-- **Not every component needs a `SmokeTest` matrix.** A matrix earns its place
-  only when the axes _interact_. When they're independent (Avatar's `size` /
-  `colorPalette` / content mode don't combine into novel visuals), skip the
-  matrix and opt the existing showcase stories into snapshots directly; fold a
-  family of near-identical or purely behavioral stories into one labeled
-  snapshot (Avatar's `AllFallbacks`) when it aids review without losing
-  coverage.
+- **A matrix is only for _interacting_ axes; independent axes are separate
+  stories.** Build a `SmokeTest` matrix only when a cross-cell is a visual
+  neither axis produces alone (Checkbox `checked × invalid` → distinct critical
+  fill). When the axes are independent - one just scales/recolors the other
+  (Badge/Avatar `size × colorPalette`, Switch `size × on/off`) - do **not**
+  build a matrix, even a 2×2; snapshot each axis as its own showcase story. The
+  cross-product adds cells, not coverage. Still fold a family of near-identical
+  behavioral stories into one labeled snapshot (Avatar's `AllFallbacks`) when it
+  aids review without losing coverage.
 - **Capture the focus ring on every distinctly-styled focusable sub-element.** A
   split button's dropdown trigger, an input's clear button or stepper, and a
   date field's calendar toggle each style their own `:focus-visible`; a

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -10,6 +10,11 @@ This doc is the runbook: how runs are triggered, how baselines work, when to
 click the manual button, and what does (and doesn't) block a merge. The YAML
 comments stay intentionally thin and point here.
 
+> **Authoring or auditing stories?** Read the per-story mechanics first: the
+> Chromatic section of [`stories.md`](./file-type-guidelines/stories.md) and the
+> [`writing-stories` skill](../.claude/skills/writing-stories/SKILL.md). This
+> doc is the _why_ behind them.
+
 ## How a run is decided
 
 ```mermaid
@@ -357,7 +362,10 @@ which no play-dispatchable event sets.
   `_focusWithin` on more than one region - needs a focus story per target, since
   each side's ring clears the seam differently. There is no "all focused" state
   to capture: only one element holds focus at a time, so the per-target stories
-  are the complete set (don't add a combined-ring snapshot).
+  are the complete set (don't add a combined-ring snapshot). Confirm the ring
+  actually renders first: if it's on a slot that never gets the focus state, the
+  snapshot captures nothing (DropZone: ring on the root, focus on a hidden inner
+  element).
 - **Cover every visual state/variation** - "the more things we have in
   Storybook, the more coverage we get." This is the governing rule: the
   `SmokeTest` matrix must be **exhaustive** over the axes that _interact_

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -210,6 +210,10 @@ should blur (or be split so the snapshotted story doesn't end focused). Give
 **each** distinctly-styled focusable sub-element (a split button's trigger, an
 input's stepper/clear button) its own `Focused` story, not just the first - only
 one element holds focus per snapshot, so one story can't capture two rings.
+First confirm the ring actually renders: if it's styled on a slot that never
+receives the focus state (a non-focusable indicator/track keyed off `data-focus`
+or `_focusWithin`), the snapshot captures nothing - verify before opting in (see
+DropZone).
 
 ```typescript
 export const Focused: Story = {

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -173,11 +173,14 @@ export const SmokeTest: Story = {
 `disableSnapshot: false` takes the picture; Chromatic never reads `vrt` (our own
 label for finding snapshot stories - keep the two together).
 
-**What to snapshot:** every prop-driven visual state. Fold the interacting axes
-into one `SmokeTest` matrix; any state it can't render in one static image gets
-its own story (`Focused`, disabled-but-focusable, an open tooltip/popover). A
-showcase whose look a snapshot already covers stays snapshot-off. Never drop a
-visual state to save cost.
+**What to snapshot:** every prop-driven visual state. Fold **interacting** axes
+into one `SmokeTest` matrix (only when a cross-cell is a visual neither axis
+produces alone); independent axes that just scale/recolor each other
+(`size × colorPalette`, `size × on/off`) get separate showcase stories, not a
+matrix. Any state the matrix can't render gets its own story (`Focused`,
+disabled-but-focusable, an open tooltip/popover). A showcase whose look a
+snapshot already covers stays snapshot-off. Never drop a visual state to save
+cost.
 
 **Enumerate surfaces from the recipe + component source first** (selectors,
 variant/size keys, conditional props, and ambient axes like RTL), then snapshot

--- a/packages/nimbus/src/components/alert/alert.stories.tsx
+++ b/packages/nimbus/src/components/alert/alert.stories.tsx
@@ -37,7 +37,10 @@ const mockOnDismiss = fn();
  * Uses the args pattern for dynamic control panel inputs.
  * Includes interaction tests.
  */
+/** Full composition incl. the Actions row (the one layout part not in SmokeTest). */
 export const Base: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     colorPalette: "positive",
     variant: "outlined",
@@ -110,36 +113,6 @@ export const ColorPalettesShowcase: Story = {
             onPress={() => alert(`Dismissed ${colorPalette as string}`)}
           />
         </Alert.Root>
-      ))}
-    </Stack>
-  ),
-};
-
-export const VariantsShowcase: Story = {
-  name: "Showcase: Variants",
-  render: () => (
-    <Stack direction="column" gap="400" alignItems="flex-start">
-      {colorPalettes.map((colorPalette) => (
-        <Stack
-          key={`stack-${colorPalette as string}`}
-          direction="row"
-          gap="400"
-          width="100%"
-        >
-          {variants.map((variant) => (
-            <Alert.Root
-              key={`alert-${colorPalette as string}-${variant as string}`}
-              colorPalette={colorPalette}
-              variant={variant}
-            >
-              <Alert.Title>
-                {colorPalette as string} / {variant as string}
-              </Alert.Title>
-              <Alert.Description>Desc.</Alert.Description>
-              <Alert.DismissButton onPress={() => alert("Dismissed")} />
-            </Alert.Root>
-          ))}
-        </Stack>
       ))}
     </Stack>
   ),
@@ -307,4 +280,36 @@ export const NoActions: Story = {
       await expect(mockDismissNoActions).toHaveBeenCalledTimes(1);
     });
   },
+};
+
+/** SmokeTest: colorPalette × variant (each palette auto-renders its own icon). */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="400" alignItems="flex-start">
+      {colorPalettes.map((colorPalette) => (
+        <Stack
+          key={`stack-${colorPalette as string}`}
+          direction="row"
+          gap="400"
+          width="100%"
+        >
+          {variants.map((variant) => (
+            <Alert.Root
+              key={`alert-${colorPalette as string}-${variant as string}`}
+              colorPalette={colorPalette}
+              variant={variant}
+            >
+              <Alert.Title>
+                {colorPalette as string} / {variant as string}
+              </Alert.Title>
+              <Alert.Description>Desc.</Alert.Description>
+              <Alert.DismissButton onPress={() => alert("Dismissed")} />
+            </Alert.Root>
+          ))}
+        </Stack>
+      ))}
+    </Stack>
+  ),
 };

--- a/packages/nimbus/src/components/badge/badge.stories.tsx
+++ b/packages/nimbus/src/components/badge/badge.stories.tsx
@@ -55,16 +55,17 @@ export const Base: Story = {
   },
 };
 
-/**
- * Showcase Sizes
- */
+/** Size axis (+ an icon so `_icon` sizing per size is covered); independent of palette, so its own story. */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {},
   render: (args) => {
     return (
       <Stack direction="row" gap="400" alignItems="center">
         {sizes.map((size) => (
           <Badge key={size as string} {...args} size={size}>
+            <DemoIcon />
             {String(size)}
           </Badge>
         ))}
@@ -73,10 +74,10 @@ export const Sizes: Story = {
   },
 };
 
-/**
- * Showcase Possible Color Palettes
- */
+/** All palettes (semantic + brand + system); the palette axis, snapshotted in one flat showcase. */
 export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     size: "xs",
   },
@@ -93,10 +94,10 @@ export const ColorPalettes: Story = {
   },
 };
 
-/**
- * Showcase Icons
- */
+/** Icon layouts (leading / trailing / both); a distinct visual vs the text-only matrix. */
 export const WithIcons: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     size: "md",
   },

--- a/packages/nimbus/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/nimbus/src/components/checkbox/checkbox.stories.tsx
@@ -62,7 +62,7 @@ export const Base: Story = {
     const onChange = args.onChange;
 
     await step(
-      "Forwards data- & aria-attributes to the checkbox element",
+      "Forwards data-attributes to the root and aria-attributes to the input",
       async () => {
         await expect(rootLabel.tagName).toBe("LABEL");
         await expect(rootLabel).toHaveAttribute("data-testid", "test-checkbox");
@@ -103,30 +103,40 @@ export const Base: Story = {
   },
 };
 
+/** Disabled is uniform opacity, folded out of the matrix; shown across all three glyphs. */
 export const Disabled: Story = {
-  args: {
-    children: "Disabled Checkbox",
-    // @ts-expect-error: data-testid is not a valid prop
-    "data-testid": "test-checkbox",
-    isDisabled: true,
-    isSelected: false,
-  },
-
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="row" gap="400" alignItems="flex-start">
+      <Checkbox isDisabled isSelected={false}>
+        Unchecked
+      </Checkbox>
+      <Checkbox isDisabled isSelected>
+        Checked
+      </Checkbox>
+      <Checkbox isDisabled isIndeterminate>
+        Indeterminate
+      </Checkbox>
+    </Stack>
+  ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    const checkboxElement = canvas.getByTestId("test-checkbox");
-    const inputElement = checkboxElement.querySelector(
-      "input"
-    ) as HTMLInputElement;
+    const inputs = canvas.getAllByRole("checkbox");
 
     // A disabled Checkbox renders a disabled underlying <input>. The browser
     // won't forward label clicks to a disabled control or let it take focus, so
-    // asserting the input is disabled (plus the root's data-disabled state) is
-    // sufficient — simulating clicks that physically can't toggle it adds no
+    // asserting the inputs are disabled (plus the roots' data-disabled state) is
+    // sufficient — simulating clicks that physically can't toggle them adds no
     // coverage.
-    await step("Is disabled", async () => {
-      await expect(inputElement).toBeDisabled();
-      await expect(checkboxElement).toHaveAttribute("data-disabled", "true");
+    await step("Every checkbox is disabled", async () => {
+      for (const input of inputs) {
+        await expect(input).toBeDisabled();
+        await expect(input.closest("label")).toHaveAttribute(
+          "data-disabled",
+          "true"
+        );
+      }
     });
   },
 };
@@ -146,6 +156,23 @@ export const Invalid: Story = {
     await step("checkbox element has invalid state", async () => {
       await expect(checkboxElement).toHaveAttribute("data-invalid", "true");
     });
+  },
+};
+
+/** Indicator focus ring; independent of check-state, so one snapshot. */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: {
+    children: "Focused Checkbox",
+    "aria-label": "focused-checkbox",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.tab();
+    await expect(
+      canvas.getByRole("checkbox", { name: "focused-checkbox" })
+    ).toHaveFocus();
   },
 };
 
@@ -192,51 +219,26 @@ export const StyleProps: Story = {
   },
 };
 
-/**
- * Smoke Test
- * This story attempts to capture all visual permutations
- */
+/** SmokeTest: check-state × invalid (the interacting axes). Size/colorPalette fixed; disabled folded out. */
 export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack gap="1000">
         {[false, true].map((isInvalid, j) => (
-          <Stack direction="row" key={j}>
-            {[false, true].map((isDisabled, i) => (
-              <Stack
-                width="1/2"
-                key={i}
-                direction="column"
-                alignItems="flex-start"
-              >
-                <Checkbox
-                  isSelected={false}
-                  isDisabled={isDisabled}
-                  isInvalid={isInvalid}
-                >
-                  Unchecked, {isDisabled ? "disabled" : "not disabled"},{" "}
-                  {isInvalid ? "invalid" : ""}
-                </Checkbox>
+          <Stack direction="row" gap="400" key={j} alignItems="flex-start">
+            <Checkbox isSelected={false} isInvalid={isInvalid}>
+              Unchecked{isInvalid ? ", invalid" : ""}
+            </Checkbox>
 
-                <Checkbox
-                  isDisabled={isDisabled}
-                  isInvalid={isInvalid}
-                  isSelected
-                >
-                  Checked, {isDisabled ? "disabled" : "not disabled"},{" "}
-                  {isInvalid ? "invalid" : ""}
-                </Checkbox>
+            <Checkbox isSelected isInvalid={isInvalid}>
+              Checked{isInvalid ? ", invalid" : ""}
+            </Checkbox>
 
-                <Checkbox
-                  isDisabled={isDisabled}
-                  isInvalid={isInvalid}
-                  isIndeterminate
-                >
-                  Indeterminate, {isDisabled ? "disabled" : "not disabled"},{" "}
-                  {isInvalid ? "invalid" : ""}
-                </Checkbox>
-              </Stack>
-            ))}
+            <Checkbox isIndeterminate isInvalid={isInvalid}>
+              Indeterminate{isInvalid ? ", invalid" : ""}
+            </Checkbox>
           </Stack>
         ))}
       </Stack>

--- a/packages/nimbus/src/components/field-errors/field-errors.stories.tsx
+++ b/packages/nimbus/src/components/field-errors/field-errors.stories.tsx
@@ -795,3 +795,25 @@ export const FormFieldIntegration: Story = {
     },
   },
 };
+
+/** SmokeTest: message color per colorPalette (critical default / warning) × multi-line stacking. Other stories only vary error text. */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack gap="400" alignItems="flex-start">
+      <FieldErrors
+        id="smoke-critical"
+        isVisible
+        errors={{ missing: true, invalid: true, format: true }}
+      />
+      <FieldErrors
+        id="smoke-warning"
+        isVisible
+        colorPalette="warning"
+        role="status"
+        errors={{ missing: true, invalid: true, format: true }}
+      />
+    </Stack>
+  ),
+};

--- a/packages/nimbus/src/components/form-field/form-field.stories.tsx
+++ b/packages/nimbus/src/components/form-field/form-field.stories.tsx
@@ -469,3 +469,71 @@ export const Controlled: Story = {
     );
   },
 };
+
+/** Open InfoBox popover - the `popover` slot chrome (border/shadow/radius); portal overlay a matrix can't reach. */
+export const OpenInfoBox: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: defaultArgs,
+  render: (args) => (
+    <FormField.Root {...args}>
+      <FormField.Label>Input Label</FormField.Label>
+      <FormField.Input>
+        <TextInput placeholder="Enter some text here" type="text" />
+      </FormField.Input>
+      <FormField.InfoBox>Show me in a tooltip box</FormField.InfoBox>
+    </FormField.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button"));
+    await within(document.body).findByText(/Show me in a tooltip/);
+  },
+};
+
+/** SmokeTest: direction × size × state (default / required-asterisk / invalid-error). Wrapped input is TextInput's coverage. */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => {
+    const states = [
+      { key: "default", props: {} },
+      { key: "required", props: { isRequired: true } },
+      { key: "invalid", props: { isInvalid: true } },
+    ] as const;
+    return (
+      <Stack direction="column" gap="600" alignItems="flex-start">
+        {(["column", "row"] as const).map((direction) =>
+          sizes.map((size) => (
+            <Stack
+              key={`${direction}-${size as string}`}
+              direction="row"
+              gap="600"
+              alignItems="flex-start"
+            >
+              {states.map((state) => (
+                <FormField.Root
+                  key={state.key}
+                  direction={direction}
+                  size={size}
+                  {...state.props}
+                >
+                  <FormField.Label>
+                    {direction}/{size as string} {state.key}
+                  </FormField.Label>
+                  <FormField.Input>
+                    <TextInput placeholder="Enter some text here" type="text" />
+                  </FormField.Input>
+                  <FormField.Description>
+                    Description text
+                  </FormField.Description>
+                  <FormField.Error>Error message</FormField.Error>
+                </FormField.Root>
+              ))}
+            </Stack>
+          ))
+        )}
+      </Stack>
+    );
+  },
+};

--- a/packages/nimbus/src/components/localized-field/localized-field.stories.tsx
+++ b/packages/nimbus/src/components/localized-field/localized-field.stories.tsx
@@ -222,6 +222,8 @@ export const Base: Story = {
 };
 
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack gap="500">
@@ -243,6 +245,8 @@ export const Sizes: Story = {
 };
 
 export const Required: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return <LocalizedFieldStoryComponent {...baseStoryProps} isRequired />;
   },
@@ -328,6 +332,8 @@ export const Required: Story = {
 };
 
 export const Disabled: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return <LocalizedFieldStoryComponent {...baseStoryProps} isDisabled />;
   },
@@ -656,6 +662,8 @@ export const SingleLocaleOrCurrency: Story = {
 };
 
 export const DefaultExpanded: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return <LocalizedFieldStoryComponent {...baseStoryProps} defaultExpanded />;
   },
@@ -783,6 +791,8 @@ export const DisplayAllLocalesOrCurrencies: Story = {
 };
 
 export const HintDialog: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return <LocalizedFieldStoryComponent {...hintStoryProps} />;
   },
@@ -832,16 +842,14 @@ export const HintDialog: Story = {
     });
     await step("Money Field", async () => {
       const moneyField = await getFieldContainerForType(canvas, "money");
-      await step(
-        "Hint dialog button displays dialog with correct value when pressed",
-        async () => {
-          await checkFieldDetailsDialog(
-            moneyField,
-            document.body,
-            baseMoneyContextFields.hint
-          );
-        }
-      );
+      // Last field: open the hint and leave it open (no closing click) so the
+      // VRT snapshot captures the infoDialog popover.
+      await step("Hint dialog opens and stays open", async () => {
+        await userEvent.click(
+          within(moneyField).getByRole("button", { name: "more info" })
+        );
+        await within(document.body).findByText(baseMoneyContextFields.hint);
+      });
     });
   },
 };
@@ -2107,4 +2115,85 @@ export const CustomWidth: Story = {
       );
     }
   },
+};
+
+const localizedValues = { en: "Hello", de: "Hallo", "zh-Hans": "你好" };
+const noop = () => {};
+
+/** Collapsed default state: the default locale field + the show-all toggle. */
+export const Collapsed: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <LocalizedField
+      type="text"
+      label="Product name"
+      defaultLocaleOrCurrency="en"
+      valuesByLocaleOrCurrency={localizedValues}
+      onChange={noop}
+    />
+  ),
+};
+
+/** Fused locale label+input focus ring (`:has(:focus-within)` outline spanning both). */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <LocalizedField
+      type="text"
+      label="Product name"
+      defaultLocaleOrCurrency="en"
+      valuesByLocaleOrCurrency={localizedValues}
+      onChange={noop}
+      displayAllLocalesOrCurrencies
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    canvasElement.style.caretColor = "transparent"; // native caret can't be paused
+    const canvas = within(canvasElement);
+    const inputs = await canvas.findAllByRole("textbox");
+    inputs[0].focus();
+    await expect(inputs[0]).toHaveFocus();
+  },
+};
+
+/** Invalid: red locale fields + group error (touched). */
+export const Invalid: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <LocalizedField
+      type="text"
+      label="Product name"
+      defaultLocaleOrCurrency="en"
+      valuesByLocaleOrCurrency={localizedValues}
+      onChange={noop}
+      displayAllLocalesOrCurrencies
+      error="Group error"
+      touched
+    />
+  ),
+};
+
+/** Warning: per-locale warning text in `warning.11` + the amber `WarningAmber` icon (distinct from neutral description / critical error). */
+export const Warning: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <LocalizedField
+      type="text"
+      label="Product name"
+      defaultLocaleOrCurrency="en"
+      valuesByLocaleOrCurrency={localizedValues}
+      warningsByLocaleOrCurrency={{
+        en: "Heads up",
+        de: "Achtung",
+        "zh-Hans": "注意",
+      }}
+      touched
+      onChange={noop}
+      displayAllLocalesOrCurrencies
+    />
+  ),
 };

--- a/packages/nimbus/src/components/radio-input/radio-input.stories.tsx
+++ b/packages/nimbus/src/components/radio-input/radio-input.stories.tsx
@@ -47,7 +47,7 @@ export const Base: Story = {
     const radioInput = canvas.getByLabelText("No");
 
     await step(
-      "Forwards data- & aria-attributes to the actual html-input",
+      "Forwards data- & aria-attributes to the radio group root",
       async () => {
         await expect(htmlInput.tagName).toBe("DIV");
         await expect(htmlInput).toHaveAttribute(
@@ -78,16 +78,22 @@ export const Base: Story = {
       await expect(onChange).toHaveBeenCalledTimes(1);
     });
 
-    await step("Can be triggered by clicking on a label", async () => {
-      await userEvent.click(radioInput);
-      await expect(onChange).toHaveBeenCalledTimes(1);
-    });
+    await step(
+      "Selecting a different option by clicking triggers onChange",
+      async () => {
+        const radioYes = canvas.getByLabelText("Yes");
+        await userEvent.click(radioYes);
+        await expect(radioYes).toBeChecked();
+        await expect(onChange).toHaveBeenCalledTimes(2);
+      }
+    );
 
     await step(
-      "Clicking the display label does not trigger onChange again",
+      "Clicking the already-selected option does not trigger onChange again",
       async () => {
-        await userEvent.click(radioInput);
-        await expect(onChange).toHaveBeenCalledTimes(1);
+        const radioYes = canvas.getByLabelText("Yes");
+        await userEvent.click(radioYes);
+        await expect(onChange).toHaveBeenCalledTimes(2);
       }
     );
   },
@@ -136,7 +142,10 @@ export const Disabled: Story = {
   },
 };
 
+/** Disabled (uniform opacity), folded out; one preselected group shows both glyphs dimmed. */
 export const DisabledAndSelected: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <Stack gap="1000">
       <RadioInput.Root
@@ -326,7 +335,10 @@ export const InvisibleLabel: Story = {
   },
 };
 
+/** `orientation` variant (vertical/horizontal); a layout surface, so its own snapshot. */
 export const Orientation: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <Stack gap="1000">
       {/* Vertical (default) */}
@@ -423,9 +435,8 @@ export const WithFormField: StoryObj = {
     await step(
       "RadioInput renders a radio group with correct ARIA attributes",
       async () => {
-        // Check that ARIA attributes exist
-        radioGroup.getAttribute("aria-labelledby");
-        radioGroup.getAttribute("aria-describedby");
+        await expect(radioGroup).toHaveAttribute("aria-labelledby");
+        await expect(radioGroup).toHaveAttribute("aria-describedby");
       }
     );
 
@@ -491,4 +502,48 @@ export const WithTooltip: Story = {
       }
     );
   },
+};
+
+/** Option focus ring (keyboard-only via useFocusRing); one focus surface. */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <RadioInput.Root aria-label="focused-radio" name="focused-radio">
+      <RadioInput.Option value="first">First</RadioInput.Option>
+      <RadioInput.Option value="second">Second</RadioInput.Option>
+    </RadioInput.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.tab();
+    await expect(canvas.getByLabelText("First")).toHaveFocus();
+  },
+};
+
+/** SmokeTest: selection × invalid. One group per invalid value shows selected + unselected together. */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack gap="800">
+      <RadioInput.Root aria-label="smoke-default" defaultValue="selected">
+        <RadioInput.Option value="unselected">Unselected</RadioInput.Option>
+        <RadioInput.Option value="selected">Selected</RadioInput.Option>
+      </RadioInput.Root>
+
+      <RadioInput.Root
+        aria-label="smoke-invalid"
+        isInvalid
+        defaultValue="selected"
+      >
+        <RadioInput.Option value="unselected">
+          Unselected, invalid
+        </RadioInput.Option>
+        <RadioInput.Option value="selected">
+          Selected, invalid
+        </RadioInput.Option>
+      </RadioInput.Root>
+    </Stack>
+  ),
 };

--- a/packages/nimbus/src/components/switch/switch.stories.tsx
+++ b/packages/nimbus/src/components/switch/switch.stories.tsx
@@ -64,7 +64,7 @@ export const Accessibility: Story = {
     const switchRoot = canvasElement.querySelector('[data-slot="root"]');
 
     await step("Has proper role", async () => {
-      await expect(switchEl).toHaveAttribute("type", "checkbox");
+      await expect(switchEl).toHaveAttribute("role", "switch");
     });
 
     await step("Supports keyboard navigation", async () => {
@@ -117,35 +117,48 @@ export const ControlledUse: Story = {
   },
 };
 
+/** Disabled (uniform opacity), folded out; off and on dim different track colors, so both shown. */
 export const Disabled: Story = {
-  args: {
-    isDisabled: true,
-    children: "Disabled Switch",
-    onChange: fn(),
-    // @ts-expect-error: data-testid is not a valid prop
-    ["data-testid"]: "disabled-switch",
-  },
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { onChange: fn() },
+  render: (args) => (
+    <Stack direction="row" gap="600" alignItems="center">
+      <Switch {...args} isDisabled>
+        Off, disabled
+      </Switch>
+      <Switch {...args} isDisabled defaultSelected>
+        On, disabled
+      </Switch>
+    </Stack>
+  ),
   play: async ({ canvasElement, step, args }) => {
     const canvas = within(canvasElement);
-    const switchEl = canvas.getByTestId("disabled-switch");
-    const switchRoot = canvasElement.querySelector('[data-slot="root"]');
+    const switches = canvas.getAllByRole("switch");
     const onChange = args.onChange;
 
-    await step("Has disabled attribute", async () => {
-      await expect(switchEl).toHaveAttribute("disabled");
-      await expect(switchRoot?.getAttribute("data-disabled")).toBe("true");
+    await step("Both switches are disabled", async () => {
+      for (const el of switches) {
+        await expect(el).toBeDisabled();
+        await expect(el.closest('[data-slot="root"]')).toHaveAttribute(
+          "data-disabled",
+          "true"
+        );
+      }
     });
 
     await step("Cannot be focused or toggled", async () => {
       await userEvent.tab();
-      await expect(switchEl).not.toHaveFocus();
-
-      switchEl.click();
+      for (const el of switches) {
+        await expect(el).not.toHaveFocus();
+      }
+      switches[0].click();
       await expect(onChange).toHaveBeenCalledTimes(0);
     });
   },
 };
 
+/** No `data-invalid` recipe rule, so invalid looks identical to default: behavioral only, no snapshot. */
 export const Invalid: Story = {
   args: {
     isInvalid: true,
@@ -293,6 +306,36 @@ export const Sizes: Story = {
       <Box>
         <Switch size="md" {...args} />
       </Box>
+    </Stack>
+  ),
+};
+
+/** Track focus ring (keyboard-only via useFocusRing); one focus surface. */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { children: "Focused Switch" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.tab();
+    await expect(canvas.getByRole("switch")).toHaveFocus();
+  },
+};
+
+/** SmokeTest: selected × size (the interacting axes). Disabled folded out; invalid has no visual; colorPalette fixed. */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack gap="600" alignItems="flex-start">
+      {(["sm", "md"] as const).map((size) => (
+        <Stack key={size} direction="row" gap="600" alignItems="center">
+          <Switch size={size}>Off, {size}</Switch>
+          <Switch size={size} defaultSelected>
+            On, {size}
+          </Switch>
+        </Stack>
+      ))}
     </Stack>
   ),
 };

--- a/packages/nimbus/src/components/switch/switch.stories.tsx
+++ b/packages/nimbus/src/components/switch/switch.stories.tsx
@@ -294,7 +294,10 @@ export const WithTooltipDisabled: Story = {
   },
 };
 
+/** Size axis (sm / md); independent of on/off, so its own story (no matrix). */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     children: "Switch Label",
   },
@@ -322,20 +325,14 @@ export const Focused: Story = {
   },
 };
 
-/** SmokeTest: selected × size (the interacting axes). Disabled folded out; invalid has no visual; colorPalette fixed. */
-export const SmokeTest: Story = {
+/** On/off track surfaces (neutral vs primary + thumb position); independent of size. */
+export const States: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
-    <Stack gap="600" alignItems="flex-start">
-      {(["sm", "md"] as const).map((size) => (
-        <Stack key={size} direction="row" gap="600" alignItems="center">
-          <Switch size={size}>Off, {size}</Switch>
-          <Switch size={size} defaultSelected>
-            On, {size}
-          </Switch>
-        </Stack>
-      ))}
+    <Stack direction="row" gap="600" alignItems="center">
+      <Switch>Off</Switch>
+      <Switch defaultSelected>On</Switch>
     </Stack>
   ),
 };

--- a/packages/nimbus/src/components/switch/switch.stories.tsx
+++ b/packages/nimbus/src/components/switch/switch.stories.tsx
@@ -218,7 +218,7 @@ export const WithRef: Story = {
 /**
  * Verifies that Switch can trigger a Tooltip when wrapped in Tooltip.Root
  */
-export const WithTooltip: Story = {
+export const ToggleWithTooltip: Story = {
   args: {
     children: "Switch with Tooltip",
     onChange: fn(),
@@ -249,6 +249,31 @@ export const WithTooltip: Story = {
       await expect(args.onChange).toHaveBeenCalledTimes(1);
       await expect(switchRoot.getAttribute("data-selected")).toBe("true");
     });
+  },
+};
+
+/**
+ * Snapshots the open tooltip on a switch. Focuses the trigger so the bubble is
+ * visible in the frame; Chromatic captures the resting open state.
+ */
+export const DisplaysTooltip: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: {
+    children: "Switch with Tooltip",
+  },
+  render: (args) => (
+    <Tooltip.Root delay={0} closeDelay={0}>
+      <Switch {...args} />
+      <Tooltip.Content>Switch tooltip text</Tooltip.Content>
+    </Tooltip.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+    await userEvent.tab();
+    await canvas.findByRole("tooltip", { name: "Switch tooltip text" });
   },
 };
 

--- a/packages/nimbus/src/components/tag-group/tag-group.stories.tsx
+++ b/packages/nimbus/src/components/tag-group/tag-group.stories.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from "@commercetools/nimbus";
 import { DisplayColorPalettes } from "@/utils/display-color-palettes";
+import { SEMANTIC_COLOR_PALETTES } from "@/constants/color-palettes";
 
 /**
  * Storybook metadata configuration
@@ -268,10 +269,10 @@ export const EmptyState: Story = {
     });
   },
 };
-/**
- * Showcase Sizes
- */
+/** `size` variant (sm/md/lg); independent of color/selection, so its own snapshot. */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {},
   render: () => {
     const animalList = useListData({
@@ -295,9 +296,48 @@ export const Sizes: Story = {
   },
 };
 
-/**
- * Showcase Color Palettes
- */
+/** Removable resting chip (dismiss button); removal is offered only when the group is not selectable. */
+export const Removable: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { onRemove: fn() },
+  render: ({ onRemove }) => (
+    <TagGroup.Root
+      aria-label="removable animals"
+      selectionMode="none"
+      onRemove={onRemove}
+    >
+      <TagGroup.TagList items={animalOptions.slice(0, 3)}>
+        {(item) => <TagGroup.Tag>{item.name}</TagGroup.Tag>}
+      </TagGroup.TagList>
+    </TagGroup.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("Each tag renders a dismiss button", async () => {
+      await expect(canvas.getAllByLabelText("Remove tag")).toHaveLength(3);
+    });
+  },
+};
+
+/** Tag focus ring; roving tabindex means one focus surface, so one snapshot. */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <TagGroup.Root aria-label="focused tags">
+      <TagGroup.TagList items={animalOptions.slice(0, 3)}>
+        {(item) => <TagGroup.Tag>{item.name}</TagGroup.Tag>}
+      </TagGroup.TagList>
+    </TagGroup.Root>
+  ),
+  play: async () => {
+    await userEvent.tab();
+    expect(document.activeElement?.textContent).toContain("Koala");
+  },
+};
+
+/** Not snapshotted: renders all 34 palettes, but only the 6 semantic are in scope (covered by SmokeTest). */
 export const ColorPalettes: Story = {
   args: {},
   render: () => (
@@ -312,5 +352,34 @@ export const ColorPalettes: Story = {
         </TagGroup.Root>
       )}
     </DisplayColorPalettes>
+  ),
+};
+
+/** SmokeTest: colorPalette × selected (both use palette-dependent fills). Size is its own story; disabled has no visual (see coverage matrix). */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="400" alignItems="flex-start">
+      {SEMANTIC_COLOR_PALETTES.map((palette) => (
+        <TagGroup.Root
+          key={palette}
+          aria-label={`${palette} tags`}
+          selectionMode="multiple"
+          defaultSelectedKeys={new Set(["selected"])}
+        >
+          <TagGroup.TagList
+            items={[
+              { id: "unselected", name: `${palette} unselected` },
+              { id: "selected", name: `${palette} selected` },
+            ]}
+          >
+            {(item) => (
+              <TagGroup.Tag colorPalette={palette}>{item.name}</TagGroup.Tag>
+            )}
+          </TagGroup.TagList>
+        </TagGroup.Root>
+      ))}
+    </Stack>
   ),
 };

--- a/packages/nimbus/src/components/time-input/time-input.stories.tsx
+++ b/packages/nimbus/src/components/time-input/time-input.stories.tsx
@@ -11,7 +11,11 @@ import {
   TimeInput,
   type TimeValue,
 } from "@commercetools/nimbus";
-import { parseZonedDateTime, Time } from "@internationalized/date";
+import {
+  CalendarDateTime,
+  parseZonedDateTime,
+  Time,
+} from "@internationalized/date";
 import { useState } from "react";
 import { userEvent, within, expect, fn } from "storybook/test";
 import {
@@ -25,6 +29,9 @@ import {
 const inventionOfTheInternet = parseZonedDateTime(
   "1993-04-30T14:30[Europe/Zurich]"
 );
+
+// Fixed anchor (2026-06-15, shared with the Date components) for deterministic snapshots.
+const ANCHOR = new CalendarDateTime(2026, 6, 15, 14, 30);
 
 /**
  * Storybook metadata configuration
@@ -382,6 +389,8 @@ export const Variants: Story = {
  * including IconButton examples for different sizes and variants
  */
 export const LeadingAndTrailingElements: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const examples: Array<{
       label: string;
@@ -571,6 +580,8 @@ export const HourCycle: Story = {
  * Showcase Hide Time Zone
  */
 export const HideTimeZone: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     defaultValue: inventionOfTheInternet,
   },
@@ -641,6 +652,8 @@ export const HideTimeZone: Story = {
  * Showcase Granularity
  */
 export const Granularity: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     defaultValue: inventionOfTheInternet,
     hideTimeZone: true,
@@ -728,6 +741,8 @@ export const Granularity: Story = {
  * Showcase Should Force Leading Zeros
  */
 export const ShouldForceLeadingZeros: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     defaultValue: new Time(2, 5), // Use a single-digit hour and minute
     hideTimeZone: true,
@@ -1173,4 +1188,51 @@ export const WithFormField: Story = {
       await expect(errorMessage).toBeNull();
     });
   },
+};
+
+/** Focused segment highlight + root `_focusWithin` ring; one focus surface. */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { ["aria-label"]: "focused time input", defaultValue: ANCHOR },
+  play: async ({ canvasElement }) => {
+    canvasElement.style.caretColor = "transparent"; // native caret can't be paused
+    const canvas = within(canvasElement);
+    await userEvent.tab();
+    const group = canvas.getByRole("group", { name: "focused time input" });
+    const firstSegment = group.querySelectorAll('[role="spinbutton"]')[0];
+    await expect(firstSegment).toHaveFocus();
+  },
+};
+
+/** SmokeTest: state × size × variant (the interacting axes; invalid border only shows on solid). */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="400" alignItems="flex-start">
+      {(["solid", "ghost"] as const).map((variant) => (
+        <Stack key={variant} direction="row" gap="400" alignItems="center">
+          {(["sm", "md"] as const).map((size) =>
+            (
+              [
+                { label: "default", props: {} },
+                { label: "invalid", props: { isInvalid: true } },
+                { label: "disabled", props: { isDisabled: true } },
+              ] as const
+            ).map((state) => (
+              <TimeInput
+                key={`${variant}-${size}-${state.label}`}
+                variant={variant}
+                size={size}
+                defaultValue={ANCHOR}
+                aria-label={`${variant} ${size} ${state.label}`}
+                {...state.props}
+              />
+            ))
+          )}
+        </Stack>
+      ))}
+    </Stack>
+  ),
 };


### PR DESCRIPTION
> You know the drill. Got all my notes, so ask away if you'd like. 

P1 Nimbus - Batch 4 & 5 Audit - Selection controls & time / Field composition & badges
  Relates to: #1797 (Batch 3), #1790 (Batch 2) & #1782 (Batch 1)

  VRT components audited & tagged:

  Batch 4 (FEC-1156) - selection controls & time
  - Checkbox
  - RadioInput
  - Switch
  - TagGroup
  - TimeInput

  Batch 5 (FEC-1157) - field composition & badges
  - Badge
  - Alert
  - FormField
  - FieldErrors
  - LocalizedField

Test-integrity fixes
Extended the VRT guidance in chromatic-related docs (chromatic-visual-testing.md, stories.md & writing-stories skill)

Possible bugs flagged noted, but not fixed here