### PR TITLE
docs: link supply chain security baseline from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ All commands should be run from the repository root.
 
 ### Dependencies & supply chain security
 
-Dependency management in this repository follows the Merchant Center supply chain security baseline: a pnpm publish cooldown (`minimumReleaseAge`), build-script allowlists, SHA-pinned GitHub Actions, and centralized Renovate configuration. Before adding, updating, or overriding a dependency — or when a `minimumReleaseAge` cooldown or `pnpm audit --fix` blocks you — follow the [Supply Chain Security — Baseline & Override Procedures](https://commercetools.atlassian.net/wiki/spaces/MCF/pages/3580231746/Supply+Chain+Security+-+Baseline+Override+Procedures).
+Dependency management in this repository follows the Merchant Center supply
+chain security baseline: a pnpm install delay/cooldown (`minimumReleaseAge`),
+build-script allowlists, SHA-pinned GitHub Actions, and centralized Renovate
+configuration. Before adding, updating, or overriding a dependency — or when a
+`minimumReleaseAge` cooldown or `pnpm audit --fix` blocks you — follow the
+[Supply Chain Security — Baseline & Override Procedures](https://commercetools.atlassian.net/wiki/spaces/MCF/pages/3580231746/Supply+Chain+Security+-+Baseline+Override+Procedures).
 
 ## 💻 Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [🚀 Getting Started](#-getting-started)
     - [Prerequisites](#prerequisites)
     - [Installation](#installation)
+    - [Dependencies \& supply chain security](#dependencies--supply-chain-security)
   - [💻 Development Workflow](#-development-workflow)
     - [Development Mode](#development-mode)
     - [Building the Project](#building-the-project)
@@ -97,6 +98,10 @@ All commands should be run from the repository root.
 > switching branches, you must run `pnpm nimbus:init` or `pnpm build` to
 > generate the required `*.messages.ts` and `intl/*.ts` files. Without these
 > files, TypeScript compilation and Storybook will fail.
+
+### Dependencies & supply chain security
+
+Dependency management in this repository follows the Merchant Center supply chain security baseline: a pnpm publish cooldown (`minimumReleaseAge`), build-script allowlists, SHA-pinned GitHub Actions, and centralized Renovate configuration. Before adding, updating, or overriding a dependency — or when a `minimumReleaseAge` cooldown or `pnpm audit --fix` blocks you — follow the [Supply Chain Security — Baseline & Override Procedures](https://commercetools.atlassian.net/wiki/spaces/MCF/pages/3580231746/Supply+Chain+Security+-+Baseline+Override+Procedures).
 
 ## 💻 Development Workflow
 


### PR DESCRIPTION
Adds a pointer from the README to the Supply Chain Security — Baseline & Override Procedures wiki page (FEC-972), so contributors can find the pnpm cooldown (minimumReleaseAge), build-script allowlists, GitHub Actions SHA pinning, centralized Renovate config, and the override procedures when adding, updating, or overriding a dependency.