### PR TITLE
fix(test): add explicit waitFor timeouts to drawer, split-button, and menu close assertions

### DIFF
--- a/packages/nimbus/src/components/drawer/drawer.stories.tsx
+++ b/packages/nimbus/src/components/drawer/drawer.stories.tsx
@@ -117,9 +117,12 @@ export const Default: Story = {
       await userEvent.click(closeButton);
 
       // Wait for drawer to close
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step(
@@ -140,9 +143,12 @@ export const Default: Story = {
         await userEvent.click(cancelButton);
 
         // Wait for drawer to close
-        await waitFor(() => {
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        });
+        await waitFor(
+          () => {
+            expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
       }
     );
 
@@ -174,9 +180,12 @@ export const Default: Story = {
 
       // Close with Escape key
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Focus should return to trigger
       await waitFor(
@@ -262,9 +271,12 @@ export const ButtonAsTrigger: Story = {
       await userEvent.click(confirmButton);
 
       // Drawer should close and focus should return to custom trigger
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Wait for focus to be restored to the custom button trigger
       await waitFor(
@@ -533,10 +545,13 @@ export const ControlledState: Story = {
       // Test onOpenChange callback synchronization via close button
       const closeButton = canvas.getByRole("button", { name: /close/i });
       await userEvent.click(closeButton);
-      await waitFor(() => {
-        expect(canvas.getByText("Drawer is closed")).toBeInTheDocument();
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.getByText("Drawer is closed")).toBeInTheDocument();
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
       expect(switchElement).not.toBeChecked();
     });
   },
@@ -754,9 +769,12 @@ export const ComplexDismissalScenarios: Story = {
         .closest('[role="presentation"]');
       if (modalOverlay1) {
         await userEvent.click(modalOverlay1);
-        await waitFor(() => {
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        });
+        await waitFor(
+          () => {
+            expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
       }
 
       // Test backdrop disabled, keyboard enabled
@@ -779,9 +797,12 @@ export const ComplexDismissalScenarios: Story = {
 
       // Escape SHOULD close
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Test both disabled
       const trigger3 = canvas.getByRole("button", {
@@ -799,9 +820,12 @@ export const ComplexDismissalScenarios: Story = {
       // Only close button works
       const closeButton = canvas.getByRole("button", { name: "Close" });
       await userEvent.click(closeButton);
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };
@@ -887,16 +911,19 @@ export const NestedDrawers: Story = {
       });
       await userEvent.click(secondTrigger);
 
-      await waitFor(() => {
-        // Both drawers should be present
-        const drawers = canvas.getAllByRole("dialog");
-        expect(drawers).toHaveLength(2);
-        expect(
-          canvas.getByText(
-            /This is a nested drawer that should appear above the first/
-          )
-        ).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          // Both drawers should be present
+          const drawers = canvas.getAllByRole("dialog");
+          expect(drawers).toHaveLength(2);
+          expect(
+            canvas.getByText(
+              /This is a nested drawer that should appear above the first/
+            )
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Close second drawer first (should close in proper order)
       const secondCloseButton = canvas.getByRole("button", {
@@ -904,13 +931,16 @@ export const NestedDrawers: Story = {
       });
       await userEvent.click(secondCloseButton);
 
-      await waitFor(() => {
-        const drawers = canvas.getAllByRole("dialog");
-        expect(drawers).toHaveLength(1);
-        expect(
-          canvas.getByText("This is the first level drawer.")
-        ).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          const drawers = canvas.getAllByRole("dialog");
+          expect(drawers).toHaveLength(1);
+          expect(
+            canvas.getByText("This is the first level drawer.")
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Close first drawer
       const firstCloseButton = canvas.getByRole("button", {
@@ -918,9 +948,12 @@ export const NestedDrawers: Story = {
       });
       await userEvent.click(firstCloseButton);
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify focus restoration to original trigger
       await waitFor(
@@ -948,28 +981,37 @@ export const NestedDrawers: Story = {
       });
       await userEvent.click(secondTrigger);
 
-      await waitFor(() => {
-        const drawers = canvas.getAllByRole("dialog");
-        expect(drawers).toHaveLength(2);
-      });
+      await waitFor(
+        () => {
+          const drawers = canvas.getAllByRole("dialog");
+          expect(drawers).toHaveLength(2);
+        },
+        { timeout: 3000 }
+      );
 
       // Escape should close the topmost drawer first
       await userEvent.keyboard("{Escape}");
 
-      await waitFor(() => {
-        const drawers = canvas.getAllByRole("dialog");
-        expect(drawers).toHaveLength(1);
-        expect(
-          canvas.getByText("This is the first level drawer.")
-        ).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          const drawers = canvas.getAllByRole("dialog");
+          expect(drawers).toHaveLength(1);
+          expect(
+            canvas.getByText("This is the first level drawer.")
+          ).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Another Escape should close the remaining drawer
       await userEvent.keyboard("{Escape}");
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Focus should return to original trigger
       await waitFor(
@@ -1133,11 +1175,14 @@ export const UnsavedChangesConfirmation: Story = {
       const keepButton = canvas.getByRole("button", { name: "Keep Editing" });
       await userEvent.click(keepButton);
 
-      await waitFor(() => {
-        expect(
-          canvas.queryByText("You have unsaved changes. Discard them?")
-        ).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(
+            canvas.queryByText("You have unsaved changes. Discard them?")
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
       expect(canvas.getByRole("dialog")).toBeInTheDocument();
     });
 
@@ -1159,9 +1204,12 @@ export const UnsavedChangesConfirmation: Story = {
       });
       await userEvent.click(discardButton);
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };

--- a/packages/nimbus/src/components/menu/menu.stories.tsx
+++ b/packages/nimbus/src/components/menu/menu.stories.tsx
@@ -164,9 +164,12 @@ export const Basic: Story = {
       // Press Enter to select
       await userEvent.keyboard("{Enter}");
       await expect(args.onAction).toHaveBeenCalledWith("copy", undefined);
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     // Skip escape test for now as previous tests may have left menu in unexpected state
@@ -330,9 +333,12 @@ export const TriggerVariations: Story = {
 
       // Close menu
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Test outline button trigger
       const outlineTrigger = canvas.getAllByRole("button", {
@@ -587,9 +593,12 @@ export const SingleSelection: Story = {
       await expect(args.onSelectionChange).toHaveBeenCalled();
 
       // Menu should close after selection
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify display updated
       await expect(canvas.getByText("Selected: small")).toBeInTheDocument();
@@ -622,9 +631,12 @@ export const SingleSelection: Story = {
       // Select with Enter
       await userEvent.keyboard("{Enter}");
       await expect(args.onSelectionChange).toHaveBeenCalled();
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify display updated
       await expect(canvas.getByText("Selected: medium")).toBeInTheDocument();
@@ -790,9 +802,12 @@ export const MultiSelection: Story = {
     await step("Close and verify display updated", async () => {
       // Press Escape to close
       await userEvent.keyboard("{Escape}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify display updated
       await expect(
@@ -825,9 +840,12 @@ export const MultiSelection: Story = {
 
       // Press Enter - should close menu without toggling
       await userEvent.keyboard("{Enter}");
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // The display should show current selections
       // We don't know exact state, just verify it exists
@@ -1111,9 +1129,12 @@ export const MixedSelection: Story = {
         await expect(args.onAction).toHaveBeenCalledWith("copy", undefined);
 
         // First menu should be closed
-        await waitFor(() => {
-          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-        });
+        await waitFor(
+          () => {
+            expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
       }
     );
 
@@ -1145,9 +1166,12 @@ export const MixedSelection: Story = {
       await expect(args.onSelectionChange).toHaveBeenCalled();
 
       // Menu should close after single selection
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify display updated
       await expect(canvas.getByText("Alignment: center")).toBeInTheDocument();
@@ -1172,9 +1196,12 @@ export const MixedSelection: Story = {
       await expect(args.onSelectionChange).toHaveBeenCalled();
 
       // Menu should close due to single selection at root
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
 
       // Verify display updated
       await expect(
@@ -1803,9 +1830,12 @@ export const ComplexExample: Story = {
       await userEvent.keyboard("{Escape}");
 
       // Verify menu is closed
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Test item with href behaves as link", async () => {
@@ -2067,9 +2097,12 @@ export const CollectionPatternDemo: Story = {
       await userEvent.click(newFileItem);
 
       await expect(args.onAction).toHaveBeenCalledWith("new", undefined);
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
 
     await step("Test critical action", async () => {
@@ -2085,9 +2118,12 @@ export const CollectionPatternDemo: Story = {
       await userEvent.click(deleteItem);
 
       await expect(args.onAction).toHaveBeenCalledWith("delete", undefined);
-      await waitFor(() => {
-        expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("menu")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
     });
   },
 };

--- a/packages/nimbus/src/components/split-button/split-button.stories.tsx
+++ b/packages/nimbus/src/components/split-button/split-button.stories.tsx
@@ -134,7 +134,7 @@ export const Basic: Story = {
           () => {
             expect(portalCanvas.queryByRole("menu")).not.toBeInTheDocument();
           },
-          { timeout: 1000 }
+          { timeout: 3000 }
         );
 
         // Primary button should still show the first action (Save)
@@ -572,9 +572,12 @@ export const AccessibilityTest: Story = {
         });
         await userEvent.click(scheduleItem);
 
-        await waitFor(() => {
-          expect(portalCanvas.queryByRole("menu")).not.toBeInTheDocument();
-        });
+        await waitFor(
+          () => {
+            expect(portalCanvas.queryByRole("menu")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
 
         // Primary button should still show first action (Send Message)
         await waitFor(() => {


### PR DESCRIPTION
## Summary
- The fix in 7a2bebd (`#1804`) addressed flaky close assertions in dialog, modal-page, and form-dialog but missed drawer, split-button, and menu
- These overlay components have the same exit animation + portal teardown timing issue in CI where the default 1000ms `waitFor` timeout is too short
- Added `{ timeout: 3000 }` to all `waitFor` calls that assert overlay absence (`not.toBeInTheDocument()`) or element count changes (`toHaveLength`) after close actions:
  - **drawer.stories.tsx**: 16 assertions updated
  - **menu.stories.tsx**: 12 assertions updated
  - **split-button.stories.tsx**: 2 assertions updated (one bumped from 1000ms, one added)

## Test plan
- [x] All 35 storybook tests pass locally for drawer, split-button, and menu
- [x] Matches the same pattern used in the dialog/modal-page/form-dialog fix (#1804)

🤖 Generated with [Claude Code](https://claude.com/claude-code)