### PR TITLE
feat(tooltip): add `isDisabled` prop to suppress tooltip rendering

### DIFF
--- a/.changeset/tooltip-is-disabled.md
+++ b/.changeset/tooltip-is-disabled.md
@@ -2,9 +2,10 @@
 "@commercetools/nimbus": minor
 ---
 
-`Tooltip`: add `isDisabled` prop to `Tooltip.Root` that suppresses tooltip
-rendering without requiring conditional JSX wrappers.
+`Tooltip`: document and test the `isDisabled` prop on `Tooltip.Root`.
 
-When `isDisabled` is `true`, hover/focus listeners are inactive, the overlay
-never opens, and no `aria-describedby` is added to the trigger. Children render
+The prop (from React Aria's `TooltipTrigger`) was already forwarded via the
+rest-spread but was not explicitly surfaced, tested, or documented. When
+`isDisabled` is `true`, hover/focus listeners are inactive, the overlay never
+opens, and no `aria-describedby` is added to the trigger. Children render
 unchanged with the same DOM, focus order, and ref forwarding.

--- a/.changeset/tooltip-is-disabled.md
+++ b/.changeset/tooltip-is-disabled.md
@@ -1,0 +1,10 @@
+---
+"@commercetools/nimbus": minor
+---
+
+`Tooltip`: add `isDisabled` prop to `Tooltip.Root` that suppresses tooltip
+rendering without requiring conditional JSX wrappers.
+
+When `isDisabled` is `true`, hover/focus listeners are inactive, the overlay
+never opens, and no `aria-describedby` is added to the trigger. Children render
+unchanged with the same DOM, focus order, and ref forwarding.

--- a/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
+++ b/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
@@ -12,11 +12,17 @@ export function TooltipRoot({
   // Match delays to current ui-kit tooltip
   delay = 300,
   closeDelay = 200,
+  isDisabled,
   ...props
 }: TooltipTriggerComponentProps) {
-  // Note: In React 19, ref forwarding is automatic for function components
-  // The ref should be placed on the trigger element directly when needed
-  return <TooltipTrigger delay={delay} closeDelay={closeDelay} {...props} />;
+  return (
+    <TooltipTrigger
+      delay={delay}
+      closeDelay={closeDelay}
+      isDisabled={isDisabled}
+      {...props}
+    />
+  );
 }
 
 TooltipRoot.displayName = "Tooltip.Root";

--- a/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
+++ b/packages/nimbus/src/components/tooltip/components/tooltip.root.tsx
@@ -15,6 +15,8 @@ export function TooltipRoot({
   isDisabled,
   ...props
 }: TooltipTriggerComponentProps) {
+  // Note: In React 19, ref forwarding is automatic for function components
+  // The ref should be placed on the trigger element directly when needed
   return (
     <TooltipTrigger
       delay={delay}

--- a/packages/nimbus/src/components/tooltip/tooltip.dev.mdx
+++ b/packages/nimbus/src/components/tooltip/tooltip.dev.mdx
@@ -202,6 +202,41 @@ const App = () => (
 )
 ```
 
+### Disabling the tooltip
+
+Use the `isDisabled` prop on `Tooltip.Root` to suppress the tooltip without
+removing the trigger from the tree. When `isDisabled` is `true`, hover and focus
+listeners are inactive, the overlay never opens, and no `aria-describedby` is
+added to the trigger. The trigger element renders unchanged with the same DOM
+and focus order.
+
+This is useful when tooltip text is conditionally irrelevant (e.g. the trigger
+label already conveys the information) or when a parent feature flag should
+suppress all tooltips in a region.
+
+```jsx live-dev
+const App = () => {
+  const [isDisabled, setIsDisabled] = useState(true);
+  return (
+    <Stack direction="row" alignItems="center" gap="400">
+      <Switch isSelected={isDisabled} onChange={setIsDisabled}>
+        Tooltip disabled
+      </Switch>
+      <Tooltip.Root isDisabled={isDisabled}>
+        <Button>Hover me</Button>
+        <Tooltip.Content>
+          This tooltip can be toggled
+        </Tooltip.Content>
+      </Tooltip.Root>
+    </Stack>
+  );
+}
+```
+
+> **Note:** `isDisabled` on `Tooltip.Root` disables the *tooltip overlay*. To
+> keep a tooltip visible on a *disabled button*, see
+> [With disabled buttons](#with-disabled-buttons) below.
+
 ### With disabled buttons
 
 A natively disabled button cannot host a tooltip: the `disabled` attribute

--- a/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { within, expect } from "storybook/test";
+import { within, expect, userEvent } from "storybook/test";
 import { useState } from "react";
 import {
   Button,
@@ -188,5 +188,28 @@ export const IsDisabledToggle: Story = {
         </Tooltip.Root>
       </Stack>
     );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+
+    await step("tooltip is suppressed while isDisabled is true", async () => {
+      const button = canvas.getByRole("button", { name: "hover/focus me" });
+      button.focus();
+      await new Promise((r) => setTimeout(r, 100));
+      await expect(canvas.queryByRole("tooltip")).not.toBeInTheDocument();
+      button.blur();
+    });
+
+    await step("toggle isDisabled off and tooltip appears", async () => {
+      const switchEl =
+        canvasElement.querySelector<HTMLElement>('[data-slot="root"]');
+      if (!switchEl) throw new Error("Switch not found");
+      await userEvent.click(switchEl);
+      // tab from the switch to the button — triggers a real focus event
+      await userEvent.tab();
+      await canvas.findByRole("tooltip");
+    });
   },
 };

--- a/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { within, expect } from "storybook/test";
+import { useState } from "react";
 import {
   Button,
   Stack,
+  Switch,
   Tooltip,
   type TooltipProps,
 } from "@commercetools/nimbus";
@@ -124,5 +126,67 @@ export const Placement: Story = {
         await expect(tooltip).toHaveTextContent(placement);
       });
     }
+  },
+};
+
+/**
+ * When `isDisabled` is set on `Tooltip.Root`, the tooltip never opens
+ * via hover or focus, and no `aria-describedby` is added to the trigger.
+ */
+export const IsDisabled: Story = {
+  args: {
+    children: "Disabled Tooltip",
+  },
+  render: (args) => (
+    <Tooltip.Root delay={0} closeDelay={0} isDisabled>
+      <Button>hover/focus me</Button>
+      <Tooltip.Content {...args} />
+    </Tooltip.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+
+    await step("tooltip does not appear when trigger is focused", async () => {
+      const button = canvas.getByRole("button", { name: "hover/focus me" });
+      button.focus();
+
+      // small wait to allow any tooltip to appear if it were going to
+      await new Promise((r) => setTimeout(r, 100));
+
+      await expect(canvas.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    await step(
+      "trigger has no aria-describedby when tooltip is disabled",
+      async () => {
+        const button = canvas.getByRole("button", { name: "hover/focus me" });
+        await expect(button).not.toHaveAttribute("aria-describedby");
+      }
+    );
+  },
+};
+
+/**
+ * Demonstrates toggling `isDisabled` at runtime via a switch control.
+ */
+export const IsDisabledToggle: Story = {
+  args: {
+    children: "Toggle Tooltip",
+  },
+  render: (args) => {
+    const [isDisabled, setIsDisabled] = useState(true);
+    return (
+      <Stack direction="row" alignItems="center" gap="400">
+        <Switch isSelected={isDisabled} onChange={setIsDisabled}>
+          Tooltip disabled
+        </Switch>
+        <Tooltip.Root delay={0} closeDelay={0} isDisabled={isDisabled}>
+          <Button>hover/focus me</Button>
+          <Tooltip.Content {...args} />
+        </Tooltip.Root>
+      </Stack>
+    );
   },
 };

--- a/packages/nimbus/src/components/tooltip/tooltip.tsx
+++ b/packages/nimbus/src/components/tooltip/tooltip.tsx
@@ -25,6 +25,7 @@ export const Tooltip = {
    *
    * The root component that provides state management and positioning logic.
    * Wraps the trigger element and tooltip content, handling hover and focus interactions.
+   * Pass `isDisabled` to suppress the tooltip without removing the trigger from the tree.
    *
    * @example
    * ```tsx


### PR DESCRIPTION
## Summary

- Add explicit `isDisabled` prop to `Tooltip.Root` that suppresses hover/focus listeners and prevents the tooltip overlay from opening
- When disabled: no `aria-describedby` is added to the trigger, children render unchanged with same DOM, focus order, and ref forwarding
- Enables 1:1 migration from UI Kit's `Tooltip off` prop without conditional JSX wrappers
- Add Storybook stories (`IsDisabled` with play function tests, `IsDisabledToggle` visual demo)

Closes FEC-891

## Test plan
- [x] `IsDisabled` story: verifies tooltip does not appear on focus when `isDisabled` is set
- [x] `IsDisabled` story: verifies no `aria-describedby` attribute on trigger when disabled
- [x] `IsDisabledToggle` story: visual demo of runtime toggling via Switch control
- [x] All existing tooltip tests continue to pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)