### PR TITLE
feat(data-table): add scroll shadows on sticky column edges

### DIFF
--- a/.changeset/datatable-scroll-shadows.md
+++ b/.changeset/datatable-scroll-shadows.md
@@ -1,0 +1,10 @@
+---
+"@commercetools/nimbus": minor
+"@commercetools/nimbus-tokens": minor
+---
+
+`DataTable`: sticky columns now display scroll shadows at their edges when the
+table content is horizontally scrollable. Shadows appear on the left-side sticky
+columns when scrolled away from the start, and on the right-side pin column when
+scrolled away from the end. New `right` and `left` shadow design tokens are
+available for directional shadow effects.

--- a/docs/file-type-guidelines/recipes.md
+++ b/docs/file-type-guidelines/recipes.md
@@ -353,7 +353,7 @@ with the component name in kebab-case (e.g., `--accordion-font-size`,
 - **Typography (fontWeight)**: `100`, `200`, `300`, `400`, `500`, `600`, `700`,
   `800`, `900`
 - **Radii**: `50`, `100`, `150`, `200`, `300`, `400`, `500`, `600`, `full`
-- **Shadows**: `1`, `2`, `3`, `4`, `5`, `6`
+- **Shadows**: `1`, `2`, `3`, `4`, `5`, `6`, `right`, `left`
 - **Transitions (duration)**: `fastest`, `faster`, `fast`, `moderate`, `slow`,
   `slower`, `slowest`
 
@@ -517,15 +517,9 @@ export const buttonRecipe = defineRecipe({
   },
   variants: {
     variant: {
-      solid: {
-        /* ... */
-      },
-      outline: {
-        /* ... */
-      },
-      ghost: {
-        /* ... */
-      },
+      solid: {/* ... */},
+      outline: {/* ... */},
+      ghost: {/* ... */},
     },
     size: {
       sm: { paddingX: "300", fontSize: "350" },

--- a/packages/nimbus/src/components/data-table/components/data-table.header.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.header.tsx
@@ -4,7 +4,8 @@ import {
   Collection as RaCollection,
   useTableOptions,
 } from "react-aria-components";
-import { Box, Checkbox } from "@/components";
+import { Box, Checkbox, Icon } from "@/components";
+import { KeyboardArrowRight, PushPin } from "@commercetools/nimbus-icons";
 import { extractStyleProps } from "@/utils";
 import { useLocalizedStringFormatter } from "@/hooks";
 import type {
@@ -91,6 +92,16 @@ export const DataTableHeader = <
             isInternalColumn={true}
           >
             <VisuallyHidden>{msg.format("expandRows")}</VisuallyHidden>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              w="100%"
+              h="100%"
+              aria-hidden="true"
+            >
+              <Icon as={KeyboardArrowRight} boxSize="400" color="neutral.10" />
+            </Box>
           </DataTableColumn>
         )}
         <RaCollection items={activeColumns}>
@@ -139,6 +150,16 @@ export const DataTableHeader = <
             aria-label={msg.format("pinRows")}
           >
             <VisuallyHidden>{msg.format("pinRows")}</VisuallyHidden>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              w="100%"
+              h="100%"
+              aria-hidden="true"
+            >
+              <Icon as={PushPin} boxSize="400" color="neutral.10" />
+            </Box>
           </DataTableColumn>
         )}
       </RaTableHeader>

--- a/packages/nimbus/src/components/data-table/components/data-table.root.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.root.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState, useCallback, useRef, startTransition } from "react";
+import {
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  startTransition,
+} from "react";
 import { ResizableTableContainer } from "react-aria-components";
 import { useObjectRef } from "react-aria";
 import { mergeRefs } from "@/utils";
@@ -71,6 +78,29 @@ export const DataTableRoot = function DataTableRoot<
   const ref = useObjectRef(mergeRefs(localRef, forwardedRef));
   const msg = useLocalizedStringFormatter(dataTableMessagesStrings);
   const selectRowLabel = msg.format("selectRow");
+
+  useEffect(() => {
+    const el = localRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      const canScrollLeft = scrollLeft > 1;
+      const canScrollRight = scrollLeft + clientWidth < scrollWidth - 1;
+      el.setAttribute("data-scroll-left", String(canScrollLeft));
+      el.setAttribute("data-scroll-right", String(canScrollRight));
+    };
+
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", update);
+      ro.disconnect();
+    };
+  }, []);
 
   const [internalSortDescriptor, setInternalSortDescriptor] = useState<
     SortDescriptor | undefined

--- a/packages/nimbus/src/components/data-table/components/data-table.root.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.root.tsx
@@ -83,12 +83,21 @@ export const DataTableRoot = function DataTableRoot<
     const el = localRef.current;
     if (!el) return;
 
+    let prevLeft: boolean | undefined;
+    let prevRight: boolean | undefined;
+
     const update = () => {
       const { scrollLeft, scrollWidth, clientWidth } = el;
       const canScrollLeft = scrollLeft > 1;
       const canScrollRight = scrollLeft + clientWidth < scrollWidth - 1;
-      el.setAttribute("data-scroll-left", String(canScrollLeft));
-      el.setAttribute("data-scroll-right", String(canScrollRight));
+      if (canScrollLeft !== prevLeft) {
+        prevLeft = canScrollLeft;
+        el.setAttribute("data-scroll-left", String(canScrollLeft));
+      }
+      if (canScrollRight !== prevRight) {
+        prevRight = canScrollRight;
+        el.setAttribute("data-scroll-right", String(canScrollRight));
+      }
     };
 
     update();

--- a/packages/nimbus/src/components/data-table/components/data-table.row.tsx
+++ b/packages/nimbus/src/components/data-table/components/data-table.row.tsx
@@ -507,6 +507,7 @@ const DataTableRowInner = <T extends DataTableRowItem = DataTableRowItem>({
                   cursor="pointer"
                   focusVisibleRing="inside"
                   borderRadius="0"
+                  color="neutral.10"
                   aria-label={
                     isExpanded
                       ? msg.format("collapseRow")

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -104,21 +104,21 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         },
         // When drag column is present, offset selection and expand columns
         "& [data-slot='drag'] ~ [data-slot='selection']": {
-          left: "{sizes.600}",
+          left: "600",
         },
         "& [data-slot='drag'] ~ [data-slot='expand']": {
-          left: "{sizes.600}",
+          left: "600",
         },
         // When selection column is present, move expand column to the right
         // and lower its z-index so it doesn't overlap selection during scroll
         "& [data-slot='selection'] ~ [data-slot='expand']": {
-          left: "{sizes.1800}",
+          left: "1800",
           zIndex: 10,
         },
         // When both drag and selection columns are present, offset expand column
         "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
           {
-            left: "{sizes.2400}",
+            left: "2400",
           },
         _hover: {
           backgroundColor: "{colors.primary.3}",
@@ -140,20 +140,20 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           },
           // When drag column is present, offset selection and expand columns on hover
           "& [data-slot='drag'] ~ [data-slot='selection']": {
-            left: "{sizes.600}",
+            left: "600",
           },
           "& [data-slot='drag'] ~ [data-slot='expand']": {
-            left: "{sizes.600}",
+            left: "600",
           },
           // When selection column is present, move expand column to the right on hover
           "& [data-slot='selection'] ~ [data-slot='expand']": {
-            left: "{sizes.1800}",
+            left: "1800",
             zIndex: 10,
           },
           // When both drag and selection columns are present, offset expand column on hover
           "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
             {
-              left: "{sizes.2400}",
+              left: "2400",
             },
           "& [data-slot='pin-row-cell']": {
             right: 0,
@@ -193,20 +193,20 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         },
         // When drag column is present in pinned rows, offset selection and expand columns
         "& [data-slot='drag'] ~ [data-slot='selection']": {
-          left: "{sizes.600}",
+          left: "600",
         },
         "& [data-slot='drag'] ~ [data-slot='expand']": {
-          left: "{sizes.600}",
+          left: "600",
         },
         // When selection column is present in pinned rows, move expand column
         "& [data-slot='selection'] ~ [data-slot='expand']": {
-          left: "{sizes.1800}",
+          left: "1800",
           zIndex: 10,
         },
         // When both drag and selection columns are present in pinned rows
         "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
           {
-            left: "{sizes.2400}",
+            left: "2400",
           },
         "& [data-slot='pin-row-cell']": {
           backgroundColor: "bg",
@@ -373,19 +373,19 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       },
       // When drag column is present, offset selection and expand columns
       "&.drag-column-header + &.selection-column-header": {
-        left: "{sizes.600}",
+        left: "600",
       },
       "&.drag-column-header + &.expand-column-header": {
-        left: "{sizes.600}",
+        left: "600",
       },
       // When selection column is present, adjust expand column header position
       "&.selection-column-header + &.expand-column-header": {
-        left: "{sizes.1800}",
+        left: "1800",
       },
       // When both drag and selection columns are present, offset expand column
       "&.drag-column-header + &.selection-column-header + &.expand-column-header":
         {
-          left: "{sizes.2400}",
+          left: "2400",
         },
       "&.pin-rows-column-header": {
         cursor: "default",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -100,21 +100,21 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         },
         // When drag column is present, offset selection and expand columns
         "& [data-slot='drag'] ~ [data-slot='selection']": {
-          left: "600",
+          left: "{sizes.600}",
         },
         "& [data-slot='drag'] ~ [data-slot='expand']": {
-          left: "600",
+          left: "{sizes.600}",
         },
         // When selection column is present, move expand column to the right
         // and lower its z-index so it doesn't overlap selection during scroll
         "& [data-slot='selection'] ~ [data-slot='expand']": {
-          left: "1800",
+          left: "{sizes.1800}",
           zIndex: 10,
         },
         // When both drag and selection columns are present, offset expand column
         "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
           {
-            left: "2400",
+            left: "{sizes.2400}",
           },
         _hover: {
           backgroundColor: "{colors.primary.3}",
@@ -136,20 +136,20 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           },
           // When drag column is present, offset selection and expand columns on hover
           "& [data-slot='drag'] ~ [data-slot='selection']": {
-            left: "600",
+            left: "{sizes.600}",
           },
           "& [data-slot='drag'] ~ [data-slot='expand']": {
-            left: "600",
+            left: "{sizes.600}",
           },
           // When selection column is present, move expand column to the right on hover
           "& [data-slot='selection'] ~ [data-slot='expand']": {
-            left: "1800",
+            left: "{sizes.1800}",
             zIndex: 10,
           },
           // When both drag and selection columns are present, offset expand column on hover
           "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
             {
-              left: "2400",
+              left: "{sizes.2400}",
             },
           "& [data-slot='pin-row-cell']": {
             right: 0,
@@ -189,20 +189,20 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         },
         // When drag column is present in pinned rows, offset selection and expand columns
         "& [data-slot='drag'] ~ [data-slot='selection']": {
-          left: "600",
+          left: "{sizes.600}",
         },
         "& [data-slot='drag'] ~ [data-slot='expand']": {
-          left: "600",
+          left: "{sizes.600}",
         },
         // When selection column is present in pinned rows, move expand column
         "& [data-slot='selection'] ~ [data-slot='expand']": {
-          left: "1800",
+          left: "{sizes.1800}",
           zIndex: 10,
         },
         // When both drag and selection columns are present in pinned rows
         "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
           {
-            left: "2400",
+            left: "{sizes.2400}",
           },
         "& [data-slot='pin-row-cell']": {
           backgroundColor: "bg",
@@ -369,19 +369,19 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       },
       // When drag column is present, offset selection and expand columns
       "&.drag-column-header + &.selection-column-header": {
-        left: "600",
+        left: "{sizes.600}",
       },
       "&.drag-column-header + &.expand-column-header": {
-        left: "600",
+        left: "{sizes.600}",
       },
       // When selection column is present, adjust expand column header position
       "&.selection-column-header + &.expand-column-header": {
-        left: "1800",
+        left: "{sizes.1800}",
       },
       // When both drag and selection columns are present, offset expand column
       "&.drag-column-header + &.selection-column-header + &.expand-column-header":
         {
-          left: "2400",
+          left: "{sizes.2400}",
         },
       "&.pin-rows-column-header": {
         cursor: "default",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -50,6 +50,24 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       display: "block",
       overflow: "auto",
       contain: "layout style",
+
+      // Scroll shadows activated by JS scroll detection via data attributes.
+      // Body selectors include .data-table-row to beat the base specificity.
+      "&[data-scroll-left='true']": {
+        "& .data-table-row .data-table-sticky-cell:not([data-slot='pin-row-cell']):not([data-slot='selection'] ~ [data-slot='expand'])":
+          { boxShadow: "{shadows.right}" },
+        "& .data-table-header .selection-column-header, & .data-table-header .drag-column-header, & .data-table-header .expand-column-header:not(.selection-column-header ~ .expand-column-header)":
+          { boxShadow: "{shadows.right}" },
+      },
+      "&[data-scroll-right='true']": {
+        "& .data-table-row [data-slot='pin-row-cell']": {
+          boxShadow: "{shadows.left}",
+        },
+        "& .data-table-header .pin-rows-column-header": {
+          boxShadow: "{shadows.left}",
+        },
+      },
+
       "& .data-table-row": {
         "& [data-slot='pin-row-cell']": {
           position: "sticky",
@@ -57,6 +75,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           zIndex: 3,
           backgroundColor: "bg",
           ...stickyBgOverlap,
+          "&::before": { right: 0 },
           "& [data-slot='nimbus-table-cell-pin-button']": {
             opacity: 0,
           },
@@ -64,7 +83,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
             opacity: 1,
           },
         },
-        "& .data-table-sticky-cell": {
+        "& .data-table-sticky-cell:not([data-slot='pin-row-cell'])": {
           position: "sticky",
           left: 0,
           backgroundColor: "bg",
@@ -87,8 +106,10 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           left: "600",
         },
         // When selection column is present, move expand column to the right
+        // and lower its z-index so it doesn't overlap selection during scroll
         "& [data-slot='selection'] ~ [data-slot='expand']": {
           left: "1800",
+          zIndex: 10,
         },
         // When both drag and selection columns are present, offset expand column
         "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
@@ -123,6 +144,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
           // When selection column is present, move expand column to the right on hover
           "& [data-slot='selection'] ~ [data-slot='expand']": {
             left: "1800",
+            zIndex: 10,
           },
           // When both drag and selection columns are present, offset expand column on hover
           "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
@@ -175,6 +197,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         // When selection column is present in pinned rows, move expand column
         "& [data-slot='selection'] ~ [data-slot='expand']": {
           left: "1800",
+          zIndex: 10,
         },
         // When both drag and selection columns are present in pinned rows
         "& [data-slot='drag'] ~ [data-slot='selection'] ~ [data-slot='expand']":
@@ -369,6 +392,7 @@ export const dataTableSlotRecipe = defineSlotRecipe({
         zIndex: 11,
         background: "colorPalette.2",
         ...stickyBgOverlap,
+        "&::before": { right: 0 },
       },
       "&[aria-sort]": {
         fontWeight: 600,

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -60,12 +60,17 @@ export const dataTableSlotRecipe = defineSlotRecipe({
       "&[data-scroll-left='true']": {
         "& .data-table-row .data-table-sticky-cell:not([data-slot='pin-row-cell']):not([data-slot='selection'] ~ [data-slot='expand'])":
           { boxShadow: "{shadows.right}" },
+        "& .data-table-row-pinned .data-table-sticky-cell:not([data-slot='pin-row-cell'])":
+          { clipPath: "none" },
         "& .data-table-header .selection-column-header, & .data-table-header .drag-column-header, & .data-table-header .expand-column-header:not(.selection-column-header ~ .expand-column-header)":
           { boxShadow: "{shadows.right}" },
       },
       "&[data-scroll-right='true']": {
         "& .data-table-row [data-slot='pin-row-cell']": {
           boxShadow: "{shadows.left}",
+        },
+        "& .data-table-row-pinned [data-slot='pin-row-cell']": {
+          clipPath: "none",
         },
         "& .data-table-header .pin-rows-column-header": {
           boxShadow: "{shadows.left}",

--- a/packages/nimbus/src/components/data-table/data-table.recipe.ts
+++ b/packages/nimbus/src/components/data-table/data-table.recipe.ts
@@ -53,6 +53,10 @@ export const dataTableSlotRecipe = defineSlotRecipe({
 
       // Scroll shadows activated by JS scroll detection via data attributes.
       // Body selectors include .data-table-row to beat the base specificity.
+      // Left-side sticky cells get a right shadow (facing the scrolled content).
+      // Pin-row-cell is excluded (it's sticky-right, shadowed separately).
+      // The expand column is excluded when it follows selection, because
+      // selection already casts the shadow at that edge.
       "&[data-scroll-left='true']": {
         "& .data-table-row .data-table-sticky-cell:not([data-slot='pin-row-cell']):not([data-slot='selection'] ~ [data-slot='expand'])":
           { boxShadow: "{shadows.right}" },

--- a/packages/nimbus/src/components/data-table/data-table.stories.tsx
+++ b/packages/nimbus/src/components/data-table/data-table.stories.tsx
@@ -6006,3 +6006,133 @@ export const HiddenExpandColumnWithRowClick: Story = {
     });
   },
 };
+
+export const ScrollShadows: Story = {
+  render: () => {
+    const scrollColumns: DataTableColumnItem[] = [
+      {
+        id: "name",
+        header: "Name",
+        accessor: (row) => row.name as React.ReactNode,
+        minWidth: 150,
+      },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        id: `col-${i}`,
+        header: `Column ${i + 1}`,
+        accessor: (row: Record<string, unknown>) =>
+          (row[`col${i}`] || `Value ${i + 1}`) as React.ReactNode,
+        minWidth: 200,
+      })),
+    ];
+
+    const scrollRows: DataTableRowItem[] = Array.from(
+      { length: 10 },
+      (_, i) => ({
+        id: `${i + 1}`,
+        name: `Employee ${i + 1}`,
+        ...Object.fromEntries(
+          Array.from({ length: 10 }, (_, j) => [
+            `col${j}`,
+            `Data R${i + 1}C${j + 1}`,
+          ])
+        ),
+      })
+    );
+
+    return (
+      <Box maxW="700px" data-testid="scroll-shadow-container">
+        <DataTable
+          columns={scrollColumns}
+          rows={scrollRows}
+          selectionMode="multiple"
+          selectionBehavior="toggle"
+          data-testid="scroll-shadow-table"
+        />
+      </Box>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Table renders with scroll attributes", async () => {
+      const table = await canvas.findByRole("grid");
+      expect(table).toBeInTheDocument();
+
+      const root = table.closest(
+        '[data-testid="scroll-shadow-table"]'
+      ) as HTMLElement;
+      expect(root).toBeInTheDocument();
+    });
+
+    await step(
+      "No left shadow at initial scroll position (scrolled to start)",
+      async () => {
+        const root = canvasElement.querySelector(
+          '[data-testid="scroll-shadow-table"]'
+        ) as HTMLElement;
+
+        await waitFor(() => {
+          expect(root.getAttribute("data-scroll-left")).toBe("false");
+        });
+      }
+    );
+
+    await step(
+      "Right shadow present when content overflows to the right",
+      async () => {
+        const root = canvasElement.querySelector(
+          '[data-testid="scroll-shadow-table"]'
+        ) as HTMLElement;
+
+        await waitFor(() => {
+          expect(root.getAttribute("data-scroll-right")).toBe("true");
+        });
+      }
+    );
+
+    await step("Left shadow appears after scrolling right", async () => {
+      const root = canvasElement.querySelector(
+        '[data-testid="scroll-shadow-table"]'
+      ) as HTMLElement;
+
+      root.scrollLeft = 200;
+      root.dispatchEvent(new Event("scroll"));
+
+      await waitFor(() => {
+        expect(root.getAttribute("data-scroll-left")).toBe("true");
+      });
+
+      const stickyCells = canvasElement.querySelectorAll(
+        ".data-table-sticky-cell:not([data-slot='pin-row-cell'])"
+      );
+      expect(stickyCells.length).toBeGreaterThan(0);
+    });
+
+    await step("Right shadow disappears when scrolled to the end", async () => {
+      const root = canvasElement.querySelector(
+        '[data-testid="scroll-shadow-table"]'
+      ) as HTMLElement;
+
+      root.scrollLeft = root.scrollWidth - root.clientWidth;
+      root.dispatchEvent(new Event("scroll"));
+
+      await waitFor(() => {
+        expect(root.getAttribute("data-scroll-right")).toBe("false");
+      });
+    });
+
+    await step("Both shadows gone at scroll start", async () => {
+      const root = canvasElement.querySelector(
+        '[data-testid="scroll-shadow-table"]'
+      ) as HTMLElement;
+
+      root.scrollLeft = 0;
+      root.dispatchEvent(new Event("scroll"));
+
+      await waitFor(() => {
+        expect(root.getAttribute("data-scroll-left")).toBe("false");
+        expect(root.getAttribute("data-scroll-right")).toBe("true");
+      });
+    });
+  },
+};

--- a/packages/tokens/css/design-tokens.css
+++ b/packages/tokens/css/design-tokens.css
@@ -2260,6 +2260,8 @@
   --shadow-4: 0 6px 16px 0 hsla(0, 0%, 0%, 0.1);
   --shadow-5: 0 8px 20px 0 hsla(0, 0%, 0%, 0.1);
   --shadow-6: 0 10px 24px 0 hsla(0, 0%, 0%, 0.15);
+  --shadow-right: 6px 0 8px -2px hsla(0, 0%, 0%, 0.15);
+  --shadow-left: -6px 0 8px -2px hsla(0, 0%, 0%, 0.15);
   --opacity-5: 0.05;
   --opacity-10: 0.1;
   --opacity-15: 0.15;

--- a/packages/tokens/src/base/tokens.json
+++ b/packages/tokens/src/base/tokens.json
@@ -7316,6 +7316,24 @@
         "spread": 0,
         "color": "{color.blacks-and-whites.blackAlpha.3}"
       }
+    },
+    "right": {
+      "$value": {
+        "x": "{spacing.150}",
+        "y": 0,
+        "blur": "{blur.200}",
+        "spread": "-{spacing.50}",
+        "color": "{color.blacks-and-whites.blackAlpha.3}"
+      }
+    },
+    "left": {
+      "$value": {
+        "x": "-{spacing.150}",
+        "y": 0,
+        "blur": "{blur.200}",
+        "spread": "-{spacing.50}",
+        "color": "{color.blacks-and-whites.blackAlpha.3}"
+      }
     }
   },
   "opacity": {

--- a/packages/tokens/src/generated/chakra/theme-tokens.ts
+++ b/packages/tokens/src/generated/chakra/theme-tokens.ts
@@ -7014,6 +7014,12 @@ export default {
     "6": {
       value: "0 10px 24px 0 hsla(0, 0%, 0%, 0.15)",
     },
+    right: {
+      value: "6px 0 8px -2px hsla(0, 0%, 0%, 0.15)",
+    },
+    left: {
+      value: "-6px 0 8px -2px hsla(0, 0%, 0%, 0.15)",
+    },
   },
   opacity: {
     "5": {

--- a/packages/tokens/src/generated/ts/design-tokens.ts
+++ b/packages/tokens/src/generated/ts/design-tokens.ts
@@ -2785,6 +2785,8 @@ export default {
     "4": "0 6px 16px 0 hsla(0, 0%, 0%, 0.1)",
     "5": "0 8px 20px 0 hsla(0, 0%, 0%, 0.1)",
     "6": "0 10px 24px 0 hsla(0, 0%, 0%, 0.15)",
+    right: "6px 0 8px -2px hsla(0, 0%, 0%, 0.15)",
+    left: "-6px 0 8px -2px hsla(0, 0%, 0%, 0.15)",
   },
   opacity: {
     "5": 0.05,


### PR DESCRIPTION
## Summary
- Add `shadow.left` and `shadow.right` design tokens for horizontal scroll indicators
- Detect horizontal scroll position via passive scroll listener + ResizeObserver on the DataTable root
- Apply `box-shadow` to sticky column cells when content is hidden beyond the scroll edges
- Fix pin column `::before` extending beyond the table boundary (caused unwanted horizontal scrollbar)
- Add visible expand (chevron) and pin icons in column headers with `neutral.10` color
- Lower expand column z-index when selection column is present to prevent overlap during scroll
- Add `ScrollShadows` story with play function verifying shadow data attributes on scroll

Closes FEC-1169

## Test plan
- [x] All 45 DataTable storybook tests pass
- [x] All 41 docs spec tests pass
- [x] Verify shadows appear/disappear correctly on horizontal scroll
- [x] Verify no unwanted horizontal scrollbar on non-scrolling stories
- [x] Verify expand column doesn't overlap selection during scroll
- [x] Verify header icons match cell icon size and color

🤖 Generated with [Claude Code](https://claude.com/claude-code)