### PR TITLE
feat(claude worktrees): add .worktreeinclude for Claude Code worktree support

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.vscode/
+.claude/settings.local.json
+.env


### PR DESCRIPTION
## Summary
- Adds a `.worktreeinclude` file so Claude Code's worktree feature copies essential local-only files (`.vscode/`, `.claude/settings.local.json`, `.env`) into new worktrees
- This enables the recently expanded [Claude Code worktree features](https://code.claude.com/docs/en/worktrees) to work seamlessly with our repo's local configuration

## Test plan
- [x] Verify `.worktreeinclude` is picked up when Claude Code creates a worktree
- [x] Confirm `.vscode/`, `.claude/settings.local.json`, and `.env` are copied into new worktrees