### PR TITLE
FEC- 1151 & 1152 - Batch 6 (Progress & feedback)  & 7 (Overlays)

### DIFF
--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -424,6 +424,23 @@ live in docs/chromatic-visual-testing.md.
   for async-derived state, no stray focus ring. Hide the caret in a `Focused`
   text-input story. `:hover` and `:active`/pressed can't be captured statically
   yet.
+- **Name the interacting-axes matrix `SmokeTest`, render it last** - the role
+  name stays accurate as axes change; the axis list goes in the doc comment (not
+  the story name).
+- **Animated components: pin only when the paused frame hides the target.**
+  Chromatic pauses CSS/SVG animations at a fixed frame (last by default;
+  `pauseAnimationAtEnd: false` = first), so most animated states are already
+  deterministic. The trap is an infinite animation whose endpoints both hide the
+  content (`progress-indeterminate` parks its pill off-track) - pin a
+  representative frame in the play (`el.style.animation = "none"` + an explicit
+  `transform`).
+- **The snapshot is the play's end state** - Chromatic captures after the play
+  passes, so land on the target frame: open an overlay/portal and don't dismiss
+  it; a play that resets to default loses its frame (keep it behavioral).
+- **Portals (Toast, overlays)** - capture is page-wide, so portal content is
+  in-frame; hold it open (`duration: Infinity`), await it, clean up between
+  stories (`clearToasts()`). Reach a portal component's own focus via its real
+  keyboard path, not a synthetic `.focus()`.
 
 **When a VRT pattern changes, sync all three canonical docs.** Any change to a
 Chromatic/VRT convention (a new opt-in state, a matrix rule, or a determinism fix
@@ -773,6 +790,16 @@ You MUST validate against these requirements:
       unless intended. Chromatic captures the play's final state and nothing
       blurs it, so a play can be assertion-honest yet still snapshot the wrong
       picture (blur, reset, or split the story)
+- [ ] The interacting-axes matrix is named **`SmokeTest`** and rendered **last**
+      (not `Variants`/`VariantsAndSizes`/etc.); the axis list lives in the doc
+      comment
+- [ ] **Animated** states: paused frame confirmed to show the target; if an
+      infinite animation's endpoints both hide it (indeterminate progress), the
+      play **pins** a representative frame (`animation: none` + explicit
+      `transform`)
+- [ ] **Portal** components (Toast/overlays): transient UI held open
+      (`duration: Infinity`), awaited, and cleaned up between stories; the
+      component's own focus reached via its **real keyboard path**, not `.focus()`
 
 #### Play Functions (CRITICAL)
 

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -446,10 +446,9 @@ live in docs/chromatic-visual-testing.md.
   - await) and leave it open (entrance settles on its last frame). Each distinct
     open surface is its own story (backdrops can't share a frame); open/close and
     dismissal stay behavioral.
-- **Snapshot `placement` only when it's a recipe variant** - Dialog/Drawer
-  placement is a recipe layout (snapshot each); Menu/Tooltip placement is RA
-  positioning (same box repositioned, no arrow) - behavioral, no per-placement
-  snapshot.
+- **Snapshot `placement` only when it changes the _layout_, not just position** -
+  Drawer (side panel ↔ top/bottom bar) → snapshot each; Dialog (same box, just
+  higher/lower) → center only; Menu/Tooltip (RA positioning) → behavioral.
 
 **When a VRT pattern changes, sync all three canonical docs — at their set
 depth.** The overlap is intentional but tiered: the rationale lives in **one**
@@ -813,9 +812,9 @@ You MUST validate against these requirements:
       component's own focus reached via its **real keyboard path**, not `.focus()`
 - [ ] **Overlays** snapshot the **open** state (rendered open, left open); each
       distinct open surface is its own story; open/close & dismissal stay behavioral
-- [ ] **`placement`** snapshotted only when it's a **recipe variant**
-      (Dialog/Drawer); RA-positioning placement (Menu/Tooltip, same box) is
-      behavioral
+- [ ] **`placement`** snapshotted only when it changes the **layout** (Drawer
+      side/top/bottom panels), not a mere reposition (Dialog = center only;
+      Menu/Tooltip RA-positioning = behavioral)
 
 #### Play Functions (CRITICAL)
 

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: writing-stories
 description:
   Create, update, or validate Storybook stories with comprehensive play
   functions
@@ -441,17 +442,27 @@ live in docs/chromatic-visual-testing.md.
   in-frame; hold it open (`duration: Infinity`), await it, clean up between
   stories (`clearToasts()`). Reach a portal component's own focus via its real
   keyboard path, not a synthetic `.focus()`.
+- **Overlays: snapshot the open state** - render open (`defaultOpen` or play-open
+  - await) and leave it open (entrance settles on its last frame). Each distinct
+    open surface is its own story (backdrops can't share a frame); open/close and
+    dismissal stay behavioral.
+- **Snapshot `placement` only when it's a recipe variant** - Dialog/Drawer
+  placement is a recipe layout (snapshot each); Menu/Tooltip placement is RA
+  positioning (same box repositioned, no arrow) - behavioral, no per-placement
+  snapshot.
 
-**When a VRT pattern changes, sync all three canonical docs.** Any change to a
-Chromatic/VRT convention (a new opt-in state, a matrix rule, or a determinism fix
-like `caret-color: transparent` for focused text inputs) must land in all three
-places at once, or they drift:
+**When a VRT pattern changes, sync all three canonical docs — at their set
+depth.** The overlap is intentional but tiered: the rationale lives in **one**
+place; the others state the rule and point to it. Don't paste reasoning/examples
+into more than one, or they duplicate and drift. Any change must land in all
+three, each at its depth:
 
-1. `docs/chromatic-visual-testing.md` — the how/why guide + best practices.
-2. `docs/file-type-guidelines/stories.md` — the "Chromatic Visual Regression
-   Snapshots" section.
-3. `.claude/skills/writing-stories/SKILL.md` (this file) — the `SmokeTest` /
-   `Focused` templates, the "what gets captured" blurb, and the checklist.
+1. `docs/chromatic-visual-testing.md` — **source of truth**: full rationale,
+   examples, edge cases.
+2. `docs/file-type-guidelines/stories.md` — **terse rule + the copy-paste
+   snippet only**; defer the _why_ to #1 (no restated reasoning).
+3. `.claude/skills/writing-stories/SKILL.md` (this file) — templates + the
+   "what gets captured" bullets + the checklist.
 
 ### Step 3: Portal Content Handling
 
@@ -800,6 +811,11 @@ You MUST validate against these requirements:
 - [ ] **Portal** components (Toast/overlays): transient UI held open
       (`duration: Infinity`), awaited, and cleaned up between stories; the
       component's own focus reached via its **real keyboard path**, not `.focus()`
+- [ ] **Overlays** snapshot the **open** state (rendered open, left open); each
+      distinct open surface is its own story; open/close & dismissal stay behavioral
+- [ ] **`placement`** snapshotted only when it's a **recipe variant**
+      (Dialog/Drawer); RA-positioning placement (Menu/Tooltip, same box) is
+      behavioral
 
 #### Play Functions (CRITICAL)
 

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -508,6 +508,22 @@ which no play-dispatchable event sets.
   so nothing leaks into the next capture. A component can be focusable in its
   own right (Toast's root has `tabIndex=0` + `focusRing: outside`) - reach it
   the real way (its keyboard hotkey + Tab), not a synthetic `.focus()`.
+- **Overlays: snapshot the _open_ state.** A portal component's primary visual
+  is its open state, so render it open - `defaultOpen` (Dialog/Drawer/Menu) or
+  open it in the play and await the portal - and leave it open; the entrance
+  animation settles on its last frame. Give each distinct open surface its own
+  story: open dialogs/drawers fill the viewport with a backdrop and can't share
+  a frame, so there's no `SmokeTest` matrix (independent recipe variants become
+  separate open showcases). open/close, focus trap, and dismissal stay
+  behavioral.
+- **Snapshot `placement` only when it's a _recipe variant_, not RA
+  positioning.** Dialog/Drawer `placement` is a recipe layout variant (different
+  `alignItems`/margins, a full-height side panel vs a full-width top panel) -
+  one open snapshot per placement. Menu/Tooltip `placement` is React Aria
+  positioning
+  - the same box repositioned, no arrow, no recipe delta - so it's behavioral,
+    no per-placement snapshot. The test: does the axis flow through the recipe
+    (visual) or RA's positioning engine (behavioral)?
 - **Hide the blinking text caret on a focused input.** A `Focused` snapshot of a
   text-entry input captures the focus ring, but focusing also paints the
   browser's native caret - which Chromatic can't stabilize (its

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -468,7 +468,11 @@ which no play-dispatchable event sets.
   build a matrix, even a 2×2; snapshot each axis as its own showcase story. The
   cross-product adds cells, not coverage. Still fold a family of near-identical
   behavioral stories into one labeled snapshot (Avatar's `AllFallbacks`) when it
-  aids review without losing coverage.
+  aids review without losing coverage. **Name that matrix `SmokeTest` and render
+  it last** - it marks the role (the comprehensive resting-visual carrier) and
+  stays accurate when axes change, unlike an axis-list name; the axis list lives
+  in the doc comment. (Older components use descriptive names like
+  `VariantsSizesAndStates` - being reconciled to `SmokeTest`.)
 - **Capture the focus ring on every distinctly-styled focusable sub-element.** A
   split button's dropdown trigger, an input's clear button or stepper, and a
   date field's calendar toggle each style their own `:focus-visible`; a
@@ -476,9 +480,34 @@ which no play-dispatchable event sets.
   untested.
 - **Use `play` for functional testing alongside visual** - the two aren't in
   tension; a story can both assert behavior and be snapshotted.
-- **Pause JS-driven animations manually** - Chromatic auto-pauses CSS
-  animations/transitions, videos, GIFs, but not JS animations. Worth remembering
-  if any button state animates via JS.
+- **Animated components: know where Chromatic pauses.** It auto-pauses CSS
+  transitions, CSS/SVG animations, and videos (not JS animations - pause those
+  manually) and seeks to a **fixed** frame, so the capture is deterministic
+  regardless of when the run fires. The default pause point is the **last**
+  frame of the cycle (`pauseAnimationAtEnd: false` switches it to the first).
+  That cuts differently per keyframe, and the trap is an
+  `iteration-count: infinite` animation whose endpoints both hide the content:
+  `progress-indeterminate` sweeps a 40% pill `translateX(-100% → 300%)`, so both
+  the first and last frame park it off the track - a default snapshot is an
+  empty track. When that happens, **pin a representative frame** in the play
+  (`animation: none` + an explicit transform), e.g. ProgressBar's
+  `Indeterminate` centers the pill with `translateX(75%)`. A full-turn `spin`
+  (0deg → 360deg) needs no pin - both endpoints render identically. The docs
+  don't spell out the infinite case, so confirm the paused frame on the first
+  run.
+- **A snapshot is the play function's _end state_.** Chromatic runs the whole
+  play, waits for it to **pass**, then captures - so the play must _land_ on the
+  frame you want and can't be flaky. Open an overlay/portal and **don't**
+  dismiss it; if a play cleans up or resets to default, its interesting frame is
+  gone (that's why `DescriptionsAndWarnings`-style stories stay behavioral).
+  This is also what makes `Focused` and open-popover snapshots work.
+- **Portal-rendered components (Toast, overlays).** Chromatic captures the whole
+  page, so portal content is in-frame even though it renders outside the story
+  root. Hold transient UI open for the shot (`duration: Infinity` for toasts),
+  await it in the play, and clean up between stories (Toast's `clearToasts()`)
+  so nothing leaks into the next capture. A component can be focusable in its
+  own right (Toast's root has `tabIndex=0` + `focusRing: outside`) - reach it
+  the real way (its keyboard hotkey + Tab), not a synthetic `.focus()`.
 - **Hide the blinking text caret on a focused input.** A `Focused` snapshot of a
   text-entry input captures the focus ring, but focusing also paints the
   browser's native caret - which Chromatic can't stabilize (its

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -516,14 +516,16 @@ which no play-dispatchable event sets.
   a frame, so there's no `SmokeTest` matrix (independent recipe variants become
   separate open showcases). open/close, focus trap, and dismissal stay
   behavioral.
-- **Snapshot `placement` only when it's a _recipe variant_, not RA
-  positioning.** Dialog/Drawer `placement` is a recipe layout variant (different
-  `alignItems`/margins, a full-height side panel vs a full-width top panel) -
-  one open snapshot per placement. Menu/Tooltip `placement` is React Aria
-  positioning
-  - the same box repositioned, no arrow, no recipe delta - so it's behavioral,
-    no per-placement snapshot. The test: does the axis flow through the recipe
-    (visual) or RA's positioning engine (behavioral)?
+- **Snapshot `placement` only when it changes the _layout_, not when it merely
+  repositions the same box.** The test isn't "is it a recipe variant" - it's
+  "does the box render differently, or just sit somewhere else?"
+  - **Drawer** placement swaps the layout (full-height side panel ↔ full-width
+    top/bottom bar) - a different shape per placement → one open snapshot each.
+  - **Dialog** placement is a recipe variant but only shifts vertical position
+    (`alignItems` + margin; the same box, higher/lower) → snapshot **center
+    only**; top/bottom add no new visual.
+  - **Menu/Tooltip** placement is React Aria positioning (same box repositioned,
+    no arrow) → behavioral, no per-placement snapshot.
 - **Hide the blinking text caret on a focused input.** A `Focused` snapshot of a
   text-entry input captures the focus ring, but focusing also paints the
   browser's native caret - which Chromatic can't stabilize (its

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -261,10 +261,42 @@ play: async ({ canvasElement }) => {
 },
 ```
 
+**Name the interacting-axes matrix `SmokeTest` and put it last.** The name marks
+the role (resting-visual carrier), not an axis list that goes stale; the axis
+list belongs in the doc comment.
+
+**Animated components: pin only when the paused frame hides the content.**
+Chromatic pauses CSS/SVG animations at a fixed frame (last by default;
+`pauseAnimationAtEnd: false` for first), so most animated states are already
+deterministic (`spin` 0→360, a settled slide-in). The exception is an infinite
+animation whose endpoints both hide the target - `progress-indeterminate` parks
+its pill off-track - so pin a representative frame in the play:
+
+```typescript
+play: async ({ canvasElement }) => {
+  canvasElement
+    .querySelectorAll<HTMLElement>('[data-indeterminate="true"]')
+    .forEach((el) => {
+      el.style.animation = "none";
+      el.style.transform = "translateX(75%)"; // center the pill for a stable shot
+    });
+},
+```
+
+**The snapshot is the play's end state.** Chromatic captures after the play
+_passes_, so the play must land on the target frame - open an overlay/portal and
+don't dismiss it; a play that resets to default loses its interesting frame
+(keep those behavioral).
+
+**Portals (Toast, overlays): capture is page-wide.** Portal content is in-frame;
+hold it open (`duration: Infinity`), await it, and clean up between stories
+(`clearToasts()`). Reach a portal component's own focus (Toast root) via its
+real keyboard path, not a synthetic `.focus()`.
+
 Full rationale - matrix tradeoffs, the fold-an-axis and hardcoded-axis rules,
 `SEMANTIC_COLOR_PALETTES` scope, thin-wrapper coverage, why modes are
-global-only, the hover/pressed gap, CI, baselines, TurboSnap - is in
-[Chromatic Visual Testing](../chromatic-visual-testing.md).
+global-only, animation pausing, portals, the hover/pressed gap, CI, baselines,
+TurboSnap - is in [Chromatic Visual Testing](../chromatic-visual-testing.md).
 
 ## File Structure
 

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -173,52 +173,48 @@ export const SmokeTest: Story = {
 `disableSnapshot: false` takes the picture; Chromatic never reads `vrt` (our own
 label for finding snapshot stories - keep the two together).
 
-**What to snapshot:** every prop-driven visual state. Fold **interacting** axes
-into one `SmokeTest` matrix (only when a cross-cell is a visual neither axis
-produces alone); independent axes that just scale/recolor each other
-(`size × colorPalette`, `size × on/off`) get separate showcase stories, not a
-matrix. Any state the matrix can't render gets its own story (`Focused`,
-disabled-but-focusable, an open tooltip/popover). A showcase whose look a
-snapshot already covers stays snapshot-off. Never drop a visual state to save
-cost.
+> **Editing rule:** keep this section **rule + snippet only**.
+> [chromatic-visual-testing.md](../chromatic-visual-testing.md) is the source of
+> truth for the _why_/examples - if you're about to write a paragraph explaining
+> a rule here, it belongs there. State the rule in one line and let the pointer
+> below carry the depth.
 
-**Enumerate surfaces from the recipe + component source first** (selectors,
-variant/size keys, conditional props, and ambient axes like RTL), then snapshot
-their cross-product - not remembered states. See the full rule in
-[chromatic-visual-testing.md](../chromatic-visual-testing.md).
+- **What to snapshot:** every prop-driven visual state. Fold **interacting**
+  axes into one `SmokeTest` matrix; independent axes (`size × colorPalette`,
+  `size × on/off`) get separate showcase stories. Any state the matrix can't
+  render (`Focused`, disabled-but-focusable, open overlay) gets its own story.
+  Never drop a visual state to save cost.
+- **Enumerate surfaces from the recipe + component source**, then snapshot their
+  cross-product - not remembered states.
+- **One state rendered more than one way → one story each**
+  (mode-/variant-driven, e.g. MoneyInput dropdown vs. label mode), not a folded
+  gallery.
+- **A state with no distinct recipe surface gets no story** (read-only with no
+  `data-readonly` rule renders like default → no snapshot).
+- **Snapshot the component, not the harness** - no debug read-outs/wrappers in a
+  snapshotted frame.
+- **Name the interacting-axes matrix `SmokeTest`, rendered last** - the axis
+  list lives in the doc comment, not the name.
+- **Give each distinctly-styled focusable sub-element its own `Focused`** (not
+  just the first), and confirm the ring actually renders (a ring on a slot that
+  never gets focus captures nothing).
+- **Overlays: snapshot the open state** - render open (`defaultOpen` or
+  play-open
+  - await), leave it open; each distinct open surface is its own story.
+- **Snapshot `placement` only when it's a recipe variant** (Dialog/Drawer);
+  RA-positioning placement (Menu/Tooltip, same box) is behavioral.
+- **Portals: capture is page-wide** - hold open (`duration: Infinity`), await,
+  clean up between stories (`clearToasts()`); reach a portal's own focus via its
+  real keyboard path, not `.focus()`.
+- **The snapshot is the play's end state** - land on the target frame; a play
+  that resets/dismisses loses it.
+- **Crop padding is global** - a `preview.tsx` decorator wraps non-`fullscreen`
+  stories in `1rem` so rings don't clip. Not opt-in.
 
-**One state, multiple distinct surfaces → one story each, not a gallery frame.**
-If a component renders a state more than one way (mode-/variant-driven), each
-surface gets its own snapshot - MoneyInput's `Focused` +
-`FocusedWithCurrencyLabel` and `DisabledState` + `DisabledWithCurrencyLabel`
-(dropdown vs. `currencies={[]}` label mode). Folding is only for the interacting
-axes in `SmokeTest`.
-
-**A state with no distinct recipe surface gets no story.** Confirm the recipe
-renders the state differently from default first. Read-only is the
-component-dependent trap: MoneyInput styles it (`ReadOnlyState`), but
-MultilineTextInput / NumberInput / TextInput have no `data-readonly` rule, so it
-renders like default and correctly gets no snapshot.
-
-**Snapshot the component, not the harness.** A snapshotted story renders the
-component directly - no debug read-outs or demo wrappers in the frame
-(MoneyInput's `MoneyInputExample` JSON panel is fine on behavioral stories, but
-would flap a snapshot on every value change). Keep wrappers on the behavioral
-stories.
-
-**A `Focused` story keeps its ring for free** - nothing blurs the focused
-element after a play function, so a story that legitimately ends focused
-snapshots the ring as-is. Conversely, a behavior story that leaves a stray ring
-should blur (or be split so the snapshotted story doesn't end focused). Give
-**each** distinctly-styled focusable sub-element (a split button's trigger, an
-input's stepper/clear button) its own `Focused` story, not just the first - only
-one element holds focus per snapshot, so one story can't capture two rings.
-First confirm the ring actually renders: if it's styled on a slot that never
-receives the focus state (a non-focusable indicator/track keyed off `data-focus`
-or `_focusWithin`), the snapshot captures nothing - verify before opting in (see
-DropZone).
+Snippets to paste:
 
 ```typescript
+// Focused ring
 export const Focused: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -229,74 +225,38 @@ export const Focused: Story = {
     await expect(canvas.getByRole("button")).toHaveFocus();
   },
 };
-```
 
-**Text-input `Focused`: hide the caret** so the snapshot is deterministic
-(Chromatic can't pause the native caret blink). `caret-color` is inherited:
-
-```typescript
+// Text-input Focused: hide the native caret (Chromatic can't pause its blink)
 play: async ({ canvasElement }) => {
-  canvasElement.style.caretColor = "transparent"; // deterministic focused snapshot
+  canvasElement.style.caretColor = "transparent";
   await userEvent.tab();
   // ...assert focus
-},
-```
+};
 
-**Crop padding is global** - a `preview.tsx` decorator wraps every
-non-`fullscreen` story in `1rem` so focus/selection rings don't clip at
-Chromatic's crop. Not opt-in.
-
-**Prefer local images, and wait for image-derived state.** Serve images from
-`public/` via `staticDirs` (a remote URL is a flaky network dependency).
-Chromatic waits for images to load but not for state your component _derives_
-from the load (Avatar hides its `<img>` until `onLoad`, swaps to a fallback on
-error), so wait for that state before the snapshot:
-
-```typescript
-play: async ({ canvasElement }) => {
-  const img = canvasElement.querySelector("img");
-  await waitFor(() => expect(img).toHaveStyle("display: none"), {
-    timeout: 3000,
-  });
-},
-```
-
-**Name the interacting-axes matrix `SmokeTest` and put it last.** The name marks
-the role (resting-visual carrier), not an axis list that goes stale; the axis
-list belongs in the doc comment.
-
-**Animated components: pin only when the paused frame hides the content.**
-Chromatic pauses CSS/SVG animations at a fixed frame (last by default;
-`pauseAnimationAtEnd: false` for first), so most animated states are already
-deterministic (`spin` 0→360, a settled slide-in). The exception is an infinite
-animation whose endpoints both hide the target - `progress-indeterminate` parks
-its pill off-track - so pin a representative frame in the play:
-
-```typescript
+// Animated: pin a frame only when the paused endpoints hide the content
 play: async ({ canvasElement }) => {
   canvasElement
     .querySelectorAll<HTMLElement>('[data-indeterminate="true"]')
     .forEach((el) => {
       el.style.animation = "none";
-      el.style.transform = "translateX(75%)"; // center the pill for a stable shot
+      el.style.transform = "translateX(75%)";
     });
-},
+};
+
+// Image-derived state: wait for it (Chromatic waits for load, not derived state)
+play: async ({ canvasElement }) => {
+  const img = canvasElement.querySelector("img");
+  await waitFor(() => expect(img).toHaveStyle("display: none"), {
+    timeout: 3000,
+  });
+};
 ```
-
-**The snapshot is the play's end state.** Chromatic captures after the play
-_passes_, so the play must land on the target frame - open an overlay/portal and
-don't dismiss it; a play that resets to default loses its interesting frame
-(keep those behavioral).
-
-**Portals (Toast, overlays): capture is page-wide.** Portal content is in-frame;
-hold it open (`duration: Infinity`), await it, and clean up between stories
-(`clearToasts()`). Reach a portal component's own focus (Toast root) via its
-real keyboard path, not a synthetic `.focus()`.
 
 Full rationale - matrix tradeoffs, the fold-an-axis and hardcoded-axis rules,
 `SEMANTIC_COLOR_PALETTES` scope, thin-wrapper coverage, why modes are
-global-only, animation pausing, portals, the hover/pressed gap, CI, baselines,
-TurboSnap - is in [Chromatic Visual Testing](../chromatic-visual-testing.md).
+global-only, animation pausing, portals/overlays, placement (recipe vs RA
+positioning), the hover/pressed gap, CI, baselines, TurboSnap - is in
+[Chromatic Visual Testing](../chromatic-visual-testing.md).
 
 ## File Structure
 

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -201,8 +201,8 @@ label for finding snapshot stories - keep the two together).
 - **Overlays: snapshot the open state** - render open (`defaultOpen` or
   play-open
   - await), leave it open; each distinct open surface is its own story.
-- **Snapshot `placement` only when it's a recipe variant** (Dialog/Drawer);
-  RA-positioning placement (Menu/Tooltip, same box) is behavioral.
+- **Snapshot `placement` only when it changes the layout, not just reposition
+  the same box** (Drawer qualifies; Dialog/Menu/Tooltip don't).
 - **Portals: capture is page-wide** - hold open (`duration: Infinity`), await,
   clean up between stories (`clearToasts()`); reach a portal's own focus via its
   real keyboard path, not `.focus()`.

--- a/packages/nimbus/src/components/activity-indicator/activity-indicator.stories.tsx
+++ b/packages/nimbus/src/components/activity-indicator/activity-indicator.stories.tsx
@@ -71,6 +71,8 @@ export const Base: Story = {
  * the same inline position, to compare how each reads next to a status label.
  */
 export const InlineWithText: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: (args) => {
     const [showIcon, setShowIcon] = useState(false);
 
@@ -98,6 +100,8 @@ export const InlineWithText: Story = {
  * All sizes: `inherit` plus the fixed icon-box sizes.
  */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: (args) => (
     <Stack direction="row" gap="400" alignItems="center">
       {sizes.map((size) => (
@@ -238,6 +242,8 @@ export const SizeCalibration: Story = {
  * read on a solid colored surface.
  */
 export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <DisplayColorPalettes>
       {(palette) => (

--- a/packages/nimbus/src/components/dialog/dialog.stories.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.stories.tsx
@@ -1098,56 +1098,6 @@ export const Open: Story = {
   play: async ({ canvasElement }) => awaitOpen(canvasElement),
 };
 
-/**
- * Placement `top` - dialog pinned to the top of the viewport.
- */
-export const OpenTop: Story = {
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
-  render: () => (
-    <Dialog.Root defaultOpen placement="top">
-      <Dialog.Content>
-        <Dialog.Header>
-          <Dialog.Title>Placement: top</Dialog.Title>
-          <Dialog.CloseTrigger />
-        </Dialog.Header>
-        <Dialog.Body>
-          <Text>This dialog is positioned at the top.</Text>
-        </Dialog.Body>
-        <Dialog.Footer>
-          <Button slot="close">Close</Button>
-        </Dialog.Footer>
-      </Dialog.Content>
-    </Dialog.Root>
-  ),
-  play: async ({ canvasElement }) => awaitOpen(canvasElement),
-};
-
-/**
- * Placement `bottom` - dialog pinned to the bottom of the viewport.
- */
-export const OpenBottom: Story = {
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
-  render: () => (
-    <Dialog.Root defaultOpen placement="bottom">
-      <Dialog.Content>
-        <Dialog.Header>
-          <Dialog.Title>Placement: bottom</Dialog.Title>
-          <Dialog.CloseTrigger />
-        </Dialog.Header>
-        <Dialog.Body>
-          <Text>This dialog is positioned at the bottom.</Text>
-        </Dialog.Body>
-        <Dialog.Footer>
-          <Button slot="close">Close</Button>
-        </Dialog.Footer>
-      </Dialog.Content>
-    </Dialog.Root>
-  ),
-  play: async ({ canvasElement }) => awaitOpen(canvasElement),
-};
-
 const ScrollInsideDialog = () => (
   <Dialog.Root defaultOpen scrollBehavior="inside">
     <Dialog.Content>

--- a/packages/nimbus/src/components/dialog/dialog.stories.tsx
+++ b/packages/nimbus/src/components/dialog/dialog.stories.tsx
@@ -424,108 +424,37 @@ export const ScrollBehavior: Story = {
       (canvasElement.parentNode as HTMLElement) ?? canvasElement
     );
 
-    await step("Test 'scroll inside' keyboard accessibility", async () => {
-      // Test scroll inside dialog
-      const scrollInsideTrigger = canvas.getByRole("button", {
-        name: "Scroll inside",
-      });
-      await userEvent.click(scrollInsideTrigger);
+    await step(
+      "Scroll-inside body is the keyboard-focusable scroll region",
+      async () => {
+        const scrollInsideTrigger = canvas.getByRole("button", {
+          name: "Scroll inside",
+        });
+        await userEvent.click(scrollInsideTrigger);
+        await waitFor(() => {
+          expect(canvas.getByRole("dialog")).toBeInTheDocument();
+        });
 
-      await waitFor(() => {
-        expect(canvas.getByRole("dialog")).toBeInTheDocument();
-      });
-
-      // Verify dialog body is focusable (tabIndex=0) for scroll inside
-      const dialogBody = canvas.getByTestId("dialog-body-inside");
-      expect(dialogBody).toHaveAttribute("tabIndex", "0");
-
-      // Test keyboard navigation to dialog body
-      await userEvent.tab(); // Move to Close button
-      await userEvent.tab(); // Move to Dialog.Body
-      await waitFor(() => {
-        // Verify dialog body is focusable and accessible
-        expect(dialogBody).toBeInTheDocument();
+        const dialogBody = canvas.getByTestId("dialog-body-inside");
         expect(dialogBody).toHaveAttribute("tabIndex", "0");
-      });
 
-      // Test keyboard scrolling with arrow keys
-      // Get initial scroll position - re-query to ensure we have the current state
-      const initialDialogBody = canvas.getByTestId("dialog-body-inside");
-      const initialScrollTop = initialDialogBody?.scrollTop || 0;
+        // Tab (real keyboard) until the scroll region holds focus.
+        for (let i = 0; i < 6 && document.activeElement !== dialogBody; i++) {
+          await userEvent.tab();
+        }
+        await expect(dialogBody).toHaveFocus();
+        // Keyboard scroll (Arrow/PageDown/Home/End moving scrollTop) is not
+        // asserted - scrollTop doesn't update in the test browser. See matrix.
 
-      // Scroll down with arrow keys
-      await userEvent.keyboard("{ArrowDown}");
-      await userEvent.keyboard("{ArrowDown}");
-      await userEvent.keyboard("{ArrowDown}");
-
-      // Verify scrolling occurred
-      // Note: In some test environments, scrollTop might not update immediately
-      // or might be subject to environment differences. We check both scroll position
-      // change and ensure the element remains focused (indicating key handling works)
-      await waitFor(
-        () => {
-          // Re-query the element to ensure we have the current state
-          const currentDialogBody = canvas.getByTestId("dialog-body-inside");
-          const currentScrollTop = currentDialogBody?.scrollTop || 0;
-
-          // Check that keyboard interaction is working by verifying the dialog body
-          // is still focusable and the arrow keys didn't cause navigation away from the dialog
-          expect(currentDialogBody).toBeInTheDocument();
-          expect(currentDialogBody).toHaveAttribute("tabIndex", "0");
-
-          // Then check for scroll position change (if supported in this environment)
-          // If scroll position doesn't change due to environment limitations,
-          // the focus check above already validates keyboard interaction works
-          if (currentScrollTop > 0 || initialScrollTop > 0) {
-            expect(currentScrollTop).toBeGreaterThanOrEqual(initialScrollTop);
-          }
-        },
-        { timeout: 3000, interval: 100 }
-      );
-
-      // Test Page Down key
-      await userEvent.keyboard("{PageDown}");
-      await waitFor(
-        () => {
-          const currentDialogBody = canvas.getByTestId("dialog-body-inside");
-          // Verify keyboard navigation is working by confirming dialog still exists and is interactive
-          expect(currentDialogBody).toBeInTheDocument();
-          expect(currentDialogBody).toHaveAttribute("tabIndex", "0");
-        },
-        { timeout: 3000, interval: 100 }
-      );
-
-      // Test Home key to scroll to top
-      await userEvent.keyboard("{Home}");
-      await waitFor(
-        () => {
-          const currentDialogBody = canvas.getByTestId("dialog-body-inside");
-          expect(currentDialogBody).toBeInTheDocument();
-          expect(currentDialogBody).toHaveAttribute("tabIndex", "0");
-        },
-        { timeout: 3000, interval: 100 }
-      );
-
-      // Test End key to scroll to bottom
-      await userEvent.keyboard("{End}");
-      await waitFor(
-        () => {
-          const currentDialogBody = canvas.getByTestId("dialog-body-inside");
-          expect(currentDialogBody).toBeInTheDocument();
-          expect(currentDialogBody).toHaveAttribute("tabIndex", "0");
-        },
-        { timeout: 3000, interval: 100 }
-      );
-
-      // Close dialog
-      await userEvent.keyboard("{Escape}");
-      await waitFor(
-        () => {
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        },
-        { timeout: 3000 }
-      );
-    });
+        await userEvent.keyboard("{Escape}");
+        await waitFor(
+          () => {
+            expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
+      }
+    );
 
     await step("Test 'scroll outside' behavior comparison", async () => {
       // Test scroll outside dialog
@@ -577,31 +506,15 @@ export const ScrollBehavior: Story = {
       );
     });
 
-    await step("Test focus restoration after keyboard scrolling", async () => {
-      // Re-open scroll inside dialog
+    await step("Focus returns to the trigger after close", async () => {
       const scrollInsideTrigger = canvas.getByRole("button", {
         name: "Scroll inside",
       });
       await userEvent.click(scrollInsideTrigger);
-
       await waitFor(() => {
         expect(canvas.getByRole("dialog")).toBeInTheDocument();
       });
 
-      // Tab to dialog body and scroll
-      const dialogBody = canvas.getByTestId("dialog-body-inside");
-      await userEvent.tab(); // Move to Decline button
-      await userEvent.tab(); // Move to Accept button
-      await userEvent.tab(); // Move to dialog body
-      await userEvent.keyboard("{PageDown}"); // Scroll
-
-      // Verify dialog body remains accessible during scrolling
-      await waitFor(() => {
-        expect(dialogBody).toBeInTheDocument();
-        expect(dialogBody).toHaveAttribute("tabIndex", "0");
-      });
-
-      // Close dialog and verify focus restoration
       await userEvent.keyboard("{Escape}");
       await waitFor(
         () => {
@@ -609,54 +522,9 @@ export const ScrollBehavior: Story = {
         },
         { timeout: 3000 }
       );
-
-      // Verify focus restoration (focus should return to original trigger)
-      // Note: Focus restoration may vary by test environment
-      await waitFor(
-        () => {
-          // Check if trigger is at least accessible and in document
-          expect(scrollInsideTrigger).toBeInTheDocument();
-          expect(scrollInsideTrigger).toHaveAttribute("type", "button");
-        },
-        { timeout: 1000 }
-      );
-    });
-
-    await step("Test scroll indicators and visual feedback", async () => {
-      // Test that focus ring is visible when dialog body is focused
-      const scrollInsideTrigger = canvas.getByRole("button", {
-        name: "Scroll inside",
+      await waitFor(() => expect(scrollInsideTrigger).toHaveFocus(), {
+        timeout: 1000,
       });
-      await userEvent.click(scrollInsideTrigger);
-
-      await waitFor(() => {
-        expect(canvas.getByRole("dialog")).toBeInTheDocument();
-      });
-
-      const dialogBody = canvas.getByTestId("dialog-body-inside");
-
-      // Tab to dialog body
-      await userEvent.tab(); // Move to Decline button
-      await userEvent.tab(); // Move to Accept button
-      await userEvent.tab(); // Move to dialog body
-      await waitFor(() => {
-        // Verify dialog body is accessible for keyboard interaction
-        expect(dialogBody).toBeInTheDocument();
-        expect(dialogBody).toHaveAttribute("tabIndex", "0");
-      });
-
-      // Verify dialog body is properly configured for focus and scroll
-      expect(dialogBody).toHaveAttribute("tabIndex", "0");
-
-      // Close dialog
-      const closeButton = canvas.getByRole("button", { name: /close/i });
-      await userEvent.click(closeButton);
-      await waitFor(
-        () => {
-          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-        },
-        { timeout: 3000 }
-      );
     });
   },
 };
@@ -1191,5 +1059,152 @@ export const NestedDialogs: Story = {
         { timeout: 1000 }
       );
     });
+  },
+};
+
+// VRT open-state snapshots: `defaultOpen` so Chromatic captures the settled overlay (entrance animation pauses in place).
+
+const awaitOpen = async (canvasElement: HTMLElement) => {
+  const canvas = within(
+    (canvasElement.parentNode as HTMLElement) ?? canvasElement
+  );
+  await waitFor(() => expect(canvas.getByRole("dialog")).toBeInTheDocument());
+};
+
+/**
+ * Open dialog (center) - the canonical chrome: header + title + close button,
+ * body, footer actions, and the blurred backdrop.
+ */
+export const Open: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Dialog.Root defaultOpen>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>Dialog Title</Dialog.Title>
+          <Dialog.CloseTrigger />
+        </Dialog.Header>
+        <Dialog.Body>
+          <Text>This is the default dialog with basic functionality.</Text>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button slot="close">Cancel</Button>
+          <Button variant="solid">Save</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  ),
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/**
+ * Placement `top` - dialog pinned to the top of the viewport.
+ */
+export const OpenTop: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Dialog.Root defaultOpen placement="top">
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>Placement: top</Dialog.Title>
+          <Dialog.CloseTrigger />
+        </Dialog.Header>
+        <Dialog.Body>
+          <Text>This dialog is positioned at the top.</Text>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button slot="close">Close</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  ),
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/**
+ * Placement `bottom` - dialog pinned to the bottom of the viewport.
+ */
+export const OpenBottom: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Dialog.Root defaultOpen placement="bottom">
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>Placement: bottom</Dialog.Title>
+          <Dialog.CloseTrigger />
+        </Dialog.Header>
+        <Dialog.Body>
+          <Text>This dialog is positioned at the bottom.</Text>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button slot="close">Close</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  ),
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+const ScrollInsideDialog = () => (
+  <Dialog.Root defaultOpen scrollBehavior="inside">
+    <Dialog.Content>
+      <Dialog.Header>
+        <Dialog.Title>Terms and conditions</Dialog.Title>
+        <Dialog.CloseTrigger />
+      </Dialog.Header>
+      <Separator />
+      <Dialog.Body data-testid="scroll-inside-body">
+        <Stack>
+          {Array.from({ length: 20 }, (_, i) => (
+            <Text key={i}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. This
+              is paragraph {i + 1} of scrollable content.
+            </Text>
+          ))}
+        </Stack>
+      </Dialog.Body>
+      <Separator />
+      <Dialog.Footer>
+        <Button slot="close">Decline</Button>
+        <Button variant="solid">Accept</Button>
+      </Dialog.Footer>
+    </Dialog.Content>
+  </Dialog.Root>
+);
+
+/**
+ * `scrollBehavior="inside"` - constrained height with a scrollable body and
+ * header/footer separators; distinct from the default `outside`.
+ */
+export const OpenScrollInside: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <ScrollInsideDialog />,
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/**
+ * The scroll-inside body is a keyboard-focusable scroll region with its own
+ * `focusVisibleRing` (a11y for scrolling). Reached via Tab, so the ring renders.
+ */
+export const OpenScrollInsideFocused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <ScrollInsideDialog />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+    await waitFor(() => expect(canvas.getByRole("dialog")).toBeInTheDocument());
+    const body = canvas.getByTestId("scroll-inside-body");
+    // Tab (real keyboard, so :focus-visible fires) until the body holds focus.
+    for (let i = 0; i < 6 && document.activeElement !== body; i++) {
+      await userEvent.tab();
+    }
+    await expect(body).toHaveFocus();
   },
 };

--- a/packages/nimbus/src/components/drawer/drawer.stories.tsx
+++ b/packages/nimbus/src/components/drawer/drawer.stories.tsx
@@ -467,21 +467,18 @@ export const ScrollableContent: Story = {
       expect(drawerBody).toHaveAttribute("tabIndex", "0");
     });
 
-    await step("Test keyboard navigation to drawer body", async () => {
+    await step("Drawer body is focusable", async () => {
       const drawerBody = canvas.getByTestId("scrollable-drawer-body");
-
-      // Verify drawer body is focusable
       expect(drawerBody).toHaveAttribute("tabIndex", "0");
-
-      // Focus the drawer body directly to test keyboard scrolling capability
       drawerBody.focus();
-
       await waitFor(() => {
         expect(drawerBody).toHaveFocus();
       });
     });
 
-    await step("Test keyboard scrolling functionality", async () => {
+    await step("Drawer body is scrollable", async () => {
+      // fireEvent sets scrollTop directly (not keyboard); keyboard-scroll
+      // assertion is deferred - scrollTop doesn't update on key press in-env.
       const drawerBody = canvas.getByTestId("scrollable-drawer-body");
       await fireEvent.scroll(drawerBody, { target: { scrollTop: 500 } });
       expect(drawerBody.scrollTop).toBeGreaterThan(0);
@@ -1211,5 +1208,137 @@ export const UnsavedChangesConfirmation: Story = {
         { timeout: 3000 }
       );
     });
+  },
+};
+
+// VRT open-state snapshots: `defaultOpen` so Chromatic captures the settled drawer (slide-in pauses in place).
+
+const awaitOpen = async (canvasElement: HTMLElement) => {
+  const canvas = within(
+    (canvasElement.parentNode as HTMLElement) ?? canvasElement
+  );
+  await waitFor(() => expect(canvas.getByRole("dialog")).toBeInTheDocument());
+};
+
+const PlacementDrawer = ({
+  placement,
+}: {
+  placement: "left" | "right" | "top" | "bottom";
+}) => (
+  <Drawer.Root defaultOpen placement={placement}>
+    <Drawer.Content>
+      <Drawer.Header>
+        <Drawer.Title>Placement: {placement}</Drawer.Title>
+        <Drawer.CloseTrigger />
+      </Drawer.Header>
+      <Drawer.Body>
+        <Text>This drawer slides in from the {placement}.</Text>
+      </Drawer.Body>
+      <Drawer.Footer>
+        <Button slot="close">Cancel</Button>
+        <Button variant="solid">Save</Button>
+      </Drawer.Footer>
+    </Drawer.Content>
+  </Drawer.Root>
+);
+
+/** Open drawer, `right` placement (default) - the canonical chrome + backdrop. */
+export const OpenRight: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <PlacementDrawer placement="right" />,
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/** `placement="left"` - full-height panel on the inline-start edge. */
+export const OpenLeft: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <PlacementDrawer placement="left" />,
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/** `placement="top"` - full-width panel on the top edge. */
+export const OpenTop: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <PlacementDrawer placement="top" />,
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/** `placement="bottom"` - full-width panel on the bottom edge. */
+export const OpenBottom: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <PlacementDrawer placement="bottom" />,
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/** `showBackdrop={false}` - transparent overlay (no dim/blur behind the drawer). */
+export const OpenNoBackdrop: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Drawer.Root defaultOpen showBackdrop={false}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>No backdrop</Drawer.Title>
+          <Drawer.CloseTrigger />
+        </Drawer.Header>
+        <Drawer.Body>
+          <Text>This drawer renders without a backdrop overlay.</Text>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button slot="close">Close</Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer.Root>
+  ),
+  play: async ({ canvasElement }) => awaitOpen(canvasElement),
+};
+
+/**
+ * The scrollable body is keyboard-focusable with its own `focusVisibleRing`;
+ * reached via Tab, so the ring renders.
+ */
+export const OpenScrollFocused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Drawer.Root defaultOpen>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Scrollable body</Drawer.Title>
+          <Drawer.CloseTrigger />
+        </Drawer.Header>
+        <Separator />
+        <Drawer.Body data-testid="drawer-focus-body">
+          <Stack>
+            {Array.from({ length: 25 }, (_, i) => (
+              <Text key={i}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. This is
+                paragraph {i + 1} of scrollable content.
+              </Text>
+            ))}
+          </Stack>
+        </Drawer.Body>
+        <Separator />
+        <Drawer.Footer>
+          <Button slot="close">Close</Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+    await waitFor(() => expect(canvas.getByRole("dialog")).toBeInTheDocument());
+    const body = canvas.getByTestId("drawer-focus-body");
+    // Tab (real keyboard, so :focus-visible fires) until the body holds focus.
+    for (let i = 0; i < 6 && document.activeElement !== body; i++) {
+      await userEvent.tab();
+    }
+    await expect(body).toHaveFocus();
   },
 };

--- a/packages/nimbus/src/components/loading-spinner/loading-spinner.stories.tsx
+++ b/packages/nimbus/src/components/loading-spinner/loading-spinner.stories.tsx
@@ -54,6 +54,8 @@ export const Base: Story = {
 };
 
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: (args) => {
     return (
       <Stack direction="row" gap="400" alignItems="center">
@@ -71,6 +73,8 @@ export const Sizes: Story = {
  * One color palette for a light background and one for a dark background
  */
 export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: (args) => {
     return (
       <Box backgroundColor="blackAlpha.5">

--- a/packages/nimbus/src/components/menu/menu.stories.tsx
+++ b/packages/nimbus/src/components/menu/menu.stories.tsx
@@ -2178,3 +2178,161 @@ export const CustomWidth: Story = {
     });
   },
 };
+
+// VRT open-state snapshots: `defaultOpen` so Chromatic captures the settled open popover (entry animation pauses in place).
+
+const awaitMenuOpen = async (canvasElement: HTMLElement) => {
+  const canvas = within(
+    (canvasElement.parentNode as HTMLElement) ?? canvasElement
+  );
+  await waitFor(() => expect(canvas.getByRole("menu")).toBeInTheDocument());
+};
+
+/**
+ * Open action menu - item slot layouts (icon/label/description/keyboard), a
+ * section with an uppercase label, separators, a critical item, a disabled item,
+ * and a submenu-parent (caret). The auto-focused first item shows the focus ring.
+ */
+export const OpenMenu: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Menu.Root defaultOpen>
+      <Menu.Trigger>Menu</Menu.Trigger>
+      <Menu.Content>
+        <Menu.Section label="Menu items">
+          {/* Every 4-column grid combo: icon / description / keyboard on & off */}
+          <Menu.Item id="full">
+            <Icon slot="icon">
+              <InsertDriveFile />
+            </Icon>
+            <Text slot="label">Icon + label + description + kbd</Text>
+            <Text slot="description">All four columns populated</Text>
+            <Kbd slot="keyboard">⌘N</Kbd>
+          </Menu.Item>
+          <Menu.Item id="label-only">
+            <Text slot="label">Label only</Text>
+          </Menu.Item>
+          <Menu.Item id="label-desc">
+            <Text slot="label">Label + description</Text>
+            <Text slot="description">No icon, no keyboard</Text>
+          </Menu.Item>
+          <Menu.Item id="label-kbd">
+            <Text slot="label">Label + keyboard</Text>
+            <Kbd slot="keyboard">⌘K</Kbd>
+          </Menu.Item>
+          <Menu.Item id="delete" isCritical>
+            <Icon slot="icon">
+              <Delete />
+            </Icon>
+            <Text slot="label">Critical (icon + label + kbd)</Text>
+            <Kbd slot="keyboard">⌫</Kbd>
+          </Menu.Item>
+          <Menu.Item id="disabled" isDisabled>
+            <Icon slot="icon">
+              <Backup />
+            </Icon>
+            <Text slot="label">Disabled (icon + label)</Text>
+          </Menu.Item>
+        </Menu.Section>
+        <Separator />
+        <Menu.SubmenuTrigger>
+          <Menu.Item>
+            <Icon slot="icon">
+              <Settings />
+            </Icon>
+            <Text slot="label">More options</Text>
+          </Menu.Item>
+          <Menu.Submenu>
+            <Menu.Item id="sub1">
+              <Text slot="label">Submenu item</Text>
+            </Menu.Item>
+          </Menu.Submenu>
+        </Menu.SubmenuTrigger>
+      </Menu.Content>
+    </Menu.Root>
+  ),
+  play: async ({ canvasElement }) => awaitMenuOpen(canvasElement),
+};
+
+/**
+ * Selection menu - selected items render the `data-selected` background
+ * (distinct from the focus/hover background).
+ */
+export const OpenSelection: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Menu.Root
+      defaultOpen
+      selectionMode="multiple"
+      defaultSelectedKeys={new Set(["bold", "italic"])}
+    >
+      <Menu.Trigger>Format</Menu.Trigger>
+      <Menu.Content>
+        <Menu.Section label="Text style">
+          <Menu.Item id="bold">
+            <Text slot="label">Bold</Text>
+          </Menu.Item>
+          <Menu.Item id="italic">
+            <Text slot="label">Italic</Text>
+          </Menu.Item>
+          <Menu.Item id="underline">
+            <Text slot="label">Underline</Text>
+          </Menu.Item>
+        </Menu.Section>
+      </Menu.Content>
+    </Menu.Root>
+  ),
+  play: async ({ canvasElement }) => awaitMenuOpen(canvasElement),
+};
+
+/**
+ * Open submenu - the nested flyout, opened by hovering the submenu-parent and
+ * left open so the second popover + caret are captured.
+ */
+export const OpenSubmenu: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Menu.Root defaultOpen>
+      <Menu.Trigger>Menu</Menu.Trigger>
+      <Menu.Content>
+        <Menu.SubmenuTrigger>
+          <Menu.Item>
+            <Icon slot="icon">
+              <Settings />
+            </Icon>
+            <Text slot="label">Settings</Text>
+            <Text slot="description">Opens a submenu</Text>
+          </Menu.Item>
+          <Menu.Submenu>
+            <Menu.Item id="general">
+              <Icon slot="icon">
+                <Settings />
+              </Icon>
+              <Text slot="label">General</Text>
+            </Menu.Item>
+            <Menu.Item id="account">
+              <Icon slot="icon">
+                <AccountCircle />
+              </Icon>
+              <Text slot="label">Account</Text>
+            </Menu.Item>
+          </Menu.Submenu>
+        </Menu.SubmenuTrigger>
+        <Menu.Item id="other">
+          <Text slot="label">Other item</Text>
+        </Menu.Item>
+      </Menu.Content>
+    </Menu.Root>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(
+      (canvasElement.parentNode as HTMLElement) ?? canvasElement
+    );
+    await waitFor(() => expect(canvas.getByRole("menu")).toBeInTheDocument());
+    await userEvent.hover(canvas.getByRole("menuitem", { name: /Settings/ }));
+    await waitFor(() => expect(canvas.getAllByRole("menu")).toHaveLength(2));
+  },
+};

--- a/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
+++ b/packages/nimbus/src/components/modal-page/modal-page.stories.tsx
@@ -102,6 +102,9 @@ export const InfoPage: Story = {
  * Form page — header actions and footer with save/cancel buttons.
  */
 export const FormPage: Story = {
+  // VRT: the back button auto-focuses on open (a11y, focus-trapped), so its focus ring is expected in the snapshot.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <ModalPage.Root isOpen onClose={() => {}}>
       <ModalPage.TopBar
@@ -211,6 +214,8 @@ const TabularPageRender = () => {
 };
 
 export const TabularPage: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => <TabularPageRender />,
 
   play: async ({ canvasElement, step }) => {

--- a/packages/nimbus/src/components/progress-bar/progress-bar.stories.tsx
+++ b/packages/nimbus/src/components/progress-bar/progress-bar.stories.tsx
@@ -79,6 +79,8 @@ export const Base: Story = {
  * Showcase Sizes
  */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     value: 60,
     label: "Progress",
@@ -141,6 +143,8 @@ export const Variants: Story = {
  * Showcase Layouts
  */
 export const Layouts: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     value: 45,
     label: "Loading",
@@ -177,6 +181,8 @@ export const Layouts: Story = {
  * Showcase Possible Color Palettes
  */
 export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     value: 70,
     layout: "stacked",
@@ -270,6 +276,8 @@ export const IsDynamic: Story = {
  * Indeterminate State
  */
 export const Indeterminate: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     isIndeterminate: true,
     size: "md",
@@ -298,6 +306,25 @@ export const Indeterminate: Story = {
         ))}
       </Stack>
     );
+  },
+  play: async ({ canvasElement, step }) => {
+    const fills = canvasElement.querySelectorAll<HTMLElement>(
+      '[data-indeterminate="true"]'
+    );
+
+    await step("Renders an indeterminate fill per layout", async () => {
+      await expect(fills.length).toBe(layouts.length);
+    });
+
+    // progress-indeterminate sweeps the 40%-wide pill off both track edges at
+    // its keyframe endpoints, so Chromatic's paused frame would show an empty
+    // track. Freeze each fill centered for a deterministic, representative shot.
+    await step("Pin the sweeping pill mid-track for a stable snapshot", () => {
+      fills.forEach((fill) => {
+        fill.style.animation = "none";
+        fill.style.transform = "translateX(75%)";
+      });
+    });
   },
 };
 

--- a/packages/nimbus/src/components/steps/steps.stories.tsx
+++ b/packages/nimbus/src/components/steps/steps.stories.tsx
@@ -266,6 +266,8 @@ export const Controlled: Story = {
  * Displays xs, sm, and md sizes
  */
 export const Sizes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack direction="column" gap="800" alignItems="stretch" width="100%">
@@ -367,6 +369,8 @@ export const Sizes: Story = {
  * Displays horizontal and vertical layouts
  */
 export const Orientations: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Stack direction="row" gap="800" alignItems="flex-start" width="100%">
@@ -475,10 +479,75 @@ export const Orientations: Story = {
 };
 
 /**
+ * Focused trigger
+ * Keyboard focus lands on the current step's trigger (roving tabindex), showing
+ * the `_focusVisible` ring. The matrix stories can't render focus, so it gets its
+ * own snapshot.
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Steps.Root defaultStep={1} count={3} size="sm">
+      <Steps.List>
+        <Steps.Item index={0}>
+          <Steps.Trigger>
+            <Steps.Indicator>
+              <Steps.Status
+                complete={<Check />}
+                incomplete={<Steps.Number />}
+              />
+            </Steps.Indicator>
+            <Steps.Title>Account</Steps.Title>
+          </Steps.Trigger>
+          <Steps.Separator />
+        </Steps.Item>
+
+        <Steps.Item index={1}>
+          <Steps.Trigger>
+            <Steps.Indicator>
+              <Steps.Status
+                complete={<Check />}
+                incomplete={<Steps.Number />}
+              />
+            </Steps.Indicator>
+            <Steps.Title>Profile</Steps.Title>
+          </Steps.Trigger>
+          <Steps.Separator />
+        </Steps.Item>
+
+        <Steps.Item index={2}>
+          <Steps.Trigger>
+            <Steps.Indicator>
+              <Steps.Status
+                complete={<Check />}
+                incomplete={<Steps.Number />}
+              />
+            </Steps.Indicator>
+            <Steps.Title>Review</Steps.Title>
+          </Steps.Trigger>
+        </Steps.Item>
+      </Steps.List>
+    </Steps.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const user = userEvent.setup();
+
+    await step("Keyboard focus lands on a step trigger", async () => {
+      await user.tab();
+      const active = canvasElement.ownerDocument.activeElement;
+      await expect(active).toHaveAttribute("role", "tab");
+    });
+  },
+};
+
+/**
  * With Custom Icons
  * Using custom icons in the indicator
  */
 export const WithIcons: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <Steps.Root

--- a/packages/nimbus/src/components/toast/toast.stories.tsx
+++ b/packages/nimbus/src/components/toast/toast.stories.tsx
@@ -37,6 +37,8 @@ const meta: Meta = {
     layout: "centered",
   },
   tags: ["autodocs"],
+  // Teardown (post-snapshot) clear so persistent VRT toasts don't leak into the next story under isolate:false.
+  beforeEach: () => clearToasts,
 };
 
 export default meta;

--- a/packages/nimbus/src/components/toast/toast.stories.tsx
+++ b/packages/nimbus/src/components/toast/toast.stories.tsx
@@ -311,84 +311,6 @@ export const CustomIcon: Story = {
   },
 };
 
-const TOAST_TYPES = ["info", "success", "warning", "error"] as const;
-
-const VARIANT_PLACEMENTS: Array<{
-  variant: ToastVariant;
-  placement: "top-start" | "top-end" | "bottom-end";
-}> = [
-  { variant: "accent-start", placement: "top-start" },
-  { variant: "subtle", placement: "top-end" },
-  { variant: "solid", placement: "bottom-end" },
-];
-
-/**
- * Variants
- * Fires all type × variant combinations, each variant in a different corner.
- *
- * - accent-start → top-start
- * - subtle → top-end
- * - solid → bottom-end
- */
-export const Variants: Story = {
-  parameters: {
-    layout: "fullscreen",
-  },
-  render: () => {
-    const showAll = () => {
-      VARIANT_PLACEMENTS.forEach(({ variant, placement }) => {
-        TOAST_TYPES.forEach((type) => {
-          toast[type]({
-            title: `${type} (${variant})`,
-            description: "Supporting text that provides additional context.",
-            variant,
-            placement,
-            closable: true,
-            duration: Infinity,
-            action: {
-              label: "Undo",
-              onPress: () => {},
-            },
-          });
-        });
-      });
-    };
-
-    return (
-      <Button onPress={showAll} margin="400" data-testid="show-all-variants">
-        Show All Variants
-      </Button>
-    );
-  },
-  play: async ({ canvasElement, step }) => {
-    await clearToasts();
-    const canvas = within(canvasElement);
-    const body = within(document.body);
-    const button = canvas.getByRole("button", { name: /Show All Variants/i });
-
-    await step(
-      "Clicking the button renders one toast per variant",
-      async () => {
-        await userEvent.click(button);
-
-        // One representative title per variant — each variant fires 4 types so we
-        // spot-check one per variant to confirm all three variants rendered.
-        const accentStartToast = await body.findByText(
-          "info (accent-start)",
-          {},
-          { timeout: 3000 }
-        );
-        const subtleToast = await body.findByText("info (subtle)");
-        const solidToast = await body.findByText("info (solid)");
-
-        await expect(accentStartToast).toBeInTheDocument();
-        await expect(subtleToast).toBeInTheDocument();
-        await expect(solidToast).toBeInTheDocument();
-      }
-    );
-  },
-};
-
 /**
  * Auto-Dismiss Behavior
  * Tests custom duration and disabled auto-dismiss (duration: Infinity).
@@ -1171,6 +1093,8 @@ export const KeyboardNavigation: Story = {
  * - Explicit closable: true: close button shown
  */
 export const ClosableControl: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const showClosableToasts = () => {
       toast({
@@ -1626,6 +1550,139 @@ export const ZIndexLayering: Story = {
           },
           { timeout: 3000 }
         );
+      }
+    );
+  },
+};
+
+/**
+ * Focused
+ * The toast root is focusable (`tabIndex=0`) and styles its own
+ * `focusRing: outside` - a visual the SmokeTest matrix can't render and one that
+ * isn't delegated (the action/close buttons carry their own Button/IconButton
+ * rings). The play focuses the toast so the ring renders in the snapshot.
+ */
+export const Focused: Story = {
+  tags: ["vrt"],
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { disableSnapshot: false },
+  },
+  render: () => <div />,
+  play: async ({ step }) => {
+    await clearToasts();
+    toast.info({
+      title: "Focused toast",
+      description: "The toast root shows its focus ring when focused.",
+      duration: Infinity,
+      closable: true,
+      action: { label: "Undo", onPress: () => {} },
+      placement: "top-end",
+    });
+    const body = within(document.body);
+    const toastText = await body.findByText("Focused toast");
+    const root = toastText.closest('[data-part="root"]') as HTMLElement;
+
+    await step(
+      "Keyboard navigation focuses the toast root, showing its ring",
+      async () => {
+        // The toast region is reached by its hotkey (Ctrl+Shift+9 = top-end),
+        // then Tab lands on the toast root - the real keyboard path, not a
+        // synthetic .focus().
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            code: "Digit9",
+            key: "9",
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        await userEvent.tab();
+        await expect(root).toHaveFocus();
+      }
+    );
+  },
+};
+
+const TOAST_TYPES = ["info", "success", "warning", "error"] as const;
+
+const VARIANT_PLACEMENTS: Array<{
+  variant: ToastVariant;
+  placement: "top-start" | "top-end" | "bottom-end";
+}> = [
+  { variant: "accent-start", placement: "top-start" },
+  { variant: "subtle", placement: "top-end" },
+  { variant: "solid", placement: "bottom-end" },
+];
+
+/**
+ * SmokeTest
+ * The interacting-axes matrix (resting-visual carrier), rendered last per the
+ * SmokeTest convention: fires all type × variant combinations, each variant in a
+ * different corner.
+ *
+ * - accent-start → top-start
+ * - subtle → top-end
+ * - solid → bottom-end
+ */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { disableSnapshot: false },
+  },
+  render: () => {
+    const showAll = () => {
+      VARIANT_PLACEMENTS.forEach(({ variant, placement }) => {
+        TOAST_TYPES.forEach((type) => {
+          toast[type]({
+            title: `${type} (${variant})`,
+            description: "Supporting text that provides additional context.",
+            variant,
+            placement,
+            closable: true,
+            duration: Infinity,
+            action: {
+              label: "Undo",
+              onPress: () => {},
+            },
+          });
+        });
+      });
+    };
+
+    return (
+      <Button onPress={showAll} margin="400" data-testid="show-all-variants">
+        Show All Variants
+      </Button>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    await clearToasts();
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const button = canvas.getByRole("button", { name: /Show All Variants/i });
+
+    await step(
+      "Clicking the button renders one toast per variant",
+      async () => {
+        await userEvent.click(button);
+
+        // One representative title per variant — each variant fires 4 types so we
+        // spot-check one per variant to confirm all three variants rendered.
+        const accentStartToast = await body.findByText(
+          "info (accent-start)",
+          {},
+          { timeout: 3000 }
+        );
+        const subtleToast = await body.findByText("info (subtle)");
+        const solidToast = await body.findByText("info (solid)");
+
+        await expect(accentStartToast).toBeInTheDocument();
+        await expect(subtleToast).toBeInTheDocument();
+        await expect(solidToast).toBeInTheDocument();
       }
     );
   },

--- a/packages/nimbus/src/components/toast/toast.stories.tsx
+++ b/packages/nimbus/src/components/toast/toast.stories.tsx
@@ -1093,6 +1093,7 @@ export const KeyboardNavigation: Story = {
  * - Explicit closable: true: close button shown
  */
 export const ClosableControl: Story = {
+  // VRT: only snapshot of the no-chrome toast layout (action/close buttons absent) - SmokeTest always renders both.
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
@@ -1151,6 +1152,9 @@ export const ClosableControl: Story = {
       await expect(closeButton).toBeInTheDocument();
       await expect(closeButton).toBeEnabled();
     });
+
+    // Blur the clicked trigger so its focus ring isn't snapshotted.
+    button.blur();
   },
 };
 
@@ -1685,5 +1689,9 @@ export const SmokeTest: Story = {
         await expect(solidToast).toBeInTheDocument();
       }
     );
+
+    // Clicking the trigger leaves it focused; its ring would otherwise be
+    // snapshotted behind the top-start toasts. Blur so the frame is clean.
+    button.blur();
   },
 };

--- a/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/nimbus/src/components/tooltip/tooltip.stories.tsx
@@ -55,6 +55,8 @@ type Story = StoryObj<typeof Tooltip.Content>;
  * Demonstrates the most basic implementation
  */
 export const Base: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     children: "Demo Tooltip",
   },


### PR DESCRIPTION
>   You know the drill — full per-component notes live in the coverage matrix, so ask away.

  P1 Nimbus - Batch 6 & 7 Audit - Progress & feedback / Overlays
    Relates to: #1807 (Batch 4 & 5), #1797 (Batch 3), #1790 (Batch 2), #1782 (Batch 1)

  VRT components audited & tagged:

  Batch 6 (FEC-1158) - progress & feedback
  - ActivityIndicator
  - LoadingSpinner
  - ProgressBar
  - Steps
  - Toast

  
  Batch 7 (FEC-1159) - Overlays
  - Drawer
  - DIalog
  - ModalPage
  - Menu
  - Tooltip  
  

  Test-integrity fixes (honest scroll/keyboard step names, removed a fake conditional assertion, blurred stray trigger rings)

  Extended the VRT guidance in the chromatic docs and de-duplicated stories.md down to rule + snippet, with the
  rationale kept in chromatic-visual-testing.md

  Possible bugs flagged, not fixed here