### PR TITLE
fix(tabs): stop forwarding an empty href to non-link tabs

### DIFF
--- a/.changeset/fix-tabs-empty-href.md
+++ b/.changeset/fix-tabs-empty-href.md
@@ -1,0 +1,8 @@
+---
+"@commercetools/nimbus": patch
+---
+
+`Tabs`: fixed a spurious React console error — _"An empty string (`""`) was
+passed to the `href` attribute"_ — that appeared in development for every
+ordinary (non-link) tab. Plain tabs no longer emit the warning. Tabs that opt
+into link behavior with an `href` are unaffected and still render as anchors.

--- a/packages/nimbus/src/components/tabs/components/tabs.tab.tsx
+++ b/packages/nimbus/src/components/tabs/components/tabs.tab.tsx
@@ -18,15 +18,16 @@ export const TabsTab = ({
   routerOptions,
   ...props
 }: TabProps) => {
+  // React Aria keys its link handling off the *presence* of the `href` prop,
+  // not its value: forwarding `href={undefined}` still makes it coerce the href
+  // to an empty string, and React then rejects the resulting `href=""` on the
+  // non-anchor tab element with a dev-only "An empty string was passed to the
+  // href attribute" console error. Only forward the link props when there's an
+  // actual href, so plain (non-link) tabs never carry them.
+  const linkProps = href != null ? { href, target, rel, routerOptions } : {};
   return (
     <TabsTabSlot asChild {...props}>
-      <RATab
-        isDisabled={isDisabled}
-        href={href}
-        target={target}
-        rel={rel}
-        routerOptions={routerOptions}
-      >
+      <RATab isDisabled={isDisabled} {...linkProps}>
         {children}
       </RATab>
     </TabsTabSlot>

--- a/packages/nimbus/src/components/tabs/tabs.spec.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.spec.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach, type MockInstance } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NimbusProvider, Tabs } from "@commercetools/nimbus";
+
+/**
+ * Whether React logged the dev-only empty-`href` error. React formats it as
+ * `console.error("An empty string ... %s attribute ...", "href", "href")`, so
+ * the attribute name arrives as a substitution argument rather than in the
+ * template — match on both.
+ */
+const collectedHrefWarning = (error: MockInstance) =>
+  error.mock.calls.some(
+    (args) =>
+      typeof args[0] === "string" &&
+      args[0].includes("An empty string") &&
+      args.includes("href")
+  );
+
+/**
+ * Regression guard for the empty-`href` warning on plain tabs.
+ *
+ * React Aria keys its link handling off the *presence* of the `href` prop, not
+ * its value. Forwarding `href={undefined}` to a non-link tab made React Aria
+ * coerce it to an empty string and render `href=""` on the tab's `<div>`, which
+ * React rejects at runtime with a dev-only console error ("An empty string was
+ * passed to the href attribute"). Plain tabs must never forward an href, so
+ * this warning must never fire for them.
+ */
+describe("Tabs — plain (non-link) tabs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not emit an empty-string href warning", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <NimbusProvider>
+        <Tabs.Root>
+          <Tabs.List aria-label="Example tabs">
+            <Tabs.Tab id="one">One</Tabs.Tab>
+            <Tabs.Tab id="two">Two</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panels>
+            <Tabs.Panel id="one">First panel</Tabs.Panel>
+            <Tabs.Panel id="two">Second panel</Tabs.Panel>
+          </Tabs.Panels>
+        </Tabs.Root>
+      </NimbusProvider>
+    );
+
+    expect(collectedHrefWarning(error)).toBe(false);
+  });
+
+  it("does not emit an empty-string href warning via the `tabs` prop", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <NimbusProvider>
+        <Tabs.Root
+          tabListAriaLabel="Example tabs"
+          tabs={[
+            { id: "one", tabLabel: "One", panelContent: "First panel" },
+            { id: "two", tabLabel: "Two", panelContent: "Second panel" },
+          ]}
+        />
+      </NimbusProvider>
+    );
+
+    expect(collectedHrefWarning(error)).toBe(false);
+  });
+});
+
+describe("Tabs — link tabs", () => {
+  it("renders a tab with an href as an anchor pointing at that href", () => {
+    render(
+      <NimbusProvider>
+        <Tabs.Root>
+          <Tabs.List aria-label="Example tabs">
+            <Tabs.Tab id="home" href="https://example.com/home">
+              Home
+            </Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panels>
+            <Tabs.Panel id="home">Home panel</Tabs.Panel>
+          </Tabs.Panels>
+        </Tabs.Root>
+      </NimbusProvider>
+    );
+
+    const tab = screen.getByRole("tab", { name: "Home" });
+    expect(tab.tagName).toBe("A");
+    expect(tab).toHaveAttribute("href", "https://example.com/home");
+  });
+});


### PR DESCRIPTION
## Summary
Plain `Tabs` tabs logged a spurious React console error in development — _"An empty string (`""`) was passed to the `href` attribute"_ — one per tab. This removes it without changing any behavior.

## Root cause
React Aria keys its link handling off the **presence** of the `href` prop, not its value. `Tabs.Tab` always spread `href={href}` onto React Aria's `Tab`, so an ordinary tab (with `href` undefined) still carried the `href` key. React Aria's `useLinkProps` coerces a present-but-nullish href to `""` (`props.href ?? ''`), and since the tab is a non-link it renders as a `<div role="tab">`. React then rejects the resulting `href=""` on that non-anchor element with a dev-only `console.error`. Surfaced when opening the icon detail dialog on the docs Icons page (4 usage tabs → 4 errors), but it affected every non-link tab in the app.

## Fix
Only forward `href`/`target`/`rel`/`routerOptions` to React Aria's `Tab` when an `href` is actually provided, so plain tabs never carry the key. The fix lives in the single `Tabs.Tab` wrapper, so it covers both the compound (`Tabs.Tab`) and the `tabs`-prop APIs. Link tabs (with an `href`) are unaffected and still render as anchors.

## Regression test
New `tabs.spec.tsx` (JSDOM, mirrors the existing `markdown.spec.tsx` console-assertion pattern — the empty attribute is stripped from the final DOM, so the console error is the only observable signal):
- no empty-`href` warning for children-based plain tabs
- no empty-`href` warning via the `tabs` prop
- a tab **with** an `href` still renders as `<a href="…">`

## Test plan
- [x] New spec fails on the old code, passes on the fix
- [x] Full Tabs unit specs — 10/10 (incl. existing `.docs.spec`)
- [x] Tabs Storybook tests in a real browser (dev/source) — 12/12
- [x] `typecheck:dev` 0 errors · eslint 0 · prettier clean

## Notes
- Consumer-facing patch changeset included (`@commercetools/nimbus`).
- No linked ticket — this was an ad-hoc bug report.

## AI assistance disclosure
Generated with assistance from Claude Code. Human review checklist:
- [ ] Logic verified against intent
- [ ] No fabricated APIs / functions / imports
- [ ] Tests reflect actual behavior, not assumed behavior