### PR TITLE
fix(badge,checkbox): add Badge sm variant and fix label-less Checkbox spacing

### DIFF
--- a/.changeset/badge-sm-checkbox-spacing.md
+++ b/.changeset/badge-sm-checkbox-spacing.md
@@ -1,0 +1,9 @@
+---
+"@commercetools/nimbus": patch
+---
+
+`Badge`: Added `sm` size variant, providing an intermediate option between `xs`
+and `md`.
+
+`Checkbox`: Fixed excess horizontal spacing when rendered without a visible
+label.

--- a/packages/nimbus/src/components/badge/badge.recipe.ts
+++ b/packages/nimbus/src/components/badge/badge.recipe.ts
@@ -51,6 +51,17 @@ export const badgeRecipe = defineRecipe({
           height: "500",
         },
       },
+      sm: {
+        fontSize: "400",
+        gap: "100",
+        h: "900",
+        lineHeight: "500",
+        px: "300",
+        _icon: {
+          width: "500",
+          height: "500",
+        },
+      },
       md: {
         fontSize: "400",
         gap: "200",

--- a/packages/nimbus/src/components/badge/badge.stories.tsx
+++ b/packages/nimbus/src/components/badge/badge.stories.tsx
@@ -4,7 +4,7 @@ import { SentimentSatisfied as DemoIcon } from "@commercetools/nimbus-icons";
 import { within, expect } from "storybook/test";
 import { DisplayColorPalettes } from "@/utils/display-color-palettes";
 
-const sizes: BadgeProps["size"][] = ["2xs", "xs", "md"];
+const sizes: BadgeProps["size"][] = ["2xs", "xs", "sm", "md"];
 
 /**
  * Storybook metadata configuration

--- a/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
+++ b/packages/nimbus/src/components/checkbox/checkbox.recipe.ts
@@ -16,8 +16,10 @@ export const checkboxSlotRecipe = defineSlotRecipe({
       gap: "200",
       alignItems: "center",
       verticalAlign: "top",
-      minWidth: "600",
       minHeight: "600",
+      "&:has([data-slot='label'])": {
+        minWidth: "600",
+      },
 
       ["&[data-disabled='true']"]: {
         layerStyle: "disabled",


### PR DESCRIPTION
## Summary

- **Badge**: Added `sm` size variant between `xs` and `md` — uses `md` text sizing with `xs`-level density (gap, padding, icon size) at `h: 900`.
- **Checkbox**: Fixed excess horizontal spacing on label-less checkboxes by scoping `minWidth: 600` behind `&:has([data-slot='label'])` so it only applies when a visible label is present.

## Test plan

- [x] Verified Badge `sm` renders correctly in Storybook Sizes story
- [ ] Run `pnpm test:dev` to confirm all existing tests pass
- [ ] Chromatic visual regression captures the new Badge size
- [ ] Verify label-less Checkbox no longer has extra horizontal spacing in Storybook