### PR TITLE
FEC-1198 - tighten chromatic docs & wire them up

### DIFF
--- a/.claude/agents/nimbus-coder.md
+++ b/.claude/agents/nimbus-coder.md
@@ -74,8 +74,8 @@ is to orchestrate these skills, not replace them.
 | File Type                       | Skill to Invoke                     | When                                                       |
 | ------------------------------- | ----------------------------------- | ---------------------------------------------------------- |
 | `*.types.ts`                    | **writing-types**                   | ALL type definition work                                   |
-| `*.recipe.ts`                   | **writing-recipes**                 | ALL recipe creation/updates                                |
-| `*.slots.tsx`                   | **writing-slots**                   | ALL slot component work                                    |
+| `*.recipe.*` (`.ts` or `.tsx`)  | **writing-recipes**                 | ALL recipe creation/updates                                |
+| `*.slots.*` (usually `.tsx`)    | **writing-slots**                   | ALL slot component work                                    |
 | `*.stories.tsx`                 | **writing-stories**                 | ALL story creation/updates                                 |
 | `*.i18n.ts`                     | **writing-i18n**                    | When component has default aria-labels or user-facing text |
 | `utils/*.ts` + `constants/*.ts` | **writing-utils-and-constants**     | ALL pure helper / constant work in a component             |
@@ -120,7 +120,7 @@ See
 
 **YOU code directly:**
 
-- Main component implementation files (`{component}.tsx`) — these contain the
+- Main component implementation files (`{component}.tsx`) - these contain the
   React component ONLY, never pure helpers
 - Component-specific logic and hooks
 - Integration of slot components with React Aria
@@ -131,8 +131,10 @@ of the component**, organized per the merge rule in
 `docs/file-type-guidelines/utils-and-constants.md#file-organization` (solo files
 for unrelated helpers, family files for cohesive sets), with a sibling
 `{name}.spec.ts` per util file and a `utils/index.ts` barrel. NEVER export
-utility functions from `{component}.tsx`. See existing patterns in
-`combobox/utils/`, `inline-svg/utils/`, `money-input/utils/`. Invoke the
+utility functions from `{component}.tsx`. **Copy `combobox/utils/`** - it is the
+one that follows the full convention, sibling specs included.
+`inline-svg/utils/` and `money-input/utils/` show the folder shape but predate
+the spec rule, so don't take them as the standard. Invoke the
 `writing-utils-and-constants` skill for these files.
 
 **INVOKE skills:**

--- a/.claude/agents/nimbus-coder.md
+++ b/.claude/agents/nimbus-coder.md
@@ -105,7 +105,11 @@ See
    - Main component implementation (YOU handle this directly)
 
 3. **Quality Layer** (after integration):
-   - Invoke `writing-stories` for Storybook stories + tests
+   - Invoke `writing-stories` for Storybook stories + tests. This includes
+     **Chromatic (VRT) instrumentation** - snapshots are opt-in, so a story file
+     with no `tags: ["vrt"]` story leaves the component at **zero** visual
+     coverage. The story task is not done until either some story opts in, or
+     the recipe paints nothing and `meta` carries a one-line note saying so.
    - Invoke `writing-i18n` if component has default labels
 
 4. **Documentation Layer** (after quality):
@@ -153,6 +157,10 @@ If a skill reports validation failures:
   /docs/file-type-guidelines/
 - ALWAYS register recipes in theme configuration when creating new styling
 - ALWAYS include play functions for interactive components in stories
+- ALWAYS instrument stories for Chromatic - every state the recipe paints
+  distinctly must be reachable in some snapshotted frame. Derive that list from
+  the **recipe**, not from the story names. Snapshots are opt-in, so silence
+  means no coverage, not default coverage
 - ALWAYS use jsx live blocks in MDX documentation (never Storybook imports)
 - ALWAYS follow the compound component pattern with .Root as first property when
   applicable

--- a/.claude/agents/nimbus-reviewer.md
+++ b/.claude/agents/nimbus-reviewer.md
@@ -70,6 +70,8 @@ review:
 - Recipes: [✅ PASS / ❌ FAIL / ⚠️ WARNING] - writing-recipes skill report
 - Slots: [✅ PASS / ❌ FAIL / ⚠️ WARNING] - writing-slots skill report
 - Stories: [✅ PASS / ❌ FAIL / ⚠️ WARNING] - writing-stories skill report
+- VRT coverage: [✅ PASS / ❌ FAIL / ⚠️ WARNING] - your own check, recipe vs.
+  opted-in stories (see "Chromatic (VRT) Coverage Review")
 - i18n: [✅ PASS / ❌ FAIL / ⚠️ WARNING] - writing-i18n skill report
 - Dev Docs: [✅ PASS / ❌ FAIL / ⚠️ WARNING] - writing-developer-documentation
   skill report
@@ -104,6 +106,39 @@ instead of consumer integration patterns (form libraries, async data).
 See
 [Testing Strategy Guide](../../docs/file-type-guidelines/testing-strategy.md).
 
+### Chromatic (VRT) Coverage Review
+
+Visual coverage is **opt-in**, so its failure mode is silence: a story file with
+no `tags: ["vrt"]` story reads as finished while having zero visual coverage.
+Nothing else in the review will catch that, so check it explicitly.
+
+Read the component's `*.recipe.ts` first - the surface list is derived from the
+recipe, never from the story names. Then verify:
+
+- [ ] Some story opts in (`tags: ["vrt"]` +
+      `parameters: { chromatic: { disableSnapshot: false } }`), **or** the
+      recipe paints nothing and `meta` carries a one-line note saying so
+- [ ] Every state the recipe paints distinctly is reachable in some snapshotted
+      frame - including states no prop names (RTL, an inherited `colorPalette`)
+      and every child type a comma-separated selector list reaches
+- [ ] Interacting axes folded into one `SmokeTest` (rendered last); independent
+      axes given their own showcase stories rather than a cross-product
+- [ ] States a matrix can't hold have their own snapshotted story - `Focused`
+      per **independent** focus surface, open overlays, condition-fired states
+      (sticky/overflow/variant-zeroed)
+- [ ] Snapshotted stories are deterministic - no live dates, no stray focus ring
+      (a `userEvent.click` leaves one), caret hidden on a focused text input,
+      async-derived state awaited
+- [ ] Any state deliberately left un-snapshotted names where its visual **is**
+      covered. Reject "it's behavioral" on its own, and reject reasons resting
+      on `aria-*` values or callback arguments - those prove state, not pixels
+
+Flag a missing opt-in as a **critical violation**, not a warning: it ships a
+component with no visual regression protection.
+
+Rules and rationale: `docs/file-type-guidelines/stories.md`, then
+`docs/chromatic-visual-testing.md` for calls a rule doesn't settle.
+
 ### When You Review Directly vs. Invoke Skills
 
 **YOU review directly:**
@@ -113,6 +148,8 @@ See
 - Barrel exports and module structure
 - Build/test execution results
 - Cross-component dependencies
+- **VRT coverage** - it spans the recipe and the story file, so no single
+  file-type skill can see the whole picture
 
 **INVOKE skills:**
 

--- a/.claude/agents/nimbus-reviewer.md
+++ b/.claude/agents/nimbus-reviewer.md
@@ -20,7 +20,7 @@ When reviewing code, you MUST follow the File Review Protocol:
    (_.mdx, _.stories.tsx, _.recipe.tsx, _.slots.tsx, \*.types.ts, etc.)
 
 2. **Load Guidelines**: Reference the appropriate guidelines document from
-   /docs/file-type-guidelines/ based on the file type
+   `docs/file-type-guidelines/` based on the file type
 
 3. **Run Validation Checklist**: Systematically check each item in the
    validation checklist found at the end of each guidelines document
@@ -38,8 +38,8 @@ compliance checks.
 | File Extension/Type             | Skill to Invoke                     | Command                                                  |
 | ------------------------------- | ----------------------------------- | -------------------------------------------------------- |
 | `*.types.ts`                    | **writing-types**                   | `writing-types validate ComponentName`                   |
-| `*.recipe.ts`                   | **writing-recipes**                 | `writing-recipes validate ComponentName`                 |
-| `*.slots.tsx`                   | **writing-slots**                   | `writing-slots validate ComponentName`                   |
+| `*.recipe.*` (`.ts` or `.tsx`)  | **writing-recipes**                 | `writing-recipes validate ComponentName`                 |
+| `*.slots.*` (usually `.tsx`)    | **writing-slots**                   | `writing-slots validate ComponentName`                   |
 | `*.stories.tsx`                 | **writing-stories**                 | `writing-stories validate ComponentName`                 |
 | `*.i18n.ts`                     | **writing-i18n**                    | `writing-i18n validate ComponentName`                    |
 | `utils/*.ts` + `constants/*.ts` | **writing-utils-and-constants**     | `writing-utils-and-constants validate ComponentName`     |
@@ -48,10 +48,12 @@ compliance checks.
 
 ### Review Process (UPDATED)
 
-**Step 1: File Discovery**
+**Step 1: File Discovery** - not everything lives under `components/`. Patterns
+(`*Field`, FormActionBar, FloatingActionButton, PublicPageLayout, …) live in
+`src/patterns/`, and hooks in `src/hooks/`, so search rather than assume:
 
 ```bash
-ls packages/nimbus/src/components/{component}/
+find packages/nimbus/src -type d -name "{component}"
 ```
 
 **Step 2: Skill Validation (Parallel)** For each file type found, invoke
@@ -112,15 +114,19 @@ Visual coverage is **opt-in**, so its failure mode is silence: a story file with
 no `tags: ["vrt"]` story reads as finished while having zero visual coverage.
 Nothing else in the review will catch that, so check it explicitly.
 
-Read the component's `*.recipe.ts` first - the surface list is derived from the
-recipe, never from the story names. Then verify:
+Read the component's recipe first - the surface list is derived from the recipe,
+never from the story names. Glob `*.recipe.*`, not just `*.recipe.ts`: 9 recipes
+are `.recipe.tsx` (menu, select, icon, popover, money-input, split-button,
+tag-group, field-errors, toggle-button-group), so a `.ts`-only check would
+wrongly conclude those components have no recipe and no surfaces to cover. Then
+verify:
 
 - [ ] Some story opts in (`tags: ["vrt"]` +
       `parameters: { chromatic: { disableSnapshot: false } }`), **or** the
       recipe paints nothing and `meta` carries a one-line note saying so
 - [ ] Every state the recipe paints distinctly is reachable in some snapshotted
-      frame - including states no prop names (RTL, an inherited `colorPalette`)
-      and every child type a comma-separated selector list reaches
+      frame - including the ones no prop names (RTL, an inherited
+      `colorPalette`) and every child type a comma-separated selector reaches
 - [ ] Interacting axes folded into one `SmokeTest` (rendered last); independent
       axes given their own showcase stories rather than a cross-product
 - [ ] States a matrix can't hold have their own snapshotted story - `Focused`

--- a/.claude/commands/housekeeping.md
+++ b/.claude/commands/housekeeping.md
@@ -352,8 +352,10 @@ For each dependency group (or the specified target group):
 7. **Chromatic visual check (automatic):**
 
    No manual dispatch needed - the changed-files gate watches `pnpm-lock.yaml`,
-   so the PR auto-runs a full Chromatic snapshot. Review the visual diff before
-   merging. See [Chromatic CI Runbook](../../docs/chromatic-ci.md).
+   so the PR runs Chromatic on its own. TurboSnap stays on, but a lockfile
+   change can't be traced to specific stories, so nothing gets skipped and you
+   effectively get a full snapshot. Review the visual diff before merging. See
+   [Chromatic CI Runbook](../../docs/chromatic-ci.md).
 
 ---
 

--- a/.claude/commands/housekeeping.md
+++ b/.claude/commands/housekeeping.md
@@ -353,8 +353,7 @@ For each dependency group (or the specified target group):
 
    No manual dispatch needed - the changed-files gate watches `pnpm-lock.yaml`,
    so the PR auto-runs a full Chromatic snapshot. Review the visual diff before
-   merging. See
-   [Chromatic Visual Testing](../../docs/chromatic-visual-testing.md).
+   merging. See [Chromatic CI Runbook](../../docs/chromatic-ci.md).
 
 ---
 

--- a/.claude/commands/propose-component.md
+++ b/.claude/commands/propose-component.md
@@ -119,13 +119,42 @@ The task list MUST include these file creation steps in this order:
    - Run linting and TypeScript checks (violations block shipping)
    - Run the full test suite
 
-4. **Validation steps** - You MUST verify standards compliance before shipping:
+4. **Instrument for Chromatic (VRT)** - You MUST include this as its own task,
+   after the recipe exists and before validation. Snapshots are opt-in, so a
+   component with no opted-in story has **zero** visual coverage and this step
+   is the only thing that prevents that.
+
+   The task MUST say: audit the finished stories per
+   `docs/chromatic-visual-testing.md`, then opt each genuine visual state in
+   with `tags: ["vrt"]` +
+   `parameters: { chromatic: { disableSnapshot: false } }`. Derive the list from
+   the **recipe**, not from the story names.
+
+   Acceptance criteria for the task:
+   - Every state the recipe paints distinctly is reachable in some snapshotted
+     frame; interacting axes folded into one `SmokeTest` (rendered last),
+     independent axes given their own showcase stories
+   - States a matrix can't hold have their own snapshotted story (`Focused` per
+     independent focus surface, open overlay, condition-fired states)
+   - Behavior-only stories left un-snapshotted (project default), and any state
+     deliberately not snapshotted has a reason naming where its visual **is**
+     covered
+   - A component whose recipe paints nothing gets **no** VRT plus a one-line
+     `meta` note, so the omission reads as deliberate
+   - Snapshotted stories are deterministic: no live dates, no stray focus ring,
+     caret hidden on a focused text input, async-derived state awaited
+   - A row added to `docs/chromatic/chromatic-vrt-coverage-matrix.md` recording
+     the decision for every story
+
+5. **Validation steps** - You MUST verify standards compliance before shipping:
    - Component TypeScript compiles without errors
    - Storybook tests pass (play functions execute without error)
    - Unit tests pass (if applicable for hooks/utils)
    - Linting passes (`pnpm lint`)
    - Documentation is complete and accurate
    - Component is exported from main `packages/nimbus` barrel export
+   - **VRT instrumented** - at least one story opts in, or a `meta` note
+     documents why the component gets none
 
 **Proposal Completion**: You MUST ensure the proposal includes clear acceptance
 criteria for each task. Acceptance criteria help implementers know when they're
@@ -143,6 +172,9 @@ done and prevent ambiguous task definitions.
       component, index)
 - [ ] MUST follow the order specified in Step 3
 - [ ] MUST include play functions for all component behaviors in story file
+- [ ] MUST include a **Chromatic (VRT) instrumentation task** with acceptance
+      criteria - not folded into the story-writing task, since snapshots are
+      opt-in and a missed opt-in means zero visual coverage
 - [ ] SHOULD use appropriate skills (developer-documentation,
       designer-documentation) for documentation tasks
 - [ ] MUST explicitly check standards compliance in validation steps

--- a/.claude/commands/propose-component.md
+++ b/.claude/commands/propose-component.md
@@ -126,7 +126,7 @@ The task list MUST include these file creation steps in this order:
 
    The task MUST say: audit the finished stories per
    `docs/chromatic-visual-testing.md`, then opt each genuine visual state in
-   with `tags: ["vrt"]` +
+   with `tags: ["vrt"]` plus
    `parameters: { chromatic: { disableSnapshot: false } }`. Derive the list from
    the **recipe**, not from the story names.
 
@@ -143,8 +143,6 @@ The task list MUST include these file creation steps in this order:
      `meta` note, so the omission reads as deliberate
    - Snapshotted stories are deterministic: no live dates, no stray focus ring,
      caret hidden on a focused text input, async-derived state awaited
-   - A row added to `docs/chromatic/chromatic-vrt-coverage-matrix.md` recording
-     the decision for every story
 
 5. **Validation steps** - You MUST verify standards compliance before shipping:
    - Component TypeScript compiles without errors

--- a/.claude/commands/review-nimbus-pr.md
+++ b/.claude/commands/review-nimbus-pr.md
@@ -3,6 +3,7 @@ currently checked out branch.
 
 Branch argument: $ARGUMENTS
 
-Use the nimbus-reviewer agent to review the current branch's changes vs `main`
-for accuracy, effectiveness, consistency, performance, security posture, and any
-potential for adding bugs, regressions or undue maintenance.
+Use the nimbus-reviewer agent to review the current branch's changes vs
+`origin/main` (not local `main`, which is often stale) for accuracy,
+effectiveness, consistency, performance, security posture, and any potential for
+adding bugs, regressions or undue maintenance.

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -73,9 +73,10 @@ Before implementation, you MUST research in parallel:
 
 2. **Analyze** component characteristics to determine story type
 
-3. **Review** similar story implementations:
+3. **Review** similar story implementations - patterns live outside
+   `components/`, so search both:
    ```bash
-   ls packages/nimbus/src/components/*/*.stories.tsx
+   find packages/nimbus/src -name "*.stories.tsx"
    ```
 
 **Conditionally, for a first-pass VRT audit only** - when you are deciding _which_
@@ -99,7 +100,9 @@ decision flowchart.
 
 Quick reference:
 
-- **Simple components**: Base, Sizes, Variants, Disabled, SmokeTest
+- **Simple components**: Base, Sizes, Variants, Disabled, plus `SmokeTest` **only
+  if its axes interact** (see the SmokeTest section - independent axes get their
+  own showcase stories instead)
 - **Form components**: Add Required, Invalid, Controlled stories
 - **Interactive components**: Add KeyboardNavigation, Controlled stories
 - **Portal components**: Add Placement, Dismissal stories with special portal
@@ -147,7 +150,9 @@ Stories MUST be exported in this order:
 5. **States** - Disabled, Invalid, Required, etc.
 6. **Controlled** - Controlled state example
 7. **Complex** - Advanced scenarios, edge cases
-8. **SmokeTest** - Comprehensive matrix (last story)
+8. **SmokeTest** - the interacting-axes matrix, last story. Omit it entirely when
+   the axes are independent; don't substitute a cross-product that adds no
+   coverage
 
 ## Create Mode
 
@@ -156,7 +161,8 @@ Stories MUST be exported in this order:
 **Start with the recipe. Read it, don't recall it.**
 
 ```bash
-cat packages/nimbus/src/components/{component}/{component}.recipe.ts
+# .tsx as well as .ts; patterns live in src/patterns/, not src/components/
+find packages/nimbus/src -path "*{component}*" -name "*.recipe.*"
 ```
 
 Every VRT decision is derived from this file, so read it before deciding anything
@@ -171,8 +177,9 @@ about snapshots:
   the default and gets no story of its own. If the recipe sets no color, border or
   spacing at all, the component gets no VRT (see "What Gets Captured").
 
-Not every component has one - 61 of them do. A missing `.recipe.ts` is itself the
-answer for pass-through style primitives.
+Not every component has one - 70 do (61 `.ts` + 9 `.tsx`). Genuinely having none
+is itself the answer for pass-through style primitives, so glob both extensions
+before concluding a component has no recipe.
 
 Then analyze:
 
@@ -438,7 +445,7 @@ The **visual snapshot role**. Snapshots are **opt-in**: `preview.tsx` defaults t
 can find snapshot stories. Crop padding is global (a `preview.tsx` decorator wraps
 non-`fullscreen` stories in `1rem`), so focus rings aren't clipped.
 
-Four questions decide every snapshot call:
+Four questions decide every snapshot call, then a fifth step packs the survivors:
 
 1. **Does it paint?** Is there a component-owned pixel at all.
 2. **Is the state reachable in this frame?** Inert props, zeroing variants,
@@ -447,8 +454,7 @@ Four questions decide every snapshot call:
    composition patterns.
 4. **Does the play land the frame?** End state, blur, settled animation,
    determinism.
-
-Then pack what survives into as few frames as the axes allow.
+5. **Packing the surfaces into frames.** Into as few as the axes allow.
 
 **The rules themselves live in `docs/file-type-guidelines/stories.md`** (its
 "Chromatic Visual Regression Snapshots" section) - terse rules plus paste-ready
@@ -457,9 +463,9 @@ Snapshots** validation checklist repeats them as checkboxes under the same five
 headings, and is what you tick off when validating.
 
 **Escalate to `docs/chromatic-visual-testing.md` only when a rule doesn't settle
-the case.** Do not load it by default: it is ~5k tokens of rationale and worked
-examples, and adds nothing for mechanical authoring. Read it when you hit one of
-these, because each is a call the terse rule states but cannot decide for you:
+the case** - it is ~5k tokens of rationale and worked examples, so don't load it
+by default. Read it when you hit one of these, because each is a call the terse
+rule states but cannot decide for you:
 
 - **Does this state paint differently from the default?** Read-only is the
   classic - the answer is component-dependent (MoneyInput yes, TextInput no).
@@ -746,7 +752,8 @@ await step("Verify state changes", async () => {
 You MUST verify the changes:
 
 ```bash
-pnpm test:dev packages/nimbus/src/components/{component}/{component}.stories.tsx
+# components/ for a component; patterns/{group}/ for a pattern
+pnpm test:dev $(find packages/nimbus/src -name "{component}.stories.tsx")
 ```
 
 ## Validate Mode
@@ -757,13 +764,14 @@ You MUST validate against these requirements:
 
 #### File Structure
 
-- [ ] Story file location:
-      `packages/nimbus/src/components/{component}/{component}.stories.tsx`
+- [ ] Story file location - `src/components/{name}/{name}.stories.tsx` for a
+      component, `src/patterns/{group}/{name}/{name}.stories.tsx` for a pattern
+      (groups: `buttons`, `actions`, `dialogs`, `fields`, `pages`)
 - [ ] Imports from `@storybook/react-vite` and `storybook/test`
 - [ ] Meta configuration with title, component, tags
 - [ ] Default export of meta
 - [ ] Story type from `StoryObj<typeof ComponentName>` (the component, not
-      `typeof meta` — see note in `docs/file-type-guidelines/stories.md`)
+      `typeof meta` - see note in `docs/file-type-guidelines/stories.md`)
 
 #### Required Stories
 

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -78,6 +78,19 @@ Before implementation, you MUST research in parallel:
    ls packages/nimbus/src/components/*/*.stories.tsx
    ```
 
+**Conditionally, for a first-pass VRT audit only** - when you are deciding _which_
+stories snapshot rather than writing one to a settled spec:
+
+```bash
+cat docs/chromatic-visual-testing.md
+```
+
+That doc is rationale and worked precedent, not instructions; it is ~5k tokens and
+adds nothing for mechanical authoring. See
+"Chromatic Snapshots: What Gets Captured" below for the specific calls that
+warrant reading it. For CI behavior (triggers, baselines, gating) see
+`docs/chromatic-ci.md` - never needed to author a story.
+
 ## Story Requirements by Component Type
 
 You MUST determine which story types are needed based on component category. See
@@ -140,9 +153,33 @@ Stories MUST be exported in this order:
 
 ### Step 1: Component Analysis
 
-You MUST analyze:
+**Start with the recipe. Read it, don't recall it.**
 
-- Component props and variants
+```bash
+cat packages/nimbus/src/components/{component}/{component}.recipe.ts
+```
+
+Every VRT decision is derived from this file, so read it before deciding anything
+about snapshots:
+
+- **Every painting selector** - `_hover`, `_focusWithin`, `_disabled`, `_active`,
+  `data-invalid`, `data-readonly`, `:has()`, and any comma-separated selector list
+  (which counts once **per child type it names**).
+- **Every `variant` / `size` / `colorPalette` key**, and any the recipe
+  **hardcodes** - a pinned value was never an axis.
+- **What it does _not_ style.** A state with no rule here renders identically to
+  the default and gets no story of its own. If the recipe sets no color, border or
+  spacing at all, the component gets no VRT (see "What Gets Captured").
+
+Not every component has one - 61 of them do. A missing `.recipe.ts` is itself the
+answer for pass-through style primitives.
+
+Then analyze:
+
+- **The component source** - every conditional render or prop that changes what
+  paints (e.g. `isDisabled={x || isReadOnly}`). Coverage is the cross-product of
+  recipe states x conditional branches, not the recipe states alone.
+- Component props and variants (drives `argTypes`)
 - Interactive behavior (click, type, keyboard nav)
 - State management (controlled vs uncontrolled)
 - Portal content (overlays, dropdowns)
@@ -340,8 +377,8 @@ instead.
 Don't fold in an axis that applies a uniform, axis-independent transform:
 `disabled` resolves to one shared style regardless of palette/size/variant, so
 capture it once in a dedicated `Disabled` story, not multiplied through the grid.
-(`:hover` and `:active`/pressed can't be captured statically - see "What Gets
-Captured".)
+(Hover and pressed can't be forced from a play at all, so they're not matrix
+axes either - see "What Gets Captured".)
 
 **Span the full supported range, not a dev subset** - a trimmed or commented-out
 axis (three sizes when the component has five) leaves those cells covered by
@@ -398,73 +435,53 @@ export const SmokeTest: Story = {
 The **visual snapshot role**. Snapshots are **opt-in**: `preview.tsx` defaults to
 `disableSnapshot: true`; a story opts in with `disableSnapshot: false` + `tags:
 ["vrt"]`. Chromatic reads only `disableSnapshot`; `vrt` is just a label so tooling
-can find snapshot stories. Full rationale, CI details, and the hover/pressed gap
-live in docs/chromatic-visual-testing.md.
+can find snapshot stories. Crop padding is global (a `preview.tsx` decorator wraps
+non-`fullscreen` stories in `1rem`), so focus rings aren't clipped.
 
-- **Enumerate surfaces from source, never memory** - every painting selector,
-  `variant`/`size` key, conditional prop, and ambient axis (RTL/locale/theme);
-  snapshot the cross-product, then diff against sibling components' story sets. A
-  comma-separated selector list is one surface **per child type it names** - render
-  each, or that half is baselined nowhere.
-- **Cover every state that changes pixels**, economically: interacting axes fold into
-  one `SmokeTest`, each state it can't hold gets its own story. Never drop a state to
-  save cost.
-- **Leave snapshots off** for behavior-only stories and any look `SmokeTest` already
-  holds. Verify per component.
-- **One state, multiple distinct surfaces → one story each**, not a gallery
-  (MoneyInput's dropdown vs label mode). `chromatic.modes` is global config only
-  (viewport/theme/locale), never prop-driven.
-- **A state with no distinct recipe surface gets no story** - read-only is the
-  component-dependent trap.
-- **`*Field` patterns snapshot the composition** - composed resting + composed error;
-  layout/`size`, InfoButton, disabled/read-only and input-painted surfaces delegate.
-  Check `FormField.Input`'s `cloneElement(child, inputProps)` before deciding a state
-  isn't forwarded.
-- **A composition pattern snapshots what it hardcodes**, not what children paint or
-  consumers pass.
-- **Inherited tokens make cross-cells** - a child with no `colorPalette` takes its
-  host's; one frame per host.
-- **A play's end state never justifies skipping a snapshot** - fix the play. A
-  snapshotted story ending focused needs `blur()`.
-- **A compound component's unit is the recipe rule, not the realistic composition** -
-  slot presence only counts where a rule keys off it (`:has()`). Name the rule the
-  frame alone fires; "it's a realistic page" means documentation, not a snapshot.
-- **A state inert in the default frame** - snapshot the condition that fires it. Sticky
-  needs a scroll in the play (bounded `overflow: auto` ancestor, `offsetHeight`-derived
-  target, each combination its own frame); `scrollBehavior="inside"` needs overflowing
-  content; a surface a variant zeroes needs the variant that paints it (a showcase left
-  at that default baselines blank boxes while reading as coverage); an inherited
-  property needs a consumer value to inherit. Ask what in the frame makes the rule
-  fire - if nothing does, the baseline is recording the state **off**.
-- **Primitives that paint no surface get no VRT** - pass-through style props, a recipe
-  that paints nothing (Group), or headless `display: contents` (Region). Leave a
-  one-line note on `meta`. One that does paint gets a normal audit.
-- **A step name is a promise** - raise the assertion to meet it, don't rename down.
-  Watch for tautologies and un-`await`ed helpers.
-- **Snapshot the component, not the harness** - no debug read-outs or demo wrappers in
-  the frame. Exception: **load-bearing, static** scaffolding - a bounded scroll port
-  `height: 100%`/sticky needs to resolve, or visible children for a component that
-  paints nothing itself.
-- **Determinism** - no live dates or random values, await async-derived state, no stray
-  focus ring, hide the caret in a `Focused` text-input story. `:hover` and pressed
-  aren't capturable yet.
-- **Name the interacting-axes matrix `SmokeTest`, render it last**; the axis list goes
-  in the doc comment, not the name.
-- **Animated components: pin only when the paused frame hides the target** - the trap
-  is an infinite animation whose endpoints both park content off-screen.
-- **The snapshot is the play's end state** - land on the target frame; a play that
-  resets to default loses it.
-- **Portals** - capture is page-wide, so hold the content open, await it, and clean up
-  between stories. Reach portal focus via its real keyboard path.
-- **Overlays: snapshot the open state**, one story per distinct open surface;
-  open/close and dismissal stay behavioral.
-- **Snapshot `placement` only when it changes the layout** - Drawer each, Dialog center
-  only, Menu/Tooltip behavioral.
+Four questions decide every snapshot call:
+
+1. **Does it paint?** Is there a component-owned pixel at all.
+2. **Is the state reachable in this frame?** Inert props, zeroing variants,
+   inherited values with nothing to inherit, hover/pressed.
+3. **Who owns the pixels?** Delegation to children, consumers, thin wrappers,
+   composition patterns.
+4. **Does the play land the frame?** End state, blur, settled animation,
+   determinism.
+
+Then pack what survives into as few frames as the axes allow.
+
+**The rules themselves live in `docs/file-type-guidelines/stories.md`** (its
+"Chromatic Visual Regression Snapshots" section) - terse rules plus paste-ready
+snippets, already loaded by Required Research. This skill's **Chromatic
+Snapshots** validation checklist repeats them as checkboxes under the same five
+headings, and is what you tick off when validating.
+
+**Escalate to `docs/chromatic-visual-testing.md` only when a rule doesn't settle
+the case.** Do not load it by default: it is ~5k tokens of rationale and worked
+examples, and adds nothing for mechanical authoring. Read it when you hit one of
+these, because each is a call the terse rule states but cannot decide for you:
+
+- **Does this state paint differently from the default?** Read-only is the
+  classic - the answer is component-dependent (MoneyInput yes, TextInput no).
+- **Do these two axes interact, or are they independent?** Decides `SmokeTest`
+  matrix vs. separate showcase stories.
+- **A recipe variant that zeroes the surface**, or an inherited property with
+  nothing to inherit - the state is inert in the default frame.
+- **One rule with a comma-separated selector list** - how many frames it needs.
+- **A compound component with optional slots** - which arrangements are genuine
+  surfaces rather than the same slots rearranged.
+- **A focus ring possibly styled on a slot that never receives focus.**
+- Any **"renders like default"** verdict you are about to write without having
+  named the exact delta you checked.
+
+Rule of thumb: **auditing** a component's coverage for the first time → read it.
+**Authoring** a story into an already-audited component, or fixing a play → don't.
 
 **When a VRT pattern changes, sync all three canonical docs at their set depth** -
-rationale and examples in `docs/chromatic-visual-testing.md` only;
-`docs/file-type-guidelines/stories.md` gets the terse rule + snippet; this file gets
-the bullet + checklist item. Don't restate reasoning in more than one, or they drift.
+rationale and worked examples in `docs/chromatic-visual-testing.md`;
+`docs/file-type-guidelines/stories.md` gets the terse rule + snippet; this file
+gets the checklist item, under the matching numbered heading. One statement per
+depth - don't restate a rule at two depths, or they drift.
 
 ### Step 3: Portal Content Handling
 
@@ -760,95 +777,113 @@ You MUST validate against these requirements:
 
 #### Chromatic Snapshots
 
-- [ ] Surfaces enumerated from the **recipe + component source** (selectors,
-      variant/size keys, conditional props), and snapshots cover their
-      **cross-product** - not recalled from memory
-- [ ] `SmokeTest` matrix is **exhaustive** over the interacting axes the
-      component has (e.g. size x variant x palette, plus selected/unselected for
-      toggles) - every distinct combined look appears in the one snapshot
-- [ ] Axis arrays span the **full supported range** - no trimmed or
-      commented-out values; palettes use the 6 `SEMANTIC_COLOR_PALETTES`
-- [ ] Axes the recipe **hardcodes** are dropped from the grid (a pinned
-      `colorPalette` is not a palette axis - MultilineTextInput's neutral-only
-      recipe gives `state x size x variant`)
-- [ ] Distinct **state-combinations** are covered, not just single flags
-      (selected-disabled is a separate look from unselected-disabled)
-- [ ] For each state (focus, disabled, read-only, invalid), checked whether the
-      component renders it more than one way (mode-/variant-driven); each distinct
-      surface gets its **own** snapshotted story, not a folded gallery frame
-      (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`, `DisabledState` +
-      `DisabledWithCurrencyLabel`)
+One line per check; the rule and its reasoning are in **Chromatic Snapshots: What
+Gets Captured** above.
+
+**1. Does it paint?**
+
+- [ ] Surfaces enumerated from the **recipe + component source** (painting
+      selectors, variant/size keys, conditional props, ambient RTL/locale/theme
+      axes), and snapshots cover their **cross-product** - not recalled from memory
+- [ ] Every child type a **comma-separated selector** names appears in some frame
+- [ ] Diffed against **sibling components'** story sets; each surface a peer
+      snapshots and this one doesn't is either covered or named as not applicable
+- [ ] Any "renders like default" verdict **names the exact delta** checked
 - [ ] A state with **no distinct recipe surface** gets no dedicated story
-      (read-only with no `data-readonly` rule renders like default - no snapshot)
-- [ ] A child inheriting `colorPalette` from its host is snapshotted per host
-- [ ] A composition pattern snapshots what it hardcodes, not what children paint or
-      consumers pass
-- [ ] A `*Field` pattern has exactly **two** snapshots, with every delegation named
-- [ ] No `No` verdict rests on the play's end state; snapshotted stories that end
-      focused call `blur()`
-- [ ] No `No` verdict rests on an assertion that tests **state instead of pixels** -
-      `aria-*` values, callback arguments and attributes prove the state, not the
-      rendered layout, so they can't be why a visual goes uncaptured
+      (read-only with no `data-readonly` rule renders like default)
 - [ ] **Primitives that paint no surface** get **no VRT at all**, with a one-line
       note on `meta` - pass-through style props, a recipe that paints nothing
-      (Group), or headless `display: contents` (Region). Check whether the recipe
+      (Group), headless `display: contents` (Region). Check whether the recipe
       **paints**, not whether it exists (Separator and Icon get normal audits)
-- [ ] Every `step()` name matches what it asserts; where it overstated, the
-      **assertion was raised to the name** (not the name lowered). No tautological
-      assertions, no un-`await`ed async helpers
-- [ ] Snapshotted stories render the component **directly** - no debug read-outs,
-      value dumps, or demo-wrapper scaffolding in the frame (those stay on the
-      un-snapshotted behavioral stories). **Load-bearing, static** scaffolding is
-      admissible and named as such (a bounded scroll port; visible children for a
-      component that paints nothing)
-- [ ] For a **compound component with optional slots**, each frame names the recipe
-      rule it alone fires (typically a `:has()` selector); plausible-but-duplicate
-      compositions stay off-snapshot with a pointer to the frame that holds them
-- [ ] **Condition-triggered** states get a frame where the trigger actually holds -
-      at rest they are identical to their absence. Sticky scrolled in the play
-      (bounded `overflow: auto` ancestor, `offsetHeight`-derived target, each
-      combination its own frame); `scrollBehavior="inside"` given overflowing content
-- [ ] Uniform, axis-independent states are captured in a **dedicated** story,
-      not folded into the matrix (`disabled` typically resolves to one shared
-      style regardless of size/variant/palette → its own `Disabled` snapshot, not
-      a grid dimension)
-- [ ] Thin wrappers snapshot only the axis they introduce (+ `Focused`/`Disabled`
-      if added), not a re-rendered copy of the wrapped component's matrix
+
+**2. Is the state reachable in this frame?**
+
+- [ ] **Condition-triggered** states get a frame where the trigger actually holds:
+      sticky scrolled in the play (bounded `overflow: auto` ancestor,
+      `offsetHeight`-derived target, each combination its own frame),
+      `scrollBehavior="inside"` given overflowing content, a variant-zeroed surface
+      pinned to the variant that paints it, an inherited property given a value to
+      inherit
 - [ ] A **separate `Focused` story per independent focus surface** (fused/adjacent
-      controls, or multiple `_focusWithin` regions) - not just the primary, and
-      not one story tabbing through all (only one element holds focus per
-      snapshot, so one story can't capture two rings). Each opts in
-      (`disableSnapshot: false` + `vrt`)
-- [ ] Text-entry `Focused` plays hide the caret
-      (`canvasElement.style.caretColor = "transparent"`) before tabbing
-- [ ] Only behavior-only stories and stories whose look is already in `SmokeTest`
-      left snapshot-off (project default) - never drop a visual state to save cost
-- [ ] Each snapshotted story's **play ends in the state the snapshot is named
-      for** - no stray focus ring, no cleared/mutated value, no left-open overlay
-      unless intended. Chromatic captures the play's final state and nothing
-      blurs it, so a play can be assertion-honest yet still snapshot the wrong
-      picture (blur, reset, or split the story)
-- [ ] No play added **for completeness** - each one is there because the story's
-      name makes a behavioral claim or its frame needs an interaction to exist; a
-      resting visual props alone produce is covered by the snapshot + a11y check
-- [ ] A story left focused by `userEvent.click` is blurred - React Aria keeps
-      `data-focus-visible` set after a synthetic click, so the ring lands in the
-      capture even though a real mouse click wouldn't paint it
-- [ ] The interacting-axes matrix is named **`SmokeTest`** and rendered **last**
-      (not `Variants`/`VariantsAndSizes`/etc.); the axis list lives in the doc
-      comment
-- [ ] **Animated** states: paused frame confirmed to show the target; if an
-      infinite animation's endpoints both hide it (indeterminate progress), the
-      play **pins** a representative frame (`animation: none` + explicit
-      `transform`)
+      controls, or multiple `_focusWithin` regions) - not one story tabbing through
+      all, since only one element holds focus per snapshot. Each opts in
+- [ ] The focus **ring is confirmed to render** before opting in - not styled on a
+      slot that never gets the focus state (DropZone)
+- [ ] **Overlays** snapshot the **open** state (rendered open, left open); each
+      distinct open surface is its own story; open/close & dismissal stay behavioral
 - [ ] **Portal** components (Toast/overlays): transient UI held open
       (`duration: Infinity`), awaited, and cleaned up between stories; the
       component's own focus reached via its **real keyboard path**, not `.focus()`
-- [ ] **Overlays** snapshot the **open** state (rendered open, left open); each
-      distinct open surface is its own story; open/close & dismissal stay behavioral
 - [ ] **`placement`** snapshotted only when it changes the **layout** (Drawer
       side/top/bottom panels), not a mere reposition (Dialog = center only;
       Menu/Tooltip RA-positioning = behavioral)
+- [ ] No hand-rolled **hover/pressed** capture - a play can't force the
+      pseudo-class, and setting `[data-hovered]`/`[data-pressed]` by hand
+      half-styles the frame (recipes are split with Chakra `_hover`/`_active`).
+      Pressed is not categorically a no-op - the recipe was checked. Everything
+      else a play can drive is snapshotted settled
+
+**3. Who owns the pixels?**
+
+- [ ] Snapshotted stories render the component **directly** - no debug read-outs,
+      value dumps, or demo-wrapper scaffolding in the frame. **Load-bearing,
+      static** scaffolding is admissible and named as such
+- [ ] **Thin wrappers** snapshot only the axis they introduce (+ `Focused`/`Disabled`
+      if added), not a re-rendered copy of the wrapped component's matrix
+- [ ] A **composition pattern** snapshots what it hardcodes, not what children paint
+      or consumers pass
+- [ ] A **`*Field` pattern** has exactly **two** snapshots, with every delegation
+      named; `FormField.Input`'s `cloneElement` checked before calling a state
+      un-forwarded
+- [ ] For a **compound component with optional slots**, each frame names the recipe
+      rule it alone fires (typically a `:has()` selector); plausible-but-duplicate
+      compositions stay off-snapshot with a pointer to the frame that holds them
+- [ ] A child **inheriting `colorPalette`** from its host is snapshotted per host
+
+**4. Does the play land the frame?**
+
+- [ ] Each snapshotted story's **play ends in the state the snapshot is named for** -
+      no stray focus ring, cleared/mutated value, or left-open overlay unless
+      intended. A play can be assertion-honest yet snapshot the wrong picture
+- [ ] A story left focused by **`userEvent.click`** is blurred - React Aria keeps
+      `data-focus-visible` set after a synthetic click
+- [ ] No `No` verdict rests on the play's **end state**; snapshotted stories that end
+      focused call `blur()`
+- [ ] No `No` verdict rests on an assertion that tests **state instead of pixels** -
+      `aria-*` values, callback arguments and attributes prove the state, not the
+      rendered layout
+- [ ] Every `step()` name matches what it asserts; where it overstated, the
+      **assertion was raised to the name** (not the name lowered). No tautological
+      assertions, no un-`await`ed async helpers
+- [ ] No play added **for completeness** - each is there because the story's name
+      makes a behavioral claim or its frame needs an interaction to exist
+- [ ] Text-entry `Focused` plays hide the caret
+      (`canvasElement.style.caretColor = "transparent"`) before tabbing
+- [ ] **Determinism**: dates pinned to a fixed anchor (live "today" stays
+      off-snapshot), no random values, async-derived state awaited
+- [ ] **Animated** states: paused frame confirmed to show the target; if an infinite
+      animation's endpoints both hide it (indeterminate progress), the play **pins** a
+      representative frame (`animation: none` + explicit `transform`)
+
+**5. Packing the surfaces into frames**
+
+- [ ] `SmokeTest` matrix is **exhaustive** over the interacting axes the component
+      has (e.g. size x variant x palette, plus selected/unselected for toggles)
+- [ ] Axis arrays span the **full supported range** - no trimmed or commented-out
+      values; palettes use the 6 `SEMANTIC_COLOR_PALETTES`
+- [ ] Axes the recipe **hardcodes** are dropped from the grid (MultilineTextInput's
+      neutral-only recipe gives `state x size x variant`)
+- [ ] **Uniform, axis-independent** states are captured in a **dedicated** story, not
+      folded into the matrix (`disabled` → its own `Disabled` snapshot)
+- [ ] Distinct **state-combinations** are covered, not just single flags
+      (selected-disabled is a separate look from unselected-disabled)
+- [ ] Each state checked for being rendered **more than one way** (mode-/variant-
+      driven); each distinct surface gets its **own** story, not a folded gallery
+      (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`)
+- [ ] The interacting-axes matrix is named **`SmokeTest`** and rendered **last** (not
+      `Variants`/`VariantsAndSizes`); the axis list lives in the doc comment
+- [ ] Only behavior-only stories and stories whose look is already in `SmokeTest` left
+      snapshot-off (project default) - never drop a visual state to save cost
 
 #### Play Functions (CRITICAL)
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,7 +1,7 @@
 name: Chromatic
 
 # Visual regression testing. Runbook (triggers, baselines, gating, the manual
-# button): docs/chromatic-visual-testing.md
+# button): docs/chromatic-ci.md
 on:
   # Manual full build: TurboSnap off, gate bypassed. See runbook "The manual button".
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,11 +500,11 @@ The testing system uses Vitest with three distinct test categories:
 See [Testing Strategy Guide](./docs/file-type-guidelines/testing-strategy.md)
 for detailed rules and examples.
 
-Visual regression is handled separately by Chromatic in CI. See
-[Chromatic CI Runbook](./docs/chromatic-ci.md) for triggers, baselines, the
-manual full-snapshot run, and merge gating, and
-[Chromatic Visual Regression: Authoring Stories](./docs/chromatic-visual-testing.md)
-for which stories to snapshot and why.
+Visual regression is handled separately by Chromatic in CI. Which stories get
+snapshotted and why is in
+[Chromatic Visual Regression: Authoring Stories](./docs/chromatic-visual-testing.md);
+triggers, baselines, the manual full-snapshot run and merge gating are in the
+[Chromatic CI Runbook](./docs/chromatic-ci.md).
 
 ### Git Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,8 +501,10 @@ See [Testing Strategy Guide](./docs/file-type-guidelines/testing-strategy.md)
 for detailed rules and examples.
 
 Visual regression is handled separately by Chromatic in CI. See
-[Chromatic Visual Testing](./docs/chromatic-visual-testing.md) for triggers,
-baselines, the manual full-snapshot run, and merge gating.
+[Chromatic CI Runbook](./docs/chromatic-ci.md) for triggers, baselines, the
+manual full-snapshot run, and merge gating, and
+[Chromatic Visual Regression: Authoring Stories](./docs/chromatic-visual-testing.md)
+for which stories to snapshot and why.
 
 ### Git Conventions
 

--- a/docs/chromatic-ci.md
+++ b/docs/chromatic-ci.md
@@ -1,0 +1,221 @@
+# Chromatic CI Runbook
+
+Nimbus runs [Chromatic](https://www.chromatic.com/) to catch unintended visual
+changes in components. It builds Storybook, uploads it to Chromatic, and
+snapshots each story in a consistent cloud browser, then diffs those snapshots
+against a stored baseline. The workflow lives in
+[`.github/workflows/chromatic.yml`](../.github/workflows/chromatic.yml).
+
+This doc is the CI runbook: how runs are triggered, how baselines work, when to
+click the manual button, and what does (and doesn't) block a merge. The YAML
+comments stay intentionally thin and point here.
+
+> **Authoring or auditing stories?** You want
+> [`chromatic-visual-testing.md`](./chromatic-visual-testing.md) instead - which
+> stories to snapshot and why. Nothing on this page changes how you write one.
+
+## How a run is decided
+
+```mermaid
+flowchart TD
+    A[Trigger:<br/>push to main / PR event] --> B{PR and draft?}
+    B -->|yes| S[Skip job entirely]
+    B -->|no| C{UI-affecting files changed?}
+    M[workflow_dispatch<br/>manual button] --> D
+    C -->|no| N["Notice: no UI changes,<br/>skip build + Chromatic"]
+    C -->|yes| D[Install deps + build Storybook]
+    D --> R[Run Chromatic]
+    R --> E{workflow_dispatch?}
+    E -->|yes| F[TurboSnap OFF:<br/>snapshot every story]
+    E -->|no| G[TurboSnap ON:<br/>only changed stories]
+    F --> H[Diff against existing baseline]
+    G --> H
+    H --> I["GHA job check 'Chromatic / chromatic':<br/>exitOnceUploaded returns at upload (before diffing), stays GREEN"]
+    H --> K["Chromatic's own 'UI Tests' check, posted async:<br/>still reports the diff (can go red)"]
+
+    style S fill:#9e9e9e,color:#fff
+    style N fill:#9e9e9e,color:#fff
+    style H fill:#1565C0,color:#fff
+```
+
+## When it runs
+
+Triggers (the `on:` block):
+
+- **`push` to `main`** - runs Chromatic on `main`'s history, the source of the
+  baseline other branches inherit. A push builds and diffs; the baseline
+  advances only on acceptance (see
+  [Baselines and acceptance](#baselines-and-acceptance)).
+- **`pull_request`** (`opened`, `synchronize`, `reopened`, `ready_for_review`) -
+  `synchronize` is the workhorse (fires on every new commit pushed to the PR).
+  `ready_for_review` matters because draft PRs are skipped, so it's what fires
+  the first run when a draft is marked ready.
+- **`workflow_dispatch`** - the manual "Run workflow" button. See
+  [The manual button](#the-manual-button).
+
+Two filters decide whether the job actually does work:
+
+1. **Draft skip** (job-level `if:`) - draft PRs are skipped; pushes and manual
+   runs always proceed.
+2. **Changed-files gate** - Chromatic only builds when files that affect
+   rendered output changed.
+
+### The changed-files gate
+
+The gate watches the paths whose contents feed rendered output:
+
+| Path                       | Why it's watched                                                 |
+| -------------------------- | ---------------------------------------------------------------- |
+| `packages/nimbus/**`       | Component source + Storybook globals (`preview.tsx`, decorators) |
+| `packages/tokens/**`       | Design tokens (colors, spacing, type)                            |
+| `packages/nimbus-icons/**` | Icons rendered inside components                                 |
+| `pnpm-lock.yaml`           | Dependency version changes that can shift rendered output        |
+
+`color-tokens` and `design-token-ts-plugin` are deliberately **not** watched:
+`color-tokens` isn't consumed by any rendered package, and the TS plugin is
+editor-only autocomplete tooling. Neither changes rendered pixels.
+
+Two files inside the watched packages are ignored because they don't change how
+components look: `chromatic.config.json` and `.storybook/main.ts`.
+
+The changesets **"Version Packages" release PR** (`changeset-release/main`) is a
+special case: its only diff is version bumps and `CHANGELOG.md` under
+`packages/nimbus/**`, which would open the gate for zero rendered-output change.
+It's routed to the skip-path instead (build + Chromatic steps carry
+`github.head_ref != 'changeset-release/main'`), posting a passing `UI Tests`
+status without building - so it stays unblocked if `UI Tests` becomes required
+(see [Merge gating](#merge-gating)). The release commit still gets a real build
+on the `push` to `main`.
+
+**What the gate diffs depends on the event** (`since_last_remote_commit` is
+`${{ github.event_name == 'push' }}`): `push` compares only the newest commit,
+`pull_request` compares the whole PR (`base...head`).
+
+That PR behavior matters. Diffing only the newest commit would let a PR that
+touched `button.tsx` first and `README.md` last **skip** Chromatic on the final
+push, leaving the head with no build.
+
+## TurboSnap
+
+TurboSnap (`onlyChanged`) snapshots only the stories affected by the git diff,
+traced through the module graph. This keeps normal PR runs fast and cheap.
+
+Two things defeat it, both by design:
+
+- **Storybook config files.** `preview.tsx` and other `.storybook/` globals are
+  injected at the document level, so no story imports them and Chromatic can't
+  link them to specific stories. Any change disables TurboSnap for that build.
+  Batch such edits into one commit so only one full build fires.
+- **Dependency bumps.** The gate watches `pnpm-lock.yaml`, and a lockfile change
+  can't be traced to specific stories. That's the safe scope anyway - a React
+  Aria or Chakra bump can shift pixels anywhere. Grouped Dependabot PRs keep
+  this to a handful of full builds rather than one per package.
+
+## Baselines and acceptance
+
+A baseline isn't a build you designate - it's **the last accepted snapshot on
+the branch's git ancestry**:
+
+- Every build **diffs against** the existing baseline; running doesn't make it
+  the new one.
+- A baseline **moves only on acceptance** in the dashboard. Accepting on a
+  branch makes that snapshot what its descendants inherit, so accepting on a PR
+  branch (or on `main`) is what future branches pick up after merge.
+- **Merging does not auto-accept.** No `autoAcceptChanges` is set, so a diff
+  that lands on `main` unaccepted keeps resurfacing on every later build until a
+  human accepts it. (`exitZeroOnChanges` only affects the CLI exit code, and
+  isn't set either.)
+
+## The manual button
+
+`workflow_dispatch` (the "Run workflow" button in the Actions tab) forces a
+**full** Chromatic build:
+
+- Turns TurboSnap **off** (`onlyChanged: false`), so **every** story is
+  snapshotted, not just changed ones.
+- Bypasses the changed-files gate, so it runs even with no UI diff.
+
+Reach for it to:
+
+- **Re-seed a baseline** - run a full snapshot, then accept the snapshots in
+  Chromatic. The button alone does not reset the baseline; acceptance is what
+  establishes it. Run it on `main` to re-seed the baseline everyone inherits;
+  run it on a feature branch and it only diffs against that branch's baseline.
+- **Cover a TurboSnap gap** - force a full snapshot when you suspect its
+  diff-tracing missed an affected story.
+
+You can also run Chromatic locally
+(`pnpm --filter @commercetools/nimbus chromatic`), but it needs
+`CHROMATIC_PROJECT_TOKEN` set locally plus `--no-only-changed` to force the full
+snapshot, so the button is usually the easier path.
+
+### Config lives in two places (by design)
+
+`packages/nimbus/chromatic.config.json` (`storybookBaseDir`, `buildScriptName`,
+`zip`) drives **local** runs from inside `packages/nimbus`. The **CI** action
+runs at the repo root and does not load that config, so the workflow mirrors the
+values as `with:` inputs. `storybookBaseDir` and `zip` are identical - **keep
+them in sync**. `buildScriptName` differs by design: CI resolves it at the root
+(`build:storybook`), the config file inside `packages/nimbus`
+(`build-storybook`).
+
+## Two checks on the PR (read this before merge gating)
+
+A PR shows **two distinct Chromatic rows**, and they mean different things.
+Conflating them is the most common source of confusion:
+
+| Check on the PR                        | What it is                                                                                         | What controls its color                                                                                                                                            |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Chromatic / chromatic (pull_request)` | The **GHA job** in this workflow                                                                   | The action's exit code. With `exitOnceUploaded: true` the job returns at upload - _before_ diffing - so it's **green whenever the upload succeeds**, diffs or not. |
+| `UI Tests` (orange Chromatic icon)     | A status check **posted by Chromatic's servers**, asynchronously (the `exitOnceUploaded` behavior) | Chromatic's own verdict. It **still reports the diff** and goes red on an unaccepted diff, independent of the GHA job.                                             |
+
+So "the check stays green" refers **only** to the GHA job row:
+`exitOnceUploaded: true` makes the action exit before Chromatic diffs.
+(`exitZeroOnChanges` is **not** set; it would only matter if we dropped
+`exitOnceUploaded`.)
+
+That row answers **"did the job run without breaking?"**, not "are there visual
+changes?" Genuine breakage still turns it red: Storybook fails to build,
+dependency install / `./.github/actions/ci` fails, `chromaui/action` errors
+(missing or invalid `CHROMATIC_PROJECT_TOKEN`, upload/network/API failure), or a
+malformed workflow. It can also show **cancelled** when
+`concurrency: cancel-in-progress` supersedes the run with a newer push, or on
+timeout.
+
+## Merge gating
+
+**Current state: `UI Tests` reports on every PR but is not a required check, so
+nothing Chromatic-related blocks a merge.** Branch protection on `main` requires
+only `build-and-test` (confirmed against both classic protection and rulesets);
+merges are gated today only by review approval.
+
+Two workflow pieces already make `UI Tests` a reliable gate candidate:
+
+- **`exitZeroOnChanges` is not set**, so diffs surface on the async `UI Tests`
+  check while the GHA job stays green via `exitOnceUploaded: true`. Genuine
+  build failures still turn the GHA job red.
+- **The skip path posts its own `UI Tests` status.** With no UI changes
+  Chromatic never runs and never posts `UI Tests`, and a required check that
+  never reports blocks the PR forever ("Expected - waiting for status to be
+  reported") - which would wedge every docs-only PR. So the "No UI changes
+  detected" step posts a passing `UI Tests` (context must match Chromatic's
+  exactly) on the PR head SHA. Net: always reported, never stuck.
+
+### Turning gating on
+
+One switch remains: add **`UI Tests`** to the required status checks on `main`
+(Settings -> Branches, or a ruleset). Point branch protection at the async
+`UI Tests` check, **not** the `Chromatic / chromatic` GHA job - that one goes
+green at upload, before the verdict exists, so requiring it would let a PR merge
+before Chromatic finishes diffing.
+
+Caveats:
+
+- **Coverage is opt-in.** Only stories with `disableSnapshot: false` snapshot,
+  so a regression in an un-instrumented component won't block anything until its
+  stories opt in.
+- **Admins bypass.** `enforce_admins` is off, so an admin can still merge past a
+  red `UI Tests`.
+- **Context-name coupling.** The skip-path status hardcodes the `UI Tests`
+  context to match Chromatic's. If that name changes, update both the workflow
+  step and the required-check config.

--- a/docs/chromatic-ci.md
+++ b/docs/chromatic-ci.md
@@ -123,8 +123,8 @@ the branch's git ancestry**:
   branch (or on `main`) is what future branches pick up after merge.
 - **Merging does not auto-accept.** No `autoAcceptChanges` is set, so a diff
   that lands on `main` unaccepted keeps resurfacing on every later build until a
-  human accepts it. (`exitZeroOnChanges` only affects the CLI exit code, and
-  isn't set either.)
+  human accepts it. (`exitZeroOnChanges` only affects the CLI exit code, and the
+  workflow doesn't set it either - though the local `chromatic` script does.)
 
 ## The manual button
 
@@ -146,18 +146,21 @@ Reach for it to:
 
 You can also run Chromatic locally
 (`pnpm --filter @commercetools/nimbus chromatic`), but it needs
-`CHROMATIC_PROJECT_TOKEN` set locally plus `--no-only-changed` to force the full
-snapshot, so the button is usually the easier path.
+`CHROMATIC_PROJECT_TOKEN` set locally, and two behaviors differ from CI: the
+config file sets `onlyChanged: true`, so pass `--no-only-changed` to force the
+full snapshot, and the script itself passes `--exit-zero-on-changes`, so a local
+run reports diffs without failing. The button is usually the easier path.
 
 ### Config lives in two places (by design)
 
 `packages/nimbus/chromatic.config.json` (`storybookBaseDir`, `buildScriptName`,
-`zip`) drives **local** runs from inside `packages/nimbus`. The **CI** action
-runs at the repo root and does not load that config, so the workflow mirrors the
-values as `with:` inputs. `storybookBaseDir` and `zip` are identical - **keep
-them in sync**. `buildScriptName` differs by design: CI resolves it at the root
-(`build:storybook`), the config file inside `packages/nimbus`
-(`build-storybook`).
+`onlyChanged`, `zip`) drives **local** runs from inside `packages/nimbus`. The
+**CI** action runs at the repo root and does not load that config, so the
+workflow mirrors the values as `with:` inputs. `storybookBaseDir` and `zip` are
+identical - **keep them in sync**. Two differ by design: `buildScriptName` (CI
+resolves it at the root, `build:storybook`; the config file inside
+`packages/nimbus`, `build-storybook`) and `onlyChanged` (pinned `true` in the
+config, but expression-driven in CI so the manual button can turn it off).
 
 ## Two checks on the PR (read this before merge gating)
 

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -1,574 +1,369 @@
-# Chromatic Visual Regression Testing
+# Chromatic Visual Regression: Authoring Stories
 
-Nimbus runs [Chromatic](https://www.chromatic.com/) to catch unintended visual
-changes in components. It builds Storybook, uploads it to Chromatic, and
-snapshots each story in a consistent cloud browser, then diffs those snapshots
-against a stored baseline. The workflow lives in
-[`.github/workflows/chromatic.yml`](../.github/workflows/chromatic.yml).
+Which stories get snapshotted, and why. Nimbus runs
+[Chromatic](https://www.chromatic.com/) over Storybook, capturing each opted-in
+story in a consistent cloud browser and diffing it against a stored baseline -
+so a story is a visual test, and this doc is how you decide what it should
+capture.
 
-This doc is the runbook: how runs are triggered, how baselines work, when to
-click the manual button, and what does (and doesn't) block a merge. The YAML
-comments stay intentionally thin and point here.
+This is the _why_ behind the two rule-docs that sit closer to the code: the
+Chromatic section of [`stories.md`](./file-type-guidelines/stories.md) (terse
+rules plus paste-ready snippets) and the
+[`writing-stories` skill](../.claude/skills/writing-stories/SKILL.md) (templates
+plus a validation checklist). All three group their rules under the same five
+headings used below.
 
-> **Authoring or auditing stories?** Read the per-story mechanics first: the
-> Chromatic section of [`stories.md`](./file-type-guidelines/stories.md) and the
-> [`writing-stories` skill](../.claude/skills/writing-stories/SKILL.md). This
-> doc is the _why_ behind them.
+> **Looking for CI?** Triggers, the changed-files gate, TurboSnap, baselines and
+> acceptance, the two PR checks, and merge gating live in
+> [`chromatic-ci.md`](./chromatic-ci.md).
 
-## How a run is decided
+Four questions decide every snapshot call, and nearly every rule below is an
+instance of one:
 
-```mermaid
-flowchart TD
-    A[Trigger:<br/>push to main / PR event] --> B{PR and draft?}
-    B -->|yes| S[Skip job entirely]
-    B -->|no| C{UI-affecting files changed?}
-    M[workflow_dispatch<br/>manual button] --> D
-    C -->|no| N["Notice: no UI changes,<br/>skip build + Chromatic"]
-    C -->|yes| D[Install deps + build Storybook]
-    D --> R[Run Chromatic]
-    R --> E{workflow_dispatch?}
-    E -->|yes| F[TurboSnap OFF:<br/>snapshot every story]
-    E -->|no| G[TurboSnap ON:<br/>only changed stories]
-    F --> H[Diff against existing baseline]
-    G --> H
-    H --> I["GHA job check 'Chromatic / chromatic':<br/>exitOnceUploaded returns at upload (before diffing), stays GREEN"]
-    H --> K["Chromatic's own 'UI Tests' check, posted async:<br/>still reports the diff (can go red)"]
+1. **Does it paint?** Is there a component-owned pixel at all.
+2. **Is the state reachable in this frame?** Inert props, zeroing variants,
+   inherited values with nothing to inherit, hover/pressed.
+3. **Who owns the pixels?** Delegation to children, consumers, thin wrappers,
+   composition patterns.
+4. **Does the play land the frame?** End state, blur, settled animation,
+   determinism.
 
-    style S fill:#9e9e9e,color:#fff
-    style N fill:#9e9e9e,color:#fff
-    style H fill:#1565C0,color:#fff
+Work them in order, then
+[pack what survives](#5-packing-the-surfaces-into-frames) into as few frames as
+the axes allow.
+
+## How the mechanism works
+
+**Snapshots are opt-in, at three levels.** `chromatic.disableSnapshot` is
+settable at story, component and project level - our layering is
+`disableSnapshot: true` as the project default in `preview.tsx`, overridden to
+`false` on the VRT stories. Chromatic's docs recommend disabling for
+interaction-focused tests to "prevent false positives," which is why `WithRef`
+and Button's context/DOM-filtering stories stay off.
+
+**Crop padding is global, not per story.** Chromatic crops each snapshot to the
+story's rendered content, so a ring painted outside layout (box-shadow, CSS
+outline) clips at the crop edge when content sits flush against it - body or
+`layout: "padded"` padding sits outside the crop and can't reach in. A
+`preview.tsx` decorator wraps every non-`fullscreen` story in `1rem`, giving
+rings room inside the crop and keeping the canvas from jumping as you browse.
+`fullscreen` stories are exempt because they mean to touch the edges.
+
+**Keep barrel imports out of `preview.tsx`** - they trigger full rebuilds under
+TurboSnap.
+
+## 1. Does it paint?
+
+**Enumerate surfaces from source, not memory.** Read the recipe (every painting
+selector - `_hover`, `_focusWithin`, `_disabled`, `_active`, `data-invalid`,
+`data-readonly`, ... - and every `variant`/`size` key) and the component (every
+conditional render or prop, e.g. `isDisabled={x || isReadOnly}`). Coverage is
+the **cross-product** of recipe states × conditional branches: a read-only field
+that stays undimmed but disables its trailing button is a distinct surface even
+though the field "looks like default." Any "renders like default" call must name
+the exact delta you checked. Three things that get missed:
+
+- **Ambient axes no prop names** - RTL/`dir` (mirrored adornment layout),
+  locale, theme - and built-in adornments.
+- **A comma-separated selector list is as many surfaces as it names**, while
+  reading like one rule. Toolbar styles
+  `& .nimbus-group, & .nimbus-toggle-button-group__root` together, so a matrix
+  built from `Group` alone leaves the toggle-group half baselined nowhere; a
+  frame has to contain each child type the rule reaches.
+- **Sibling story sets.** A surface a peer snapshots and yours doesn't (e.g.
+  `RTLSupport`) is a gap until you can name why it doesn't apply.
+
+**A state that renders identically to the default gets no snapshot.** With no
+recipe rule for it, a dedicated `ReadOnly` / `Disabled` / `Invalid` story is a
+redundant baseline, not coverage. Read-only is the trap because the call is
+component-dependent: MoneyInput styles it (it disables the currency Select) and
+carries `ReadOnlyState`; MultilineTextInput / NumberInput / TextInput have no
+`data-readonly` rule and correctly carry none.
+
+**Primitives with no painted surface get no VRT at all.** The test isn't "has a
+`.recipe.ts`" - it's **does it paint, and is there a state space to enumerate?**
+Three shapes fail it, each getting zero snapshots plus a one-line `meta` note so
+the omission reads as deliberate:
+
+- **Pass-through style-prop primitives** (Box, Flex, Stack, Grid, SimpleGrid,
+  Spacer - a `<div>`, no recipe). Every appearance comes from consumer style
+  props, so a snapshot tests Chakra + tokens, not the component.
+- **A recipe that paints nothing** (Group: `inline-flex` + `alignItems`, zero
+  variants). It sets no color, border or spacing, so the pixels are the
+  children's.
+- **Headless / layout-transparent** (Region: `display: contents`). No box is
+  rendered; the stories assert _where content lands_, which is DOM containment.
+
+The inverse is the more common case: a primitive whose recipe **does** paint
+gets a normal audit - Separator's `orientation` over a `colorPalette.6` fill,
+Icon's six-value `size`.
+
+## 2. Is the state reachable in this frame?
+
+**A state can be inert in the default frame - snapshot the condition that fires
+it.** Nothing looks wrong: the prop is set, the story renders, and the baseline
+records the state _off_ while reading as coverage. Four triggers seen so far:
+
+- **Sticky.** `position: sticky` (a recipe variant in DefaultPage, an inline
+  prop on PageContent.Column) paints nothing until content passes beneath it, so
+  scroll in the play and capture pinned. Needs a **bounded scroll port**
+  (`height: 100%` resolves against nothing otherwise) and an
+  **`offsetHeight`-derived** target, so a padding-token change can't silently
+  stop it scrolling past.
+- **Overflow.** `scrollBehavior="inside"` is only `maxH` + `overflow: auto`, so
+  it wants tall content, not a scroll.
+- **A variant that zeroes the surface.** ScrollArea's default `hover` sets
+  `scrollbar { opacity: 0 }`, so a frame has to pin `always` to paint a track at
+  all - its `Sizes` showcase, left at the default, renders four empty boxes
+  while its width assertions still pass.
+- **An inherited property with nothing to inherit.** ScrollArea's viewport sets
+  `borderRadius: inherit`, inert until a consumer passes a radius, so the
+  rounded-corner clipping was baselined nowhere until the matrix cells set one.
+
+**Hover and pressed need a forced pseudo-class, which a play can't deliver.**
+`userEvent.hover` fires DOM events without recomputing the pseudo-class - a
+spike confirmed it yields neither a real CSS `:hover` nor React Aria's
+`data-hovered`, and a synthetic `pointerenter` doesn't either. The two
+conventions in our recipes fail differently: Chakra `_hover` / `_active` compile
+to CSS pseudo-classes, which page JS cannot force at all, while React Aria's
+`[data-hovered]` / `[data-pressed]` are JS-set attributes a play _could_ set by
+hand. Don't - our recipes are split across both, so forcing the attribute styles
+only part of the frame and baselines a half-hovered state, which is worse than
+no snapshot. Pressed isn't automatically a no-op either: Button sets
+`data-pressed` but styles no rule for it, while NumberInput's steppers paint
+`_active` (`bg: neutral.4`). Check the recipe.
+
+**Everything else a play _can_ drive, snapshot settled** - drag-over
+(`data-drop-target`), option focus (`data-focused`), selection
+(`aria-selected`). Only `:hover` / `:active` / `data-hovered` have no
+play-dispatchable event.
+
+**One focus snapshot per reachable focus surface.** Fused or adjacent focusable
+sub-controls, and `_focusWithin` on more than one region, need a focus story per
+target - each side's ring clears the seam differently. There is no "all focused"
+state, since only one element holds focus at a time, so the per-target stories
+are the complete set (don't add a combined-ring snapshot). **Confirm the ring
+renders first**: on a slot that never gets the focus state the snapshot captures
+nothing (DropZone: ring on the root, focus on a hidden inner element).
+
+**Overlays: snapshot the _open_ state** - `defaultOpen` (Dialog/Drawer/Menu) or
+open it in the play and await the portal - and leave it open; the entrance
+animation settles on its last frame. Each distinct open surface is its own
+story: open dialogs/drawers fill the viewport with a backdrop and can't share a
+frame, so there's no `SmokeTest` matrix (independent recipe variants become
+separate open showcases). open/close, focus trap and dismissal stay behavioral.
+
+**Portals land in the frame, so the capture is page-wide.** Hold transient UI
+open (`duration: Infinity` for toasts), await it, and clean up between stories
+(Toast's `clearToasts()`) so nothing leaks into the next capture. A portal
+component can be focusable in its own right (Toast's root has `tabIndex=0` +
+`focusRing: outside`) - reach it the real way (hotkey + Tab), not a synthetic
+`.focus()`.
+
+**Snapshot `placement` only when it changes the _layout_**, not when it merely
+repositions the same box:
+
+- **Drawer** swaps the layout (full-height side panel ↔ full-width top/bottom
+  bar) → one open snapshot each.
+- **Dialog** is a recipe variant but only shifts vertical position (an
+  `alignItems`/margin change; the same box, higher or lower) → **center only**.
+- **Menu/Tooltip** is React Aria positioning (same box repositioned, no arrow) →
+  behavioral.
+
+## 3. Who owns the pixels?
+
+**Snapshot the component, not the harness.** Anything in the render tree lands
+in the baseline, so a snapshotted story renders the component **directly** - no
+debug read-outs, value dumps or controls scaffolding. Those aids are fine on
+un-snapshotted behavioral stories (MoneyInput's `MoneyInputExample` renders a
+`JSON.stringify(value)` panel); snapshotting one bakes the read-out into the
+baseline and flaps on every value change. The line is **load-bearing and
+static**, not "is it a wrapper": a wrapper the component needs to resolve at all
+(DefaultPage's fixed-height `overflow: auto` Box), or visible children for a
+component that paints nothing (PageContent's placeholder boxes). Both are
+static; a read-out isn't.
+
+**Thin wrappers get no matrix.** A component that only constrains or forwards a
+wrapped component's props re-covers nothing by re-rendering the wrapped grid.
+FloatingActionButton wraps IconButton at a fixed circular shape, so it snapshots
+`ColorPalettes` + `Focused` + `Disabled` only - size × variant are IconButton's,
+already covered there. (Distinct from independent axes: there the axes don't
+interact; here the wrapper delegates them wholesale.)
+
+**A composition pattern owns the values it hardcodes.** Same paint-vs-forward
+test as the primitives, one level up: FormActionBar fixes the button set, order
+and palettes; PublicPageLayout fixes `gap`, `maxW`, `minHeight`. Snapshot those;
+delegate what the children paint and anything the consumer passes in.
+
+**Composed field patterns snapshot the composition, not its parts.** A `*Field`
+(`src/patterns/fields/`) has no recipe - it wraps `FormField` around an input -
+so it takes two snapshots: composed resting field, composed error state.
+Delegate layout / `direction` / `size` to FormField's `SmokeTest`, the
+InfoButton to its `OpenInfoBox`, disabled and read-only to the input
+(FormField's recipe styles neither), and every input-painted surface to that
+input's audit. Read propagation from `FormField.Input`, not the pattern's JSX:
+`cloneElement(child, inputProps)` delivers `isInvalid` / `isDisabled` /
+`isRequired` / `isReadOnly` by context, so the prop list will tell you a state
+isn't forwarded when it is.
+
+**A compound component's unit is the recipe rule, not the realistic
+composition.** With several optional slots the pull is to snapshot every
+plausible arrangement - DefaultPage's info/form/tabular × main/detail. Slot
+presence only makes a new surface where a **rule keys off it** (there, two
+`:has()` selectors); the rest is the same slots in a different grid row. Ask
+which rule the frame alone fires - "it's a realistic page" means documentation,
+not a snapshot.
+
+**An inherited token makes a cross-cell neither audit covers.** `colorPalette`
+cascades, so a child with no palette default takes its host's - FormActionBar's
+spinner strokes `primary.10` in save, `critical.10` in delete. One frame per
+host palette.
+
+## 4. Does the play land the frame?
+
+**The snapshot is the play's end state.** "Chromatic waits for the entire play
+function to execute and captures a snapshot only at the end," so IconButton's
+six-`step()` `Base` produces exactly one. Nothing blurs the element for you:
+whatever the last step leaves (a stray focus ring, a cleared value, a left-open
+overlay) is what gets captured. Separate axis from assertion-honesty - a play
+can assert exactly what its step names claim and still leave the wrong picture,
+which is how an honest-looking `ReadOnly` / `Clearable` snapshots a focused or
+emptied control. For an intermediate state, split it into its own story rather
+than expect a mid-play capture.
+
+**A play's end state is never a reason to skip a snapshot.** "Ends focused",
+"ends open", "ends cleaned up", "drifts because nothing is pinned" are work to
+do: adjust the play to land on the frame, or author one that does. Conversely a
+snapshotted story that ends focused needs `blur()`, or the ring and caret land
+in the baseline - and **a click leaves it focused**: React Aria keeps
+`data-focus-visible` set after `userEvent.click`, so a clicked trigger paints
+its ring even though a real mouse click wouldn't.
+
+**Don't add a play to a snapshotted story for completeness.** Each interaction
+is another frame to land deliberately, while a resting visual props alone
+produce is already tested by the snapshot plus the always-on a11y check. Where a
+play does belong the two aren't in tension - a story can both assert behavior
+and be snapshotted. The rule is per **component**, not per story; see
+[stories.md](./file-type-guidelines/stories.md) for which stories need one.
+
+**Hide the blinking text caret on a focused input.** Focusing paints the
+browser's native caret, which Chromatic can't stabilize (its
+[animations docs](https://www.chromatic.com/docs/animations/) cover only CSS and
+JS animations), so the snapshot diffs on whichever blink phase it lands on.
+`caret-color` inherits, so one line on the canvas cascades to the input - scoped
+to the story, not the shared `preview.tsx`:
+
+```typescript
+play: async ({ canvasElement }) => {
+  canvasElement.style.caretColor = "transparent"; // native caret can't be paused
+  await userEvent.tab();
+  // ...assert the ring
+},
 ```
 
-## When it runs
+**Animated components: know where Chromatic pauses.** It auto-pauses CSS
+transitions, CSS/SVG animations and videos (not JS animations - pause those
+manually) and seeks a **fixed** frame. The default pause point is the **last**
+frame of the cycle (`pauseAnimationAtEnd: false` switches it to the first). The
+trap is an `iteration-count: infinite` animation whose endpoints both hide the
+content: `progress-indeterminate` sweeps a 40% pill `translateX(-100% → 300%)`,
+parking it off the track at both ends, so the default snapshot is an empty
+track. **Pin a representative frame** in the play (`animation: none` + an
+explicit transform), as ProgressBar's `Indeterminate` does with
+`translateX(75%)`. A full-turn `spin` needs no pin - both endpoints render
+identically. The docs don't spell out the infinite case, so confirm the paused
+frame on the first run.
 
-Triggers (the `on:` block):
+**Pin dates; opt live ones out.** A snapshotted date story pins a fixed anchor
+(a `CalendarDate` / `CalendarDateTime` in the args or `defaultValue` /
+`defaultFocusedValue`). One rendering a live "today" drifts the baseline daily,
+so it omits `tags: ["vrt"]` and verifies its behavior with a play instead.
 
-- **`push` to `main`** - runs Chromatic on `main`'s history, the source of the
-  baseline other branches inherit. A push builds and diffs; the baseline
-  advances only on acceptance (see
-  [Baselines and acceptance](#baselines-and-acceptance)).
-- **`pull_request`** (`opened`, `synchronize`, `reopened`, `ready_for_review`) -
-  `synchronize` is the workhorse (fires on every new commit pushed to the PR).
-  `ready_for_review` matters because draft PRs are skipped, so it's what fires
-  the first run when a draft is marked ready.
-- **`workflow_dispatch`** - the manual "Run workflow" button. See
-  [The manual button](#the-manual-button).
+**Await state your component _derives_ from an image load.** Chromatic waits for
+images to load, but not for that (Avatar hides its `<img>` until `onLoad`, and
+swaps to a fallback on error). Serve images locally (`staticDirs`) to avoid a
+flaky network dependency, and wait in the play for the post-load / post-error
+state you mean to snapshot. See [stories.md](./file-type-guidelines/stories.md)
+for the pattern.
 
-Two filters decide whether the job actually does work:
+**Fonts/async loading can shift tooltips/menus** - relevant to IconButton's
+`ColorPalettes` story (it wraps each button in a `Tooltip`). Preload fonts or
+add a delay if those snapshots turn out flaky.
 
-1. **Draft skip** (job-level `if:`) - draft PRs are skipped; pushes and manual
-   runs always proceed.
-2. **Changed-files gate** - Chromatic only builds when files that affect
-   rendered output changed.
+## 5. Packing the surfaces into frames
 
-### The changed-files gate
-
-The gate watches the paths whose contents feed rendered output:
-
-| Path                       | Why it's watched                                                 |
-| -------------------------- | ---------------------------------------------------------------- |
-| `packages/nimbus/**`       | Component source + Storybook globals (`preview.tsx`, decorators) |
-| `packages/tokens/**`       | Design tokens (colors, spacing, type)                            |
-| `packages/nimbus-icons/**` | Icons rendered inside components                                 |
-| `pnpm-lock.yaml`           | Dependency version changes that can shift rendered output        |
-
-`color-tokens` and `design-token-ts-plugin` are deliberately **not** watched:
-`color-tokens` isn't consumed by any rendered package, and the TS plugin is
-editor-only autocomplete tooling. Neither changes rendered pixels.
-
-Two files inside the watched packages are ignored because they don't change how
-components look: `chromatic.config.json` and `.storybook/main.ts`.
-
-The changesets **"Version Packages" release PR** (`changeset-release/main`) is a
-special case: its only diff is version bumps and `CHANGELOG.md` under
-`packages/nimbus/**`, which would open the gate for zero rendered-output change.
-It's routed to the skip-path instead (build + Chromatic steps carry
-`github.head_ref != 'changeset-release/main'`), posting a passing `UI Tests`
-status without building - so it stays unblocked if `UI Tests` becomes required
-(see [Merge gating](#merge-gating)). The release commit still gets a real build
-on the `push` to `main`.
-
-**What the gate diffs depends on the event** (`since_last_remote_commit` is
-`${{ github.event_name == 'push' }}`): `push` compares only the newest commit,
-`pull_request` compares the whole PR (`base...head`).
-
-That PR behavior matters. Diffing only the newest commit would let a PR that
-touched `button.tsx` first and `README.md` last **skip** Chromatic on the final
-push, leaving the head with no build.
-
-## TurboSnap
-
-TurboSnap (`onlyChanged`) snapshots only the stories affected by the git diff,
-traced through the module graph. This keeps normal PR runs fast and cheap.
-
-Two things defeat it, both by design:
-
-- **Storybook config files.** `preview.tsx` and other `.storybook/` globals are
-  injected at the document level, so no story imports them and Chromatic can't
-  link them to specific stories. Any change disables TurboSnap for that build.
-  Batch such edits into one commit so only one full build fires.
-- **Dependency bumps.** The gate watches `pnpm-lock.yaml`, and a lockfile change
-  can't be traced to specific stories. That's the safe scope anyway - a React
-  Aria or Chakra bump can shift pixels anywhere. Grouped Dependabot PRs keep
-  this to a handful of full builds rather than one per package.
-
-## Baselines and acceptance
-
-A baseline isn't a build you designate - it's **the last accepted snapshot on
-the branch's git ancestry**:
-
-- Every build **diffs against** the existing baseline; running doesn't make it
-  the new one.
-- A baseline **moves only on acceptance** in the dashboard. Accepting on a
-  branch makes that snapshot what its descendants inherit, so accepting on a PR
-  branch (or on `main`) is what future branches pick up after merge.
-- **Merging does not auto-accept.** No `autoAcceptChanges` is set, so a diff
-  that lands on `main` unaccepted keeps resurfacing on every later build until a
-  human accepts it. (`exitZeroOnChanges` only affects the CLI exit code, and
-  isn't set either.)
-
-## The manual button
-
-`workflow_dispatch` (the "Run workflow" button in the Actions tab) forces a
-**full** Chromatic build:
-
-- Turns TurboSnap **off** (`onlyChanged: false`), so **every** story is
-  snapshotted, not just changed ones.
-- Bypasses the changed-files gate, so it runs even with no UI diff.
-
-Reach for it to:
-
-- **Re-seed a baseline** - run a full snapshot, then accept the snapshots in
-  Chromatic. The button alone does not reset the baseline; acceptance is what
-  establishes it. Run it on `main` to re-seed the baseline everyone inherits;
-  run it on a feature branch and it only diffs against that branch's baseline.
-- **Cover a TurboSnap gap** - force a full snapshot when you suspect its
-  diff-tracing missed an affected story.
-
-You can also run Chromatic locally
-(`pnpm --filter @commercetools/nimbus chromatic`), but it needs
-`CHROMATIC_PROJECT_TOKEN` set locally plus `--no-only-changed` to force the full
-snapshot, so the button is usually the easier path.
-
-### Config lives in two places (by design)
-
-`packages/nimbus/chromatic.config.json` (`storybookBaseDir`, `buildScriptName`,
-`zip`) drives **local** runs from inside `packages/nimbus`. The **CI** action
-runs at the repo root and does not load that config, so the workflow mirrors the
-values as `with:` inputs. `storybookBaseDir` and `zip` are identical - **keep
-them in sync**. `buildScriptName` differs by design: CI resolves it at the root
-(`build:storybook`), the config file inside `packages/nimbus`
-(`build-storybook`).
-
-## Two checks on the PR (read this before merge gating)
-
-A PR shows **two distinct Chromatic rows**, and they mean different things.
-Conflating them is the most common source of confusion:
-
-| Check on the PR                        | What it is                                                                                         | What controls its color                                                                                                                                            |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Chromatic / chromatic (pull_request)` | The **GHA job** in this workflow                                                                   | The action's exit code. With `exitOnceUploaded: true` the job returns at upload - _before_ diffing - so it's **green whenever the upload succeeds**, diffs or not. |
-| `UI Tests` (orange Chromatic icon)     | A status check **posted by Chromatic's servers**, asynchronously (the `exitOnceUploaded` behavior) | Chromatic's own verdict. It **still reports the diff** and goes red on an unaccepted diff, independent of the GHA job.                                             |
-
-So "the check stays green" refers **only** to the GHA job row:
-`exitOnceUploaded: true` makes the action exit before Chromatic diffs.
-(`exitZeroOnChanges` is **not** set; it would only matter if we dropped
-`exitOnceUploaded`.)
-
-That row answers **"did the job run without breaking?"**, not "are there visual
-changes?" Genuine breakage still turns it red: Storybook fails to build,
-dependency install / `./.github/actions/ci` fails, `chromaui/action` errors
-(missing or invalid `CHROMATIC_PROJECT_TOKEN`, upload/network/API failure), or a
-malformed workflow. It can also show **cancelled** when
-`concurrency: cancel-in-progress` supersedes the run with a newer push, or on
-timeout.
-
-## Merge gating
-
-**Current state: `UI Tests` reports on every PR but is not a required check, so
-nothing Chromatic-related blocks a merge.** Branch protection on `main` requires
-only `build-and-test` (confirmed against both classic protection and rulesets);
-merges are gated today only by review approval.
-
-Two workflow pieces already make `UI Tests` a reliable gate candidate:
-
-- **`exitZeroOnChanges` is not set**, so diffs surface on the async `UI Tests`
-  check while the GHA job stays green via `exitOnceUploaded: true`. Genuine
-  build failures still turn the GHA job red.
-- **The skip path posts its own `UI Tests` status.** With no UI changes
-  Chromatic never runs and never posts `UI Tests`, and a required check that
-  never reports blocks the PR forever ("Expected - waiting for status to be
-  reported") - which would wedge every docs-only PR. So the "No UI changes
-  detected" step posts a passing `UI Tests` (context must match Chromatic's
-  exactly) on the PR head SHA. Net: always reported, never stuck.
-
-### Turning gating on
-
-One switch remains: add **`UI Tests`** to the required status checks on `main`
-(Settings -> Branches, or a ruleset). Point branch protection at the async
-`UI Tests` check, **not** the `Chromatic / chromatic` GHA job - that one goes
-green at upload, before the verdict exists, so requiring it would let a PR merge
-before Chromatic finishes diffing.
-
-Caveats:
-
-- **Coverage is opt-in.** Only stories with `disableSnapshot: false` snapshot,
-  so a regression in an un-instrumented component won't block anything until its
-  stories opt in.
-- **Admins bypass.** `enforce_admins` is off, so an admin can still merge past a
-  red `UI Tests`.
-- **Context-name coupling.** The skip-path status hardcodes the `UI Tests`
-  context to match Chromatic's. If that name changes, update both the workflow
-  step and the required-check config.
-
-## Deterministic dates in snapshots
-
-Date-dependent stories are made deterministic per story: snapshotted stories pin
-a fixed date anchor (a `CalendarDate` / `CalendarDateTime` in the story args or
-`defaultValue` / `defaultFocusedValue`), while stories that render a live
-"today" opt out of snapshots (`tags: ["vrt"]` is omitted) and verify their
-behavior with a play function instead.
-
-## Writing stories for Chromatic (best practices from Chromatic's docs)
-
-What Chromatic's docs say, and how it maps to how we author Nimbus stories.
-
-### Directly relevant to our setup
-
-**Snapshot is taken only at the end of the play function.** "Chromatic waits for
-the entire play function to execute and captures a snapshot only at the end."
-Two consequences:
-
-- IconButton's `Base`, with its six `step()`s, produces exactly one snapshot -
-  its final resting state. Nothing blurs the element for you, so whatever the
-  last step leaves (a stray focus ring, a cleared value, a left-open overlay) is
-  what gets captured. This is a separate axis from assertion-honesty: a play can
-  assert exactly what its step names claim and still leave the wrong picture, so
-  confirm each snapshotted story's **final state is the visual its name
-  implies** - it's why an honest-looking `ReadOnly`/`Clearable` can snapshot a
-  focused or emptied control.
-- For an intermediate state, the docs say split it into its own story rather
-  than expect a mid-play capture.
-
-**Disabling snapshots is a first-class mechanism.** `chromatic.disableSnapshot`
-is settable "at story, component, and project levels" - exactly our layering:
-project default `disableSnapshot: true` in `preview.tsx`, overridden to `false`
-on the VRT stories. The docs explicitly recommend disabling for
-interaction-focused tests to "prevent false positives," which validates leaving
-`WithRef` and Button's context/DOM-filtering stories un-snapshotted.
-
-**Crop padding is applied to every story, globally.** Chromatic crops each
-snapshot to the story's rendered content, so an outline/selection/focus ring
-(painted outside layout as a box-shadow or CSS outline) clips at the crop edge
-when content sits flush against it - body or `layout: "padded"` padding sits
-outside the crop and can't reach in. A `preview.tsx` decorator therefore wraps
-every non-`fullscreen` story in `1rem` of padding, giving rings room in the crop
-and keeping the canvas from jumping as you browse. It's independent of
-`disableSnapshot` - not something you opt into per story. `fullscreen` stories
-are exempt because they're meant to touch the edges.
-
-**Cost is TurboSnap and matrix-packing, never dropping states.** TurboSnap bills
-unchanged snapshots at 1/5, and folding a
-`colorPalette × size × variant × state` grid into one `SmokeTest` keeps
-combinatorial coverage to a single billable snapshot (a reviewer also catches
-cross-axis regressions in one image). Those are the only levers. The `vrt`
-selection means "don't re-snapshot a state an on-snapshot already covers" -
-never "snapshot fewer states"; dropping a state no snapshot covers does lose
-coverage. The matrix's tradeoff is granularity: a diff in any cell flags the
+**Coverage is the target; the matrix is only the cheapest container.** Cost has
+two levers and no others: TurboSnap bills unchanged snapshots at 1/5, and
+folding a `colorPalette × size × variant × state` grid into one `SmokeTest`
+keeps combinatorial coverage to a single billable snapshot (a reviewer also
+catches cross-axis regressions in one image). The `vrt` selection means "don't
+re-snapshot a state an on-snapshot already covers", never "snapshot fewer
+states". The matrix's tradeoff is granularity: a diff in any cell flags the
 whole snapshot, and editing it re-snapshots the whole grid, so reserve
 standalone snapshots for states needing distinct setup or isolated review
 (`Focused`, `DisabledGroup`, an open menu), not straight recipe output.
 
-**Hover and pressed are a known coverage gap.** They are genuine visual states,
-but neither is currently captured, and it's an infra limitation, not a choice:
+**Any state the matrix can't render in one static image gets its own snapshotted
+story.** This is the governing rule behind the whole section - focus rings,
+disabled-but-focusable, an open tooltip/popover, special layouts. The matrix
+holds the interacting axes; a state it structurally can't hold becomes a
+separate frame, never a dropped state.
 
-- **Hover** can't be landed from a play function. A spike confirmed
-  `userEvent.hover` produces neither a real CSS `:hover` nor React Aria's
-  `data-hovered`, and a synthetic `pointerenter` doesn't either. Capturing it
-  needs `storybook-addon-pseudo-states` to force the state **plus** recipe
-  normalization: our button-family recipes are split between Chakra `_hover`
-  (compiles to `:hover, [data-hover]`) and React Aria's `[data-hovered]`, and an
-  addon forces one convention. Cross-cutting foundation work, not per-component.
-- **Pressed** needs nothing _for the button family_ - none of its recipes paint
-  `:active` (Button sets `data-pressed` but no rule styles it). Don't
-  generalize: NumberInput's steppers set `_active` (`bg: neutral.4`), a real
-  pressed visual, and for components like it pressed is a genuine uncaptured
-  state deferred alongside hover. Check the recipe rather than assuming pressed
-  is a no-op.
+**A matrix is only for _interacting_ axes.** When axes are independent - one
+just scales or recolors the other (Badge/Avatar `size × colorPalette`, Switch
+`size × on/off`) - snapshot each as its own showcase; the cross-product adds
+cells, not coverage. **Name the matrix `SmokeTest` and render it last** - the
+role name stays accurate as axes change, and the axis list goes in the doc
+comment.
 
-**If a play can drive the real interaction, snapshot the result and leave it
-settled** - drag-over (`data-drop-target`), option focus (`data-focused`),
-selection (`aria-selected`). The gap is `:hover`/`:active` and `data-hovered`,
-which no play-dispatchable event sets.
+**Over the axes it does span, the matrix must be exhaustive.** A single-axis
+showcase varies one axis with the rest at defaults, so
+`size="2xs" variant="ghost" colorPalette="critical"` is captured by **nothing**
+but the matrix - exactly where recipe regressions hide. Axis arrays span the
+**full supported range**; a trimmed or commented-out value leaves those cells
+covered by nothing. Scope call: matrices iterate the 6
+`SEMANTIC_COLOR_PALETTES`; the `BRAND` (3) and `SYSTEM` (25) palettes run the
+same token machinery and are deliberately not snapshotted.
 
-### Broader best practices
+**Fold an axis in only if it interacts.** `disabled` is the canonical exception:
+it resolves to a single shared `layerStyle` (`opacity: 0.5` +
+`cursor: not-allowed`) identical across every palette/size/variant, so a
+`Disabled`/`DisabledGroup` story captures it once instead of the matrix
+re-rendering every cell at half opacity for no new coverage.
 
-- **Enumerate surfaces from source, not memory.** Read the recipe (every
-  painting selector - `_hover`, `_focusWithin`, `_disabled`, `_active`,
-  `data-invalid`, `data-readonly`, ... - and every `variant`/`size` key) and the
-  component (every conditional render or prop, e.g.
-  `isDisabled={x || isReadOnly}`). Coverage is the **cross-product** of recipe
-  states × conditional branches, not the states alone: a read-only field that
-  stays undimmed but disables its trailing button is a distinct surface even
-  though the field "looks like default." Any "renders like default" call must
-  name the exact delta you checked. Also account for **ambient axes** no prop
-  names - RTL/`dir` (mirrored adornment layout), locale, theme - and for
-  built-in adornments. **A comma-separated selector list is as many surfaces as
-  it names**, and reads like one rule: Toolbar styles
-  `& .nimbus-group, & .nimbus-toggle-button-group__root` together, so a matrix
-  built from `Group` alone leaves the toggle-group half baselined nowhere - a
-  frame has to contain each child type the rule reaches. Then **diff against
-  sibling components' story sets**: a surface a peer snapshots but yours doesn't
-  (e.g. `RTLSupport`) is a gap until you can name why it doesn't apply.
-- **One focus snapshot per reachable focus surface.** A component with multiple
-  independent focus targets - fused/adjacent focusable sub-controls, or
-  `_focusWithin` on more than one region - needs a focus story per target, since
-  each side's ring clears the seam differently. There is no "all focused" state
-  to capture: only one element holds focus at a time, so the per-target stories
-  are the complete set (don't add a combined-ring snapshot). Confirm the ring
-  actually renders first: if it's on a slot that never gets the focus state, the
-  snapshot captures nothing (DropZone: ring on the root, focus on a hidden inner
-  element).
-- **Cover every visual state/variation** - "the more things we have in
-  Storybook, the more coverage we get." This is the governing rule: the
-  `SmokeTest` matrix must be **exhaustive** over the axes that _interact_
-  (`colorPalette × size × variant`, plus selected/unselected for toggles), and
-  any state the matrix can't render in one static image (focus ring,
-  disabled-but-focusable, open tooltip/popover, special layouts) gets its own
-  snapshotted story. Coverage is the target; the matrix is just the most
-  efficient container for the interacting axes. A single-axis showcase varies
-  one axis with the rest at defaults, so a cell like
-  `size="2xs" variant="ghost" colorPalette="critical"` is captured by
-  **nothing** but the matrix - exactly where recipe regressions hide. Axis
-  arrays must span the **full supported range**; a trimmed or commented-out
-  value leaves those cells covered by nothing. Scope call: matrices iterate the
-  6 `SEMANTIC_COLOR_PALETTES`; the `BRAND` (3) and `SYSTEM` (25) palettes run
-  the same token machinery and are deliberately not snapshotted.
-- **An inherited token makes a cross-cell neither audit covers.** `colorPalette`
-  cascades, so a child with no palette default takes its host's -
-  FormActionBar's spinner strokes `primary.10` in save, `critical.10` in delete.
-  One frame per host palette.
-- **Fold an axis into the matrix only if it interacts.** An axis whose
-  combination with the others yields a distinct visual belongs in the grid; one
-  that applies a **uniform, axis-independent transform** does not. `disabled` is
-  the canonical example: it resolves to a single shared `layerStyle`
-  (`opacity: 0.5` + `cursor: not-allowed`) identical across every
-  palette/size/variant, so a `Disabled`/`DisabledGroup` story captures it once
-  instead of the matrix re-rendering every cell at half opacity for no new
-  coverage.
-- **An axis the recipe hardcodes is not a matrix axis.** The
-  `size × variant × colorPalette` grid only spans the axes the component
-  actually varies. When a recipe pins one of them to a single value, that axis
-  drops out entirely - MultilineTextInput hardcodes `colorPalette: "neutral"`,
-  so its matrix is `state × size × variant` with no palette axis at all. This is
-  distinct from the uniform-transform case above: `disabled` is a real axis
-  folded out because it multiplies cells without adding signal; a hardcoded
-  palette was never an axis to begin with. Don't force the full
-  `SEMANTIC_COLOR_PALETTES` sweep onto a component whose recipe can only ever
-  render one.
-- **Cover distinct state-combinations, not just single flags.** When a component
-  has multiple boolean states (selected, disabled, invalid, read-only), each
-  combination that renders differently needs its own coverage. Selected-disabled
-  is visually distinct from unselected-disabled, so a `Disabled` story showing
-  only the unselected case leaves a gap.
-- **A single state can render more than one distinct surface - give each its own
-  story, not a gallery frame.** Before assuming one `Focused` / `Disabled` /
-  `ReadOnly` / `Invalid` story covers a state, check whether the component
-  renders it more than one way (mode-/variant-driven); if so, each distinct
-  recipe surface gets its own snapshotted story. MoneyInput renders focus and
-  disabled two ways - dropdown mode (a currency Select) and label mode
-  (`currencies={[]}`, a static label with its own
-  `currencyLabel[data-disabled] { opacity: 0.5 }` rule) - so it carries
-  `Focused` and `FocusedWithCurrencyLabel`, `DisabledState` and
-  `DisabledWithCurrencyLabel`. Independent surfaces don't interact the way
-  matrix axes do, so folding them into one render trades away their independent
-  baselines and per-surface triage. Snapshot count isn't a performance concern
-  (Chromatic parallelizes; TurboSnap keeps a stable extra story near free).
-- **A state that renders identically to the default gets no snapshot at all.**
-  The flip side: before adding a `ReadOnly` / `Disabled` / `Invalid` story,
-  confirm the recipe renders that state distinctly. With no rule for it, it
-  looks exactly like the default, and a dedicated snapshot is a redundant
-  baseline, not coverage. Read-only is the common trap because the call is
-  component-dependent: MoneyInput styles it distinctly (it disables the currency
-  Select) so it carries `ReadOnlyState`, but MultilineTextInput / NumberInput /
-  TextInput have no `data-readonly` rule, so read-only renders identically to
-  default and they correctly have no read-only snapshot. Same state, opposite
-  call, decided purely by whether a distinct recipe surface exists.
-- **Modes are for global config, not component props.** Chromatic
-  [modes](https://www.chromatic.com/docs/modes/) (`chromatic.modes`) capture the
-  same story under different _global_ settings - viewport, theme, locale - each
-  independently baselined. A difference you produce by passing props
-  (MoneyInput's dropdown vs. label mode) is a separate **story**, not a mode. We
-  don't use modes at launch (single desktop viewport, light theme only); they're
-  the tool if dark-mode or multi-viewport coverage lands.
-- **Snapshot the component, not the harness.** Anything in the render tree lands
-  in the baseline, so a snapshotted story must render the component
-  **directly** - no debug read-outs, value dumps, or controls scaffolding in the
-  frame. Those aids are fine on un-snapshotted behavioral stories (MoneyInput's
-  `MoneyInputExample` renders a `JSON.stringify(value)` panel), but snapshotting
-  one would bake the read-out into the baseline and flap on every value change.
-  The line is **load-bearing and static**, not "is it a wrapper": a wrapper the
-  component needs to resolve at all (DefaultPage's fixed-height `overflow: auto`
-  Box), or visible children for a component that paints nothing (PageContent's
-  placeholder boxes). Both are static; a read-out isn't.
-- **Thin wrappers get no matrix.** A component that only constrains or forwards
-  a wrapped component's props re-covers nothing by re-rendering the wrapped
-  grid. FloatingActionButton wraps IconButton with a fixed circular shape, so it
-  snapshots only `ColorPalettes` + `Focused` + `Disabled`, not a size × variant
-  matrix - those are IconButton's states, already covered there. (Distinct from
-  the independent-axes case below: there the axes don't interact; here the
-  wrapper delegates them wholesale to a component that already snapshots them.)
-- **A composition pattern owns the values it hardcodes.** Same paint-vs-forward
-  test as the primitives, one level up: FormActionBar fixes the button set,
-  order and palettes; PublicPageLayout fixes `gap`, `maxW`, `minHeight`.
-  Snapshot those. Delegate what the children paint, and anything the consumer
-  passes in.
-- **Composed field patterns snapshot the composition, not its parts.** A
-  `*Field` (`src/patterns/fields/`) has no recipe - it wraps `FormField` around
-  an input - so it takes two snapshots: composed resting field, composed error
-  state. Delegate the rest: layout / `direction` / `size` to FormField's
-  `SmokeTest`, the InfoButton to its `OpenInfoBox`, disabled and read-only to
-  the input (FormField's recipe styles neither), and every input-painted surface
-  to that input's audit. Read propagation from `FormField.Input`, not the
-  pattern's JSX: `cloneElement(child, inputProps)` delivers `isInvalid` /
-  `isDisabled` / `isRequired` / `isReadOnly` by context, so the prop list will
-  tell you a state isn't forwarded when it is.
-- **A play's end state is never a reason to skip a snapshot.** Adjust the play
-  to land on the frame, or author one that does. "Ends focused", "ends open",
-  "ends cleaned up", "drifts because nothing is pinned" are work to do.
-  Conversely a snapshotted story that ends focused needs `blur()`, or the ring
-  and caret land in the baseline - and **a click leaves it focused**: React Aria
-  keeps `data-focus-visible` set after `userEvent.click`, so a clicked trigger
-  paints its ring even though a real mouse click wouldn't.
-- **A play on a snapshotted story is a determinism liability, so don't add one
-  for completeness.** The capture is its end state, so each interaction is
-  another frame to land deliberately, while a resting visual props alone produce
-  is already tested by the snapshot plus the always-on a11y check. The
-  plays-for-interactive-components rule is per **component**, not per story; see
-  [stories.md](./file-type-guidelines/stories.md) for which stories need one.
-- **A compound component's unit is the recipe rule, not the realistic
-  composition.** With several optional slots the pull is to snapshot every
-  plausible arrangement - DefaultPage's info/form/tabular x main/detail. Slot
-  presence only makes a new surface where a **rule keys off it** (there, two
-  `:has()` selectors); the rest is the same slots in a different grid row. Ask
-  which rule the frame alone fires - "it's a realistic page" means
-  documentation, not a snapshot. It cost three of twelve first-pass opt-ins.
-- **A state can be inert in the default frame - snapshot the condition that
-  fires it.** Nothing looks wrong: the prop is set, the story renders, and the
-  baseline records the state being _off_ while reading as coverage.
-  `position: sticky` (a recipe variant in DefaultPage, an inline prop on
-  PageContent.Column) paints nothing until content passes beneath it, so scroll
-  in the play and capture pinned - that needs a **bounded scroll port**
-  (`height: 100%` resolves against nothing otherwise) and an
-  **`offsetHeight`-derived** target, so a padding-token change can't silently
-  stop it scrolling past. Three more triggers seen so far:
+**An axis the recipe hardcodes was never an axis.** MultilineTextInput pins
+`colorPalette: "neutral"`, so its matrix is `state × size × variant` with no
+palette axis - don't force the full `SEMANTIC_COLOR_PALETTES` sweep onto a
+recipe that can only ever render one. Distinct from the uniform-transform case
+above: `disabled` is a real axis folded out; a hardcoded palette had nothing to
+fold.
 
-  - **Overflow.** `scrollBehavior="inside"` is only `maxH` + `overflow: auto`,
-    so it wants tall content, not a scroll.
-  - **A variant that zeroes the surface.** ScrollArea's default `hover` sets
-    `scrollbar { opacity: 0 }`, so the matrix has to pin `always` to paint a
-    track at all - and its `Sizes` showcase, left at the default, baselines four
-    blank boxes while its width assertions still pass.
-  - **An inherited property with nothing to inherit.** ScrollArea's viewport
-    sets `borderRadius: inherit`, inert until a consumer passes a radius, so the
-    rounded-corner clipping was baselined nowhere until the matrix cells set
-    one.
+**Cover distinct state-combinations, not just single flags.** With multiple
+booleans (selected, disabled, invalid, read-only), each combination that renders
+differently needs coverage: selected-disabled is visually distinct from
+unselected-disabled, so a `Disabled` story showing only the unselected case
+leaves a gap.
 
-- **Primitives with no painted surface get no VRT at all.** The test isn't "has
-  a `.recipe.ts`" - it's **does it paint, and is there a state space to
-  enumerate?** Three shapes fail it, and each gets zero snapshots plus a
-  one-line `meta` note so the omission reads as deliberate:
-  - **Pass-through style-prop primitives** (Box, Flex, Stack, Grid, SimpleGrid,
-    Spacer - a `<div>`, no recipe). Every appearance comes from consumer style
-    props, so a snapshot tests Chakra + tokens, not the component.
-  - **A recipe that paints nothing** (Group: `inline-flex` + `alignItems`, zero
-    variants). The recipe's existence isn't the point - it sets no color,
-    border, or spacing, so the pixels are the children's.
-  - **Headless / layout-transparent** (Region: `display: contents`). No box is
-    rendered, so there's nothing to capture; the stories assert _where content
-    lands_, which is DOM containment.
+**One state rendered more than one way → one story each, not a gallery frame.**
+Check whether the component renders `Focused` / `Disabled` / `ReadOnly` /
+`Invalid` mode- or variant-driven before assuming one story covers it.
+MoneyInput renders focus and disabled two ways - dropdown mode (a currency
+Select) and label mode (`currencies={[]}`, a static label with its own
+`currencyLabel[data-disabled] { opacity: 0.5 }` rule) - so it carries
+`Focused` + `FocusedWithCurrencyLabel` and `DisabledState` +
+`DisabledWithCurrencyLabel`. Independent surfaces don't interact the way matrix
+axes do, so folding them into one render trades away their independent baselines
+and per-surface triage. Snapshot count isn't a performance concern (Chromatic
+parallelizes; TurboSnap keeps a stable extra story near free).
 
-  The inverse is the more common case: a primitive whose recipe **does** paint
-  gets a normal audit - Separator's `orientation` over a `colorPalette.6` fill,
-  Icon's six-value `size`.
+**Modes are for global config, not component props.** Chromatic
+[modes](https://www.chromatic.com/docs/modes/) (`chromatic.modes`) capture the
+same story under different _global_ settings - viewport, theme, locale - each
+independently baselined. A difference you produce by passing props (MoneyInput's
+dropdown vs. label mode) is a separate **story**, not a mode. No modes are
+configured: one desktop viewport, light theme.
 
-- **A matrix is only for _interacting_ axes.** When axes are independent - one
-  just scales or recolors the other (Badge/Avatar `size × colorPalette`, Switch
-  `size × on/off`) - snapshot each as its own showcase; the cross-product adds
-  cells, not coverage. **Name the matrix `SmokeTest` and render it last** - the
-  role name stays accurate as axes change; the axis list goes in the doc
-  comment. (Older components use names like `VariantsSizesAndStates` - being
-  reconciled.)
-- **Use `play` for functional testing alongside visual** - the two aren't in
-  tension; a story can both assert behavior and be snapshotted.
-- **Animated components: know where Chromatic pauses.** It auto-pauses CSS
-  transitions, CSS/SVG animations, and videos (not JS animations - pause those
-  manually) and seeks a **fixed** frame, so the capture is deterministic. The
-  default pause point is the **last** frame of the cycle
-  (`pauseAnimationAtEnd: false` switches it to the first). The trap is an
-  `iteration-count: infinite` animation whose endpoints both hide the content:
-  `progress-indeterminate` sweeps a 40% pill `translateX(-100% → 300%)`, so both
-  endpoints park it off the track and the default snapshot is an empty track.
-  Then **pin a representative frame** in the play (`animation: none` + an
-  explicit transform), as ProgressBar's `Indeterminate` does with
-  `translateX(75%)`. A full-turn `spin` needs no pin - both endpoints render
-  identically. The docs don't spell out the infinite case, so confirm the paused
-  frame on the first run.
-- **Portal-rendered components (Toast, overlays).** Chromatic captures the whole
-  page, so portal content is in-frame even though it renders outside the story
-  root. Hold transient UI open for the shot (`duration: Infinity` for toasts),
-  await it, and clean up between stories (Toast's `clearToasts()`) so nothing
-  leaks into the next capture. A portal component can be focusable in its own
-  right (Toast's root has `tabIndex=0` + `focusRing: outside`) - reach it the
-  real way (hotkey + Tab), not a synthetic `.focus()`.
-- **Overlays: snapshot the _open_ state.** A portal component's primary visual
-  is its open state, so render it open - `defaultOpen` (Dialog/Drawer/Menu) or
-  open it in the play and await the portal - and leave it open; the entrance
-  animation settles on its last frame. Give each distinct open surface its own
-  story: open dialogs/drawers fill the viewport with a backdrop and can't share
-  a frame, so there's no `SmokeTest` matrix (independent recipe variants become
-  separate open showcases). open/close, focus trap, and dismissal stay
-  behavioral.
-- **Snapshot `placement` only when it changes the _layout_, not when it merely
-  repositions the same box.** The test isn't "is it a recipe variant" - it's
-  "does the box render differently, or just sit somewhere else?"
-  - **Drawer** placement swaps the layout (full-height side panel ↔ full-width
-    top/bottom bar) - a different shape per placement → one open snapshot each.
-  - **Dialog** placement is a recipe variant but only shifts vertical position
-    (`alignItems` + margin; the same box, higher/lower) → snapshot **center
-    only**; top/bottom add no new visual.
-  - **Menu/Tooltip** placement is React Aria positioning (same box repositioned,
-    no arrow) → behavioral, no per-placement snapshot.
-- **Hide the blinking text caret on a focused input.** A `Focused` snapshot
-  captures the focus ring, but focusing also paints the browser's native caret,
-  which Chromatic can't stabilize (its
-  [animations docs](https://www.chromatic.com/docs/animations/) cover only CSS
-  and JS animations), so the snapshot diffs on whichever blink phase it lands
-  on. Hide it in the `Focused` play; `caret-color` inherits, so one line on the
-  canvas cascades to the input. Scoped to the story rather than the shared
-  `preview.tsx`:
-
-  ```typescript
-  play: async ({ canvasElement }) => {
-    canvasElement.style.caretColor = "transparent"; // native caret can't be paused
-    await userEvent.tab();
-    // ...assert the ring
-  },
-  ```
-
-- **Fonts/async loading can shift tooltips/menus** - relevant to IconButton's
-  `ColorPalettes` story (it wraps each button in a `Tooltip`). Preload fonts or
-  add a delay if those snapshots turn out flaky.
-- **Images need care.** Chromatic waits for images to load before capturing, but
-  not for state your component _derives_ from that load (Avatar hides its
-  `<img>` until `onLoad`, and swaps to a fallback on error). Serve images
-  locally (`staticDirs`) to avoid a flaky network dependency, and wait in the
-  play function for any post-load / post-error state you mean to snapshot. See
-  [stories.md](./file-type-guidelines/stories.md) for the pattern.
-- **`preview.js` barrel imports trigger full rebuilds under TurboSnap** - not
-  our concern in the stories, but a caution for the shared `preview.tsx`.
-
-### Sources
+## Sources
 
 - [Visual tests](https://www.chromatic.com/docs/visual/)
 - [Snapshots](https://www.chromatic.com/docs/snapshots/)

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -63,8 +63,8 @@ that stays undimmed but disables its trailing button is a distinct surface even
 though the field "looks like default." Any "renders like default" call must name
 the exact delta you checked. Three things that get missed:
 
-- **Ambient axes no prop names** - RTL/`dir` (mirrored adornment layout),
-  locale, theme - and built-in adornments.
+- **Ambient axes** - nothing in the prop list names these: RTL/`dir` (mirrored
+  adornment layout), locale, theme. Same for built-in adornments.
 - **A comma-separated selector list is as many surfaces as it names**, while
   reading like one rule. Toolbar styles
   `& .nimbus-group, & .nimbus-toggle-button-group__root` together, so a matrix
@@ -81,9 +81,10 @@ carries `ReadOnlyState`; MultilineTextInput / NumberInput / TextInput have no
 `data-readonly` rule and correctly carry none.
 
 **Primitives with no painted surface get no VRT at all.** The test isn't "has a
-`.recipe.ts`" - it's **does it paint, and is there a state space to enumerate?**
-Three shapes fail it, each getting zero snapshots plus a one-line `meta` note so
-the omission reads as deliberate:
+recipe file" - it's **does it paint, and is there a state space to enumerate?**
+(Glob `*.recipe.*` when checking: 9 recipes are `.recipe.tsx`, so a `.ts`-only
+look concludes they have none.) Three shapes fail it, each getting zero
+snapshots plus a one-line `meta` note so the omission reads as deliberate:
 
 - **Pass-through style-prop primitives** (Box, Flex, Stack, Grid, SimpleGrid,
   Spacer - a `<div>`, no recipe). Every appearance comes from consumer style

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -173,36 +173,37 @@ export const SmokeTest: Story = {
 `disableSnapshot: false` takes the picture; Chromatic never reads `vrt` (our own
 label for finding snapshot stories - keep the two together).
 
-> **Editing rule:** rule + snippet only. Reasoning and examples belong in
-> [chromatic-visual-testing.md](../chromatic-visual-testing.md).
+Crop padding is global too: a `preview.tsx` decorator wraps every
+non-`fullscreen` story in `1rem` so focus rings aren't clipped. Not opt-in.
 
-- **What to snapshot:** every prop-driven visual state. Interacting axes fold
-  into one `SmokeTest`; independent axes get separate showcases; any state the
-  matrix can't render gets its own story. Never drop a state to save cost.
+The rules below are enough to author a story. **Read
+[chromatic-visual-testing.md](../chromatic-visual-testing.md) when a rule
+doesn't settle the case** - it holds the worked precedent for the calls a terse
+rule can state but not decide: whether a state paints differently from the
+default (read-only), whether two axes interact (matrix vs. separate showcases),
+a variant that zeroes its surface, how many frames a comma-separated selector
+needs, which slot arrangements are genuine surfaces, and any "renders like
+default" verdict. Auditing coverage for the first time → read it; adding a story
+to an already-audited component → don't.
+
+> **Editing rule:** rule + snippet only. Reasoning and worked examples belong in
+> [chromatic-visual-testing.md](../chromatic-visual-testing.md), which groups
+> them under the same five headings used below.
+
+**1. Does it paint?**
+
 - **Enumerate surfaces from the recipe + component source**, then snapshot their
-  cross-product - not remembered states. A comma-separated selector list counts
-  once per child type it names; a frame needs each of them.
-- **Inherited tokens make cross-cells** - a child with no `colorPalette` takes
-  its host's; one frame per host.
-- **One state rendered more than one way → one story each**, not a folded
-  gallery.
-- **A state with no distinct recipe surface gets no story.**
-- **A composition pattern owns the values it hardcodes**; children and consumer
-  props delegate.
-- **`*Field` patterns get two snapshots** - composed resting + composed error;
-  layout/`size`, InfoButton, disabled/read-only and input-painted surfaces
-  delegate. State arrives via `FormField.Input`'s clone, not the JSX.
+  cross-product - not remembered states. Include ambient axes (RTL, locale,
+  theme). A comma-separated selector list counts once per child type it names; a
+  frame needs each of them. Diff against sibling components' story sets.
+- **A state with no distinct recipe surface gets no story** - read-only is the
+  component-dependent trap.
 - **Primitives that paint no surface get no VRT** - pass-through style props, a
   recipe that paints nothing, or headless `display: contents`. Note it on
   `meta`.
-- **A play's end state never justifies skipping a snapshot** - fix the play. A
-  snapshotted story that ends focused needs `blur()`, and `userEvent.click`
-  counts as focused (React Aria keeps `data-focus-visible` set).
-- **No play where the claim is a resting visual props alone produce** - see
-  [Which stories need one](#which-stories-need-one).
-- **A compound component's unit is the recipe rule, not the composition** - slot
-  presence only makes a new surface where a rule keys off it (`:has()`). Name
-  the rule the frame alone fires, or leave it off-snapshot.
+
+**2. Is the state reachable in this frame?**
+
 - **A state inert in the default frame → snapshot the condition that fires it.**
   Sticky needs a scroll in the play (bounded `overflow: auto` ancestor,
   `offsetHeight`-derived target, each combination its own frame);
@@ -210,25 +211,68 @@ label for finding snapshot stories - keep the two together).
   zeroes needs the variant that paints it (a showcase left at that default
   baselines blank boxes); an inherited property needs a consumer value to
   inherit.
-- **Load-bearing, static scaffolding may stay in the frame** - a bounded scroll
-  port, or visible children for a component that paints nothing itself.
-- **If a step name overstates what it asserts, raise the assertion to meet the
-  name** - don't rename the step down.
-- **Snapshot the component, not the harness** - no debug read-outs or wrappers
-  in a snapshotted frame.
-- **Name the interacting-axes matrix `SmokeTest`, rendered last** - the axis
-  list lives in the doc comment.
-- **Give each distinctly-styled focusable sub-element its own `Focused`**, and
-  confirm the ring actually renders.
+- **Hover/pressed need a forced pseudo-class a play can't deliver** - and don't
+  hand-set `[data-hovered]`/`[data-pressed]` instead: recipes are split between
+  those and Chakra `_hover`/`_active`, so it half-styles the frame. Pressed
+  isn't categorically a no-op though - check the recipe. Everything else a play
+  can drive, snapshot settled.
+- **Give each independent focus surface its own `Focused`**, and confirm the
+  ring actually renders.
 - **Overlays: snapshot the open state** and leave it open; each distinct open
   surface is its own story.
-- **Snapshot `placement` only when it changes the layout**, not when it
-  repositions the same box.
 - **Portals: capture is page-wide** - hold open, await, clean up between
   stories; reach a portal's focus via its real keyboard path.
+- **Snapshot `placement` only when it changes the layout**, not when it
+  repositions the same box.
+
+**3. Who owns the pixels?**
+
+- **Snapshot the component, not the harness** - no debug read-outs or demo
+  wrappers in a snapshotted frame. **Load-bearing, static** scaffolding may stay
+  (a bounded scroll port, or visible children for a component that paints
+  nothing itself).
+- **Thin wrappers get no matrix** - only the axis they introduce.
+- **A composition pattern owns the values it hardcodes**; children and consumer
+  props delegate.
+- **`*Field` patterns get two snapshots** - composed resting + composed error;
+  layout/`size`, InfoButton, disabled/read-only and input-painted surfaces
+  delegate. State arrives via `FormField.Input`'s clone, not the JSX.
+- **A compound component's unit is the recipe rule, not the composition** - slot
+  presence only makes a new surface where a rule keys off it (`:has()`). Name
+  the rule the frame alone fires, or leave it off-snapshot.
+- **Inherited tokens make cross-cells** - a child with no `colorPalette` takes
+  its host's; one frame per host.
+
+**4. Does the play land the frame?**
+
 - **The snapshot is the play's end state** - land on the target frame.
-- **Crop padding is global** - a `preview.tsx` decorator wraps non-`fullscreen`
-  stories in `1rem`. Not opt-in.
+- **A play's end state never justifies skipping a snapshot** - fix the play. A
+  snapshotted story that ends focused needs `blur()`, and `userEvent.click`
+  counts as focused (React Aria keeps `data-focus-visible` set).
+- **No play where the claim is a resting visual props alone produce** - see
+  [Which stories need one](#which-stories-need-one).
+- **If a step name overstates what it asserts, raise the assertion to meet the
+  name** - don't rename the step down.
+- **Pin dates** in a snapshotted story; a live "today" stays off-snapshot and
+  behavioral.
+- Caret, sticky scroll, animation pinning and image-derived state have snippets
+  below.
+
+**5. Packing the surfaces into frames**
+
+- **What to snapshot:** every prop-driven visual state. Interacting axes fold
+  into one `SmokeTest`; independent axes get separate showcases; any state the
+  matrix can't render gets its own story. Never drop a state to save cost.
+- **Name the interacting-axes matrix `SmokeTest`, rendered last** - the axis
+  list lives in the doc comment.
+- **Axis arrays span the full supported range**; an axis the recipe hardcodes
+  isn't an axis; a uniform transform (`disabled`) folds out into its own story.
+- **Cover distinct state-combinations**, not just single flags
+  (selected-disabled ≠ unselected-disabled).
+- **One state rendered more than one way → one story each**, not a folded
+  gallery.
+- **`chromatic.modes` is global config only** (viewport/theme/locale), never
+  prop-driven.
 
 Snippets to paste:
 

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -173,8 +173,8 @@ export const SmokeTest: Story = {
 `disableSnapshot: false` takes the picture; Chromatic never reads `vrt` (our own
 label for finding snapshot stories - keep the two together).
 
-Crop padding is global too: a `preview.tsx` decorator wraps every
-non-`fullscreen` story in `1rem` so focus rings aren't clipped. Not opt-in.
+Crop padding is global, not per story: a `preview.tsx` decorator wraps every
+non-`fullscreen` story in `1rem` so focus rings aren't clipped.
 
 The rules below are enough to author a story. **Read
 [chromatic-visual-testing.md](../chromatic-visual-testing.md) when a rule
@@ -183,12 +183,12 @@ rule can state but not decide: whether a state paints differently from the
 default (read-only), whether two axes interact (matrix vs. separate showcases),
 a variant that zeroes its surface, how many frames a comma-separated selector
 needs, which slot arrangements are genuine surfaces, and any "renders like
-default" verdict. Auditing coverage for the first time → read it; adding a story
-to an already-audited component → don't.
+default" verdict. It groups them under the same five headings used below.
+Auditing coverage for the first time → read it; adding a story to an
+already-audited component → don't.
 
-> **Editing rule:** rule + snippet only. Reasoning and worked examples belong in
-> [chromatic-visual-testing.md](../chromatic-visual-testing.md), which groups
-> them under the same five headings used below.
+> **Editing rule:** rule + snippet only here; reasoning and worked examples go
+> in `chromatic-visual-testing.md`.
 
 **1. Does it paint?**
 
@@ -209,8 +209,8 @@ to an already-audited component → don't.
   `offsetHeight`-derived target, each combination its own frame);
   `scrollBehavior="inside"` needs overflowing content; a surface a variant
   zeroes needs the variant that paints it (a showcase left at that default
-  baselines blank boxes); an inherited property needs a consumer value to
-  inherit.
+  renders blank boxes while its assertions still pass); an inherited property
+  needs a consumer value to inherit.
 - **Hover/pressed need a forced pseudo-class a play can't deliver** - and don't
   hand-set `[data-hovered]`/`[data-pressed]` instead: recipes are split between
   those and Chakra `_hover`/`_active`, so it half-styles the frame. Pressed
@@ -265,8 +265,10 @@ to an already-audited component → don't.
   matrix can't render gets its own story. Never drop a state to save cost.
 - **Name the interacting-axes matrix `SmokeTest`, rendered last** - the axis
   list lives in the doc comment.
-- **Axis arrays span the full supported range**; an axis the recipe hardcodes
-  isn't an axis; a uniform transform (`disabled`) folds out into its own story.
+- **Axis arrays span the full supported range** - palettes iterate the 6
+  `SEMANTIC_COLOR_PALETTES`, not the `BRAND` or `SYSTEM` sets. An axis the
+  recipe hardcodes isn't an axis; a uniform transform (`disabled`) folds out
+  into its own story.
 - **Cover distinct state-combinations**, not just single flags
   (selected-disabled ≠ unselected-disabled).
 - **One state rendered more than one way → one story each**, not a folded

--- a/packages/nimbus/CLAUDE.md
+++ b/packages/nimbus/CLAUDE.md
@@ -176,11 +176,12 @@ The testing system uses Vitest with three distinct test categories:
 - Copy-ready working examples consumers use to test components in their apps
 - Injected into `.dev.mdx` docs at build time
 
-Visual regression is handled separately by Chromatic in CI. Play functions are
-the shared source of truth: Chromatic runs them and snapshots the result, so
-visual states are verified there rather than asserted in play functions. See
-`./docs/chromatic-visual-testing.md` for which stories to snapshot, and
-`./docs/chromatic-ci.md` for the pipeline.
+Visual regression is handled separately by Chromatic in CI: it captures what the
+story renders, and where a play function exists, that play's **end state**. So a
+visual state is verified by the snapshot rather than asserted in the play, and a
+snapshotted story needs a play only when its frame requires an interaction to
+exist. See `./docs/chromatic-visual-testing.md` for which stories to snapshot,
+and `./docs/chromatic-ci.md` for the pipeline.
 
 ### Testing Workflow
 

--- a/packages/nimbus/CLAUDE.md
+++ b/packages/nimbus/CLAUDE.md
@@ -96,8 +96,9 @@ This project follows strict development standards detailed in the documentation:
     `./docs/file-type-guidelines/unit-testing.md`
   - Consumer implementation tests (`*.docs.spec.tsx`; copy-ready examples for
     consumers) `./docs/file-type-guidelines/testing-strategy.md`
-  - Visual regression is handled separately by Chromatic in CI
-    `./docs/chromatic-visual-testing.md`
+  - Visual regression is handled separately by Chromatic in CI - which stories
+    to snapshot `./docs/chromatic-visual-testing.md`, how the pipeline runs
+    `./docs/chromatic-ci.md`
 - **TypeScript**: Strict typing with comprehensive interfaces
   `./docs/file-type-guidelines/types.md`
 - **Documentation**: JSDoc comments required for all code
@@ -178,7 +179,8 @@ The testing system uses Vitest with three distinct test categories:
 Visual regression is handled separately by Chromatic in CI. Play functions are
 the shared source of truth: Chromatic runs them and snapshots the result, so
 visual states are verified there rather than asserted in play functions. See
-`./docs/chromatic-visual-testing.md`.
+`./docs/chromatic-visual-testing.md` for which stories to snapshot, and
+`./docs/chromatic-ci.md` for the pipeline.
 
 ### Testing Workflow
 


### PR DESCRIPTION
Splits CI out of the Chromatic authoring guide, regroups its rules under the four principles they are instances of & wires VRT into the component pipeline.

Epic **FEC-1097**. Completes the first DoD item of **FEC-1190**.

Docs & agent config only, no component source touched.

## Why

The authoring guide had grown to >44 flat rules across the rollout batches, past what anyone reads before starting an audit, so it got grepped after the mistake instead of before. And nothing in the agent pipeline mentioned Chromatic, so VRT only happened when `/writing-stories` was invoked by hand.

## What each file does

| File                                                                         | Role                                                                                                                                                                                                                                                                      |
| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `docs/chromatic-visual-testing.md`                                           | Which stories get snapshotted & why. Five headings: _does it paint? / is the state reachable in this frame? / who owns the pixels? / does the play land the frame?_ plus packing surfaces into frames. Holds the worked precedent for calls a terse rule cannot decide. |
| `docs/chromatic-ci.md`                                                       |  Triggers, changed-files gate, TurboSnap, baselines & acceptance, the two PR checks, merge gating. Nothing here affects how a story is written.                                                                                                                 |
| `docs/file-type-guidelines/stories.md`                                       | Terse rules plus paste-ready snippets. The doc the skill actually loads.                                                                                                                                                                                                  |
| `.claude/skills/writing-stories/SKILL.md`                                    | Templates plus the validation checklist. Step 1 leads with reading the recipe; 7 triggers say when to escalate to the rationale doc.                                                                                                                                      |
| `.claude/agents/nimbus-reviewer.md`                                          | VRT coverage review: reads the recipe, 7 checks, missing opt-in is a **critical violation**.                                                                                                                                                                              |
| `.claude/commands/propose-component.md`                                      | Generates a dedicated VRT instrumentation task with acceptance criteria, plus a validation gate.                                                                                                                                                                          |
| `.claude/agents/nimbus-coder.md`                                             | Story task is not done until a story opts in, or `meta` says why none does.                                                                                                                                                                                               |
| `CLAUDE.md`, `packages/nimbus/CLAUDE.md`, `housekeeping.md`, `chromatic.yml` | Point at `chromatic-ci.md` for CI, `chromatic-visual-testing.md` for authoring.                                                                                                                                                                                           |
| `review-nimbus-pr.md`                                                        | Diffs against `origin/main`, not stale local `main`.                                                                                                                                                                                                                      |


