### PR TITLE
chore: bundle size workflow killswitch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/ci
 
       - name: Bundle size check
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && vars.BUNDLE_SIZE_ENABLED != 'false'
         uses: ./.github/actions/bundle-size
         with:
           gh-token: ${{ github.token }}

--- a/.github/workflows/bundle-size-comment.yml
+++ b/.github/workflows/bundle-size-comment.yml
@@ -14,7 +14,7 @@ jobs:
   post-merge-label:
     # For direct trigger: only run on merged PRs.
     # For workflow_call: caller is responsible for gating on merged.
-    if: inputs.pr-number || github.event.pull_request.merged == true
+    if: (inputs.pr-number || github.event.pull_request.merged == true) && vars.BUNDLE_SIZE_ENABLED != 'false'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/docs/bundle-size-monitoring.md
+++ b/docs/bundle-size-monitoring.md
@@ -176,6 +176,12 @@ To re-enable, delete the variable or set its value to anything other than
 labeled PR before the pause. If that PR's comment has no valid data block,
 follow the [chain restoration steps](#restoring-a-broken-chain) below.
 
+**PRs opened during the pause:** these never received a bundle-size comment, so
+if one is merged after re-enabling, the post-merge workflow will add the
+`bundle-sizes` label but the comment will have no data block. The next PR will
+skip past it and fall back to the last labeled PR with a valid comment — so the
+chain recovers automatically as long as that earlier PR is still intact.
+
 ## Running Locally
 
 You need built packages and the [GitHub CLI](https://cli.github.com) (`gh`)

--- a/docs/bundle-size-monitoring.md
+++ b/docs/bundle-size-monitoring.md
@@ -41,7 +41,7 @@ comment chain is self-sustaining and the bootstrap file should be deleted.
 
 If the comment chain is ever lost (e.g., all `bundle-sizes` labels are removed),
 create a new bootstrap file to re-seed it. See
-[First-Time Setup](#first-time-setup) below.
+[Restoring a Broken Chain](#restoring-a-broken-chain) below.
 
 ### Post-Merge Labeling
 
@@ -157,6 +157,25 @@ The action:
    (`.github/actions/bundle-size/post-bundle-size-comment.mjs`)
 5. Fails the job if thresholds are exceeded and the approval label is absent
 
+## Emergency Pause (Killswitch)
+
+If the workflow is broken and blocking PRs, a maintainer can pause it
+immediately without any code change or PR:
+
+1. Go to **Settings → Secrets and variables → Actions → Variables** in the
+   GitHub UI.
+2. Create (or edit) the repository variable `BUNDLE_SIZE_ENABLED` and set its
+   value to `false`.
+3. All subsequent CI runs will skip both the bundle-size check and the
+   post-merge labeling step.
+
+To re-enable, delete the variable or set its value to anything other than
+`false`.
+
+**When re-enabling after a pause:** the comment chain resumes from the last
+labeled PR before the pause. If that PR's comment has no valid data block,
+follow the [chain restoration steps](#restoring-a-broken-chain) below.
+
 ## Running Locally
 
 You need built packages and the [GitHub CLI](https://cli.github.com) (`gh`)
@@ -212,7 +231,7 @@ Example output:
 Requires the [GitHub CLI](https://cli.github.com) (`gh`) to be installed and
 authenticated. The script is read-only — it only queries the API, never writes.
 
-## First-Time Setup
+## Restoring a Broken Chain
 
 To establish the comment chain for the first time (or re-establish it after it
 breaks):


### PR DESCRIPTION
## feat(ci): add repository variable killswitch for bundle-size monitoring

Adds an escape hatch for maintainers to pause the bundle-size workflow immediately — no PR, no code change, one click in GitHub Settings.

### Motivation

The bundle-size comment chain is critical infrastructure but has proven fragile. When it breaks, every open PR is blocked until the chain is manually restored. There was no way to quickly un-block the team while a fix was in flight — you either left CI red for everyone or started reverting workflow changes. This closes that gap.

### What changed

A single repository variable (`BUNDLE_SIZE_ENABLED`) now gates both places where the feature touches CI:

- **`build-and-test.yml`** — the bundle-size check step is skipped when `BUNDLE_SIZE_ENABLED = false`, so no failing CI and no bot comments during the pause.
- **`bundle-size-comment.yml`** — the post-merge labeling step is also skipped, preventing broken-comment PRs from accumulating the `bundle-sizes` label while the feature is off (which would otherwise break the chain again on re-enable).

The default behavior is unchanged. The variable is absent in normal operation, and `'' != 'false'` evaluates to true, so nothing changes for everyday CI runs.

### How to use it

**To pause:** GitHub → Settings → Secrets and variables → Actions → Variables → create `BUNDLE_SIZE_ENABLED` with value `false`. Takes effect on the next CI run — no merge required.

**To resume:** delete the variable or set its value to anything other than `false`.

### Docs

`docs/bundle-size-monitoring.md` gains an "Emergency Pause (Killswitch)" section with step-by-step toggle instructions and a note about chain state on re-enable. "First-Time Setup" is renamed to "Restoring a Broken Chain" (more accurate for its primary use case) and the internal link is updated to match.
