### PR TITLE
chore(deps): update workspace dependencies to latest minor/patch versions

### DIFF
--- a/.changeset/housekeeping-deps-20260805-1417.md
+++ b/.changeset/housekeeping-deps-20260805-1417.md
@@ -1,0 +1,9 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Update bundled runtime dependencies to their latest patch and minor versions.
+The React Aria stack moves to `react-aria` 3.51.0, `react-aria-components`
+1.20.0 and `react-stately` 3.49.0, alongside `@internationalized/string` 3.2.10
+and a refreshed bundled copy of `dompurify` (3.4.13). No API changes — upgrading
+requires no action.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,9 +13,13 @@ jobs:
       contents: read
       pull-requests: write
     container:
-      # Make sure to grab the latest version of the Playwright image
+      # Must track the `playwright` version in pnpm-workspace.yaml's tooling
+      # catalog. The image ships pre-downloaded browsers under a build-specific
+      # revision directory, so a Playwright bump that changes that revision
+      # fails at launch with "Executable doesn't exist at
+      # /ms-playwright/chromium_headless_shell-<rev>". Bump both together.
       # https://playwright.dev/docs/docker#pull-the-image
-      image: mcr.microsoft.com/playwright:v1.61.0-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
 
     steps:
       - name: Checkout repository

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,26 +91,26 @@ catalogs:
       specifier: ^11.14.0
       version: 11.14.0
     '@internationalized/date':
-      specifier: ^3.12.2
-      version: 3.12.2
+      specifier: ^3.12.3
+      version: 3.12.3
     '@internationalized/string':
-      specifier: ^3.2.9
-      version: 3.2.9
+      specifier: ^3.2.10
+      version: 3.2.10
     '@internationalized/string-compiler':
       specifier: ^3.4.1
       version: 3.4.1
     '@react-aria/optimize-locales-plugin':
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: 2.0.1
+      version: 2.0.1
     '@react-aria/utils':
       specifier: 3.34.1
       version: 3.34.1
     '@types/react':
-      specifier: ^19.2.17
-      version: 19.2.17
+      specifier: ^19.2.18
+      version: 19.2.18
     '@types/react-dom':
-      specifier: ^19.2.3
-      version: 19.2.3
+      specifier: ^19.2.4
+      version: 19.2.4
     next-themes:
       specifier: ^0.4.6
       version: 0.4.6
@@ -323,9 +323,9 @@ overrides:
   '@babel/runtime': ^7.29.7
   prismjs: ^1.30.0
   typescript: ~5.9.3
-  react-aria: 3.50.0
-  react-aria-components: 1.19.0
-  react-stately: 3.48.0
+  react-aria: 3.51.0
+  react-aria-components: 1.20.0
+  react-stately: 3.49.0
   '@react-aria/interactions': 3.28.1
   brace-expansion@<2: ^2.1.2
   brace-expansion@2: ^2.1.2
@@ -412,7 +412,7 @@ importers:
         version: 7.1.1(eslint@10.8.0(supports-color@8.1.1))
       eslint-plugin-storybook:
         specifier: catalog:tooling
-        version: 10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
       glob:
         specifier: catalog:tooling
         version: 13.0.6
@@ -467,10 +467,10 @@ importers:
         version: 10.0.1(eslint@10.8.0)
       '@types/react':
         specifier: catalog:react
-        version: 19.2.17
+        version: 19.2.18
       '@types/react-dom':
         specifier: catalog:react
-        version: 19.2.3(@types/react@19.2.17)
+        version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
         version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
@@ -512,13 +512,13 @@ importers:
         version: link:../../packages/nimbus-icons
       '@emotion/react':
         specifier: catalog:react
-        version: 11.14.0(@types/react@19.2.17)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.18)(react@19.2.0)
       '@huggingface/transformers':
         specifier: 'catalog:'
         version: 3.8.1
       '@internationalized/date':
         specifier: catalog:react
-        version: 3.12.2
+        version: 3.12.3
       '@mdx-js/mdx':
         specifier: catalog:apps
         version: 3.1.1
@@ -545,7 +545,7 @@ importers:
         version: 4.0.3
       jotai:
         specifier: catalog:apps
-        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0)
+        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.0)
       lodash:
         specifier: catalog:utils
         version: 4.18.1
@@ -556,11 +556,11 @@ importers:
         specifier: catalog:react
         version: 19.2.0
       react-aria:
-        specifier: 3.50.0
-        version: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 3.51.0
+        version: 3.51.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-aria-components:
-        specifier: 1.19.0
-        version: 1.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 1.20.0
+        version: 1.20.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-docgen-typescript:
         specifier: catalog:tooling
         version: 2.4.0(typescript@5.9.3)
@@ -577,8 +577,8 @@ importers:
         specifier: catalog:apps
         version: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
-        specifier: 3.48.0
-        version: 3.48.0(react@19.2.0)
+        specifier: 3.49.0
+        version: 3.49.0(react@19.2.0)
       react-syntax-highlighter:
         specifier: catalog:apps
         version: 16.1.1(react@19.2.0)
@@ -612,10 +612,10 @@ importers:
         version: 4.17.25
       '@types/react':
         specifier: catalog:react
-        version: 19.2.17
+        version: 19.2.18
       '@types/react-dom':
         specifier: catalog:react
-        version: 19.2.3(@types/react@19.2.17)
+        version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
         version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
@@ -712,16 +712,16 @@ importers:
     dependencies:
       '@chakra-ui/cli':
         specifier: catalog:react
-        version: 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)
+        version: 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)
       '@emotion/is-prop-valid':
         specifier: catalog:react
         version: 1.4.0
       '@github-ui/storybook-addon-performance-panel':
         specifier: catalog:tooling
-        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@internationalized/string':
         specifier: catalog:react
-        version: 3.2.9
+        version: 3.2.10
       '@react-aria/interactions':
         specifier: 3.28.1
         version: 3.28.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -741,20 +741,20 @@ importers:
         specifier: catalog:react
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-aria:
-        specifier: 3.50.0
-        version: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 3.51.0
+        version: 3.51.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-aria-components:
-        specifier: 1.19.0
-        version: 1.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 1.20.0
+        version: 1.20.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-hotkeys-hook:
         specifier: catalog:react
         version: 5.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-markdown:
         specifier: catalog:markdown
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.0)
+        version: 10.1.0(@types/react@19.2.18)(react@19.2.0)
       react-stately:
-        specifier: 3.48.0
-        version: 3.48.0(react@19.2.0)
+        specifier: 3.49.0
+        version: 3.49.0(react@19.2.0)
       react-use:
         specifier: catalog:react
         version: 17.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -770,7 +770,7 @@ importers:
     devDependencies:
       '@chakra-ui/react':
         specifier: catalog:react
-        version: 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.36.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools/nimbus-design-token-ts-plugin':
         specifier: workspace:^
         version: link:../design-token-ts-plugin
@@ -782,31 +782,31 @@ importers:
         version: link:../tokens
       '@internationalized/date':
         specifier: catalog:react
-        version: 3.12.2
+        version: 3.12.3
       '@react-aria/optimize-locales-plugin':
         specifier: catalog:react
-        version: 2.0.0
+        version: 2.0.1
       '@react-types/shared':
         specifier: catalog:tooling
         version: 3.36.1(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
-        version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)
+        version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.10.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: catalog:tooling
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: catalog:tooling
         version: 14.6.3(@testing-library/dom@10.4.1)
@@ -818,10 +818,10 @@ importers:
         version: 0.1.10
       '@types/react':
         specifier: catalog:react
-        version: 19.2.17
+        version: 19.2.18
       '@types/react-dom':
         specifier: catalog:react
-        version: 19.2.3(@types/react@19.2.17)
+        version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: catalog:tooling
         version: 6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
@@ -836,7 +836,7 @@ importers:
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vueless/storybook-dark-mode':
         specifier: catalog:tooling
-        version: 10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       apca-w3:
         specifier: ^0.1.9
         version: 0.1.9
@@ -878,7 +878,7 @@ importers:
         version: 0.123.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.123.0(slate@0.123.0))(slate@0.123.0)
       storybook:
         specifier: catalog:tooling
-        version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
@@ -943,7 +943,7 @@ importers:
         version: 24.13.3
       '@types/react':
         specifier: catalog:react
-        version: 19.2.17
+        version: 19.2.18
       react:
         specifier: catalog:react
         version: 19.2.0
@@ -962,10 +962,10 @@ importers:
     devDependencies:
       '@commercetools-frontend/ui-kit':
         specifier: catalog:tooling
-        version: 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: 20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/design-system':
         specifier: ^20.6.4
-        version: 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 20.6.4(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools/nimbus':
         specifier: workspace:^
         version: link:../nimbus
@@ -977,7 +977,7 @@ importers:
         version: link:../tokens
       '@modelcontextprotocol/inspector':
         specifier: catalog:tooling
-        version: 0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(supports-color@8.1.1)(typescript@5.9.3)
       '@types/node':
         specifier: catalog:utils
         version: 24.13.3
@@ -2563,6 +2563,9 @@ packages:
   '@internationalized/date@3.12.2':
     resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
   '@internationalized/number@3.6.6':
     resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
 
@@ -2572,8 +2575,8 @@ packages:
   '@internationalized/string-compiler@3.4.1':
     resolution: {integrity: sha512-S1whKbypxHbl+XrESQpE/ZzJV+WreR7HE/2KCpxWwpsZn8N9iFN3BUgI3X20RVmEqJ+73hwAtP1RSNXPhJfvmg==}
 
-  '@internationalized/string@3.2.9':
-    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
+  '@internationalized/string@3.2.10':
+    resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3654,19 +3657,14 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/optimize-locales-plugin@2.0.0':
-    resolution: {integrity: sha512-tXQiC+ud+EDzJfwlbTY6J33pU51V+PMB4PcxYN6PYHGlRpq938zq6IKhquPJkVGqKLTnOeMtSjns/yvRR5wfww==}
+  '@react-aria/optimize-locales-plugin@2.0.1':
+    resolution: {integrity: sha512-JQndO3SEGqd0xiVljvnepNznbM2yfWjhQ8PiVXp0ra+PEuBeemPChxWw2OJZfbwceaY8hH+A8YWu9FWiWmOHgg==}
 
   '@react-aria/utils@3.34.1':
     resolution: {integrity: sha512-H6+rGZL+0f58bBNaUMfctEnT+NogqwAk+nHiB8sR3K+YlQ37GTuCijy2U/pPvQtFMS5mURrjZeBH5JNNXsx14A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/shared@3.36.0':
-    resolution: {integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@react-types/shared@3.36.1':
     resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
@@ -4499,8 +4497,8 @@ packages:
   '@types/raf-schd@4.0.3':
     resolution: {integrity: sha512-dXFOLpls9K3eXBupCtMhvtbPtWVAkwa5tkqdMj1uVwYBYdPu2kVX1mGVp2qFpfeNNub85B0vzFfxA4URA0TnPA==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -4526,6 +4524,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -7832,14 +7833,14 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-aria-components@1.19.0:
-    resolution: {integrity: sha512-2smSS5nqJ8cGYMQezuUXveZm7eMyHCqTN6mDpylQBYLYbdF5dxCCuW1DHn1VKLe1DybSfPvX/cZtJlDmvFfn8A==}
+  react-aria-components@1.20.0:
+    resolution: {integrity: sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-aria@3.50.0:
-    resolution: {integrity: sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==}
+  react-aria@3.51.0:
+    resolution: {integrity: sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -7982,8 +7983,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-stately@3.48.0:
-    resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
+  react-stately@3.49.0:
+    resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -9737,12 +9738,12 @@ snapshots:
     dependencies:
       postcss-calc-ast-parser: 0.1.4
 
-  '@chakra-ui/cli@3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)':
+  '@chakra-ui/cli@3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@clack/prompts': 1.5.1
       '@pandacss/is-valid-prop': 1.11.1
       '@types/babel__core': 7.20.5
@@ -9767,11 +9768,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@ark-ui/react': 5.37.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
       '@emotion/utils': 1.4.2
@@ -9953,49 +9954,49 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)
-      '@commercetools-uikit/avatar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-panel': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/filters': 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.18)(react@19.2.0)
+      '@commercetools-uikit/avatar': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-panel': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/filters': 20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.18)(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/i18n': 20.6.7
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/notifications': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/pagination': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/progress-bar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/stamp': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/notifications': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/pagination': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/progress-bar': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/stamp': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/view-switcher': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/view-switcher': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       moment: 2.30.1
       moment-timezone: 0.6.2
       react: 19.2.0
@@ -10008,14 +10009,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/accessible-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/accessible-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       '@types/react-is': 19.2.0
       lodash: 4.18.1
       react: 19.2.0
@@ -10025,119 +10026,119 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/accessible-hidden@20.6.7(@types/react@19.2.17)(react@19.2.0)':
+  '@commercetools-uikit/accessible-hidden@20.6.7(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  '@commercetools-uikit/async-creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-creatable-select-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-creatable-select-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-select-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/avatar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/avatar@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10145,18 +10146,18 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
       react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10175,42 +10176,42 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.18)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       moment: 2.30.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/card@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/card@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
       react: 19.2.0
@@ -10220,16 +10221,16 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/checkbox-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/checkbox-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10238,14 +10239,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10253,21 +10254,21 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/collapsible-panel@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/collapsible-panel@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10277,14 +10278,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/collapsible@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10292,95 +10293,95 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/constraints@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/constraints@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/creatable-select-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/creatable-select-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.18)(react@19.2.0)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.18)(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
-      '@hello-pangea/dnd': 18.0.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
+      '@hello-pangea/dnd': 18.0.1(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/debounce-promise': 3.1.9
       debounce-promise: 3.1.2
       lodash: 4.18.1
@@ -10393,19 +10394,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10416,20 +10417,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-field@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10440,25 +10441,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-input@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.18)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10472,20 +10473,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-range-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-range-field@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10496,25 +10497,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-range-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-range-input@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.18)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10528,20 +10529,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-time-field@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10552,25 +10553,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-time-input@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.18)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10584,12 +10585,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/design-system@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/design-system@20.6.4(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10597,12 +10598,12 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/design-system@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/design-system@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10610,20 +10611,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10633,13 +10634,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-errors@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/field-errors@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10648,22 +10649,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/field-label@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10672,13 +10673,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-warnings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/field-warnings@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10687,27 +10688,27 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/password-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/time-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-creatable-select-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-select-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/creatable-select-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-field': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-field': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-field': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/number-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/password-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/search-select-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/time-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
       react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10719,25 +10720,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/filters@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/filters@20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10749,17 +10750,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/flat-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/flat-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10769,12 +10770,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/grid@20.6.7(@types/react@19.2.17)(react@19.2.0)':
+  '@commercetools-uikit/grid@20.6.7(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -10807,17 +10808,17 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
 
-  '@commercetools-uikit/icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/icon-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10827,14 +10828,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/icons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/icons@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       '@types/dompurify': 2.4.0
       dompurify: 3.4.13
       react: 19.2.0
@@ -10844,52 +10845,52 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/input-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/input-utils@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.18)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/toggle-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-money-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-rich-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/search-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/toggle-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
       react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10901,15 +10902,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/label@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10917,17 +10918,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       history: 4.10.1
       lodash: 4.18.1
       react: 19.2.0
@@ -10938,16 +10939,16 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/link@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       '@types/history': 4.7.11
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
@@ -10959,15 +10960,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/loading-spinner@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/loading-spinner@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10976,48 +10977,48 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-money-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-multiline-text-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11026,54 +11027,54 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-multiline-text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.18)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-rich-text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       immutable: 4.3.9
       is-hotkey: 0.2.0
@@ -11081,7 +11082,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.18)(react@19.2.0)
       slate: 0.75.0
       slate-history: 0.113.1(slate@0.75.0)
       slate-react: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
@@ -11090,20 +11091,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-text-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11112,24 +11113,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11147,14 +11148,14 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/messages@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/messages@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11163,68 +11164,68 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/money-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/money-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/money-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/multiline-text-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11233,42 +11234,42 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/multiline-text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.18)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/notifications@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/notifications@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11276,20 +11277,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/number-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/number-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11298,16 +11299,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/number-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/number-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11316,23 +11317,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/pagination@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/pagination@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
-      formik: 2.4.9(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
+      formik: 2.4.9(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11342,24 +11343,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/password-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/password-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11368,16 +11369,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/password-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/password-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11386,19 +11387,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11409,17 +11410,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11429,17 +11430,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/progress-bar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/progress-bar@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11449,14 +11450,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11466,20 +11467,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/radio-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11488,20 +11489,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-is: 19.2.6
     transitivePeerDependencies:
@@ -11511,24 +11512,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/rich-text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       immutable: 4.3.9
       is-hotkey: 0.2.0
@@ -11544,18 +11545,18 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/rich-text-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/rich-text-utils@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       '@types/dompurify': 2.4.0
       '@types/escape-html': 1.0.4
       dompurify: 3.4.13
@@ -11577,63 +11578,63 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/search-select-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/search-select-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/search-text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11642,17 +11643,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11662,17 +11663,17 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/secondary-icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/secondary-icon-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11682,174 +11683,174 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/select-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/select-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/select-utils@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/selectable-search-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/selectable-search-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/spacings-inline@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-inline@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset-squish@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-inset-squish@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-inset@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-stack@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-stack@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset-squish': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset-squish': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/stamp@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/stamp@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11857,19 +11858,19 @@ snapshots:
       - react-intl
       - supports-color
 
-  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11880,21 +11881,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/text-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11903,16 +11904,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/text-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11921,13 +11922,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/text@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11937,20 +11938,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/time-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/time-field@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11959,21 +11960,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/time-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/time-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11982,16 +11983,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/toggle-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/toggle-input@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -12000,16 +12001,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       popper.js: 1.16.1
       react: 19.2.0
@@ -12034,15 +12035,15 @@ snapshots:
       '@emotion/is-prop-valid': 1.4.0
       react: 19.2.0
 
-  '@commercetools-uikit/view-switcher@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/view-switcher@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -12144,7 +12145,7 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
@@ -12156,7 +12157,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
     transitivePeerDependencies:
       - supports-color
 
@@ -12170,18 +12171,18 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
       '@emotion/utils': 1.4.2
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
     transitivePeerDependencies:
       - supports-color
 
@@ -12420,22 +12421,22 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
 
-  '@hello-pangea/dnd@18.0.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@hello-pangea/dnd@18.0.1(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       css-box-model: 1.2.1
       raf-schd: 4.0.3
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.0)(redux@5.0.1)
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.0)(redux@5.0.1)
       redux: 5.0.1
     transitivePeerDependencies:
       - '@types/react'
@@ -12689,6 +12690,10 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.17
 
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
   '@internationalized/number@3.6.6':
     dependencies:
       '@swc/helpers': 0.5.17
@@ -12701,7 +12706,7 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.11.4
 
-  '@internationalized/string@3.2.9':
+  '@internationalized/string@3.2.10':
     dependencies:
       '@swc/helpers': 0.5.17
 
@@ -12955,10 +12960,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
       react: 19.2.0
 
   '@microsoft/api-extractor-model@7.31.1(@types/node@24.13.3)':
@@ -13061,26 +13066,26 @@ snapshots:
       - supports-color
       - zod
 
-  '@modelcontextprotocol/inspector-client@0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)':
+  '@modelcontextprotocol/inspector-client@0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)':
     dependencies:
       '@mcp-ui/client': 6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modelcontextprotocol/ext-apps': 1.1.2(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons': 1.3.2(react@18.3.1)
-      '@radix-ui/react-label': 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label': 2.1.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ajv: 6.14.0
       class-variance-authority: 0.7.1
       clsx: 2.1.1
-      cmdk: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      cmdk: 1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lucide-react: 0.523.0(react@18.3.1)
       pkce-challenge: 4.1.0
       prismjs: 1.30.0
@@ -13115,10 +13120,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@modelcontextprotocol/inspector@0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.22.0(zod@3.25.76)
-      '@modelcontextprotocol/inspector-client': 0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)
+      '@modelcontextprotocol/inspector-client': 0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)
       '@modelcontextprotocol/inspector-server': 0.22.0
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       concurrently: 9.2.1
@@ -13490,588 +13495,588 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/react-icons@1.3.2(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@19.2.0)
       aria-hidden: 1.2.6
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       '@radix-ui/rect': 1.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       '@radix-ui/rect': 1.1.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.18)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
       '@radix-ui/rect': 1.1.1
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
       '@radix-ui/rect': 1.1.1
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.17)(react@18.3.1)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.18)(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.17)(react@19.2.0)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.18)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@radix-ui/rect@1.1.1': {}
 
@@ -14080,10 +14085,10 @@ snapshots:
       '@react-types/shared': 3.36.1(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
-      react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-aria: 3.51.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
 
-  '@react-aria/optimize-locales-plugin@2.0.0':
+  '@react-aria/optimize-locales-plugin@2.0.1':
     dependencies:
       unplugin: 2.3.11
 
@@ -14091,13 +14096,9 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.17
       react: 19.2.0
-      react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-aria: 3.51.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
-      react-stately: 3.48.0(react@19.2.0)
-
-  '@react-types/shared@3.36.0(react@19.2.0)':
-    dependencies:
-      react: 19.2.0
+      react-stately: 3.49.0(react@19.2.0)
 
   '@react-types/shared@3.36.1(react@19.2.0)':
     dependencies:
@@ -14362,24 +14363,24 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.12.1
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
+      '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.0)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
     transitivePeerDependencies:
       - '@types/react-dom'
       - esbuild
@@ -14387,11 +14388,11 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)':
+  '@storybook/addon-vitest@10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
@@ -14401,10 +14402,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -14412,9 +14413,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -14429,28 +14430,28 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.0
       react-docgen: 8.0.2
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.12
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -14462,18 +14463,18 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14665,15 +14666,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
     dependencies:
@@ -14781,6 +14782,11 @@ snapshots:
       '@types/react': 19.2.17
       hoist-non-react-statics: 3.3.2
 
+  '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+      hoist-non-react-statics: 3.3.2
+
   '@types/is-hotkey@0.1.10': {}
 
   '@types/js-cookie@3.0.6': {}
@@ -14813,9 +14819,9 @@ snapshots:
 
   '@types/raf-schd@4.0.3': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
     dependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   '@types/react-is@19.2.0':
     dependencies:
@@ -14834,11 +14840,11 @@ snapshots:
 
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  '@types/react-transition-group@4.4.12(@types/react@19.2.17)':
+  '@types/react-transition-group@4.4.12(@types/react@19.2.18)':
     dependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   '@types/react@18.3.28':
     dependencies:
@@ -14846,6 +14852,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
 
@@ -15196,11 +15206,11 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       lodash-es: 4.18.1
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -16229,12 +16239,12 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  cmdk@1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -16681,11 +16691,11 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  eslint-plugin-storybook@10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-plugin-storybook@10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.64.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint: 10.8.0(supports-color@8.1.1)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17017,9 +17027,9 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  formik@2.4.9(@types/react@19.2.17)(react@19.2.0):
+  formik@2.4.9(@types/react@19.2.18)(react@19.2.0):
     dependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.17)
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.18)
       deepmerge: 2.2.1
       hoist-non-react-statics: 3.3.2
       lodash: 4.18.1
@@ -17582,11 +17592,11 @@ snapshots:
 
   jose@6.1.3: {}
 
-  jotai@2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0):
+  jotai@2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.0):
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/template': 7.29.7
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
       react: 19.2.0
 
   joycon@3.1.1: {}
@@ -18918,29 +18928,30 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-aria-components@1.19.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-aria-components@1.20.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@internationalized/date': 3.12.2
-      '@react-types/shared': 3.36.0(react@19.2.0)
+      '@internationalized/date': 3.12.3
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.0)
       '@swc/helpers': 0.5.17
       client-only: 0.0.1
       react: 19.2.0
-      react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-aria: 3.51.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
-      react-stately: 3.48.0(react@19.2.0)
+      react-stately: 3.49.0(react@19.2.0)
 
-  react-aria@3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-aria@3.51.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@internationalized/date': 3.12.2
+      '@internationalized/date': 3.12.3
       '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.36.0(react@19.2.0)
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.0)
       '@swc/helpers': 0.5.17
       aria-hidden: 1.2.6
       clsx: 2.1.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-stately: 3.48.0(react@19.2.0)
+      react-stately: 3.49.0(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
@@ -19014,11 +19025,11 @@ snapshots:
       sucrase: 3.35.0
       use-editable: 2.3.3(react@19.2.0)
 
-  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.0):
+  react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
@@ -19032,52 +19043,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.0)(redux@5.0.1):
+  react-redux@9.3.0(@types/react@19.2.18)(react@19.2.0)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
       redux: 5.0.1
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@18.3.1):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.18)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@19.2.18)(react@18.3.1)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.0):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.0)
+      react-style-singleton: 2.2.3(@types/react@19.2.18)(react@19.2.0)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@18.3.1):
+  react-remove-scroll@2.7.2(@types/react@19.2.18)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@18.3.1)
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@18.3.1)
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.18)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@19.2.18)(react@18.3.1)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@18.3.1)
-      use-sidecar: 1.1.3(@types/react@19.2.17)(react@18.3.1)
+      use-callback-ref: 1.3.3(@types/react@19.2.18)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@19.2.18)(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.0):
+  react-remove-scroll@2.7.2(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.0)
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.0)
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.18)(react@19.2.0)
+      react-style-singleton: 2.2.3(@types/react@19.2.18)(react@19.2.0)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.0)
-      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.0)
+      use-callback-ref: 1.3.3(@types/react@19.2.18)(react@19.2.0)
+      use-sidecar: 1.1.3(@types/react@19.2.18)(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -19100,19 +19111,19 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.0(react@19.2.0)
 
-  react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-select@5.10.2(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       '@floating-ui/dom': 1.7.6
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.18)
       memoize-one: 6.0.0
       prop-types: 15.8.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.17)(react@19.2.0)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.18)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -19122,31 +19133,31 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-stately@3.48.0(react@19.2.0):
+  react-stately@3.49.0(react@19.2.0):
     dependencies:
-      '@internationalized/date': 3.12.2
+      '@internationalized/date': 3.12.3
       '@internationalized/number': 3.6.7
-      '@internationalized/string': 3.2.9
-      '@react-types/shared': 3.36.0(react@19.2.0)
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
 
-  react-style-singleton@2.2.3(@types/react@19.2.17)(react@18.3.1):
+  react-style-singleton@2.2.3(@types/react@19.2.18)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.0):
+  react-style-singleton@2.2.3(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       get-nonce: 1.0.1
       react: 19.2.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   react-syntax-highlighter@16.1.1(react@19.2.0):
     dependencies:
@@ -19158,12 +19169,12 @@ snapshots:
       react: 19.2.0
       refractor: 5.0.0
 
-  react-textarea-autosize@8.5.9(@types/react@19.2.17)(react@19.2.0):
+  react-textarea-autosize@8.5.9(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.29.7
       react: 19.2.0
-      use-composed-ref: 1.4.0(@types/react@19.2.17)(react@19.2.0)
-      use-latest: 1.3.0(@types/react@19.2.17)(react@19.2.0)
+      use-composed-ref: 1.4.0(@types/react@19.2.18)(react@19.2.0)
+      use-latest: 1.3.0(@types/react@19.2.18)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -19824,7 +19835,7 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -19842,7 +19853,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.0)
       ws: 8.21.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
       prettier: 3.9.6
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -20316,25 +20327,25 @@ snapshots:
       punycode: 1.4.1
       qs: 6.15.2
 
-  use-callback-ref@1.3.3(@types/react@19.2.17)(react@18.3.1):
+  use-callback-ref@1.3.3(@types/react@19.2.18)(react@18.3.1):
     dependencies:
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.0):
+  use-callback-ref@1.3.3(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       react: 19.2.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  use-composed-ref@1.4.0(@types/react@19.2.17)(react@19.2.0):
+  use-composed-ref@1.4.0(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   use-debounce@10.1.1(react@19.2.0):
     dependencies:
@@ -20349,18 +20360,18 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.17)(react@19.2.0):
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  use-latest@1.3.0(@types/react@19.2.17)(react@19.2.0):
+  use-latest@1.3.0(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       react: 19.2.0
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.17)(react@19.2.0)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.18)(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   use-popper@1.1.6(react@19.2.0):
     dependencies:
@@ -20368,21 +20379,21 @@ snapshots:
       react: 19.2.0
       use-deep-compare: 0.1.0(react@19.2.0)
 
-  use-sidecar@1.1.3(@types/react@19.2.17)(react@18.3.1):
+  use-sidecar@1.1.3(@types/react@19.2.18)(react@18.3.1):
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
-  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.0):
+  use-sidecar@1.1.3(@types/react@19.2.18)(react@19.2.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 19.2.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
 
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 3.1.1
       version: 3.1.1
     '@types/mdx':
-      specifier: 2.0.13
-      version: 2.0.13
+      specifier: 2.0.14
+      version: 2.0.14
     '@types/react-syntax-highlighter':
       specifier: 15.5.13
       version: 15.5.13
@@ -22,14 +22,14 @@ catalogs:
       specifier: 5.0.0
       version: 5.0.0
     fuse.js:
-      specifier: 7.3.0
-      version: 7.3.0
+      specifier: 7.5.0
+      version: 7.5.0
     github-slugger:
       specifier: 2.0.0
       version: 2.0.0
     jotai:
-      specifier: 2.20.1
-      version: 2.20.1
+      specifier: 2.20.2
+      version: 2.20.2
     prism-react-renderer:
       specifier: 2.4.1
       version: 2.4.1
@@ -37,11 +37,11 @@ catalogs:
       specifier: 4.1.8
       version: 4.1.8
     react-router:
-      specifier: 8.1.0
-      version: 8.1.0
+      specifier: 8.3.0
+      version: 8.3.0
     react-router-dom:
-      specifier: 7.17.0
-      version: 7.17.0
+      specifier: 7.18.2
+      version: 7.18.2
     react-syntax-highlighter:
       specifier: 16.1.1
       version: 16.1.1
@@ -176,8 +176,8 @@ catalogs:
       specifier: 10.4.6
       version: 10.4.6
     '@testing-library/jest-dom':
-      specifier: ^6.10.0
-      version: 6.10.0
+      specifier: 6.9.1
+      version: 6.9.1
     '@testing-library/react':
       specifier: ^16.3.2
       version: 16.3.2
@@ -524,7 +524,7 @@ importers:
         version: 3.1.1
       '@types/mdx':
         specifier: catalog:apps
-        version: 2.0.13
+        version: 2.0.14
       '@types/react-syntax-highlighter':
         specifier: catalog:apps
         version: 15.5.13
@@ -536,7 +536,7 @@ importers:
         version: 5.0.0
       fuse.js:
         specifier: catalog:apps
-        version: 7.3.0
+        version: 7.5.0
       github-slugger:
         specifier: catalog:apps
         version: 2.0.0
@@ -545,7 +545,7 @@ importers:
         version: 4.0.3
       jotai:
         specifier: catalog:apps
-        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.0)
+        version: 2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.0)
       lodash:
         specifier: catalog:utils
         version: 4.18.1
@@ -572,10 +572,10 @@ importers:
         version: 4.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-router:
         specifier: catalog:apps
-        version: 8.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 8.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-router-dom:
         specifier: catalog:apps
-        version: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-stately:
         specifier: 3.49.0
         version: 3.49.0(react@19.2.0)
@@ -803,7 +803,7 @@ importers:
         version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
-        version: 6.10.0(@testing-library/dom@10.4.1)
+        version: 6.9.1
       '@testing-library/react':
         specifier: catalog:tooling
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -962,7 +962,7 @@ importers:
     devDependencies:
       '@commercetools-frontend/ui-kit':
         specifier: catalog:tooling
-        version: 20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: 20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/design-system':
         specifier: ^20.6.4
         version: 20.6.4(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -4339,6 +4339,10 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=10 <11'
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -4475,6 +4479,9 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -6258,8 +6265,8 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  fuse.js@7.3.0:
-    resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
+  fuse.js@7.5.0:
+    resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
     engines: {node: '>=10'}
 
   generator-function@2.0.1:
@@ -6738,8 +6745,8 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
-  jotai@2.20.1:
-    resolution: {integrity: sha512-dnuKfU/GLi8B28RRMjQ3AfoN7kfzP8o41+AX2FmITZqEMY8PHnjABq+VkEooomLwYaGjda+pgy0yFSjaHX/ZPg==}
+  jotai@2.20.2:
+    resolution: {integrity: sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@babel/core': ^7.29.7
@@ -7944,15 +7951,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.17.0:
-    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.17.0:
-    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -7961,8 +7968,8 @@ packages:
       react-dom:
         optional: true
 
-  react-router@8.1.0:
-    resolution: {integrity: sha512-Mdfi61uObuvWNN9OhChOC0HV6YWOIfKRzEWOvCHRSuQg8IM+Nv10edaM/2HE8ZixBpUTdQbruyWqC3sDkkh9vw==}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
     engines: {node: '>=22.22.0'}
     peerDependencies:
       react: '>=19.2.7'
@@ -9954,45 +9961,45 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.18)(react@19.2.0)
       '@commercetools-uikit/avatar': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/collapsible': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/collapsible-panel': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/filters': 20.6.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.18)(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/i18n': 20.6.7
       '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/notifications': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/pagination': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/progress-bar': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/stamp': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
@@ -10001,7 +10008,7 @@ snapshots:
       moment-timezone: 0.6.2
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -10146,7 +10153,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10154,13 +10161,13 @@ snapshots:
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -10203,7 +10210,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/card@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/card@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10215,7 +10222,7 @@ snapshots:
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
       react: 19.2.0
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -10353,17 +10360,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.18)(react@19.2.0)
       '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.18)(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10371,11 +10378,11 @@ snapshots:
       '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/text': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
@@ -10394,12 +10401,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10611,7 +10618,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10619,7 +10626,7 @@ snapshots:
       '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
@@ -10688,7 +10695,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10711,7 +10718,7 @@ snapshots:
       '@commercetools-uikit/time-field': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - moment
@@ -10863,7 +10870,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.18)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10893,7 +10900,7 @@ snapshots:
       '@commercetools-uikit/toggle-input': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - moment
@@ -10918,7 +10925,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10933,13 +10940,13 @@ snapshots:
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/link@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -10954,7 +10961,7 @@ snapshots:
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -11387,12 +11394,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -11450,12 +11457,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.0)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.0))(@types/react@19.2.18)(react@19.2.0)
       react: 19.2.0
@@ -11643,7 +11650,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -11657,7 +11664,7 @@ snapshots:
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -11858,7 +11865,7 @@ snapshots:
       - react-intl
       - supports-color
 
-  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
@@ -11874,7 +11881,7 @@ snapshots:
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -12935,7 +12942,7 @@ snapshots:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
-      '@types/mdx': 2.0.13
+      '@types/mdx': 2.0.14
       acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
@@ -14666,6 +14673,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -14777,11 +14793,6 @@ snapshots:
 
   '@types/history@4.7.11': {}
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17)':
-    dependencies:
-      '@types/react': 19.2.17
-      hoist-non-react-statics: 3.3.2
-
   '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.18)':
     dependencies:
       '@types/react': 19.2.18
@@ -14802,6 +14813,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
+
+  '@types/mdx@2.0.14': {}
 
   '@types/ms@2.1.0': {}
 
@@ -17087,7 +17100,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  fuse.js@7.3.0: {}
+  fuse.js@7.5.0: {}
 
   generator-function@2.0.1: {}
 
@@ -17592,7 +17605,7 @@ snapshots:
 
   jose@6.1.3: {}
 
-  jotai@2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.0):
+  jotai@2.20.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.18)(react@19.2.0):
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/template': 7.29.7
@@ -19000,8 +19013,8 @@ snapshots:
       '@formatjs/ecma402-abstract': 2.3.6
       '@formatjs/icu-messageformat-parser': 2.11.4
       '@formatjs/intl': 3.1.8(typescript@5.9.3)
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.17)
-      '@types/react': 19.2.17
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.18)
+      '@types/react': 19.2.18
       hoist-non-react-statics: 3.3.2
       intl-messageformat: 10.7.18
       react: 19.2.0
@@ -19090,13 +19103,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router-dom@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-router: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router: 7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  react-router@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.18.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.1.1
       react: 19.2.0
@@ -19104,7 +19117,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.0(react@19.2.0)
 
-  react-router@8.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@8.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie-es: 3.1.1
       react: 19.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,29 +140,29 @@ catalogs:
       specifier: 2.31.1
       version: 2.31.1
     '@commercetools-frontend/ui-kit':
-      specifier: ^20.6.4
-      version: 20.6.4
+      specifier: ^20.6.7
+      version: 20.6.7
     '@eslint/js':
       specifier: ^10.0.1
       version: 10.0.1
     '@figma/code-connect':
-      specifier: ^1.4.9
-      version: 1.4.9
+      specifier: ^1.5.2
+      version: 1.5.2
     '@fission-ai/openspec':
-      specifier: ^1.6.0
-      version: 1.6.0
+      specifier: ^1.7.0
+      version: 1.7.0
     '@github-ui/storybook-addon-performance-panel':
       specifier: ^1.1.4
       version: 1.1.4
     '@modelcontextprotocol/inspector':
-      specifier: ^0.21.2
-      version: 0.21.2
+      specifier: ^0.22.0
+      version: 0.22.0
     '@preconstruct/cli':
       specifier: ^2.8.13
       version: 2.8.13
     '@react-types/shared':
-      specifier: ^3.36.0
-      version: 3.36.0
+      specifier: ^3.36.1
+      version: 3.36.1
     '@storybook/addon-a11y':
       specifier: 10.4.6
       version: 10.4.6
@@ -176,26 +176,26 @@ catalogs:
       specifier: 10.4.6
       version: 10.4.6
     '@testing-library/jest-dom':
-      specifier: ^6.9.1
-      version: 6.9.1
+      specifier: ^6.10.0
+      version: 6.10.0
     '@testing-library/react':
       specifier: ^16.3.2
       version: 16.3.2
     '@testing-library/user-event':
-      specifier: ^14.6.1
-      version: 14.6.1
+      specifier: ^14.6.3
+      version: 14.6.3
     '@typescript-eslint/types':
-      specifier: ^8.48.1
-      version: 8.64.0
+      specifier: ^8.66.0
+      version: 8.66.0
     '@typescript-eslint/typescript-estree':
-      specifier: ^8.56.1
-      version: 8.64.0
+      specifier: ^8.66.0
+      version: 8.66.0
     '@vitejs/plugin-react':
-      specifier: ^6.0.3
-      version: 6.0.3
+      specifier: ^6.0.5
+      version: 6.0.5
     '@vitejs/plugin-react-swc':
-      specifier: ^4.3.1
-      version: 4.3.1
+      specifier: ^4.3.3
+      version: 4.3.3
     '@vitest/browser':
       specifier: ^4.1.10
       version: 4.1.10
@@ -209,14 +209,14 @@ catalogs:
       specifier: ^10.0.8
       version: 10.0.8
     axe-core:
-      specifier: ^4.11.0
-      version: 4.11.0
+      specifier: ^4.12.1
+      version: 4.12.1
     chromatic:
-      specifier: ^17.7.2
-      version: 17.7.2
+      specifier: ^17.8.0
+      version: 17.8.0
     eslint:
-      specifier: ^10.7.0
-      version: 10.7.0
+      specifier: ^10.8.0
+      version: 10.8.0
     eslint-config-prettier:
       specifier: ^10.1.8
       version: 10.1.8
@@ -236,17 +236,17 @@ catalogs:
       specifier: ^13.0.6
       version: 13.0.6
     globals:
-      specifier: ^17.7.0
-      version: 17.7.0
+      specifier: ^17.9.0
+      version: 17.9.0
     playwright:
-      specifier: ^1.61.1
-      version: 1.61.1
+      specifier: ^1.62.1
+      version: 1.62.1
     prettier:
-      specifier: ^3.9.5
-      version: 3.9.5
+      specifier: ^3.9.6
+      version: 3.9.6
     publint:
-      specifier: ^0.3.21
-      version: 0.3.21
+      specifier: ^0.3.23
+      version: 0.3.23
     react-docgen-typescript:
       specifier: ^2.4.0
       version: 2.4.0
@@ -257,14 +257,14 @@ catalogs:
       specifier: ^8.5.1
       version: 8.5.1
     tsx:
-      specifier: ^4.23.1
-      version: 4.23.1
+      specifier: ^4.23.5
+      version: 4.23.5
     typescript-eslint:
-      specifier: ^8.64.0
-      version: 8.64.0
+      specifier: ^8.66.0
+      version: 8.66.0
     vite:
-      specifier: ^8.1.5
-      version: 8.1.5
+      specifier: ^8.2.0
+      version: 8.2.0
     vite-bundle-analyzer:
       specifier: ^1.3.9
       version: 1.3.9
@@ -275,11 +275,11 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     webpack:
-      specifier: ^5.108.4
-      version: 5.108.4
+      specifier: ^5.109.2
+      version: 5.109.2
     webpack-cli:
-      specifier: ^7.2.1
-      version: 7.2.1
+      specifier: ^7.2.2
+      version: 7.2.2
   utils:
     '@types/escape-html':
       specifier: ^1.0.4
@@ -319,7 +319,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  rollup: ^4.62.2
+  rollup: ^4.62.4
   '@babel/runtime': ^7.29.7
   prismjs: ^1.30.0
   typescript: ~5.9.3
@@ -373,7 +373,7 @@ importers:
         version: 0.18.5
       '@babel/core':
         specifier: ^7.29.7
-        version: 7.29.7
+        version: 7.29.7(supports-color@8.1.1)
       '@changesets/changelog-github':
         specifier: 0.7.0
         version: 0.7.0
@@ -385,67 +385,67 @@ importers:
         version: link:packages/nimbus
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.7.0)
+        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
       '@figma/code-connect':
         specifier: catalog:tooling
-        version: 1.4.9
+        version: 1.5.2
       '@fission-ai/openspec':
         specifier: catalog:tooling
-        version: 1.6.0(@types/node@24.13.3)
+        version: 1.7.0(@types/node@24.13.3)
       '@preconstruct/cli':
         specifier: catalog:tooling
-        version: 2.8.13
+        version: 2.8.13(supports-color@8.1.1)
       dotenv:
         specifier: catalog:utils
         version: 17.4.2
       eslint:
         specifier: catalog:tooling
-        version: 10.7.0
+        version: 10.8.0(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: catalog:tooling
-        version: 10.1.8(eslint@10.7.0)
+        version: 10.1.8(eslint@10.8.0(supports-color@8.1.1))
       eslint-plugin-prettier:
         specifier: catalog:tooling
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.7.0))(eslint@10.7.0)(prettier@3.9.5)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)))(eslint@10.8.0(supports-color@8.1.1))(prettier@3.9.6)
       eslint-plugin-react-hooks:
         specifier: catalog:tooling
-        version: 7.1.1(eslint@10.7.0)
+        version: 7.1.1(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-storybook:
         specifier: catalog:tooling
-        version: 10.4.6(eslint@10.7.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+        version: 10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
       glob:
         specifier: catalog:tooling
         version: 13.0.6
       globals:
         specifier: catalog:tooling
-        version: 17.7.0
+        version: 17.9.0
       playwright:
         specifier: catalog:tooling
-        version: 1.61.1
+        version: 1.62.1
       prettier:
         specifier: catalog:tooling
-        version: 3.9.5
+        version: 3.9.6
       publint:
         specifier: catalog:tooling
-        version: 0.3.21
+        version: 0.3.23
       tsx:
         specifier: catalog:tooling
-        version: 4.23.1
+        version: 4.23.5
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       vite-bundle-analyzer:
         specifier: catalog:tooling
         version: 1.3.9
       vitest:
         specifier: catalog:tooling
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
 
   apps/blank-app:
     dependencies:
@@ -464,7 +464,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.7.0)
+        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
       '@types/react':
         specifier: catalog:react
         version: 19.2.17
@@ -473,31 +473,31 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.1(@swc/helpers@0.5.17)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
-        version: 10.7.0
+        version: 10.8.0(supports-color@8.1.1)
       eslint-plugin-react-refresh:
         specifier: catalog:tooling
-        version: 0.5.3(eslint@10.7.0)
+        version: 0.5.3(eslint@10.8.0(supports-color@8.1.1))
       globals:
         specifier: catalog:tooling
-        version: 17.7.0
+        version: 17.9.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       webpack:
         specifier: catalog:tooling
-        version: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
+        version: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
       webpack-cli:
         specifier: catalog:tooling
-        version: 7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4)
+        version: 7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2)
 
   apps/docs:
     dependencies:
@@ -512,7 +512,7 @@ importers:
         version: link:../../packages/nimbus-icons
       '@emotion/react':
         specifier: catalog:react
-        version: 11.14.0(@types/react@19.2.17)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@huggingface/transformers':
         specifier: 'catalog:'
         version: 3.8.1
@@ -521,7 +521,7 @@ importers:
         version: 3.12.2
       '@mdx-js/mdx':
         specifier: catalog:apps
-        version: 3.1.1
+        version: 3.1.1(supports-color@8.1.1)
       '@types/mdx':
         specifier: catalog:apps
         version: 2.0.13
@@ -545,7 +545,7 @@ importers:
         version: 4.0.3
       jotai:
         specifier: catalog:apps
-        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0)
+        version: 2.20.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0)
       lodash:
         specifier: catalog:utils
         version: 4.18.1
@@ -587,7 +587,7 @@ importers:
         version: 1.2.5(unified@11.0.5)
       remark-gfm:
         specifier: catalog:markdown
-        version: 4.0.1
+        version: 4.0.1(supports-color@8.1.1)
       remark-mark-highlight:
         specifier: catalog:apps
         version: 0.1.1
@@ -606,7 +606,7 @@ importers:
         version: link:../../packages/design-token-ts-plugin
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.7.0)
+        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
       '@types/lodash':
         specifier: catalog:utils
         version: 4.17.24
@@ -618,40 +618,40 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.1(@swc/helpers@0.5.17)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
-        version: 10.7.0
+        version: 10.8.0(supports-color@8.1.1)
       eslint-plugin-react-refresh:
         specifier: catalog:tooling
-        version: 0.5.3(eslint@10.7.0)
+        version: 0.5.3(eslint@10.8.0(supports-color@8.1.1))
       globals:
         specifier: catalog:tooling
-        version: 17.7.0
+        version: 17.9.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       vite-plugin-compression:
         specifier: catalog:apps
-        version: 0.5.1(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 0.5.1(supports-color@8.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
 
   apps/plugin-test:
     devDependencies:
       vite:
         specifier: catalog:tooling
-        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       webpack:
         specifier: catalog:tooling
-        version: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
+        version: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
       webpack-cli:
         specifier: catalog:tooling
-        version: 7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4)
+        version: 7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2)
 
   packages/color-tokens:
     dependencies:
@@ -688,10 +688,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:tooling
-        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       vitest:
         specifier: catalog:tooling
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
 
   packages/i18n:
     devDependencies:
@@ -706,19 +706,19 @@ importers:
         version: 13.0.6
       prettier:
         specifier: catalog:tooling
-        version: 3.9.5
+        version: 3.9.6
 
   packages/nimbus:
     dependencies:
       '@chakra-ui/cli':
         specifier: catalog:react
-        version: 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)
       '@emotion/is-prop-valid':
         specifier: catalog:react
         version: 1.4.0
       '@github-ui/storybook-addon-performance-panel':
         specifier: catalog:tooling
-        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@internationalized/string':
         specifier: catalog:react
         version: 3.2.9
@@ -751,7 +751,7 @@ importers:
         version: 5.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-markdown:
         specifier: catalog:markdown
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.0)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react-stately:
         specifier: 3.48.0
         version: 3.48.0(react@19.2.0)
@@ -760,7 +760,7 @@ importers:
         version: 17.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       remark-gfm:
         specifier: catalog:markdown
-        version: 4.0.1
+        version: 4.0.1(supports-color@8.1.1)
       remend:
         specifier: catalog:markdown
         version: 1.3.0
@@ -770,7 +770,7 @@ importers:
     devDependencies:
       '@chakra-ui/react':
         specifier: catalog:react
-        version: 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools/nimbus-design-token-ts-plugin':
         specifier: workspace:^
         version: link:../design-token-ts-plugin
@@ -788,28 +788,28 @@ importers:
         version: 2.0.0
       '@react-types/shared':
         specifier: catalog:tooling
-        version: 3.36.0(react@19.2.0)
+        version: 3.36.1(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: catalog:tooling
-        version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
       '@storybook/addon-vitest':
         specifier: catalog:tooling
-        version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)
+        version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
       '@testing-library/jest-dom':
         specifier: catalog:tooling
-        version: 6.9.1
+        version: 6.10.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: catalog:tooling
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: catalog:tooling
-        version: 14.6.1(@testing-library/dom@10.4.1)
+        version: 14.6.3(@testing-library/dom@10.4.1)
       '@types/escape-html':
         specifier: catalog:utils
         version: 1.0.4
@@ -824,28 +824,28 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: catalog:tooling
-        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       '@vitest/browser':
         specifier: catalog:tooling
-        version: 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: catalog:tooling
-        version: 4.1.10(playwright@1.61.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: catalog:tooling
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vueless/storybook-dark-mode':
         specifier: catalog:tooling
-        version: 10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       apca-w3:
         specifier: ^0.1.9
         version: 0.1.9
       axe-core:
         specifier: catalog:tooling
-        version: 4.11.0
+        version: 4.12.1
       chromatic:
         specifier: catalog:tooling
-        version: 17.7.2
+        version: 17.8.0
       dompurify:
         specifier: ^3.4.12
         version: 3.4.12
@@ -857,7 +857,7 @@ importers:
         version: 29.0.1
       playwright:
         specifier: catalog:tooling
-        version: 1.61.1
+        version: 1.62.1
       react:
         specifier: catalog:react
         version: 19.2.0
@@ -878,25 +878,25 @@ importers:
         version: 0.123.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate-dom@0.123.0(slate@0.123.0))(slate@0.123.0)
       storybook:
         specifier: catalog:tooling
-        version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
-        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: catalog:tooling
-        version: 5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
+        version: 5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
       vitest:
         specifier: catalog:tooling
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
 
   packages/nimbus-docs-build:
     dependencies:
       '@typescript-eslint/types':
         specifier: catalog:tooling
-        version: 8.64.0
+        version: 8.66.0
       '@typescript-eslint/typescript-estree':
         specifier: catalog:tooling
-        version: 8.64.0(typescript@5.9.3)
+        version: 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
       gray-matter:
         specifier: catalog:utils
         version: 4.0.3
@@ -905,7 +905,7 @@ importers:
         version: 2.4.0(typescript@5.9.3)
       remark:
         specifier: catalog:markdown
-        version: 15.0.1
+        version: 15.0.1(supports-color@8.1.1)
       remark-flexible-toc:
         specifier: catalog:markdown
         version: 1.2.5(unified@11.0.5)
@@ -930,14 +930,14 @@ importers:
         version: 0.14.15
       '@svgr/cli':
         specifier: ^8.1.0
-        version: 8.1.0(typescript@5.9.3)
+        version: 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
     devDependencies:
       '@svgr/babel-plugin-add-jsx-attribute':
         specifier: ^8.0.0
-        version: 8.0.0(@babel/core@7.29.7)
+        version: 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+        version: 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
       '@types/node':
         specifier: catalog:utils
         version: 24.13.3
@@ -955,17 +955,17 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
-        version: 1.27.1(zod@4.4.3)
+        version: 1.27.1(supports-color@8.1.1)(zod@4.4.3)
       zod:
         specifier: catalog:utils
         version: 4.4.3
     devDependencies:
       '@commercetools-frontend/ui-kit':
         specifier: catalog:tooling
-        version: 20.6.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
       '@commercetools-uikit/design-system':
         specifier: ^20.6.4
-        version: 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
       '@commercetools/nimbus':
         specifier: workspace:^
         version: link:../nimbus
@@ -977,16 +977,16 @@ importers:
         version: link:../tokens
       '@modelcontextprotocol/inspector':
         specifier: catalog:tooling
-        version: 0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(typescript@5.9.3)
+        version: 0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)(typescript@5.9.3)
       '@types/node':
         specifier: catalog:utils
         version: 24.13.3
       tsup:
         specifier: catalog:tooling
-        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.23.5)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: catalog:tooling
-        version: 4.23.1
+        version: 4.23.5
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -995,7 +995,7 @@ importers:
     devDependencies:
       '@babel/preset-typescript':
         specifier: catalog:tooling
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@tokens-studio/sd-transforms':
         specifier: ^2.0.3
         version: 2.0.3(style-dictionary@5.4.4(tslib@2.8.1))
@@ -1004,7 +1004,7 @@ importers:
         version: 4.1.0
       prettier:
         specifier: catalog:tooling
-        version: 3.9.5
+        version: 3.9.6
       style-dictionary:
         specifier: ^5.4.4
         version: 5.4.4(tslib@2.8.1)
@@ -1292,8 +1292,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@commercetools-frontend/ui-kit@20.6.4':
-    resolution: {integrity: sha512-sAPZ0YKUKFaZJnIwom3oCsw56kpljeiAcNWntzuNYkCCXGxPDWto2NKt/uB4ohUnIvrV6q76IdfbjFxbsiFGZg==}
+  '@commercetools-frontend/ui-kit@20.6.7':
+    resolution: {integrity: sha512-p3Bo6SjhvjOpa+7SQFh8xt8KHg1ewsj2up1YBrqsDQ6HZHHcWH52exGoC/CMv8tl3f+dQbmCN0JW1vJZpCoHiQ==}
     peerDependencies:
       moment: 2.x
       moment-timezone: 0.6.x
@@ -1301,151 +1301,151 @@ packages:
       react-intl: 7.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/accessible-button@20.6.4':
-    resolution: {integrity: sha512-2nvfEUoU0TdnrkvRQ0I/4eBSicKwJEStRA8LU5RNSbEF4kqAl9jJecoDA5gzd+JtbthEmsIL6iiBSaWZdCfpVg==}
+  '@commercetools-uikit/accessible-button@20.6.7':
+    resolution: {integrity: sha512-uxhF2p74zHia1AdFin06c4/DbhSCWIiNPGumjVamK8ENDtU2x/JpLHSbdlHUpB86EGlHETKe6s5+6WtHrx/yFw==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/accessible-hidden@20.6.4':
-    resolution: {integrity: sha512-u89asnsTI5s+TaiKRAvTqG3qj2RjaVh2NXc348RGJaszxXwuE2KtOwZYRc2Yol5YHDfr4/kNLVT10+OLw/MKLQ==}
+  '@commercetools-uikit/accessible-hidden@20.6.7':
+    resolution: {integrity: sha512-lRAHwrAChWor60+huWHLUBBWRbGS2ucfuEXS5adxgVELq9tRQccTsK8JfXa+FrZYSRroTugYf5RFbNeDUoKLFg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/async-creatable-select-field@20.6.4':
-    resolution: {integrity: sha512-xT1WONgOdhin996SiwtQGJp02FdAWwdN0EL7lZZH03BAQEKf6BW4+5UHxlBVisC6Zwhz98rA12XBmEM/E/+55g==}
+  '@commercetools-uikit/async-creatable-select-field@20.6.7':
+    resolution: {integrity: sha512-keO+oFFAhGjFrn5ZVTBoAW6qmBiQxINfeS1/mOCMM5oFBTvEAcYvYUEfSRl/m/FfWzUUIYjjq65piE06G89wOA==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/async-creatable-select-input@20.6.4':
-    resolution: {integrity: sha512-I1Fo+a0A10EYkEH/1kwrjgxDG2yfRsS0ZQESiSAO63zY3NQgVU/Tk6kpoeNxNVKWDmtXZi0bP7wmEBzkaXGgXw==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/async-select-field@20.6.4':
-    resolution: {integrity: sha512-MhJZpNcdIb/AxZzZYVNUy/WFYpzW9iwojzA/eFP3iecDxhZSXQYd7H7DONVwaNsvmrbjOkhsTIKodD3S9Cd7Wg==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/async-select-input@20.6.4':
-    resolution: {integrity: sha512-+1ATVEMJX5me376Thr/a3ozuVkQvdF50LIiHOhwNX7kdmw3Hals6DRtVhfR/Ki6rBIe8QtYt3FD+mb03MTuT4g==}
+  '@commercetools-uikit/async-creatable-select-input@20.6.7':
+    resolution: {integrity: sha512-ZQ/KwcKhnubwZbuh+IHL5NrY4YBJhwi5/84SANec0S3GJx9TOxCZTQqpW1Po9I6vpvBPoblOr6EkSoTebX+JKQ==}
     peerDependencies:
       react: 19.x
       react-dom: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/avatar@20.6.4':
-    resolution: {integrity: sha512-C/J6Bo16pEwJF4wmegpvdWRh9pP4qp5khdv5X/DWzgsBHrqhgUNup93/95gAWS3fbh0/swDh05Ag7c28ulfBWQ==}
+  '@commercetools-uikit/async-select-field@20.6.7':
+    resolution: {integrity: sha512-C/L4JRVEA2/bejXld7pSyJdUPlszZzWws2YI7oIG8lSM6SRu0zjCPGPQbEhBKMmqv8ENehryHKfohv9MQ9fzbg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/buttons@20.6.4':
-    resolution: {integrity: sha512-45YPE661dPtuR5x5dI/VpjNDeJl/W7zJvxo32oq3TwGfDaX0k0FrgirFDkfM9WapmpKoK2yjOGOvskyWbRsjUw==}
+  '@commercetools-uikit/async-select-input@20.6.7':
+    resolution: {integrity: sha512-se6pL21mxWJFr3uBqGFelDhAbvNq1eRuIPKWprwMSjNDcHyfHxqePgefg70lq7TNK+kz4GKCSfWVdFPEHxK5SQ==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/avatar@20.6.7':
+    resolution: {integrity: sha512-m+qb2NhpO9WcrUp8IrJn7KbQIThacPtzg1n7TbGVHVlYp1WDf/gmRmj6Hdao0rkd+4cLTWGiZBGaP2pvUjs+2Q==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/buttons@20.6.7':
+    resolution: {integrity: sha512-6/h3t3osIZYRpRZhSTq9IHBCLB/JXVyLaQ7YIRqT8nyTlb8BkTMAEgRgk3Zkjcm/3xMqhrvxmHGtsE6yurN07w==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/calendar-time-utils@20.6.4':
-    resolution: {integrity: sha512-G3q7mqLBWI1ns26jkUromJ/+wXOvrBoPP9ylrRtbIIbFxaCDYjPry5/jKEaHPTEOX0VsSXYgN1IR0pc8NK1aWA==}
+  '@commercetools-uikit/calendar-time-utils@20.6.7':
+    resolution: {integrity: sha512-TgSxmzM3iUiWbiRmNtPhsQg/taYHY0pk79ityR6Uu+su7aIWcJ9A9a0JQwheMpF8p/DWocGCw+E7faxMeRGC0Q==}
     peerDependencies:
       moment-timezone: 0.6.x
 
-  '@commercetools-uikit/calendar-utils@20.6.4':
-    resolution: {integrity: sha512-pLhSte1K5LbMV4vedlCuXMuXLKbhR2U9QRs4NtO1Ezu0XlWgGbSkeS526ohLg0qzCXxsLnf6oLHTqbQFBnyQtA==}
+  '@commercetools-uikit/calendar-utils@20.6.7':
+    resolution: {integrity: sha512-oxx4mUnpQ9PTd+1SLbeUlKFyZ87W/6OGfErZnpNAodmOZQnZgSgb0+2V+FpGrDeDSSeLecL5Fda+J1l7uHFzRw==}
     peerDependencies:
       moment: 2.x
       react: 19.x
       react-dom: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/card@20.6.4':
-    resolution: {integrity: sha512-VkI96e+cgXpl2Ah/CgtlpI+usKG/Jm/wyJY1CxwWciogq7NyokNOnBLUM0F+3TRjPS6LhbaeOThcBFP6QdUGVg==}
+  '@commercetools-uikit/card@20.6.7':
+    resolution: {integrity: sha512-Buv71Ym4C5o5gv0229tU9Wh8lgXGdo8j29IwmGnwl1JlCAjTAPAh0VgN9IgMaMUuTLYaflcpv9AFQbnqdrA4fw==}
     peerDependencies:
       react: 19.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/checkbox-input@20.6.4':
-    resolution: {integrity: sha512-0Doz+KOWhNByiFTuJ82TTCpIGOheGVzGiI7jXH5TGS6yy8RR9q5hQrD0lKiYeZFv3vg23RHm9mhJrLeEd/O6XQ==}
+  '@commercetools-uikit/checkbox-input@20.6.7':
+    resolution: {integrity: sha512-4h9Rgsg/mLHtAN55fhb4rzp6SWRhE094ZoIr9dbcK2PCcCBux4O1KxHM3o9UanZSpqGqyQmTnzGwEaZ+1bB+Mw==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/collapsible-motion@20.6.4':
-    resolution: {integrity: sha512-VSu8MvJ7sdA25CMM4L4MTlchP0cHEgCIrnmmhm67Jm3+LbxB0YKOHVGa5CDHTUQQjHf1hZeMNLUnMM7/0fh8EQ==}
+  '@commercetools-uikit/collapsible-motion@20.6.7':
+    resolution: {integrity: sha512-kbmZ9aC80AIYN0t8KHmZ/RcGLPiWpLl2fz38rrzay4JOhFmZmIPYb4eiEqJSKrknwBsljQadEh4O7pZ6d9yUQg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/collapsible-panel@20.6.4':
-    resolution: {integrity: sha512-ahd7QW6fEt2WlMFd5/Pd5xP6xcgeX1nZOoKvcdL8udLj8OYolSQZokCY6d8vMXW1njo4HxZmpPnMknxFTFuMMA==}
+  '@commercetools-uikit/collapsible-panel@20.6.7':
+    resolution: {integrity: sha512-tG2Ou59gc1XpwdJ2z9TfJmxgfuXU8gybOusLi/XJZfQRM/sN6ki6O243VwllLO2WQWu4fyb/X7jHbMKcraC2Ng==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/collapsible@20.6.4':
-    resolution: {integrity: sha512-jAkrDv089iEZMGSWfZLD/t37oUg16/qxRyLVK/g/Mucido3AaoLN7D5t/ht06weGJA73J8M4dcYcN5kC+b6Yzw==}
+  '@commercetools-uikit/collapsible@20.6.7':
+    resolution: {integrity: sha512-Vfq7KvuqE0OZ0PtQcVHeH5m4jWplfTJulDgtpx4OAbGd3eMnsUzy6AFSrvfRAtVamT3h8/EtS5ZSIvtxH5RArQ==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/constraints@20.6.4':
-    resolution: {integrity: sha512-XtmK5dl4regZm23to89kAiBioD1gD8RwwR0I8U0C+rpuQfbI/BKlqcf4bgClh3jL8+1rmMWqjwxDjgVVSd0Pfw==}
+  '@commercetools-uikit/constraints@20.6.7':
+    resolution: {integrity: sha512-ImdVnv/PNjVzsIy+i/gELkP4jLXIboXJBNq4uFXATTlXEu3q1We9XHlgjm/4FlDWQzELhum3oLUQ35lDb2kNLQ==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/creatable-select-field@20.6.4':
-    resolution: {integrity: sha512-3hJJpO8zZL93xRDaA+Xci+lw4rUfweCxmKJSP/aI1XpAytNyjIDuS3drwoj1cCPXg/MIzzX7eMT3Qov22Oiy8A==}
+  '@commercetools-uikit/creatable-select-field@20.6.7':
+    resolution: {integrity: sha512-6UVagJ7P/3kBa8CBpIyJyDiwFlYs8YCfy4jrEE0TXo3RWBvfpRnhcLHsxUq2DfjM3JEc9YgjDt81+6emWeK5ag==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/creatable-select-input@20.6.4':
-    resolution: {integrity: sha512-ECWxu88KLrnNYCv3EYUGe6UzHjdPf5VcvBfZa/Mfnnispt1hhNU3tLxCLVR4XsoHVBz9wMJwsaHqWJaw3/9L6w==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/data-table-manager@20.6.4':
-    resolution: {integrity: sha512-5QYFIoQkTChUdp/aneCB/NqJumO7iFQYw6FJsBgLnyCANYhCKnIwYptcLcdhyXAh6Co/lRbYcxXBpmRTOnh4DQ==}
+  '@commercetools-uikit/creatable-select-input@20.6.7':
+    resolution: {integrity: sha512-wnWmRwVXjBglYJP2BuTVZG+jdvu6g7NVpqLybt4n328ZyNF4718rsfU/e3GYzDQMMXodV97BhIRAqH+ctElycQ==}
     peerDependencies:
       react: 19.x
       react-dom: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/data-table@20.6.4':
-    resolution: {integrity: sha512-Y9EJpuLL6iKsOrGttEfHP28WhTiH06KB7GG1K3Gwvwk3H0m4DycEzWpR5nE99Q0Mv+Z2QeOvBjoPBdQOHdL1dw==}
+  '@commercetools-uikit/data-table-manager@20.6.7':
+    resolution: {integrity: sha512-mFfyaddKBZm8rjEOAj89zxlbUOHxoaY/BNlVlk0FoX/rzf0OA8WdG2tGcYLUBeWVDnE1+axrNNCPmTNOiAV9kw==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/data-table@20.6.7':
+    resolution: {integrity: sha512-zu7d+/21z+dEMc7JWpl2LpYz/An69iHClGICZa/QE4gzm1GzpzfmJwGrPCeUA6rqSjqyeq3jiKGwAC/o7Em7Mw==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/date-field@20.6.4':
-    resolution: {integrity: sha512-ebRm+/ReLAWCS6a9kY7qt3nTA3jo3zUH4jZ97a4pmaxLCsaIdx4YUw0HP/1/mDPD5MeMCy6onqLtsHByrHEuNA==}
+  '@commercetools-uikit/date-field@20.6.7':
+    resolution: {integrity: sha512-TuNdw04y6/oDsO81pLeRAXuwhXokV3bASCtxHjZNUbzyBDnnpq4/eZV+civpMx9KnmdCu9fm1M+K0rnRDiROMA==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/date-input@20.6.4':
-    resolution: {integrity: sha512-6njuplh2VfutzreJhQyKKCZeLI34bYOLXCdUBUrv4Zd41Do5EjzuILF4e0FksOt1mHlwxhKKmNAojVQj52gyLQ==}
+  '@commercetools-uikit/date-input@20.6.7':
+    resolution: {integrity: sha512-1tKfVWH6ynHxgAm885/UaSbIIGlf+4HG114g2tKIpPCf8LY8tMiH5a4Ryr3pmLAIRqln2ReQQsUzdssqJ6XksA==}
     peerDependencies:
       moment: 2.x
       react: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/date-range-field@20.6.4':
-    resolution: {integrity: sha512-ynLgJtuzdy9bSwiSId98iJCJsfn7b1bNaQqWRDPxEKAIzOUjv1sy9i+/8G+7CtTLcXCGwMwkziFioFNcEa5mHQ==}
+  '@commercetools-uikit/date-range-field@20.6.7':
+    resolution: {integrity: sha512-e02pfMzzajtSHfvBzuBw+09cSRvXG3XebKkthu6vA4raan1homOQkSWtmXTGDcUOoPf0kUy6ZFlkl6ESID59VQ==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/date-range-input@20.6.4':
-    resolution: {integrity: sha512-EOpXGV/GEF+7jNPlbPqFCO9VzPh10O8UYvUBI3qDwwo7jQBi3bbldk5Ec70aMrE/apdbvcprKwSf/zN/sUClRg==}
+  '@commercetools-uikit/date-range-input@20.6.7':
+    resolution: {integrity: sha512-gC10fp9ylB4Y8/P/wsJlKIjLE9UDyTh2LLkEDqNZEIS+8qa569I5wP+jtForqoEZENDUqXIeMHezy3wlRpJ40A==}
     peerDependencies:
       moment: 2.x
       react: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/date-time-field@20.6.4':
-    resolution: {integrity: sha512-vET5MulVzNW/2vis/G87Mu38Z9cTq7FBjl+BpzwFaF/DywFN8khzsai0RLLjWv5z5n+wpGyFZbP/GNu/i6KnKQ==}
+  '@commercetools-uikit/date-time-field@20.6.7':
+    resolution: {integrity: sha512-TvQUD1K823IGpGkRN0MqWuuk1GgjFmjbDl/yErryOZ1IAe3ODFiuan36wsa0W4lvaAScHNiwD/mzbM8qR1CDrg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/date-time-input@20.6.4':
-    resolution: {integrity: sha512-QufJSLxe+dT+o9zIPCtudlZc5uElVRSnq0iBvDSRKhZPAGEbubcjagZD+jsfOQil/n8wDcXDDhvfktG2IDaDCg==}
+  '@commercetools-uikit/date-time-input@20.6.7':
+    resolution: {integrity: sha512-0FF6ro363mWfRi977bQ8ktFFHfuFyAd+pu85ijUA8ka54wghKvgmRJG9+IdhVQUpJbxaVuatkLdA4evjFXCi1A==}
     peerDependencies:
       moment: 2.x
       react: 19.x
@@ -1456,48 +1456,53 @@ packages:
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/dropdown-menu@20.6.4':
-    resolution: {integrity: sha512-JLb/xdJi5YKhpMhlVTYNSZS8EdeMSgHM7Eaaa6IVGdlgo5QVTd+wwtR4iS1HzThhio2LtzvDiqVJSjT0dulB6Q==}
+  '@commercetools-uikit/design-system@20.6.7':
+    resolution: {integrity: sha512-ur1cGYhHYMHsKVROHWugDjhc4S1lAAVy1Y87uq7wgUcoJn//vxd6WRK1Yh7oJ85AOcJa3oVNBEd1qc9S0pT4KQ==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/field-errors@20.6.4':
-    resolution: {integrity: sha512-tAzWr/bqiIspzHds6G0b1mQdIxQmAIJIqtogyS005hpp3GWFqlTH6mv2/Fyarhws6h4WFvxLl/anyX0X5rXsbA==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/field-label@20.6.4':
-    resolution: {integrity: sha512-Xcd/7AdfOdxcAlmdYKtZOFxfHksWi8nh3J10gp5RsdyMLsSRWedfYQWLaliQFAP9EvYADNjVGg8u2xDJoURmqg==}
+  '@commercetools-uikit/dropdown-menu@20.6.7':
+    resolution: {integrity: sha512-BeD1Fh55cTpB5cuktjimH3YYxg+s5RuWlkVYz+hVB9958IZKw358pRsTkgdFbgNcfbcpMYT3Dndf23ywyuDFkg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/field-warnings@20.6.4':
-    resolution: {integrity: sha512-F1aN1rbxmlxn4HTfJP33IifRbTo9aDWh1mX2T4ofA/K4cXi0aHKh2GqxCis1lsRD5iq8iHJ/44cY2MQrWgfYew==}
+  '@commercetools-uikit/field-errors@20.6.7':
+    resolution: {integrity: sha512-xG3fh9oVF5P8NXl5T3qiCNwga/M28rloxQiTXawOXuXASTZ7p+S6Lkx0oxDOV8Ba+jbvsuSFZIFej3CDkj8oKg==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/fields@20.6.4':
-    resolution: {integrity: sha512-0bBj6cP0pH2bBMyRdZg4ZdR0SUtz59XK7N/xCKv1MeBituuLPKwHdx+zUbGjhLgWxFawU2eWMBej85zevHgf3A==}
+  '@commercetools-uikit/field-label@20.6.7':
+    resolution: {integrity: sha512-P406WbmbS6o4DBTuy1oRCpOERXy9DCzEFS6imb2jC1blX/FPbHlyVQKSxMN1F9GHM6Zp1RGD/0rrIJDXqSerYg==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/field-warnings@20.6.7':
+    resolution: {integrity: sha512-eM9dyTvYlpv6uPxmQg3dMoV6StQXa3O7HHfJ+IQT7hhe6zkIUzh2yJUuoi2HVrBgFM9MATrnJDaYDPwT6KI+0Q==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/fields@20.6.7':
+    resolution: {integrity: sha512-xIyeGzU6x/dUsrx1ZXuYmYoMRSoUd/wG3WxZw4A4nQIMQycdW6DuKACaAMVPe6cLfI4udCN1qACwlxWRFbKCdA==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/filters@20.6.4':
-    resolution: {integrity: sha512-oJ1sUbpKaB2cED3lH0C4PVuNLQS6T6SBEsYwSMw6JdTjYx1JbUerFz26Aq1Ylh00HMqOG0VVNuidWftqoD+J1A==}
+  '@commercetools-uikit/filters@20.6.7':
+    resolution: {integrity: sha512-0geJZ2UwEO0Yiru9XpTda0MYaN2ZQuuMcu7ItJBU0X3XXeegIBlEOwYYN742P5TcKVkCBHlJT/sGkbeM4kt9TA==}
     peerDependencies:
       react: 19.x
       react-dom: 19.x
 
-  '@commercetools-uikit/flat-button@20.6.4':
-    resolution: {integrity: sha512-NIYK5Bp/64COMuSzzcz6TovUAL5NynR2/jkBPgJP9l6GoX7YftQDSwqzWHd1UW86dPQiaPPlZLQqTkKXJ+YUVw==}
+  '@commercetools-uikit/flat-button@20.6.7':
+    resolution: {integrity: sha512-tPgcnlvWyqfaBfTjjhuNQJ2Qhwxzv8l+n/OJplfBMTeD6uUAW+e/GaX5bMfaflY/9CSu+DqLjihIYhir4J/Ezw==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/grid@20.6.4':
-    resolution: {integrity: sha512-p9QH/EhLkJU/9Yn3/BP02/TCcwW/Qw9XeOQpz7uTFQiRYTyMMVKYfsJoxxl+XQRZfKEk5DAzEMtmnxbjv32qog==}
+  '@commercetools-uikit/grid@20.6.7':
+    resolution: {integrity: sha512-AuR7+YeLb0plBNuVP/FpiV5+WMTOQQq7LRid3MeEfPfjOryiwkaswzTaPizYLEhvqsD9hCLYRTMxthLr0CQjDg==}
     peerDependencies:
       react: 19.x
 
@@ -1507,327 +1512,333 @@ packages:
       react: 19.x
       react-dom: 19.x
 
-  '@commercetools-uikit/i18n@20.6.4':
-    resolution: {integrity: sha512-o/5cVCSm3RHV8bbeqS/UGq8bmjB755nYfAmr7mtyMQKhpSHGkle0gdi4vt37Po907YCWNl920FsPWlat8SGWWA==}
+  '@commercetools-uikit/hooks@20.6.7':
+    resolution: {integrity: sha512-SlUfZDV9ls4EZEI7t8QBo2hj7Cu0AkAvDe+wd8eaWCt7S4z2ibw+UVuVzN/5wH+ZypAfRQplHhqjaCAFfmFXoQ==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
 
-  '@commercetools-uikit/icon-button@20.6.4':
-    resolution: {integrity: sha512-CE56SKaMxeqBNOkathVDxRm2PQveGaQCY277Xhgu/go9v/uf3HTQ0n23kaIhR9chRezHTT0zgEDsBT5b0AhvxQ==}
+  '@commercetools-uikit/i18n@20.6.7':
+    resolution: {integrity: sha512-22SQVoYPZC2gksy4eCgdXZ9vJ+4ndp5TywDgo8hOnxlCbnhMdFEBU0UGR8f/U/g5bON8w+kd6zX+4bTab6GoHg==}
+
+  '@commercetools-uikit/icon-button@20.6.7':
+    resolution: {integrity: sha512-CrRI8FfeUNWvUEJM9Fp7EHnNR/C7IqhDIZnYlBuSyUgk/JORdaMA/eiR4hRtos7sELefQ3m8lS2HyVE9oa5KGg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/icons@20.6.4':
-    resolution: {integrity: sha512-ig57pXNIyznAkHpK2/xhVGsSMiStwSRtqPpnc7ZIxZjdd2J6UKWmuP2MJS+lPUAN7J/ZcA2cM/IpSuS5PtBsfg==}
+  '@commercetools-uikit/icons@20.6.7':
+    resolution: {integrity: sha512-QsaIr8Oj6HE/hazKbx9ZatT9UEy9DX4gkrMDlvYcO5mmGPa+FktAbOhW4GmRzLyLnW3/6InOYYcv0KZF5bG4Ew==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/input-utils@20.6.4':
-    resolution: {integrity: sha512-MtZ79Bguo04Qhe88r05sMzqeuAMibkZggGGCjhRDW8duEvnCuhWv4Nt+8cDYF0/iLq271+rWA0Po8C96aBJQCA==}
+  '@commercetools-uikit/input-utils@20.6.7':
+    resolution: {integrity: sha512-/HYVJBVBn/aTKXDYij1C5b13Wgps6l9jhanBmn5mSbCGuY57pW17YfjgmJsimsl0wc1/QweECl1nDxoZw4IW0Q==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/inputs@20.6.4':
-    resolution: {integrity: sha512-omLk1QULw0jOYXGwPFx+8An+U22cld3LP6LPI/I2I2Ec5zIgu6US7vA4CoqZQRSPq1derpfj8qKW/8RWhc0DCA==}
+  '@commercetools-uikit/inputs@20.6.7':
+    resolution: {integrity: sha512-Bduit03cQhyGgWOQ68ov2Zvbr84nmH+fQPvhkB+rZK6N6HP9Vpn6UfyX5jk5W+SWdlevXuldtEvAG2sYf4M5Ww==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/label@20.6.4':
-    resolution: {integrity: sha512-+ERA229f9eb5gnEbn+gqSs0BDOqay5xwtYTjn1+mh9zWcWIUW3Mxd111fvqv/L/N5QUiNXhFt8hWblg24Hx4ww==}
+  '@commercetools-uikit/label@20.6.7':
+    resolution: {integrity: sha512-6xiBMtRcZ8pQ0RtxMAqW6QzNUICEP5of0eTtQw8aSlS/yTAmXxHG3ffePv9diXgvK6ulUCClupAhJ1SlmLXlzQ==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/link-button@20.6.4':
-    resolution: {integrity: sha512-hAOqqdxnQ6bvazad21m47bYOMF6fXWvHitun82+FTfAa0Te3C/kfsxHnjaJgQnGv01WYTpsd/FyBuVJRNDfaqA==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/link@20.6.4':
-    resolution: {integrity: sha512-v8OECC+yrogEPnvgXYB25z2tSrrK/YXZ5uoTiPS44McoTFb0I2tngBbWwMFrFMyp0Vp05FFTTj8bFFQRIidrRw==}
+  '@commercetools-uikit/link-button@20.6.7':
+    resolution: {integrity: sha512-nnQQbtR6Skf0h3GNLIz4Alv2W8+71PNplAPx+29t96CKsKJuJJUEaOS5zjUN0rT+Ali7Feer1Eil+aM3knGPyg==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/loading-spinner@20.6.4':
-    resolution: {integrity: sha512-YnXF+a8IvGy4gGn519JvsAIdMsByEWqgklYyKF1t4lm96YrbDLjyWzzdJU6jmza6+0V3DxaFvbO8R259q0cKww==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/localized-money-input@20.6.4':
-    resolution: {integrity: sha512-/Kq8pFCGnCcZn1KeqZ5avTPqHrCA+HBdYyM+HFNZ0P2fY6/jjTkwd1vAWQk0QKk7CroxwWzxwRjALuG5K5BVNg==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-multiline-text-field@20.6.4':
-    resolution: {integrity: sha512-KbPIGbfgrFwfrV2Oa3TGru3NvTO/4uk1Vo29oOpxigKii8M+ba0LCL3ZZcab2bpnzW19EDWdwYE1zetCVibqDA==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/localized-multiline-text-input@20.6.4':
-    resolution: {integrity: sha512-4UJvrXNVJUqVvSd4V2Eaqt1c4a9u4uftZwVoa3/UtHevLoVCegCV3dWuJAbOQJPJnpq1kppbSPGwqUUbDxt4/g==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-rich-text-input@20.6.4':
-    resolution: {integrity: sha512-0th4zYEIeUexUukgy7PvFcmirQS3xylZgc60TKB8f5M3D8v19pW/yWh7t19a6J5T2SsIQ8QXkJn304/5hS1n8Q==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-text-field@20.6.4':
-    resolution: {integrity: sha512-IxNQuorIptVN0vAs9podsLaeAiTEN1ehk1o8BqxUgSzSgijtxRVrB6lSBfXCmNhivAa7ax/ohFqaRG3tZWNWow==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/localized-text-input@20.6.4':
-    resolution: {integrity: sha512-BOy2G/zG27yWd2JdotBhDQyTN7s6KPWyfRi1bMCheaMmH19SxuEGaSMLD0Jk5SQDKmI1I4BGgj0ZbV1WSSbyFg==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-utils@20.6.4':
-    resolution: {integrity: sha512-km7NiBrb0Tu9O1k5GZ3O1AMqhRgkkBpCyL7TTsyG61x5nlqQKPrACUhq3BIxdyZrsu0HNjKqaJoEkdOh4EK0SA==}
-
-  '@commercetools-uikit/messages@20.6.4':
-    resolution: {integrity: sha512-j3yz0FMJjlrfkJgVXaOS+TLGbCFHF8oY+cCMYDCzzBYmlrzDIvfhopTyz9P6M5o0+omBITA0FpryTCpKRzvVUQ==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/money-field@20.6.4':
-    resolution: {integrity: sha512-bK2xWdv++Ma8McptL/tJYCGSennIY39N9t7tkesBkUVNmG83rhdOam9F2Nt/dh9bDlVqeoZg/FhiSGACvk8QWA==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/money-input@20.6.4':
-    resolution: {integrity: sha512-oJ4O2FZQEGPp481iNsm6n7LDtEl3/Wu0+1P+92HdA3ZlwnN5IfsJsbZ4ol8ReUyYbtXmG5CcXYkgrG1hxx+MKw==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/multiline-text-field@20.6.4':
-    resolution: {integrity: sha512-wNq2jZNzCAuGWpJoTltEHr1ClQQ7f84fsnpgSq/1htKmOum/ykgCZrUrJ85oB5PGvzJmsNpnhjJgdXUgIvnSHQ==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/multiline-text-input@20.6.4':
-    resolution: {integrity: sha512-XuyJiBv9aZjeEhUqb9XdqiKBhcKbyXPhjeNX5jwMW1D7KKg993kEFbNQEDSV9I8Nf6oCOmxEA65Uu/0ezb6GMA==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/notifications@20.6.4':
-    resolution: {integrity: sha512-pn5fbOxYD+y6uMraH973MjQNyYQJJb2dXS+p9sKz7KfGNaI1bcGgXsqYVefpFqmdV1MAvzXW9rVja/3ImYfweg==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/number-field@20.6.4':
-    resolution: {integrity: sha512-NFglk6Q/i4ZE4ggf2cy48qW7iLG3KeIa+l+xTxUF5CUU985ZmX7xPBrpYF2DNXVUkJMYh8tJpI1ukbPOknrRpQ==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/number-input@20.6.4':
-    resolution: {integrity: sha512-BWjtToSi1V1l5rVeRM0UVTXz0IPxrQs1H02AVusScIL09G8uT7tbK3WafoUc20bn+pYbkVkOFUWamrbHaerAkw==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/pagination@20.6.4':
-    resolution: {integrity: sha512-37C7l/XktCZf/SXqxfpkTGDLSB0r6xWx7GgruXLuOP9qstosYCEDOBDRQ3reCgCX8qGW2phBQGN5Pdy9zKKhYQ==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/password-field@20.6.4':
-    resolution: {integrity: sha512-PZiT7H08VHb+GoZFjekObEVGpy/HmmYfGINnbGuCx1EE4GUSOKlAAM6uev88TTsIz+OAY1LUx+hjwrMxWS3/Zg==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/password-input@20.6.4':
-    resolution: {integrity: sha512-MMzhS22nnEE6fzakekyLZrOO5M9ulXqLvYF8jo0ZzvyB9QaF5783eiIgSE0odz76V7BH3LLf0iKeEk7SmUPNTQ==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/primary-action-dropdown@20.6.4':
-    resolution: {integrity: sha512-pZY/HBobgKUrHh5QRb6aO0zZL0mfWlyd9/lNndFzNsei04TuqLNvscjR8AJUuKl5Gg4Ubrovw0njL00XHhwiHA==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/primary-button@20.6.4':
-    resolution: {integrity: sha512-oV0554cjPq1ChJMBvJoCxgXwYaZmCO3THuvQgYmhQ+kw5+ubLA7lt9QrlhN61UtOn6GSoDaFQ1QtzGEu7Pg77g==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/progress-bar@20.6.4':
-    resolution: {integrity: sha512-X2nde1/v+VOzFL3ObjSouu3HmUZg8PXKNjTj7VE4wg01YjiZfTHVbTX79s1NQt2F7hZeH0Iw32cBhlCwUiBrWw==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/quick-filters@20.6.4':
-    resolution: {integrity: sha512-udPAxDKb4Q/PJU9fCw3L+D10H8uRjiEMp0EoBLHXPyxX8byH2Yr4GaH6in7I/aHJijF7geyySgUHDQkfXlndHg==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/radio-field@20.6.4':
-    resolution: {integrity: sha512-w4lte76tsFekC7sZmeajJyttlaaBGH1RKnC5jnz9XJn65Fz9YGVnBGBjDkfTd4ILZyUf/5OenLtm7rzod96vIw==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/radio-input@20.6.4':
-    resolution: {integrity: sha512-pOYx23qf1UixKh9kFjePIUv52r7Vwobce8dwSd4EWayk2AnUckcS99VeucglK58K00fnCMAsWw5v03nxGgEPqg==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/rich-text-input@20.6.4':
-    resolution: {integrity: sha512-U3GRundlVSZQ2++aMmeq6pVrLB8tlFEj37Kny34/+8bcgsJ/ENte5ILIa2o4BTpzHxziaTENMS6WeTUpchEUIg==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/rich-text-utils@20.6.4':
-    resolution: {integrity: sha512-5Pu/2tJg/yWfouDssB+/LGkOM3XLa23xBLWnO1s7cDOqPHDlLoltSz98jpTStVDYWELtdez13M6eXouWAdRTMg==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/search-select-field@20.6.4':
-    resolution: {integrity: sha512-I5zqxDUz6HJ0JKc9iy1oSWsd9D1Fz7UDeCUbG3wV+LdozKt+E24SQS+ek6hfT0SqLDNeozKjkkI3doDCMMzhHg==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/search-select-input@20.6.4':
-    resolution: {integrity: sha512-0Yv1i1ALJxBwDUvYfk7DC5LD6tSNvtg2Pktynqq7M97GEaETmKXbi2nKuOHHqrCR4mfkqusj9lezEqWmDlIITA==}
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/search-text-input@20.6.4':
-    resolution: {integrity: sha512-X0yKy1Ren+3GVqfX96uYNvuEMxym642Rt8e389Jw2otj9gPX5l37r+0Ed/flZFPjUfhHMHPfdGbskAV7DZFLOA==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/secondary-button@20.6.4':
-    resolution: {integrity: sha512-nBah+E7ke+AUJkS2mHVKbmYursu5PTW7XPw8XVwlMZTMv36n53ttwrH/U7IFxBxcDeJNph0gPsiFcOCEC2KcrQ==}
+  '@commercetools-uikit/link@20.6.7':
+    resolution: {integrity: sha512-ORd+0xmrM2oWjfVJi9lBLyQ5g+znOp/imq6Mx5z5JuivF+mAIPFb9Xfugya8LTt6eTC8QfC7RecWBGaPPa0FLQ==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/secondary-icon-button@20.6.4':
-    resolution: {integrity: sha512-rCNshGbeMe2HRLQfo7wTillsXCh2ZgJl2B9ZdJHN6RTdTOsltdEBJfveeFAz68gwZ2qf9EcS5W8DH2oxEuYo3A==}
+  '@commercetools-uikit/loading-spinner@20.6.7':
+    resolution: {integrity: sha512-+EWCJmDFJNAJprxL6DFDzvYAT9f9qj5buGNYR7Xmzp8HOdJxbKtRY0v11ByzOshA7tNB+92Ck7p2A9aXRurPqw==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/select-field@20.6.4':
-    resolution: {integrity: sha512-jnxrO9PSMJX+AKyO/DsS3pa4anInUeEpzMtDBhtY331XOD5lGThoNcWkYcNNHkihr2LVSgT/qLB0elW+uZAJ0g==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/select-input@20.6.4':
-    resolution: {integrity: sha512-HBWbZ1gffKhGKlKzVw6QxVa4c2zCjTtDWuO+kJb74kFxC8eB0gJToAw62zfTq/q4wqsEp11HPsvyYd8+ojgZjQ==}
+  '@commercetools-uikit/localized-money-input@20.6.7':
+    resolution: {integrity: sha512-LLSkCyQdduzu5/t60phsxuCaCQHderA29aHNgZFj/XCImF5G1hj/U6Zq94cCFghfytY4f2eGsvkb5lf9YTQRFg==}
     peerDependencies:
       react: 19.x
       react-dom: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/select-utils@20.6.4':
-    resolution: {integrity: sha512-igoHb9JMX1rdWf61LbB8O5uUw+IGpA1wHMnTu2kObZTNjJkHoZgYkH7+5mpn1qp4jHGrtDv53EwYccteQ8zvlQ==}
+  '@commercetools-uikit/localized-multiline-text-field@20.6.7':
+    resolution: {integrity: sha512-hf/RTjr+tU8n9d4XmHAJT2BX1FEpOG2/DoD9d1FU+lcz0dkhL3C9IpuMB1Qy0srrQ6kxXJRVVmNMku4AJc266Q==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/localized-multiline-text-input@20.6.7':
+    resolution: {integrity: sha512-U6RU9mtW6qmt+h0BfrIXpaJ8Y3tMXo8BiIB+j9gcdJ++JI4zHYWy8KEycqlB9olQUIwAtqEEMNrXwt5fI93d6A==}
     peerDependencies:
       react: 19.x
       react-dom: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/selectable-search-input@20.6.4':
-    resolution: {integrity: sha512-OjHqiLpLfHYFZDl23zA8MYkfLWqf2yIDSylfhafroDfy5qwhMVU9oDJV5IoEYp1sA2vkwTbP9uqcmCRIBKXkyA==}
+  '@commercetools-uikit/localized-rich-text-input@20.6.7':
+    resolution: {integrity: sha512-7OU4Ju6HGNXMxL0oQjhq2RQeWQKcSPSjDNJsbiLDnVLbde4KpZ5WOKB07uYbiAHSkrz7M5yG/OQXICqPYOaaZA==}
     peerDependencies:
       react: 19.x
       react-dom: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/spacings-inline@20.6.4':
-    resolution: {integrity: sha512-x6TyH929jGqoAxMC4kEueUNujaMH6bSYi8N/WxftlAbdONvR7mBidUV2pVbqJ33xP7FH6OZV2OIgoEL6K/nnlg==}
+  '@commercetools-uikit/localized-text-field@20.6.7':
+    resolution: {integrity: sha512-uwnZPDdsqUMng5ojh/v56wtXdir5xF/5+VGUg9EA/AEbZL5mACkutptUcoYF6OGy9N5VedpV0J0ErCcWpRD8lg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/spacings-inset-squish@20.6.4':
-    resolution: {integrity: sha512-/8ApPSNt4vQ3MdQ8n0TxBI721VbB0oZzLuFSPyDDSy1BzZw0k/GgBoBrlJT2qphYZYievtfG2t94psKB2dpsog==}
+  '@commercetools-uikit/localized-text-input@20.6.7':
+    resolution: {integrity: sha512-MLxPLhl40NH8TDw92VgGWxqpcZcihbK41Zf7cGZiMdSI/1tZne1MsTe3E1oe85w4pczjpZd5n88c3gRPi4cp1g==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/localized-utils@20.6.7':
+    resolution: {integrity: sha512-Z9cqRT0ivO/pnzfV6mg8gxdGKakZaqucCbFLQSyDCmBd+ASaY1hsAebXJshnbSD+N1jj6q8VVD4hu+fCl7Zoxw==}
+
+  '@commercetools-uikit/messages@20.6.7':
+    resolution: {integrity: sha512-T+/XEGreAKhHop4+7UvK1twBaKWJZw5CVnece3mX6bEYWjF3pOYZ1UsQWgkHVQ5JAL8hB+vQnvtwUvds2PWi+A==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/spacings-inset@20.6.4':
-    resolution: {integrity: sha512-ziapcQIFsv2ugVBSo/srsymnQSXyjDHO1Tl/5F7ILKZU4YeygW/UrUfCamvoKKENZVbbFBH4h8o2l9md4pxCKA==}
+  '@commercetools-uikit/money-field@20.6.7':
+    resolution: {integrity: sha512-MptCRJa4QEFW7ijHA37Zpdh/v1rh2UCZ8LurA5Wft0hw05ZUh1ZtotzKuKFY0xqa2orPdhtd+N9bhYHKBGVXvg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/spacings-stack@20.6.4':
-    resolution: {integrity: sha512-GQFgAz6vDEvwPsz2J3DdyCbj3tmCA8Pd0/B2dkYTRx4N+E8N9mUS56b3SpGLfBsdvtlU74VUuDK6PdMnA7Ppng==}
+  '@commercetools-uikit/money-input@20.6.7':
+    resolution: {integrity: sha512-KkRYYxJ7HoByLmgogU9h+96so57LXdAM3lQlfJygtOaFp3f0nGOEQsbwDLaW0RNoUqLGXb6ObNg7wFEs+OeFGA==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/multiline-text-field@20.6.7':
+    resolution: {integrity: sha512-2E0BpQv1w/sxL1SrMnRTWUlQ12vWzJw+Qi749qqz0u+bQ3Kk41vp9OY/bYsqlczHWWnINprUUtv9PWS3UNfi9Q==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/spacings@20.6.4':
-    resolution: {integrity: sha512-vemzjJTOM0DbVcTSAgcs0xTMagZ3wYYdqsnPlKYL7S7ybjcdILb1W2lYBWEN2W/OwE3cuWrBAC4u2fapnkAWKA==}
+  '@commercetools-uikit/multiline-text-input@20.6.7':
+    resolution: {integrity: sha512-aBYtF3Xxvfd2cUQRIhLZeBbAeLTt7PDTO8wpzsr0iZWhRgXkBzUlrWFTlTuMzxb5G7psgsbaSOjzsxgSLF0m5Q==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/notifications@20.6.7':
+    resolution: {integrity: sha512-zAUQodqHatJSfoZIiFIHCra+acVo9ELf2KTeeFy6rJsSvIovFslYLb9NjPmWrB/Ze7ofn0Do3EqdzsqUFiRRsQ==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/number-field@20.6.7':
+    resolution: {integrity: sha512-c7hXl6dmNtV5GHJm9/UimfgzM6ooTavPDbfAaXpVQll6s3LXJblMGoDBA2PzjiIjZKC5p5HZT0qt9e/kgnYsCg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/stamp@20.6.4':
-    resolution: {integrity: sha512-OqzIQimDVO5sQVblewq3dTXsPvsnbKRo9gdjPQxpNvisDgQqF25lSpr2J21XTsDo+/hjzMBrDd0/GuePV1xBoA==}
+  '@commercetools-uikit/number-input@20.6.7':
+    resolution: {integrity: sha512-u/Q8RK/JRVXPvJCXUqaE9MsaD/+WV80REYeNSUcrnYJhpS30uL0jEXvlEHZnsYs/Od5MSIZuB9nukMd7U/jOGQ==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/tag@20.6.4':
-    resolution: {integrity: sha512-gOkrFCm5WWahieULcrUSqlBk1frVfNNynXfzLVJGPXBMKlFWHe1TXbrkA6k7n8Tz541WftVxOxpc9029kC7PCA==}
+  '@commercetools-uikit/pagination@20.6.7':
+    resolution: {integrity: sha512-R0p/PiCIk/9hKtOiOVlLlU/xXG1hlcJLxqk4R5Y9dgvDT0SynorLN6kmdVVFUI8LHl8qzUHsmTEyyNPoGq60Sg==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/password-field@20.6.7':
+    resolution: {integrity: sha512-J/mPki5z6v9JAjK3PQ4Ft1asmmtX9PGXjIOn3pNfn4UgMROVJYnHNqSrrws9DnF2EZHhglL63HkaWiv51L8JZQ==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/password-input@20.6.7':
+    resolution: {integrity: sha512-JrvOABb/LzCSP3SR8TVCxA7irQNax2A188vqQ5Ax0a9hC2rXkNw3ohGs8vaxmmpytHwTMr1qC/cHIoCEUwP2bg==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/primary-action-dropdown@20.6.7':
+    resolution: {integrity: sha512-ZT1yndZZp9pul5jHuW0970OW/H8DSwTk6qXNwgQCofKuPlS5Z4lNGI42/KedYiis7gnfptpL/cCO5qemV9dtFg==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/primary-button@20.6.7':
+    resolution: {integrity: sha512-vH0AUhTaY1XF7qnHEN1vA46nSxSArSDrZxj4hCNmflk9apKgFe0Sz0V3TV4cCj+n7dHCfiuTUUQFnjVgaC4DFQ==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/progress-bar@20.6.7':
+    resolution: {integrity: sha512-6aZ7xpZ5+uVE1O+6dgzADi8O3KLMUG55tjf5p9019HFIRlZqtJRuOnUyFlYLkW1dkyc3GJ7e1KydKB4FsaiO9g==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/quick-filters@20.6.7':
+    resolution: {integrity: sha512-gZfsBYyL3PxxLjiHi3j9FnBHz9b4I1DjwXAj3sIIS2NzXuVr0dNa2a/wR44CyN9n5Ot1IG2T8LPMpMMiGAaQRg==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/radio-field@20.6.7':
+    resolution: {integrity: sha512-e8Ojsa30XBSCpuAXOj0pqxaLu4ILK0s7udYIdgMGitujwWysecxC9lIb3hCbyZWib2AFgDVWDZK1yO09crtJxA==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/radio-input@20.6.7':
+    resolution: {integrity: sha512-8qPgMbM4+WekTw7sTl8CBzUDqxcimCIwAg+5m2vagsnFZj2Q4EfMULcytLus8WZiVhBzks1SuMnEfCMN34AUdA==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/rich-text-input@20.6.7':
+    resolution: {integrity: sha512-h0BZEGDTgqVs0dgdpKgCjBnBGP+CltmV0oSnlnADXlI1cV5/idIRlh16aZ7s/08IbWR0FBUOrdUL0KjUOYGyAw==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/rich-text-utils@20.6.7':
+    resolution: {integrity: sha512-Dl3M8drS6FsHWjD7vamEP5Qnb9NKz9RVAWP+52trSMxRKXdLIo5oqw0fFaF9TmLT3pfH5WBt6zAqju363rZ4qw==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/search-select-field@20.6.7':
+    resolution: {integrity: sha512-qFQmkD+tN80Y0HS3CmWESGWPeMlcageh8VRpW3Ssc+xaqNI02NNSiV5wFnejtsOdr/W9EwtjlFL2+sNLvnp+WA==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/search-select-input@20.6.7':
+    resolution: {integrity: sha512-tuopHHlOydy0nJDdMwmpxA9C/Q7mSdvTnumDDhF2hS/pqYES25bZognqwj68OTGOamJK8vOgiXvx2G9OEDbzfQ==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/search-text-input@20.6.7':
+    resolution: {integrity: sha512-QaicbbMSWcpbjPVL7hWblvq1D0XjKLnOuxAk3PcsoVamU0gXK4GeXV+07MkdLl5NKGZuc5M07SKyBfI3i4UbEg==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/secondary-button@20.6.7':
+    resolution: {integrity: sha512-LNwSG5oIBvwTLb6nVO7NSMILe+wTZTjKONaavX1ERYtPhzW5nJSqGunb+Dh1zurf8fzKN20ZUNPvjaNFGdC+Yg==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+      react-router-dom: 5.x
+
+  '@commercetools-uikit/secondary-icon-button@20.6.7':
+    resolution: {integrity: sha512-uFoDHXUajc4a10Qm2U1L6bINADIF3xoRyzS+uorfsQor6k4cS9FPv8LlpN3ZN+mHiWwtmiSraK63GtETeVlH4A==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/select-field@20.6.7':
+    resolution: {integrity: sha512-Kki6PFrv6Kp5g6R25D7TGVO2bUtQz/c0uQsYxs3gf8LEtXkSGMcbhnUkYedsEhKendyLrL75YJKihWTgmvYtzw==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/select-input@20.6.7':
+    resolution: {integrity: sha512-wnnWuEjd1EPIEBNN9FUInR18knZIGA7DVIx3fWF15nhk5Op2gQGWjxQweb2lpm/s8JCR0fL8AH1BE/aieJu4Rg==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/select-utils@20.6.7':
+    resolution: {integrity: sha512-YR/QVoYvmNxDBcDun1esHCK0PthjW1s8Z1CgcjD51sonOFCqvFD9OInnJNHHQXbHK5FWR/co5TPXR4o1uIkiqw==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/selectable-search-input@20.6.7':
+    resolution: {integrity: sha512-BvRwqRNMkggDfKcO/X9xGn0jr0Q4lQ0kKQ+Q58hDZczlB0kWX2mkpZfdFVhXAT9NCyPEc8e1nUmQYaAItsRk/w==}
+    peerDependencies:
+      react: 19.x
+      react-dom: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/spacings-inline@20.6.7':
+    resolution: {integrity: sha512-zS31kTb8pCKpkLN02+iDDVjj0FHGq6NcNHcCY9FKT2P+0xJVeBVJh5EYeUO1kg0tf1694NhOE7Rg8We/jFEzFw==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/spacings-inset-squish@20.6.7':
+    resolution: {integrity: sha512-5M18ApVkOsQ0C0eGcNTsLow6ug2NQJXMejr6gvdfBGgEygTuMKwZworNBdCZtK48xc2/bRRD4iMBONmXuNHkdw==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/spacings-inset@20.6.7':
+    resolution: {integrity: sha512-AhBe5t/IfPCswBdA/DqM7OgjYrBfnrAYx8Zbi0aVxwPNoTzIc4e0moFchUEpmoesbxxEfKdUHidhUQR2BAmDQg==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/spacings-stack@20.6.7':
+    resolution: {integrity: sha512-0c9iOht7rJAx22LIwsPgRmE2SDysqmGBN91HvH6E8RQLMJAP4NWudXtPOMaKU9Cyg3swIPetYdkp+kxpFARLlQ==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/spacings@20.6.7':
+    resolution: {integrity: sha512-Gc0SVYhGcCn7vayZMyFCgTx/diY+w7DJjZ29bHNYPlu03NUo/vczQ9KiEhdEskT53jOvmhS55pAoSHiavdTm6A==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/stamp@20.6.7':
+    resolution: {integrity: sha512-96CwyX/hIVeSdWRgXM+vtkb1SDAC+BGrw/U5DYaXalSAtfAY0d33q6oUm0Oa4j+yPnTTjtg62kaoU9NRaS2kUA==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/tag@20.6.7':
+    resolution: {integrity: sha512-XG30Gg3dR5q6DH5l9rbJikEjkiLgKLhbOXjVB7BXfxPvEQvhBP6cGIMdur66wofrhHBxhoMSNjHLeIap1Qgnjg==}
     peerDependencies:
       react: 19.x
       react-router-dom: 5.x
 
-  '@commercetools-uikit/text-field@20.6.4':
-    resolution: {integrity: sha512-lb1+PWBnheGsPkaxWFc/49MYYjVAOpWZBCXlQq254oZmBwunXfj2xcQkMOcRHM00a9bffpbfY1RiE+FTHpMdlQ==}
+  '@commercetools-uikit/text-field@20.6.7':
+    resolution: {integrity: sha512-wkEZ3BNA6poRIWdE1Wno4+pdEK+O7Ki+rj813AW0mSYb3Dk1AHg+OxCCQbVk/sNy7xH+7Lh1Snykgc1AwDXW1g==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/text-input@20.6.4':
-    resolution: {integrity: sha512-dXkbo8cCUPNCVmAh/qIuILt1PLcbjj6HLgSDTFzL4GEmKX3R8fATvSOSBgAQEvz4/w5wPa/XfeUg+HkBhxTYzw==}
+  '@commercetools-uikit/text-input@20.6.7':
+    resolution: {integrity: sha512-eCSoyogNp6t8j6dlPdn2peIPUIapKkvSrkSPpG00nUIoTnYbKemTZyyJJt/wIl+fI7MrlbMXyPz7RAbZFX31Lg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/text@20.6.4':
-    resolution: {integrity: sha512-ReB/OV397fsb3PbHYNtLZRWvWhDUwGLYo44Ei4fCUa4xqR/HJFCDtmUxJcDhgowwULXutnvnZMJYs6XiWI9TZg==}
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/time-field@20.6.4':
-    resolution: {integrity: sha512-NplGh28PzTlT03IWdTqXy473IfaXZi+TnOCMvP6ot9k0ZAkDYUb0rlUrK4NQom+YhuIpyJgS4JEx/azrSiVhTA==}
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/time-input@20.6.4':
-    resolution: {integrity: sha512-RSaXSoXTAGfDqoIs1eKh9pGvyRgldFaywhiu+70jcFBi+K9ugqhIF6vqKff3fJtEoMolCUgfVyVgdsmml1M1BQ==}
+  '@commercetools-uikit/text@20.6.7':
+    resolution: {integrity: sha512-txFX6FjBLVfR58Wsb8MmNWdnuETdF1c5bFmUh3YM/8FQbNxCJJH6QWfM6tS+GTOPHbmaC4TBOM145ruUOhUPxg==}
     peerDependencies:
       react: 19.x
       react-intl: 7.x
 
-  '@commercetools-uikit/toggle-input@20.6.4':
-    resolution: {integrity: sha512-BosCXqUN2ncfihXJdazVYROQmyOPiLF7qQcqRp14DAeYSrBznSD7Kcc7jNobcaZl1feXkLvmb/8enN/ymR/pHA==}
+  '@commercetools-uikit/time-field@20.6.7':
+    resolution: {integrity: sha512-IkTxmiuyPeXYHu3+jrMu3BUKxZEkRdprLBtEqHemlHLzYlIweoO6FNpVZvC6LIW8wKiVEa3pB27g3uWar+rTzg==}
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/tooltip@20.6.4':
-    resolution: {integrity: sha512-z5aFsx0lPlstmFO1h9ByEsLCGyJuf7kgydfHrNcDiBNFQ8XakM6fySWn624FBtOINpGcHZqzutQALcjELxw9Mg==}
+  '@commercetools-uikit/time-input@20.6.7':
+    resolution: {integrity: sha512-B+ym4tSKwf4kXR5cCSIbx1KNZ3Dol14PRASIKsSAQvMNz1pTLkVwDheO11DcN+fFeT0QSvSN3N3YZLTzfIUhTQ==}
+    peerDependencies:
+      react: 19.x
+      react-intl: 7.x
+
+  '@commercetools-uikit/toggle-input@20.6.7':
+    resolution: {integrity: sha512-kVRPxmU89S6WaI6qZJmlFJQD7bdodvDnxXgHe0939JGTNNwncP9/Num7lt6yScjd3FB0M3q8jek+5uH1/9k4Cw==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/tooltip@20.6.7':
+    resolution: {integrity: sha512-af4OCsAfaULctzjnNAyHxPXkgDBr5ViwSoRNhr8880rmzhvNzq5uisgBtlatgpjgjFaLKcbx3LlPk+VoBSUJhA==}
     peerDependencies:
       react: 19.x
 
@@ -1836,8 +1847,13 @@ packages:
     peerDependencies:
       react: 19.x
 
-  '@commercetools-uikit/view-switcher@20.6.4':
-    resolution: {integrity: sha512-87LXpS/NvBHAjjfsE5YBhSIaVoSijORBu6iPo7MKRS7MrBKzt8756aMgdXTKkleWPMW81FxIX6tJYGwiOWBm6w==}
+  '@commercetools-uikit/utils@20.6.7':
+    resolution: {integrity: sha512-51y9Y+il0cucTPELhT3vAnylpxRNAcbOVsYW8OW9KU78kVBPB7hAemWp2imreIP8OnZNK+P8XhvM6dC8kRwEsQ==}
+    peerDependencies:
+      react: 19.x
+
+  '@commercetools-uikit/view-switcher@20.6.7':
+    resolution: {integrity: sha512-nK2r8jweZlJeIz+lM4M/ogxIi33+V+gok/y2+7zmzF4MyOIssfidc7hDH3jEfZHmgqHX8ecJQ6Wvf9DdceUIuw==}
     peerDependencies:
       react: 19.x
 
@@ -2127,8 +2143,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -2161,13 +2177,13 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@figma/code-connect@1.4.9':
-    resolution: {integrity: sha512-Ifan9Kb5oXHAh0wXu0BM8Iy+AEhWM8NoJSTBr3oU0vQTwggleK55CUHnh5zEYl6tQjj83mg6mTo4klDgcgDprg==}
+  '@figma/code-connect@1.5.2':
+    resolution: {integrity: sha512-TlTFDRU3G+1EDHJU7xXf41hxtOfZZa5qWMNp9NkQTE7mmg/W+xtFY/iGfRHx1d4lfACTCldTQcW5I6PXck4yLA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fission-ai/openspec@1.6.0':
-    resolution: {integrity: sha512-7yFTQ3hrrk11mQ2ACClNv2gtAN0o116vCgwoiQKmreoB6ambSnrZh7wf2FNFoSDBXHBi9iiCQ7G16fG71ZNppA==}
+  '@fission-ai/openspec@1.7.0':
+    resolution: {integrity: sha512-FGuMzBqJVB7/mbn/+kt9MsHzCvjoAVNguDWtuHBjdlF3GkUGrc5QlU6FJ70wbb4sBPsd9zbXB2wftMmxCzEJCw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -2791,23 +2807,23 @@ packages:
       react-dom:
         optional: true
 
-  '@modelcontextprotocol/inspector-cli@0.21.2':
-    resolution: {integrity: sha512-Om2ApfIbkbfR7+PqJX0bO2Qwg0z55MgxquC+G0YL6x80ElpZMfxITsWQ1238kh3bv1zlwPSePc2kvDnCcU5tXw==}
+  '@modelcontextprotocol/inspector-cli@0.22.0':
+    resolution: {integrity: sha512-Z3NHqa1zTjZyfcd3qJcpIwqiSG7QlR3YkYPFAIoMsPw3hId0AoHtlG4SRueJzymCsF9Rqein3NzUn3qT+aqUBw==}
     deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
-  '@modelcontextprotocol/inspector-client@0.21.2':
-    resolution: {integrity: sha512-8us3hVXDgMHGb5jF1bBE/a6rRRlEaS+SKjbDFB56oE6+mNcAP9JgL8h6T0fYd3XQ3vL/CYxjVeQE+5yRdvhsVg==}
+  '@modelcontextprotocol/inspector-client@0.22.0':
+    resolution: {integrity: sha512-LAFijdt2L4xxjqA16dkqVPjB85VeyHAa32M+nAZyMe4to8s35cW9sZVPnBEFjXGFN4A2WsZ07ViiG+wM6SKS4w==}
     deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
-  '@modelcontextprotocol/inspector-server@0.21.2':
-    resolution: {integrity: sha512-ASFNPFMnT0Vn5u6aYRwwMrwA/0qpxb1lg3sE5GjWii5bUfPNXuIaLOXuXKSOFIMG4o82RxpuipdqX1ZdsmTPUw==}
+  '@modelcontextprotocol/inspector-server@0.22.0':
+    resolution: {integrity: sha512-hOrExnp8wOlSEWVU+t9UD/POHFZy09Xx8LZqX7P9R7mzcDdrwTVB96tbPD8cIi9mVYWFQDKGNVUsF6I7u7fPGA==}
     deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
-  '@modelcontextprotocol/inspector@0.21.2':
-    resolution: {integrity: sha512-f/zIzl6ccYjIxSTgmol9EKvd8AXsXkIaZX16kLGhrYwxrApvU3IL6IzgOqATKP/2kgyKdFUOVLlHMxX9e6BZZA==}
+  '@modelcontextprotocol/inspector@0.22.0':
+    resolution: {integrity: sha512-HUyvF+6C3e/sL3wZSc71Li1SkuWysixblFpVdm8csJKBOlT2kNG5kWP0AAgdXRiRWRZ27ZajNtagYgwoJ+QBpQ==}
     engines: {node: '>=22.7.5'}
     deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
@@ -2821,6 +2837,13 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3025,8 +3048,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@oxc-project/types@0.139.0':
-    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -3150,9 +3173,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/core@1.17.0':
-    resolution: {integrity: sha512-8pDNL+/u9ojzXloA5wILVDXBCV5daJ7w2ipCALQlEEZmL752cCKhRpbyiHn3tjKXh3Hy6aOboJneYa1JdlVHrQ==}
-
   '@preact/signals-core@1.13.0':
     resolution: {integrity: sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==}
 
@@ -3190,8 +3210,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@publint/pack@0.1.4':
-    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+  '@publint/pack@0.1.6':
+    resolution: {integrity: sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==}
     engines: {node: '>=18'}
 
   '@quilted/events@2.1.3':
@@ -3648,6 +3668,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-types/shared@3.36.1':
+    resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@remote-dom/core@1.10.1':
     resolution: {integrity: sha512-MlbUOGuHjOrB7uOkaYkIoLUG8lDK8/H1D7MHnGkgqbG6jwjwQSlGPHhbwnD6HYWsTGpAPOP02Byd8wBt9U6TEw==}
     engines: {node: '>=14.0.0'}
@@ -3673,97 +3698,92 @@ packages:
       react:
         optional: true
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.2':
+    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3775,52 +3795,52 @@ packages:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
 
   '@rollup/plugin-commonjs@15.1.0':
     resolution: {integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
 
   '@rollup/plugin-json@4.1.0':
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
 
   '@rollup/plugin-node-resolve@11.2.1':
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
 
   '@rollup/pluginutils@3.1.0':
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.62.2
+      rollup: ^4.62.4
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.62.2':
-    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.62.2':
-    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
     cpu: [arm64]
     os: [android]
 
@@ -3829,29 +3849,39 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.62.2':
     resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.62.2':
-    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.62.2':
-    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
-    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
@@ -3862,50 +3892,56 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.62.2':
-    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.62.2':
-    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.2':
-    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.2':
-    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -3916,19 +3952,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.62.2':
-    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.62.2':
-    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.62.2':
-    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -3937,18 +3979,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.2':
-    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
     cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
     cpu: [x64]
     os: [win32]
 
@@ -4035,7 +4087,7 @@ packages:
     resolution: {integrity: sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==}
     peerDependencies:
       esbuild: '>=0.28.1'
-      rollup: ^4.62.2
+      rollup: ^4.62.4
       storybook: ^10.4.6
       vite: '*'
       webpack: '*'
@@ -4182,72 +4234,86 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
-  '@swc/core-darwin-arm64@1.15.11':
-    resolution: {integrity: sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==}
+  '@swc/core-darwin-arm64@1.15.47':
+    resolution: {integrity: sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.15.11':
-    resolution: {integrity: sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==}
+  '@swc/core-darwin-x64@1.15.47':
+    resolution: {integrity: sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.15.11':
-    resolution: {integrity: sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==}
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
+    resolution: {integrity: sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.15.11':
-    resolution: {integrity: sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==}
+  '@swc/core-linux-arm64-gnu@1.15.47':
+    resolution: {integrity: sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@swc/core-linux-arm64-musl@1.15.11':
-    resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
+  '@swc/core-linux-arm64-musl@1.15.47':
+    resolution: {integrity: sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@swc/core-linux-x64-gnu@1.15.11':
-    resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
+  '@swc/core-linux-ppc64-gnu@1.15.47':
+    resolution: {integrity: sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.47':
+    resolution: {integrity: sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.47':
+    resolution: {integrity: sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@swc/core-linux-x64-musl@1.15.11':
-    resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
+  '@swc/core-linux-x64-musl@1.15.47':
+    resolution: {integrity: sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@swc/core-win32-arm64-msvc@1.15.11':
-    resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
+  '@swc/core-win32-arm64-msvc@1.15.47':
+    resolution: {integrity: sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.15.11':
-    resolution: {integrity: sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==}
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    resolution: {integrity: sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.15.11':
-    resolution: {integrity: sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==}
+  '@swc/core-win32-x64-msvc@1.15.47':
+    resolution: {integrity: sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.15.11':
-    resolution: {integrity: sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==}
+  '@swc/core@1.15.47':
+    resolution: {integrity: sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -4261,12 +4327,19 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
-  '@swc/types@0.1.25':
-    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.10.0':
+    resolution: {integrity: sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    deprecated: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
 
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
@@ -4289,6 +4362,12 @@ packages:
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@testing-library/user-event@14.6.3':
+    resolution: {integrity: sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -4476,16 +4555,16 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
-  '@typescript-eslint/eslint-plugin@8.64.0':
-    resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
+  '@typescript-eslint/eslint-plugin@8.66.0':
+    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.64.0
+      '@typescript-eslint/parser': ^8.66.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ~5.9.3
 
-  '@typescript-eslint/parser@8.64.0':
-    resolution: {integrity: sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==}
+  '@typescript-eslint/parser@8.66.0':
+    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -4497,8 +4576,18 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
+  '@typescript-eslint/project-service@8.66.0':
+    resolution: {integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
   '@typescript-eslint/scope-manager@8.64.0':
     resolution: {integrity: sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.66.0':
+    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.64.0':
@@ -4507,8 +4596,14 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
-  '@typescript-eslint/type-utils@8.64.0':
-    resolution: {integrity: sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==}
+  '@typescript-eslint/tsconfig-utils@8.66.0':
+    resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
+  '@typescript-eslint/type-utils@8.66.0':
+    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -4518,8 +4613,18 @@ packages:
     resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.66.0':
+    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.64.0':
     resolution: {integrity: sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
+  '@typescript-eslint/typescript-estree@8.66.0':
+    resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: ~5.9.3
@@ -4531,8 +4636,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ~5.9.3
 
+  '@typescript-eslint/utils@8.66.0':
+    resolution: {integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ~5.9.3
+
   '@typescript-eslint/visitor-keys@8.64.0':
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -4544,14 +4660,14 @@ packages:
     engines: {node: '>=20.18 <=25.x'}
     os: [darwin, linux, win32]
 
-  '@vitejs/plugin-react-swc@4.3.1':
-    resolution: {integrity: sha512-PaeokKjAGraNN+s5SIApgsktnJprIyt3zgEIu7awnEdfn29QiB2crTcCzyi2XGpX9rUnTc0cKU07Wm0N0g7H2w==}
+  '@vitejs/plugin-react-swc@4.3.3':
+    resolution: {integrity: sha512-bti8ZAcvz4Lh6/e4Uk2k3aa1TiUXbbMsahuqOHvd3MveFTkKDZOA6wQVkpj7J/+tepX/wGfe+lsGh/t24HTXMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7 || ^8
 
-  '@vitejs/plugin-react@6.0.3':
-    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -4632,6 +4748,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: ~5.9.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vueless/storybook-dark-mode@10.0.8':
     resolution: {integrity: sha512-nhueFjEbyNGBzye4H+STC+pRIKthttiuPJRfcqCrDwqKnLS9AkVT3Ra+F5bvOeWbvZt3xc6xNJBNV5OrjRIoZQ==}
@@ -4938,12 +5059,6 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  acorn-import-phases@1.0.4:
-    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      acorn: ^8.14.0
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -5077,8 +5192,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axe-core@4.11.0:
-    resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   babel-plugin-macros@3.1.0:
@@ -5262,8 +5377,8 @@ packages:
   chroma-js@3.1.2:
     resolution: {integrity: sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==}
 
-  chromatic@17.7.2:
-    resolution: {integrity: sha512-/y6LcCiOXG3ecWNLGhXgir29wKhkrmK1RIVAB/5gdDsakWNG/u7mPZFuUlMFkxvA8bMJ0cDHgt1J7K1MWTg3+A==}
+  chromatic@17.8.0:
+    resolution: {integrity: sha512-xcn2TGdbrKHQbGAo3wZc5qoKaPe+CEvhAEcky9OCpofGd3DJucLFEYpk8wYgHKgR5XAI9X8Op1C6fWlvdjxE/g==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -5312,6 +5427,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
 
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -5720,9 +5839,6 @@ packages:
   electron-to-chromium@1.5.371:
     resolution: {integrity: sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -5740,8 +5856,8 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  enhanced-resolve@5.24.0:
-    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -5794,6 +5910,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild-wasm@0.27.3:
+    resolution: {integrity: sha512-AUXuOxZ145/5Az+lIqk6TdJbxKTyDGkXMJpTExmBdbnHR6n6qAFx+F4oG9ORpVYJ9dQYeQAqzv51TO4DFKsbXw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -5868,8 +5989,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.7.0:
-    resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -6164,8 +6285,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -6235,8 +6356,8 @@ packages:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
 
-  globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+  globals@17.9.0:
+    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -6573,10 +6694,6 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -6591,6 +6708,9 @@ packages:
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
+
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -6734,78 +6854,78 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -6818,10 +6938,6 @@ packages:
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  loader-runner@4.3.2:
-    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
-    engines: {node: '>=6.11.5'}
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
@@ -6848,8 +6964,8 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
-  log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
   long@5.3.2:
@@ -7389,9 +7505,9 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
-  ora@8.2.0:
-    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
-    engines: {node: '>=18'}
+  ora@9.4.1:
+    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
+    engines: {node: '>=20'}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -7439,6 +7555,9 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -7506,6 +7625,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
+
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
@@ -7568,14 +7690,14 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -7623,10 +7745,6 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-node@5.24.7:
-    resolution: {integrity: sha512-IJ0Zj+v+eg/JQMZ75n0Hcp4NzuQzWcZjqFjcUQs6RhW2l5FiQIq09sKJMleXX33hYxD6sfjFsDTqugJlgeAohg==}
-    engines: {node: ^20.20.0 || >=22.22.0}
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -7645,8 +7763,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.9.5:
-    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7691,8 +7809,8 @@ packages:
   proxy-memoize@3.0.1:
     resolution: {integrity: sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==}
 
-  publint@0.3.21:
-    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+  publint@0.3.23:
+    resolution: {integrity: sha512-5MQipUPcB7MWw84zLUkHrg/H/UBtk3LL+A0GngTTBSsiNJLQurMUaSIRG3edlOrRz4UFe0AOKK9TZdIWviV+jQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7843,12 +7961,22 @@ packages:
       '@types/react':
         optional: true
 
+  react-router-dom@5.3.4:
+    resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
+    peerDependencies:
+      react: '>=15'
+
   react-router-dom@7.17.0:
     resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
+
+  react-router@5.3.4:
+    resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
+    peerDependencies:
+      react: '>=15'
 
   react-router@7.17.0:
     resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
@@ -8069,13 +8197,13 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.2:
+    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.62.2:
-    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -8383,8 +8511,8 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
   storybook@10.4.6:
@@ -8417,9 +8545,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -8576,6 +8704,10 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -8703,8 +8835,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.23.1:
-    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+  tsx@4.23.5:
+    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -8728,8 +8860,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typescript-eslint@8.64.0:
-    resolution: {integrity: sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==}
+  typescript-eslint@8.66.0:
+    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -8802,7 +8934,7 @@ packages:
       '@vue/language-core': ^3.1.5
       esbuild: '>=0.28.1'
       rolldown: '*'
-      rollup: ^4.62.2
+      rollup: ^4.62.4
       typescript: ~5.9.3
       vite: '>=3'
       webpack: ^4 || ^5
@@ -8962,7 +9094,7 @@ packages:
     resolution: {integrity: sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==}
     peerDependencies:
       '@microsoft/api-extractor': '>=7'
-      rollup: ^4.62.2
+      rollup: ^4.62.4
       vite: '>=3'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -8972,13 +9104,13 @@ packages:
       vite:
         optional: true
 
-  vite@8.1.5:
-    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
+      '@vitejs/devtools': ^0.4.0
       esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -9084,8 +9216,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  webpack-cli@7.2.1:
-    resolution: {integrity: sha512-YwSGbcZdfz12DM8JIseVPr3oBb09IgVCVc4vY3oDvZnI/mALTGPAP1QiqOi4/bBLSJrRHaqDIXeHcNA0+G38aw==}
+  webpack-cli@7.2.2:
+    resolution: {integrity: sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -9111,15 +9243,15 @@ packages:
     resolution: {integrity: sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==}
     engines: {node: '>=18.0.0'}
 
-  webpack-sources@3.5.0:
-    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
-  webpack@5.108.4:
-    resolution: {integrity: sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==}
+  webpack@5.109.2:
+    resolution: {integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -9251,6 +9383,10 @@ packages:
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.1:
@@ -9405,20 +9541,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9445,41 +9581,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7':
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9489,18 +9625,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9520,43 +9656,43 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9572,7 +9708,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -9580,7 +9716,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9629,12 +9765,12 @@ snapshots:
     dependencies:
       postcss-calc-ast-parser: 0.1.4
 
-  '@chakra-ui/cli@3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@chakra-ui/cli@3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@clack/prompts': 1.5.1
       '@pandacss/is-valid-prop': 1.11.1
       '@types/babel__core': 7.20.5
@@ -9644,7 +9780,7 @@ snapshots:
       chokidar: 5.0.0
       cli-table: 0.3.11
       commander: 14.0.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       dotenv: 17.4.2
       esbuild: 0.28.1
       get-tsconfig: 4.14.0
@@ -9659,11 +9795,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@ark-ui/react': 5.37.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
       '@emotion/utils': 1.4.2
@@ -9845,54 +9981,54 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercetools-frontend/ui-kit@20.6.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-hidden': 20.6.4(@types/react@19.2.17)(react@19.2.0)
-      '@commercetools-uikit/avatar': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-panel': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/data-table-manager': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/fields': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/filters': 20.6.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.6.4(@types/react@19.2.17)(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/i18n': 20.6.4
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/inputs': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/link': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/notifications': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/pagination': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/primary-action-dropdown': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/progress-bar': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/quick-filters': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/selectable-search-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/stamp': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@commercetools-uikit/view-switcher': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/avatar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible-panel': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/filters': 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/i18n': 20.6.7
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/notifications': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/pagination': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/progress-bar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/stamp': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@commercetools-uikit/view-switcher': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
       moment: 2.30.1
       moment-timezone: 0.6.2
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -9900,14 +10036,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/accessible-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/accessible-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@types/react-is': 19.2.0
       lodash: 4.18.1
       react: 19.2.0
@@ -9917,119 +10053,119 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/accessible-hidden@20.6.4(@types/react@19.2.17)(react@19.2.0)':
+  '@commercetools-uikit/accessible-hidden@20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  '@commercetools-uikit/async-creatable-select-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-creatable-select-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-select-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-select-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/avatar@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/avatar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10037,91 +10173,91 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/buttons@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/link-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/primary-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/calendar-time-utils@20.6.4(moment-timezone@0.6.2)(react@19.2.0)':
+  '@commercetools-uikit/calendar-time-utils@20.6.7(moment-timezone@0.6.2)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       moment-timezone: 0.6.2
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/calendar-utils@20.6.4(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       moment: 2.30.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/card@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/card@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
       react: 19.2.0
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/checkbox-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/checkbox-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10130,14 +10266,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible-motion@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10145,21 +10281,21 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/collapsible-panel@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/collapsible-panel@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10169,14 +10305,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/collapsible@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10184,94 +10320,94 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/constraints@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/constraints@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/creatable-select-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/creatable-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/creatable-select-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table-manager@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/accessible-hidden': 20.6.4(@types/react@19.2.17)(react@19.2.0)
-      '@commercetools-uikit/async-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.6.4(@types/react@19.2.17)(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/primary-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@hello-pangea/dnd': 18.0.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/debounce-promise': 3.1.9
       debounce-promise: 3.1.2
@@ -10285,19 +10421,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table-manager': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10308,20 +10444,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-field@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10332,25 +10468,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-input@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/calendar-time-utils': 20.6.4(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.4(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10364,20 +10500,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-range-field@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-range-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-range-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10388,25 +10524,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-range-input@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-range-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/calendar-time-utils': 20.6.4(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.4(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10420,20 +10556,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-field@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-time-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-time-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10444,25 +10580,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-input@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/date-time-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/calendar-time-utils': 20.6.4(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.4(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10476,12 +10612,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/design-system@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/design-system@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10489,20 +10625,33 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/dropdown-menu@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/design-system@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      lodash: 4.18.1
+      react: 19.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - supports-color
+
+  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10512,13 +10661,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-errors@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/field-errors@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10527,22 +10676,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-label@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/field-label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10551,13 +10700,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-warnings@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/field-warnings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10566,30 +10715,30 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/fields@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-field': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-field': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-field': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/password-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/time-field': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/async-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/money-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/number-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/password-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/radio-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/search-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/time-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - moment
@@ -10598,24 +10747,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/filters@20.6.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/filters@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -10628,17 +10777,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/flat-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/flat-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10648,12 +10797,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/grid@20.6.4(@types/react@19.2.17)(react@19.2.0)':
+  '@commercetools-uikit/grid@20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -10670,22 +10819,33 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@commercetools-uikit/i18n@20.6.4':
+  '@commercetools-uikit/hooks@20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@types/raf-schd': 4.0.3
+      lodash: 4.18.1
+      raf-schd: 4.0.3
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@commercetools-uikit/i18n@20.6.7':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
 
-  '@commercetools-uikit/icon-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10695,14 +10855,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/icons@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/icons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@types/dompurify': 2.4.0
       dompurify: 3.4.12
       react: 19.2.0
@@ -10712,15 +10872,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/input-utils@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/input-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
       react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
@@ -10730,37 +10890,37 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/inputs@20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/checkbox-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.6.4(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-money-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-rich-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/password-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/selectable-search-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/time-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/toggle-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/search-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/toggle-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - moment
@@ -10769,15 +10929,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/label@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10785,57 +10945,57 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       history: 4.10.1
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/link@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@types/history': 4.7.11
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/loading-spinner@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/loading-spinner@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10844,48 +11004,48 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-money-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.6.4(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-multiline-text-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10894,54 +11054,54 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-multiline-text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.6.4(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
       react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-rich-text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.6.4(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       downshift: 9.3.3(react@19.2.0)
       immutable: 4.3.9
       is-hotkey: 0.2.0
@@ -10958,20 +11118,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10980,24 +11140,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.6.4(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11006,23 +11166,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-utils@20.6.4(react@19.2.0)':
+  '@commercetools-uikit/localized-utils@20.6.7(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/messages@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/messages@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11031,68 +11191,68 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/money-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/money-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/money-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11101,23 +11261,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       downshift: 9.3.3(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11128,15 +11288,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/notifications@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/notifications@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11144,20 +11304,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/number-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/number-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11166,16 +11326,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/number-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/number-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11184,22 +11344,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/pagination@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/pagination@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/number-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       formik: 2.4.9(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
@@ -11210,24 +11370,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/password-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/password-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/password-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11236,16 +11396,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/password-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/password-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11254,19 +11414,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-action-dropdown@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11277,17 +11437,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11297,17 +11457,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/progress-bar@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/progress-bar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11317,14 +11477,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/quick-filters@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11334,20 +11494,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/radio-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11356,20 +11516,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-is: 19.2.6
     transitivePeerDependencies:
@@ -11379,24 +11539,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/rich-text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       downshift: 9.3.3(react@19.2.0)
       immutable: 4.3.9
       is-hotkey: 0.2.0
@@ -11412,18 +11572,18 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/rich-text-utils@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/rich-text-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@types/dompurify': 2.4.0
       '@types/escape-html': 1.0.4
       dompurify: 3.4.12
@@ -11445,63 +11605,63 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-select-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/search-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/search-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-select-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/search-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/search-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11510,37 +11670,37 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/secondary-icon-button@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/secondary-icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11550,174 +11710,174 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-utils@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/select-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/checkbox-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/selectable-search-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/selectable-search-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/spacings-inline@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-inline@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset-squish@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-inset-squish@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-inset@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-stack@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings-stack@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/spacings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset-squish': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inset-squish': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/stamp@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/stamp@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11725,44 +11885,44 @@ snapshots:
       - react-intl
       - supports-color
 
-  '@commercetools-uikit/tag@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router-dom: 5.3.4(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11771,16 +11931,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11789,13 +11949,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
+  '@commercetools-uikit/text@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11805,20 +11965,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/time-field@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/time-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/time-input': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11827,21 +11987,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/time-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/time-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11850,16 +12010,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/toggle-input@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
+  '@commercetools-uikit/toggle-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11868,16 +12028,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/tooltip@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       popper.js: 1.16.1
       react: 19.2.0
@@ -11895,15 +12055,22 @@ snapshots:
       '@emotion/is-prop-valid': 1.4.0
       react: 19.2.0
 
-  '@commercetools-uikit/view-switcher@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@commercetools-uikit/utils@20.6.7(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.6.4(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/is-prop-valid': 1.4.0
+      react: 19.2.0
+
+  '@commercetools-uikit/view-switcher@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -11973,9 +12140,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin@11.13.5':
+  '@emotion/babel-plugin@11.13.5(supports-color@8.1.1)':
     dependencies:
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -12005,10 +12172,10 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
@@ -12031,12 +12198,12 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
       '@emotion/utils': 1.4.2
@@ -12134,22 +12301,22 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(supports-color@8.1.1))':
     dependencies:
-      eslint: 10.7.0
+      eslint: 10.8.0(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -12157,9 +12324,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.7.0)':
+  '@eslint/js@10.0.1(eslint@10.8.0(supports-color@8.1.1))':
     optionalDependencies:
-      eslint: 10.7.0
+      eslint: 10.8.0(supports-color@8.1.1)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -12170,7 +12337,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@figma/code-connect@1.4.9':
+  '@figma/code-connect@1.5.2':
     dependencies:
       boxen: 5.1.1
       chalk: 4.1.2
@@ -12178,6 +12345,7 @@ snapshots:
       compare-versions: 6.1.1
       cross-spawn: 7.0.6
       dotenv: 16.6.1
+      esbuild-wasm: 0.27.3
       fast-fuzzy: 1.12.0
       find-up: 5.0.0
       glob: 11.1.0
@@ -12198,7 +12366,7 @@ snapshots:
       - '@noble/hashes'
       - canvas
 
-  '@fission-ai/openspec@1.6.0(@types/node@24.13.3)':
+  '@fission-ai/openspec@1.7.0(@types/node@24.13.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.13.3)
       '@inquirer/prompts': 7.10.1(@types/node@24.13.3)
@@ -12206,8 +12374,7 @@ snapshots:
       commander: 14.0.3
       cross-spawn: 7.0.6
       fast-glob: 3.3.3
-      ora: 8.2.0
-      posthog-node: 5.24.7
+      ora: 9.4.1
       yaml: 2.8.3
       zod: 4.4.3
     transitivePeerDependencies:
@@ -12272,12 +12439,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
       react: 19.2.0
 
   '@hello-pangea/dnd@18.0.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -12572,11 +12739,11 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -12760,10 +12927,10 @@ snapshots:
 
   '@material-design-icons/svg@0.14.15': {}
 
-  '@mcp-ui/client@6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mcp-ui/client@6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       '@quilted/threads': 3.3.1(@preact/signals-core@1.13.0)
       '@r2wc/react-to-web-component': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@remote-dom/core': 1.10.1(@preact/signals-core@1.13.0)
@@ -12777,7 +12944,7 @@ snapshots:
       - preact
       - supports-color
 
-  '@mdx-js/mdx@3.1.1':
+  '@mdx-js/mdx@3.1.1(supports-color@8.1.1)':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -12789,14 +12956,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@8.1.1)
+      remark-mdx: 3.1.1(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -12852,9 +13019,9 @@ snapshots:
   '@microsoft/tsdoc@0.15.1':
     optional: true
 
-  '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
       '@oven/bun-darwin-aarch64': 1.3.10
@@ -12877,9 +13044,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@modelcontextprotocol/ext-apps@1.1.2(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@1.1.2(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
       '@oven/bun-darwin-aarch64': 1.3.10
@@ -12902,22 +13069,22 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@modelcontextprotocol/inspector-cli@0.21.2(zod@3.25.76)':
+  '@modelcontextprotocol/inspector-cli@0.22.0(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       commander: 13.1.0
-      express: 5.2.1
-      spawn-rx: 5.1.2
+      express: 5.2.1(supports-color@8.1.1)
+      spawn-rx: 5.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - zod
 
-  '@modelcontextprotocol/inspector-client@0.21.2(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)':
+  '@modelcontextprotocol/inspector-client@0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)':
     dependencies:
-      '@mcp-ui/client': 6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@modelcontextprotocol/ext-apps': 1.1.2(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@mcp-ui/client': 6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@modelcontextprotocol/ext-apps': 1.1.2(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons': 1.3.2(react@18.3.1)
@@ -12950,15 +13117,15 @@ snapshots:
       - preact
       - supports-color
 
-  '@modelcontextprotocol/inspector-server@0.21.2':
+  '@modelcontextprotocol/inspector-server@0.22.0(supports-color@8.1.1)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       cors: 2.8.6
-      express: 5.2.1
-      express-rate-limit: 8.3.0(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.3.0(express@5.2.1(supports-color@8.1.1))
       shell-quote: 1.10.0
       shx: 0.3.4
-      spawn-rx: 5.1.2
+      spawn-rx: 5.1.2(supports-color@8.1.1)
       ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -12967,18 +13134,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@preact/signals-core@1.13.0)(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(typescript@5.9.3)':
+  '@modelcontextprotocol/inspector@0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@modelcontextprotocol/inspector-cli': 0.21.2(zod@3.25.76)
-      '@modelcontextprotocol/inspector-client': 0.21.2(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)
-      '@modelcontextprotocol/inspector-server': 0.21.2
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/inspector-cli': 0.22.0(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/inspector-client': 0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)
+      '@modelcontextprotocol/inspector-server': 0.22.0(supports-color@8.1.1)
+      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
       concurrently: 9.2.1
       node-fetch: 3.3.2
       open: 10.2.0
       shell-quote: 1.10.0
-      spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.9.3)
+      spawn-rx: 5.1.2(supports-color@8.1.1)
+      ts-node: 10.9.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.9.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -12994,7 +13161,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.31)
       ajv: 8.20.0
@@ -13004,8 +13171,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.0(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.3.0(express@5.2.1(supports-color@8.1.1))
       hono: 4.12.31
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -13016,7 +13183,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.31)
       ajv: 8.20.0
@@ -13026,8 +13193,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.0(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.3.0(express@5.2.1(supports-color@8.1.1))
       hono: 4.12.31
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -13037,6 +13204,9 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -13163,7 +13333,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@oxc-project/types@0.139.0': {}
+  '@oxc-project/types@0.142.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -13239,24 +13409,20 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/core@1.17.0':
-    dependencies:
-      cross-spawn: 7.0.6
-
   '@preact/signals-core@1.13.0': {}
 
-  '@preconstruct/cli@2.8.13':
+  '@preconstruct/cli@2.8.13(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/runtime': 7.29.7
-      '@preconstruct/hook': 0.4.0
-      '@rollup/plugin-alias': 3.1.9(rollup@4.62.2)
-      '@rollup/plugin-commonjs': 15.1.0(rollup@4.62.2)
-      '@rollup/plugin-json': 4.1.0(rollup@4.62.2)
-      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.62.2)
-      '@rollup/plugin-replace': 2.4.2(rollup@4.62.2)
+      '@preconstruct/hook': 0.4.0(supports-color@8.1.1)
+      '@rollup/plugin-alias': 3.1.9(rollup@4.62.4)
+      '@rollup/plugin-commonjs': 15.1.0(rollup@4.62.4)
+      '@rollup/plugin-json': 4.1.0(rollup@4.62.4)
+      '@rollup/plugin-node-resolve': 11.2.1(rollup@4.62.4)
+      '@rollup/plugin-replace': 2.4.2(rollup@4.62.4)
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -13278,7 +13444,7 @@ snapshots:
       parse-json: 5.2.0
       quick-lru: 5.1.1
       resolve-from: 5.0.0
-      rollup: 4.62.2
+      rollup: 4.62.4
       semver: 7.7.4
       terser: 5.44.0
       v8-compile-cache: 2.4.0
@@ -13286,10 +13452,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@preconstruct/hook@0.4.0':
+  '@preconstruct/hook@0.4.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       pirates: 4.0.7
       source-map-support: 0.5.21
     transitivePeerDependencies:
@@ -13315,7 +13481,9 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@publint/pack@0.1.4': {}
+  '@publint/pack@0.1.6':
+    dependencies:
+      tinyexec: 1.3.0
 
   '@quilted/events@2.1.3':
     dependencies:
@@ -13928,7 +14096,7 @@ snapshots:
 
   '@react-aria/interactions@3.28.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@react-types/shared': 3.36.0(react@19.2.0)
+      '@react-types/shared': 3.36.1(react@19.2.0)
       '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria: 3.50.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -13947,6 +14115,10 @@ snapshots:
       react-stately: 3.48.0(react@19.2.0)
 
   '@react-types/shared@3.36.0(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-types/shared@3.36.1(react@19.2.0)':
     dependencies:
       react: 19.2.0
 
@@ -13970,182 +14142,193 @@ snapshots:
       - '@preact/signals-core'
       - preact
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-arm64@1.2.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-freebsd-x64@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
+  '@rolldown/binding-openharmony-arm64@1.2.2':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-alias@3.1.9(rollup@4.62.2)':
+  '@rollup/plugin-alias@3.1.9(rollup@4.62.4)':
     dependencies:
-      rollup: 4.62.2
+      rollup: 4.62.4
       slash: 3.0.0
 
-  '@rollup/plugin-commonjs@15.1.0(rollup@4.62.2)':
+  '@rollup/plugin-commonjs@15.1.0(rollup@4.62.4)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.4)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.12
-      rollup: 4.62.2
+      rollup: 4.62.4
 
-  '@rollup/plugin-json@4.1.0(rollup@4.62.2)':
+  '@rollup/plugin-json@4.1.0(rollup@4.62.4)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
-      rollup: 4.62.2
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.4)
+      rollup: 4.62.4
 
-  '@rollup/plugin-node-resolve@11.2.1(rollup@4.62.2)':
+  '@rollup/plugin-node-resolve@11.2.1(rollup@4.62.4)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.4)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.12
-      rollup: 4.62.2
+      rollup: 4.62.4
 
-  '@rollup/plugin-replace@2.4.2(rollup@4.62.2)':
+  '@rollup/plugin-replace@2.4.2(rollup@4.62.4)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(rollup@4.62.2)
+      '@rollup/pluginutils': 3.1.0(rollup@4.62.4)
       magic-string: 0.25.9
-      rollup: 4.62.2
+      rollup: 4.62.4
 
-  '@rollup/pluginutils@3.1.0(rollup@4.62.2)':
+  '@rollup/pluginutils@3.1.0(rollup@4.62.4)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 4.0.5
-      rollup: 4.62.2
+      rollup: 4.62.4
 
-  '@rollup/pluginutils@5.3.0(rollup@4.62.2)':
+  '@rollup/pluginutils@5.3.0(rollup@4.62.4)':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.5
     optionalDependencies:
-      rollup: 4.62.2
+      rollup: 4.62.4
 
-  '@rollup/rollup-android-arm-eabi@4.62.2':
+  '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.62.2':
+  '@rollup/rollup-android-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.62.2':
+  '@rollup/rollup-darwin-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.62.2':
+  '@rollup/rollup-freebsd-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+  '@rollup/rollup-freebsd-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.62.2':
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.62.2':
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.62.2':
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.62.2':
+  '@rollup/rollup-linux-x64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.62.2':
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.62.2':
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
   '@rushstack/node-core-library@5.17.0(@types/node@24.13.3)':
@@ -14198,21 +14381,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      axe-core: 4.11.0
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      axe-core: 4.12.1
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.17
@@ -14223,40 +14406,40 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-vitest@10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)':
+  '@storybook/addon-vitest@10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
-      rollup: 4.62.2
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
-      webpack: 5.108.4(esbuild@0.28.1)
+      rollup: 4.62.4
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
 
   '@storybook/global@5.0.0': {}
 
@@ -14265,30 +14448,30 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.0
-      react-docgen: 8.0.2
+      react-docgen: 8.0.2(supports-color@8.1.1)
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.12
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -14298,15 +14481,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
-      react-docgen: 8.0.2
+      react-docgen: 8.0.2(supports-color@8.1.1)
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -14314,56 +14497,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
 
-  '@svgr/cli@8.1.0(typescript@5.9.3)':
+  '@svgr/cli@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)
       camelcase: 6.3.0
       chalk: 4.1.2
       commander: 9.5.0
@@ -14374,10 +14557,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -14390,76 +14573,84 @@ snapshots:
       '@babel/types': 7.29.7
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       deepmerge: 4.3.1
       prettier: 2.8.8
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       svgo: 4.0.2
     transitivePeerDependencies:
       - typescript
 
-  '@swc/core-darwin-arm64@1.15.11':
+  '@swc/core-darwin-arm64@1.15.47':
     optional: true
 
-  '@swc/core-darwin-x64@1.15.11':
+  '@swc/core-darwin-x64@1.15.47':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.15.11':
+  '@swc/core-linux-arm-gnueabihf@1.15.47':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.15.11':
+  '@swc/core-linux-arm64-gnu@1.15.47':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.15.11':
+  '@swc/core-linux-arm64-musl@1.15.47':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.15.11':
+  '@swc/core-linux-ppc64-gnu@1.15.47':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.15.11':
+  '@swc/core-linux-s390x-gnu@1.15.47':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.15.11':
+  '@swc/core-linux-x64-gnu@1.15.47':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.15.11':
+  '@swc/core-linux-x64-musl@1.15.47':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.15.11':
+  '@swc/core-win32-arm64-msvc@1.15.47':
     optional: true
 
-  '@swc/core@1.15.11(@swc/helpers@0.5.17)':
+  '@swc/core-win32-ia32-msvc@1.15.47':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.47':
+    optional: true
+
+  '@swc/core@1.15.47(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.25
+      '@swc/types': 0.1.28
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.11
-      '@swc/core-darwin-x64': 1.15.11
-      '@swc/core-linux-arm-gnueabihf': 1.15.11
-      '@swc/core-linux-arm64-gnu': 1.15.11
-      '@swc/core-linux-arm64-musl': 1.15.11
-      '@swc/core-linux-x64-gnu': 1.15.11
-      '@swc/core-linux-x64-musl': 1.15.11
-      '@swc/core-win32-arm64-msvc': 1.15.11
-      '@swc/core-win32-ia32-msvc': 1.15.11
-      '@swc/core-win32-x64-msvc': 1.15.11
+      '@swc/core-darwin-arm64': 1.15.47
+      '@swc/core-darwin-x64': 1.15.47
+      '@swc/core-linux-arm-gnueabihf': 1.15.47
+      '@swc/core-linux-arm64-gnu': 1.15.47
+      '@swc/core-linux-arm64-musl': 1.15.47
+      '@swc/core-linux-ppc64-gnu': 1.15.47
+      '@swc/core-linux-s390x-gnu': 1.15.47
+      '@swc/core-linux-x64-gnu': 1.15.47
+      '@swc/core-linux-x64-musl': 1.15.47
+      '@swc/core-win32-arm64-msvc': 1.15.47
+      '@swc/core-win32-ia32-msvc': 1.15.47
+      '@swc/core-win32-x64-msvc': 1.15.47
       '@swc/helpers': 0.5.17
 
   '@swc/counter@0.1.3': {}
@@ -14468,7 +14659,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/types@0.1.25':
+  '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -14482,6 +14673,16 @@ snapshots:
       lz-string: 1.5.0
       picocolors: 1.1.1
       pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.10.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
 
   '@testing-library/jest-dom@6.9.1':
     dependencies:
@@ -14503,6 +14704,10 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
 
@@ -14690,15 +14895,15 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      eslint: 10.7.0
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      eslint: 10.8.0(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -14706,23 +14911,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
-      eslint: 10.7.0
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.8.0(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.64.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14732,17 +14946,26 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
 
+  '@typescript-eslint/scope-manager@8.66.0':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+
   '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.7.0
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.8.0(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14750,13 +14973,15 @@ snapshots:
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.3)':
+  '@typescript-eslint/types@8.66.0': {}
+
+  '@typescript-eslint/typescript-estree@8.64.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.64.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.17
@@ -14765,13 +14990,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@typescript-eslint/project-service': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.64.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      eslint: 10.7.0
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.0(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.0(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14781,46 +15032,51 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript-eslint/visitor-keys@8.66.0':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      eslint-visitor-keys: 5.0.1
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@visulima/boxen@2.0.10': {}
 
-  '@vitejs/plugin-react-swc@4.3.1(@swc/helpers@0.5.17)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react-swc@4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      '@swc/core': 1.15.47(@swc/helpers@0.5.17)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
-      playwright: 1.61.1
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -14840,9 +15096,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14861,13 +15117,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -14913,17 +15169,19 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       lodash-es: 4.18.1
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -15583,10 +15841,6 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-phases@1.0.4(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -15703,7 +15957,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axe-core@4.11.0: {}
+  axe-core@4.12.1: {}
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -15735,11 +15989,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -15883,7 +16137,7 @@ snapshots:
 
   chroma-js@3.1.2: {}
 
-  chromatic@17.7.2:
+  chromatic@17.8.0:
     dependencies:
       semver: 7.7.4
 
@@ -15917,6 +16171,8 @@ snapshots:
       yargs: 16.2.0
 
   cli-spinners@2.9.2: {}
+
+  cli-spinners@3.4.0: {}
 
   cli-table3@0.6.5:
     dependencies:
@@ -16139,9 +16395,11 @@ snapshots:
 
   debounce-promise@3.1.2: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -16275,8 +16533,6 @@ snapshots:
 
   electron-to-chromium@1.5.371: {}
 
-  emoji-regex@10.6.0: {}
-
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -16287,7 +16543,7 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
-  enhanced-resolve@5.24.0:
+  enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -16339,6 +16595,8 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild-wasm@0.27.3: {}
+
   esbuild@0.28.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.1
@@ -16376,39 +16634,39 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.7.0):
+  eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.7.0
+      eslint: 10.8.0(supports-color@8.1.1)
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.7.0))(eslint@10.7.0)(prettier@3.9.5):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)))(eslint@10.8.0(supports-color@8.1.1))(prettier@3.9.6):
     dependencies:
-      eslint: 10.7.0
-      prettier: 3.9.5
+      eslint: 10.8.0(supports-color@8.1.1)
+      prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.7.0)
+      eslint-config-prettier: 10.1.8(eslint@10.8.0(supports-color@8.1.1))
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.7.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      eslint: 10.7.0
+      eslint: 10.8.0(supports-color@8.1.1)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.3(eslint@10.7.0):
+  eslint-plugin-react-refresh@0.5.3(eslint@10.8.0(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.7.0
+      eslint: 10.8.0(supports-color@8.1.1)
 
-  eslint-plugin-storybook@10.4.6(eslint@10.7.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3):
+  eslint-plugin-storybook@10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      eslint: 10.7.0
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.0(supports-color@8.1.1)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16429,12 +16687,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.7.0:
+  eslint@10.8.0(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.7
@@ -16443,7 +16701,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -16537,25 +16795,25 @@ snapshots:
 
   expr-eval-fork@3.0.1: {}
 
-  express-rate-limit@8.3.0(express@5.2.1):
+  express-rate-limit@8.3.0(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@8.1.1)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -16566,9 +16824,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -16650,9 +16908,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -16677,7 +16935,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.62.2
+      rollup: 4.62.4
 
   flat-cache@4.0.1:
     dependencies:
@@ -16773,7 +17031,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.4.0: {}
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -16872,7 +17130,7 @@ snapshots:
       semver: 7.7.4
       serialize-error: 7.0.1
 
-  globals@17.7.0: {}
+  globals@17.9.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -16935,7 +17193,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -16945,9 +17203,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.18
@@ -16956,7 +17214,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
@@ -16965,9 +17223,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.18
@@ -17216,8 +17474,6 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
-  is-unicode-supported@1.3.0: {}
-
   is-unicode-supported@2.1.0: {}
 
   is-url@1.2.4: {}
@@ -17227,6 +17483,8 @@ snapshots:
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@0.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -17272,9 +17530,9 @@ snapshots:
 
   jose@6.1.3: {}
 
-  jotai@2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0):
+  jotai@2.20.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0):
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/template': 7.29.7
       '@types/react': 19.2.17
       react: 19.2.0
@@ -17363,62 +17621,60 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-android-arm64@1.32.0:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.32.0:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.32.0:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.32.0:
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
+  lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.32.0:
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
+  lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
+  lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
-  lightningcss@1.32.0:
+  lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
 
   load-tsconfig@0.2.5: {}
-
-  loader-runner@4.3.2: {}
 
   local-pkg@1.1.2:
     dependencies:
@@ -17445,10 +17701,10 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
-  log-symbols@6.0.0:
+  log-symbols@7.0.1:
     dependencies:
-      chalk: 5.6.2
-      is-unicode-supported: 1.3.0
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.2.0
 
   long@5.3.2: {}
 
@@ -17540,14 +17796,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.2(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -17565,67 +17821,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -17633,7 +17889,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -17642,23 +17898,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.2
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -17971,10 +18227,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -18034,26 +18290,19 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.108.4(esbuild@0.28.1)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.0
-      webpack: 5.108.4(esbuild@0.28.1)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
     optionalDependencies:
+      '@swc/core': 1.15.47(@swc/helpers@0.5.17)
+      csso: 5.0.5
       esbuild: 0.28.1
-    optional: true
-
-  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.108.4):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.44.0
-      webpack: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
-    optionalDependencies:
-      esbuild: 0.28.1
+      lightningcss: 1.33.0
+      postcss: 8.5.14
 
   minipass@7.1.3: {}
 
@@ -18244,17 +18493,16 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  ora@8.2.0:
+  ora@9.4.1:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
-      cli-spinners: 2.9.2
+      cli-spinners: 3.4.0
       is-interactive: 2.0.0
       is-unicode-supported: 2.1.0
-      log-symbols: 6.0.0
-      stdin-discarder: 0.2.2
-      string-width: 7.2.0
-      strip-ansi: 7.1.2
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.2
 
   outdent@0.5.0: {}
 
@@ -18341,6 +18589,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  package-manager-detector@1.8.0: {}
+
   pako@0.2.9: {}
 
   parent-module@1.0.1:
@@ -18411,6 +18661,10 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
+  path-to-regexp@1.9.0:
+    dependencies:
+      isarray: 0.0.1
+
   path-to-regexp@3.3.0: {}
 
   path-to-regexp@8.4.1: {}
@@ -18460,11 +18714,11 @@ snapshots:
 
   platform@1.3.6: {}
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.61.1:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.61.1
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -18480,12 +18734,12 @@ snapshots:
     dependencies:
       postcss-value-parser: 3.3.1
 
-  postcss-load-config@6.0.1(postcss@8.5.14)(tsx@4.23.1)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.14)(tsx@4.23.5)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.14
-      tsx: 4.23.1
+      tsx: 4.23.5
       yaml: 2.8.3
 
   postcss-value-parser@3.3.1: {}
@@ -18495,10 +18749,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  posthog-node@5.24.7:
-    dependencies:
-      '@posthog/core': 1.17.0
 
   prelude-ls@1.2.1: {}
 
@@ -18510,7 +18760,7 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  prettier@3.9.5: {}
+  prettier@3.9.6: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -18566,10 +18816,10 @@ snapshots:
     dependencies:
       proxy-compare: 3.0.1
 
-  publint@0.3.21:
+  publint@0.3.23:
     dependencies:
-      '@publint/pack': 0.1.4
-      package-manager-detector: 1.6.0
+      '@publint/pack': 0.1.6
+      package-manager-detector: 1.8.0
       picocolors: 1.1.1
       sade: 1.8.1
 
@@ -18629,10 +18879,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  react-docgen@8.0.2:
+  react-docgen@8.0.2(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -18696,17 +18946,17 @@ snapshots:
       sucrase: 3.35.0
       use-editable: 2.3.3(react@19.2.0)
 
-  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.0):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 19.2.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -18761,11 +19011,35 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  react-router-dom@5.3.4(react@19.2.0):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      history: 4.10.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.0
+      react-router: 5.3.4(react@19.2.0)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+
   react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-router: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+
+  react-router@5.3.4(react@19.2.0):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      history: 4.10.1
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      path-to-regexp: 1.9.0
+      prop-types: 15.8.1
+      react: 19.2.0
+      react-is: 16.13.1
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
 
   react-router@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -18782,11 +19056,11 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.0(react@19.2.0)
 
-  react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1):
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       '@floating-ui/dom': 1.7.6
       '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
       memoize-one: 6.0.0
@@ -18964,11 +19238,11 @@ snapshots:
       hastscript: 9.0.1
       parse-entities: 4.0.2
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18980,12 +19254,12 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.1.0
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -18993,17 +19267,17 @@ snapshots:
 
   remark-mark-highlight@0.1.1: {}
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@8.1.1):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -19023,10 +19297,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1:
+  remark@15.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -19080,61 +19354,61 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
 
-  rolldown@1.1.5:
+  rolldown@1.2.2:
     dependencies:
-      '@oxc-project/types': 0.139.0
+      '@oxc-project/types': 0.142.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.5
-      '@rolldown/binding-darwin-arm64': 1.1.5
-      '@rolldown/binding-darwin-x64': 1.1.5
-      '@rolldown/binding-freebsd-x64': 1.1.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
-      '@rolldown/binding-linux-arm64-gnu': 1.1.5
-      '@rolldown/binding-linux-arm64-musl': 1.1.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
-      '@rolldown/binding-linux-s390x-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-musl': 1.1.5
-      '@rolldown/binding-openharmony-arm64': 1.1.5
-      '@rolldown/binding-wasm32-wasi': 1.1.5
-      '@rolldown/binding-win32-arm64-msvc': 1.1.5
-      '@rolldown/binding-win32-x64-msvc': 1.1.5
+      '@rolldown/binding-android-arm64': 1.2.2
+      '@rolldown/binding-darwin-arm64': 1.2.2
+      '@rolldown/binding-darwin-x64': 1.2.2
+      '@rolldown/binding-freebsd-x64': 1.2.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
+      '@rolldown/binding-linux-arm64-gnu': 1.2.2
+      '@rolldown/binding-linux-arm64-musl': 1.2.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
+      '@rolldown/binding-linux-s390x-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-musl': 1.2.2
+      '@rolldown/binding-openharmony-arm64': 1.2.2
+      '@rolldown/binding-win32-arm64-msvc': 1.2.2
+      '@rolldown/binding-win32-x64-msvc': 1.2.2
 
-  rollup@4.62.2:
+  rollup@4.62.4:
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.62.2
-      '@rollup/rollup-android-arm64': 4.62.2
-      '@rollup/rollup-darwin-arm64': 4.62.2
-      '@rollup/rollup-darwin-x64': 4.62.2
-      '@rollup/rollup-freebsd-arm64': 4.62.2
-      '@rollup/rollup-freebsd-x64': 4.62.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
-      '@rollup/rollup-linux-arm64-gnu': 4.62.2
-      '@rollup/rollup-linux-arm64-musl': 4.62.2
-      '@rollup/rollup-linux-loong64-gnu': 4.62.2
-      '@rollup/rollup-linux-loong64-musl': 4.62.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
-      '@rollup/rollup-linux-ppc64-musl': 4.62.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
-      '@rollup/rollup-linux-riscv64-musl': 4.62.2
-      '@rollup/rollup-linux-s390x-gnu': 4.62.2
-      '@rollup/rollup-linux-x64-gnu': 4.62.2
-      '@rollup/rollup-linux-x64-musl': 4.62.2
-      '@rollup/rollup-openbsd-x64': 4.62.2
-      '@rollup/rollup-openharmony-arm64': 4.62.2
-      '@rollup/rollup-win32-arm64-msvc': 4.62.2
-      '@rollup/rollup-win32-ia32-msvc': 4.62.2
-      '@rollup/rollup-win32-x64-gnu': 4.62.2
-      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -19217,9 +19491,9 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -19247,12 +19521,12 @@ snapshots:
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19465,9 +19739,9 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  spawn-rx@5.1.2:
+  spawn-rx@5.1.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       rxjs: 7.8.2
     transitivePeerDependencies:
       - supports-color
@@ -19504,9 +19778,9 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  stdin-discarder@0.2.2: {}
+  stdin-discarder@0.3.2: {}
 
-  storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -19525,7 +19799,7 @@ snapshots:
       ws: 8.21.0
     optionalDependencies:
       '@types/react': 19.2.17
-      prettier: 3.9.5
+      prettier: 3.9.6
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -19554,10 +19828,9 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
 
-  string-width@7.2.0:
+  string-width@8.2.2:
     dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.1.2
 
   string_decoder@1.3.0:
@@ -19603,7 +19876,7 @@ snapshots:
       is-plain-obj: 4.1.0
       json5: 2.2.3
       path-unified: 0.2.0
-      prettier: 3.9.5
+      prettier: 3.9.6
       tinycolor2: 1.6.0
     transitivePeerDependencies:
       - tslib
@@ -19720,6 +19993,8 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -19786,7 +20061,7 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -19804,7 +20079,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.47(@swc/helpers@0.5.17)
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -19814,20 +20089,20 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.11(@swc/helpers@0.5.17))(postcss@8.5.14)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.23.5)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.23.1)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.23.5)(yaml@2.8.3)
       resolve-from: 5.0.0
-      rollup: 4.62.2
+      rollup: 4.62.4
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 0.3.2
@@ -19835,7 +20110,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.3)
-      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.47(@swc/helpers@0.5.17)
       postcss: 8.5.14
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19844,7 +20119,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.23.1:
+  tsx@4.23.5:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -19870,13 +20145,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.64.0(eslint@10.7.0)(typescript@5.9.3):
+  typescript-eslint@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
-      eslint: 10.7.0
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.0(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -19941,12 +20216,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1)):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
-      '@volar/typescript': 2.4.28
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -19955,10 +20230,10 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.3)
       esbuild: 0.28.1
-      rolldown: 1.1.5
-      rollup: 4.62.2
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
-      webpack: 5.108.4(esbuild@0.28.1)
+      rolldown: 1.2.2
+      rollup: 4.62.4
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -20094,22 +20369,22 @@ snapshots:
 
   vite-bundle-analyzer@1.3.9: {}
 
-  vite-plugin-compression@0.5.1(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)):
+  vite-plugin-compression@0.5.1(supports-color@8.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)):
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1)):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(webpack@5.108.4(esbuild@0.28.1))
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.3)
-      rollup: 4.62.2
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      rollup: 4.62.4
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -20119,25 +20394,25 @@ snapshots:
       - typescript
       - webpack
 
-  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3):
+  vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3):
     dependencies:
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.14
-      rolldown: 1.1.5
+      rolldown: 1.2.2
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
       esbuild: 0.28.1
       fsevents: 2.3.3
       terser: 5.44.0
-      tsx: 4.23.1
+      tsx: 4.23.5
       yaml: 2.8.3
 
-  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -20154,11 +20429,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.0.1
     transitivePeerDependencies:
@@ -20188,7 +20463,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-cli@7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4):
+  webpack-cli@7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2):
     dependencies:
       '@discoveryjs/json-ext': 1.1.0
       commander: 14.0.3
@@ -20197,7 +20472,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
       webpack-merge: 6.0.1
     optionalDependencies:
       js-yaml: 3.15.0
@@ -20209,11 +20484,11 @@ snapshots:
       flat: 5.0.2
       wildcard: 2.0.1
 
-  webpack-sources@3.5.0: {}
+  webpack-sources@3.5.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.108.4(esbuild@0.28.1):
+  webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -20221,63 +20496,22 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.24.5
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       graceful-fs: 4.2.11
-      loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.108.4(esbuild@0.28.1))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack@5.109.2)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
       watchpack: 2.5.2
-      webpack-sources: 3.5.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-    optional: true
-
-  webpack@5.108.4(esbuild@0.28.1)(webpack-cli@7.2.1):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.108.4)
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.0
+      webpack-sources: 3.5.1
     optionalDependencies:
-      webpack-cli: 7.2.1(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.108.4)
+      webpack-cli: 7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -20406,6 +20640,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  yoctocolors@2.2.0: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ catalogs:
       specifier: ^15.0.1
       version: 15.0.1
     remark-flexible-toc:
-      specifier: ^1.2.5
-      version: 1.2.5
+      specifier: ^1.2.6
+      version: 1.2.6
     remark-gfm:
       specifier: ^4.0.1
       version: 4.0.1
@@ -288,8 +288,8 @@ catalogs:
       specifier: ^0.1.10
       version: 0.1.10
     '@types/lodash':
-      specifier: ^4.17.24
-      version: 4.17.24
+      specifier: ^4.17.25
+      version: 4.17.25
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
@@ -332,7 +332,7 @@ overrides:
   brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
   mdast-util-to-hast: ^13.2.1
   js-yaml: ^3.15.0
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   qs: '>=6.15.2'
   minimatch@>=3.0.0 <3.1.4: 3.1.4
   svgo: '>=4.0.2'
@@ -394,7 +394,7 @@ importers:
         version: 1.7.0(@types/node@24.13.3)
       '@preconstruct/cli':
         specifier: catalog:tooling
-        version: 2.8.13(supports-color@8.1.1)
+        version: 2.8.13
       dotenv:
         specifier: catalog:utils
         version: 17.4.2
@@ -409,7 +409,7 @@ importers:
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)))(eslint@10.8.0(supports-color@8.1.1))(prettier@3.9.6)
       eslint-plugin-react-hooks:
         specifier: catalog:tooling
-        version: 7.1.1(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.1.1(eslint@10.8.0(supports-color@8.1.1))
       eslint-plugin-storybook:
         specifier: catalog:tooling
         version: 10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
@@ -464,7 +464,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
+        version: 10.0.1(eslint@10.8.0)
       '@types/react':
         specifier: catalog:react
         version: 19.2.17
@@ -476,10 +476,10 @@ importers:
         version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
-        version: 10.8.0(supports-color@8.1.1)
+        version: 10.8.0
       eslint-plugin-react-refresh:
         specifier: catalog:tooling
-        version: 0.5.3(eslint@10.8.0(supports-color@8.1.1))
+        version: 0.5.3(eslint@10.8.0)
       globals:
         specifier: catalog:tooling
         version: 17.9.0
@@ -488,13 +488,13 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.66.0(eslint@10.8.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       webpack:
         specifier: catalog:tooling
-        version: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
+        version: 5.109.2(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
       webpack-cli:
         specifier: catalog:tooling
         version: 7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2)
@@ -512,7 +512,7 @@ importers:
         version: link:../../packages/nimbus-icons
       '@emotion/react':
         specifier: catalog:react
-        version: 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@huggingface/transformers':
         specifier: 'catalog:'
         version: 3.8.1
@@ -521,7 +521,7 @@ importers:
         version: 3.12.2
       '@mdx-js/mdx':
         specifier: catalog:apps
-        version: 3.1.1(supports-color@8.1.1)
+        version: 3.1.1
       '@types/mdx':
         specifier: catalog:apps
         version: 2.0.13
@@ -545,7 +545,7 @@ importers:
         version: 4.0.3
       jotai:
         specifier: catalog:apps
-        version: 2.20.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0)
+        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0)
       lodash:
         specifier: catalog:utils
         version: 4.18.1
@@ -584,10 +584,10 @@ importers:
         version: 16.1.1(react@19.2.0)
       remark-flexible-toc:
         specifier: catalog:markdown
-        version: 1.2.5(unified@11.0.5)
+        version: 1.2.6(unified@11.0.5)
       remark-gfm:
         specifier: catalog:markdown
-        version: 4.0.1(supports-color@8.1.1)
+        version: 4.0.1
       remark-mark-highlight:
         specifier: catalog:apps
         version: 0.1.1
@@ -606,10 +606,10 @@ importers:
         version: link:../../packages/design-token-ts-plugin
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
+        version: 10.0.1(eslint@10.8.0)
       '@types/lodash':
         specifier: catalog:utils
-        version: 4.17.24
+        version: 4.17.25
       '@types/react':
         specifier: catalog:react
         version: 19.2.17
@@ -621,10 +621,10 @@ importers:
         version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
-        version: 10.8.0(supports-color@8.1.1)
+        version: 10.8.0
       eslint-plugin-react-refresh:
         specifier: catalog:tooling
-        version: 0.5.3(eslint@10.8.0(supports-color@8.1.1))
+        version: 0.5.3(eslint@10.8.0)
       globals:
         specifier: catalog:tooling
         version: 17.9.0
@@ -633,7 +633,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.66.0(eslint@10.8.0)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
@@ -648,7 +648,7 @@ importers:
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       webpack:
         specifier: catalog:tooling
-        version: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
+        version: 5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2)
       webpack-cli:
         specifier: catalog:tooling
         version: 7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2)
@@ -712,13 +712,13 @@ importers:
     dependencies:
       '@chakra-ui/cli':
         specifier: catalog:react
-        version: 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)
+        version: 3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)
       '@emotion/is-prop-valid':
         specifier: catalog:react
         version: 1.4.0
       '@github-ui/storybook-addon-performance-panel':
         specifier: catalog:tooling
-        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@internationalized/string':
         specifier: catalog:react
         version: 3.2.9
@@ -751,7 +751,7 @@ importers:
         version: 5.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-markdown:
         specifier: catalog:markdown
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.0)
       react-stately:
         specifier: 3.48.0
         version: 3.48.0(react@19.2.0)
@@ -760,7 +760,7 @@ importers:
         version: 17.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       remark-gfm:
         specifier: catalog:markdown
-        version: 4.0.1(supports-color@8.1.1)
+        version: 4.0.1
       remend:
         specifier: catalog:markdown
         version: 1.3.0
@@ -770,7 +770,7 @@ importers:
     devDependencies:
       '@chakra-ui/react':
         specifier: catalog:react
-        version: 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools/nimbus-design-token-ts-plugin':
         specifier: workspace:^
         version: link:../design-token-ts-plugin
@@ -794,13 +794,13 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@storybook/addon-vitest':
         specifier: catalog:tooling
         version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.10.0(@testing-library/dom@10.4.1)
@@ -847,8 +847,8 @@ importers:
         specifier: catalog:tooling
         version: 17.8.0
       dompurify:
-        specifier: ^3.4.12
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       glob:
         specifier: catalog:tooling
         version: 13.0.6
@@ -884,7 +884,7 @@ importers:
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: catalog:tooling
-        version: 5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+        version: 5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       vitest:
         specifier: catalog:tooling
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
@@ -896,7 +896,7 @@ importers:
         version: 8.66.0
       '@typescript-eslint/typescript-estree':
         specifier: catalog:tooling
-        version: 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.66.0(typescript@5.9.3)
       gray-matter:
         specifier: catalog:utils
         version: 4.0.3
@@ -905,10 +905,10 @@ importers:
         version: 2.4.0(typescript@5.9.3)
       remark:
         specifier: catalog:markdown
-        version: 15.0.1(supports-color@8.1.1)
+        version: 15.0.1
       remark-flexible-toc:
         specifier: catalog:markdown
-        version: 1.2.5(unified@11.0.5)
+        version: 1.2.6(unified@11.0.5)
       to-vfile:
         specifier: catalog:markdown
         version: 8.0.0
@@ -930,14 +930,14 @@ importers:
         version: 0.14.15
       '@svgr/cli':
         specifier: ^8.1.0
-        version: 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.1.0(typescript@5.9.3)
     devDependencies:
       '@svgr/babel-plugin-add-jsx-attribute':
         specifier: ^8.0.0
-        version: 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+        version: 8.0.0(@babel/core@7.29.7)
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+        version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@types/node':
         specifier: catalog:utils
         version: 24.13.3
@@ -962,10 +962,10 @@ importers:
     devDependencies:
       '@commercetools-frontend/ui-kit':
         specifier: catalog:tooling
-        version: 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/design-system':
         specifier: ^20.6.4
-        version: 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+        version: 20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools/nimbus':
         specifier: workspace:^
         version: link:../nimbus
@@ -995,7 +995,7 @@ importers:
     devDependencies:
       '@babel/preset-typescript':
         specifier: catalog:tooling
-        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.29.7(@babel/core@7.29.7)
       '@tokens-studio/sd-transforms':
         specifier: ^2.0.3
         version: 2.0.3(style-dictionary@5.4.4(tslib@2.8.1))
@@ -4341,10 +4341,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=10 <11'
 
-  '@testing-library/jest-dom@6.9.1':
-    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
-    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
-
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -4359,12 +4355,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  '@testing-library/user-event@14.6.1':
-    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
-    engines: {node: '>=12', npm: '>=6'}
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
 
   '@testing-library/user-event@14.6.3':
     resolution: {integrity: sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==}
@@ -4478,6 +4468,9 @@ packages:
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -4748,11 +4741,6 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
-    peerDependencies:
-      typescript: ~5.9.3
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@vueless/storybook-dark-mode@10.0.8':
     resolution: {integrity: sha512-nhueFjEbyNGBzye4H+STC+pRIKthttiuPJRfcqCrDwqKnLS9AkVT3Ra+F5bvOeWbvZt3xc6xNJBNV5OrjRIoZQ==}
@@ -5800,8 +5788,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -6708,9 +6696,6 @@ packages:
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
-
-  isarray@0.0.1:
-    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -7625,9 +7610,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@1.9.0:
-    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
-
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
@@ -7961,22 +7943,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@5.3.4:
-    resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
-    peerDependencies:
-      react: '>=15'
-
   react-router-dom@7.17.0:
     resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
-
-  react-router@5.3.4:
-    resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
-    peerDependencies:
-      react: '>=15'
 
   react-router@7.17.0:
     resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
@@ -8118,8 +8090,8 @@ packages:
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
-  remark-flexible-toc@1.2.5:
-    resolution: {integrity: sha512-zlSVdTd21Ggw8E1u6fLP3CMynvOd19z8X//LW8jb9nyk5ei9fGkrn3Nnyy464DTPmolO2DrLT5fT3hNv9RjQhg==}
+  remark-flexible-toc@1.2.6:
+    resolution: {integrity: sha512-DJ9PeUPswJPFoeV+GO15aSXLNRXgkNwYcCojCq+0D/L5N3+2zyrAahEmZuAQ9S73B8Qm1QLO/mRrwo+qFmr2og==}
     peerDependencies:
       unified: ^11
 
@@ -9546,7 +9518,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -9581,14 +9553,14 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -9596,24 +9568,24 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9625,16 +9597,16 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
@@ -9656,43 +9628,43 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -9765,12 +9737,12 @@ snapshots:
     dependencies:
       postcss-calc-ast-parser: 0.1.4
 
-  '@chakra-ui/cli@3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)':
+  '@chakra-ui/cli@3.36.1(@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@chakra-ui/react': 3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@clack/prompts': 1.5.1
       '@pandacss/is-valid-prop': 1.11.1
       '@types/babel__core': 7.20.5
@@ -9795,11 +9767,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@chakra-ui/react@3.36.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@ark-ui/react': 5.37.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
       '@emotion/utils': 1.4.2
@@ -9981,54 +9953,54 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-frontend/ui-kit@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/avatar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/collapsible': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/collapsible-panel': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/filters': 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/avatar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-panel': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/data-table': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/fields': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/filters': 20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/i18n': 20.6.7
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/notifications': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/pagination': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/progress-bar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/stamp': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/inputs': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/link': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/notifications': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/pagination': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/primary-action-dropdown': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/progress-bar': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/quick-filters': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/stamp': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/view-switcher': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/view-switcher': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       moment: 2.30.1
       moment-timezone: 0.6.2
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -10036,14 +10008,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/accessible-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/accessible-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/react-is': 19.2.0
       lodash: 4.18.1
       react: 19.2.0
@@ -10053,119 +10025,119 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/accessible-hidden@20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/accessible-hidden@20.6.7(@types/react@19.2.17)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  '@commercetools-uikit/async-creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/async-creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/async-creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/async-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/async-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/loading-spinner': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/avatar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/avatar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10173,21 +10145,21 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/buttons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/link-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -10203,61 +10175,61 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/calendar-utils@20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       moment: 2.30.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/card@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/card@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
       react: 19.2.0
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/checkbox-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/checkbox-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10266,14 +10238,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/collapsible-motion@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10281,21 +10253,21 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/collapsible-panel@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/collapsible-panel@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10305,14 +10277,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/collapsible@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/collapsible@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10320,94 +10292,94 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/constraints@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/constraints@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/creatable-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/creatable-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table-manager@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/accessible-hidden': 20.6.7(@types/react@19.2.17)(react@19.2.0)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/card': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/dropdown-menu': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/grid': 20.6.7(@types/react@19.2.17)(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/primary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@hello-pangea/dnd': 18.0.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/debounce-promise': 3.1.9
       debounce-promise: 3.1.2
@@ -10421,19 +10393,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/data-table@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/data-table-manager': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10444,20 +10416,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/date-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10468,25 +10440,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/date-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10500,20 +10472,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-range-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/date-range-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10524,25 +10496,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-range-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/date-range-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10556,20 +10528,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/date-time-field@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10580,25 +10552,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/date-time-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/date-time-input@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/calendar-time-utils': 20.6.7(moment-timezone@0.6.2)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/calendar-utils': 20.6.7(@types/react@19.2.17)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       moment: 2.30.1
       react: 19.2.0
@@ -10612,12 +10584,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/design-system@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/design-system@20.6.4(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10625,12 +10597,12 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/design-system@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/design-system@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -10638,20 +10610,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/dropdown-menu@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/secondary-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10661,13 +10633,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-errors@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/field-errors@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10676,22 +10648,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/field-label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10700,13 +10672,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/field-warnings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/field-warnings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10715,30 +10687,30 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/fields@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/money-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/number-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/password-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/radio-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/time-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/async-creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/creatable-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-field': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/number-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/password-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/search-select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/time-field': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - moment
@@ -10747,24 +10719,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/filters@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/filters@20.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -10777,17 +10749,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/flat-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/flat-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10797,12 +10769,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/grid@20.6.7(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/grid@20.6.7(@types/react@19.2.17)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -10835,17 +10807,17 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
 
-  '@commercetools-uikit/icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -10855,16 +10827,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/icons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/icons@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/dompurify': 2.4.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       react: 19.2.0
       react-from-dom: 0.7.5(react@19.2.0)
     transitivePeerDependencies:
@@ -10872,15 +10844,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/input-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/input-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
       react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
@@ -10890,37 +10862,37 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/inputs@20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/search-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/toggle-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/async-creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/creatable-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-range-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/date-time-input': 20.6.7(@types/react@19.2.17)(moment-timezone@0.6.2)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/search-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/selectable-search-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/toggle-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - moment
@@ -10929,15 +10901,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/label@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -10945,57 +10917,57 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/link-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       history: 4.10.1
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/link@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/link@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/history': 4.7.11
       '@types/react-router-dom': 5.3.3
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/loading-spinner@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/loading-spinner@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11004,48 +10976,48 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11054,54 +11026,54 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       immutable: 4.3.9
       is-hotkey: 0.2.0
@@ -11118,20 +11090,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/localized-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11140,24 +11112,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/localized-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/localized-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/localized-utils': 20.6.7(react@19.2.0)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11175,14 +11147,14 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@commercetools-uikit/messages@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/messages@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11191,68 +11163,68 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/money-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/money-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/money-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/money-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/multiline-text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/multiline-text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11261,23 +11233,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/multiline-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11288,15 +11260,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/notifications@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/notifications@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11304,20 +11276,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/number-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/number-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11326,16 +11298,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/number-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/number-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11344,22 +11316,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/pagination@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/pagination@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+      '@commercetools-uikit/number-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       formik: 2.4.9(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
@@ -11370,24 +11342,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/password-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/password-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/password-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11396,16 +11368,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/password-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/password-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11414,19 +11386,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-action-dropdown@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/buttons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11437,17 +11409,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/primary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/primary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11457,17 +11429,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/progress-bar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/progress-bar@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11477,14 +11449,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/quick-filters@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tag': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11494,20 +11466,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/radio-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/radio-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11516,20 +11488,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/radio-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-is: 19.2.6
     transitivePeerDependencies:
@@ -11539,24 +11511,24 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/rich-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/collapsible-motion': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/flat-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/rich-text-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       downshift: 9.3.3(react@19.2.0)
       immutable: 4.3.9
       is-hotkey: 0.2.0
@@ -11572,21 +11544,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/rich-text-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/rich-text-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/tooltip': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       '@types/dompurify': 2.4.0
       '@types/escape-html': 1.0.4
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       downshift: 9.3.3(react@19.2.0)
       escape-html: 1.0.3
       is-hotkey: 0.2.0
@@ -11605,63 +11577,63 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/search-select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/search-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/search-select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/async-select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/search-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/search-text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11670,37 +11642,37 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/secondary-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/secondary-icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/secondary-icon-button@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11710,174 +11682,174 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/select-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/select-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/select-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/select-utils@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/checkbox-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/selectable-search-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/selectable-search-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/secondary-icon-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/select-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      react-select: 5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - typescript
 
-  '@commercetools-uikit/spacings-inline@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/spacings-inline@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset-squish@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/spacings-inset-squish@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-inset@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/spacings-inset@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings-stack@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/spacings-stack@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/spacings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/spacings@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inset-squish': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inset-squish': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/stamp@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/stamp@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11885,44 +11857,44 @@ snapshots:
       - react-intl
       - supports-color
 
-  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/tag@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/spacings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       history: 4.10.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
+      react-router-dom: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/text-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/messages': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/text-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11931,16 +11903,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/text-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -11949,13 +11921,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/text@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/text@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
@@ -11965,20 +11937,20 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@commercetools-uikit/time-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/time-field@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/field-errors': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-label': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/field-warnings': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-stack': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/time-input': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -11987,21 +11959,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/time-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/time-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/icons': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+      '@commercetools-uikit/spacings-inline': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
       react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -12010,16 +11982,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/toggle-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@commercetools-uikit/toggle-input@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/input-utils': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       react: 19.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -12028,16 +12000,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/tooltip@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/constraints': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/hooks': 20.6.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       popper.js: 1.16.1
       react: 19.2.0
@@ -12062,15 +12034,15 @@ snapshots:
       '@emotion/is-prop-valid': 1.4.0
       react: 19.2.0
 
-  '@commercetools-uikit/view-switcher@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)':
+  '@commercetools-uikit/view-switcher@20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.7
-      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
-      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1)
+      '@commercetools-uikit/accessible-button': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@commercetools-uikit/design-system': 20.6.7(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@commercetools-uikit/utils': 20.6.7(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)
       lodash: 4.18.1
       react: 19.2.0
     transitivePeerDependencies:
@@ -12140,9 +12112,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin@11.13.5(supports-color@8.1.1)':
+  '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -12172,10 +12144,10 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
+  '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
+      '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
@@ -12198,12 +12170,12 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.0))(@types/react@19.2.17)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5(supports-color@8.1.1)
+      '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
       '@emotion/utils': 1.4.2
@@ -12306,6 +12278,11 @@ snapshots:
       eslint: 10.8.0(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0)':
+    dependencies:
+      eslint: 10.8.0
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.23.5(supports-color@8.1.1)':
@@ -12327,6 +12304,10 @@ snapshots:
   '@eslint/js@10.0.1(eslint@10.8.0(supports-color@8.1.1))':
     optionalDependencies:
       eslint: 10.8.0(supports-color@8.1.1)
+
+  '@eslint/js@10.0.1(eslint@10.8.0)':
+    optionalDependencies:
+      eslint: 10.8.0
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -12439,12 +12420,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@github-ui/storybook-addon-performance-panel@1.1.4(@storybook/icons@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       react: 19.2.0
 
   '@hello-pangea/dnd@18.0.1(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -12927,10 +12908,10 @@ snapshots:
 
   '@material-design-icons/svg@0.14.15': {}
 
-  '@mcp-ui/client@6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)':
+  '@mcp-ui/client@6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/ext-apps': 0.3.1(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@quilted/threads': 3.3.1(@preact/signals-core@1.13.0)
       '@r2wc/react-to-web-component': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@remote-dom/core': 1.10.1(@preact/signals-core@1.13.0)
@@ -12944,7 +12925,7 @@ snapshots:
       - preact
       - supports-color
 
-  '@mdx-js/mdx@3.1.1(supports-color@8.1.1)':
+  '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -12956,14 +12937,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
+      hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0(supports-color@8.1.1)
-      remark-mdx: 3.1.1(supports-color@8.1.1)
-      remark-parse: 11.0.0(supports-color@8.1.1)
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -13019,9 +13000,9 @@ snapshots:
   '@microsoft/tsdoc@0.15.1':
     optional: true
 
-  '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@0.3.1(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
       '@oven/bun-darwin-aarch64': 1.3.10
@@ -13044,9 +13025,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@modelcontextprotocol/ext-apps@1.1.2(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
+  '@modelcontextprotocol/ext-apps@1.1.2(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
       '@oven/bun-darwin-aarch64': 1.3.10
@@ -13069,9 +13050,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@modelcontextprotocol/inspector-cli@0.22.0(supports-color@8.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/inspector-cli@0.22.0(zod@3.25.76)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       commander: 13.1.0
       express: 5.2.1(supports-color@8.1.1)
       spawn-rx: 5.1.2(supports-color@8.1.1)
@@ -13080,11 +13061,11 @@ snapshots:
       - supports-color
       - zod
 
-  '@modelcontextprotocol/inspector-client@0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)':
+  '@modelcontextprotocol/inspector-client@0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)':
     dependencies:
-      '@mcp-ui/client': 6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@modelcontextprotocol/ext-apps': 1.1.2(@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@mcp-ui/client': 6.1.0(@preact/signals-core@1.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@modelcontextprotocol/ext-apps': 1.1.2(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons': 1.3.2(react@18.3.1)
@@ -13117,9 +13098,9 @@ snapshots:
       - preact
       - supports-color
 
-  '@modelcontextprotocol/inspector-server@0.22.0(supports-color@8.1.1)':
+  '@modelcontextprotocol/inspector-server@0.22.0':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       cors: 2.8.6
       express: 5.2.1(supports-color@8.1.1)
       express-rate-limit: 8.3.0(express@5.2.1(supports-color@8.1.1))
@@ -13136,10 +13117,10 @@ snapshots:
 
   '@modelcontextprotocol/inspector@0.22.0(@preact/signals-core@1.13.0)(@swc/core@1.15.47(@swc/helpers@0.5.17))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@modelcontextprotocol/inspector-cli': 0.22.0(supports-color@8.1.1)(zod@3.25.76)
-      '@modelcontextprotocol/inspector-client': 0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(supports-color@8.1.1)
-      '@modelcontextprotocol/inspector-server': 0.22.0(supports-color@8.1.1)
-      '@modelcontextprotocol/sdk': 1.27.1(supports-color@8.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/inspector-cli': 0.22.0(zod@3.25.76)
+      '@modelcontextprotocol/inspector-client': 0.22.0(@preact/signals-core@1.13.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)
+      '@modelcontextprotocol/inspector-server': 0.22.0
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       concurrently: 9.2.1
       node-fetch: 3.3.2
       open: 10.2.0
@@ -13161,28 +13142,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.31)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.3.0(express@5.2.1(supports-color@8.1.1))
-      hono: 4.12.31
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.27.1(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.31)
@@ -13202,6 +13161,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.4.3
       zod-to-json-schema: 3.25.1(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.31)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.3.0(express@5.2.1(supports-color@8.1.1))
+      hono: 4.12.31
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -13411,13 +13392,13 @@ snapshots:
 
   '@preact/signals-core@1.13.0': {}
 
-  '@preconstruct/cli@2.8.13(supports-color@8.1.1)':
+  '@preconstruct/cli@2.8.13':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7
       '@babel/runtime': 7.29.7
-      '@preconstruct/hook': 0.4.0(supports-color@8.1.1)
+      '@preconstruct/hook': 0.4.0
       '@rollup/plugin-alias': 3.1.9(rollup@4.62.4)
       '@rollup/plugin-commonjs': 15.1.0(rollup@4.62.4)
       '@rollup/plugin-json': 4.1.0(rollup@4.62.4)
@@ -13452,10 +13433,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@preconstruct/hook@0.4.0(supports-color@8.1.1)':
+  '@preconstruct/hook@0.4.0':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
       pirates: 4.0.7
       source-map-support: 0.5.21
     transitivePeerDependencies:
@@ -14387,10 +14368,10 @@ snapshots:
       axe-core: 4.12.1
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -14420,9 +14401,9 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
@@ -14431,7 +14412,7 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
@@ -14439,7 +14420,7 @@ snapshots:
       esbuild: 0.28.1
       rollup: 4.62.4
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
-      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
+      webpack: 5.109.2(esbuild@0.28.1)
 
   '@storybook/global@5.0.0': {}
 
@@ -14457,16 +14438,16 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.0
-      react-docgen: 8.0.2(supports-color@8.1.1)
+      react-docgen: 8.0.2
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.12
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -14481,12 +14462,12 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
-      react-docgen: 8.0.2(supports-color@8.1.1)
+      react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -14497,56 +14478,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
 
-  '@svgr/cli@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@svgr/cli@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
-      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
       camelcase: 6.3.0
       chalk: 4.1.2
       commander: 9.5.0
@@ -14557,10 +14538,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -14573,25 +14554,25 @@ snapshots:
       '@babel/types': 7.29.7
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))':
+  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
       deepmerge: 4.3.1
       prettier: 2.8.8
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       svgo: 4.0.2
@@ -14684,15 +14665,6 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/jest-dom@6.9.1':
-    dependencies:
-      '@adobe/css-tools': 4.4.4
-      aria-query: 5.3.2
-      css.escape: 1.5.1
-      dom-accessibility-api: 0.6.3
-      picocolors: 1.1.1
-      redent: 3.0.0
-
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -14702,10 +14674,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
-    dependencies:
-      '@testing-library/dom': 10.4.1
 
   '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
     dependencies:
@@ -14821,6 +14789,8 @@ snapshots:
 
   '@types/lodash@4.17.24': {}
 
+  '@types/lodash@4.17.25': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -14901,9 +14871,25 @@ snapshots:
       '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.66.0
       eslint: 10.8.0(supports-color@8.1.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      eslint: 10.8.0
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -14915,10 +14901,22 @@ snapshots:
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.8.0(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.8.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14932,7 +14930,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.66.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.66.0
@@ -14962,10 +14960,22 @@ snapshots:
   '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.8.0(supports-color@8.1.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.8.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14990,9 +15000,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.66.0(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
@@ -15016,13 +15026,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
       eslint: 10.8.0(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      eslint: 10.8.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -15169,13 +15190,11 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28(typescript@5.9.3)':
+  '@volar/typescript@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@vueless/storybook-dark-mode@10.0.8(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
@@ -16491,7 +16510,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -16647,7 +16666,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.8.0(supports-color@8.1.1))
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(supports-color@8.1.1)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
@@ -16658,9 +16677,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.3(eslint@10.8.0(supports-color@8.1.1)):
+  eslint-plugin-react-refresh@0.5.3(eslint@10.8.0):
     dependencies:
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.0
 
   eslint-plugin-storybook@10.4.6(eslint@10.8.0(supports-color@8.1.1))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
@@ -16686,6 +16705,41 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.14.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@10.8.0(supports-color@8.1.1):
     dependencies:
@@ -16826,7 +16880,7 @@ snapshots:
       range-parser: 1.2.1
       router: 2.2.0(supports-color@8.1.1)
       send: 1.2.1(supports-color@8.1.1)
-      serve-static: 2.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -17193,7 +17247,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  hast-util-to-estree@3.1.3(supports-color@8.1.1):
+  hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -17203,9 +17257,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.18
@@ -17214,7 +17268,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
@@ -17223,9 +17277,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.18
@@ -17484,8 +17538,6 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
-  isarray@0.0.1: {}
-
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
@@ -17530,7 +17582,7 @@ snapshots:
 
   jose@6.1.3: {}
 
-  jotai@2.20.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0):
+  jotai@2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.0):
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/template': 7.29.7
@@ -17796,14 +17848,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2(supports-color@8.1.1):
+  mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@8.1.1)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -17821,67 +17873,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@8.1.1):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
-      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -17889,7 +17941,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -17898,23 +17950,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0(supports-color@8.1.1):
+  mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
-      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -18227,7 +18279,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@8.1.1):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@8.1.1)
@@ -18290,19 +18342,39 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack@5.109.2):
+  minimizer-webpack-plugin@5.6.1(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.0
-      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
+      webpack: 5.109.2(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
     optionalDependencies:
-      '@swc/core': 1.15.47(@swc/helpers@0.5.17)
       csso: 5.0.5
       esbuild: 0.28.1
       lightningcss: 1.33.0
       postcss: 8.5.14
+
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.109.2(esbuild@0.28.1)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.44.0
+      webpack: 5.109.2(esbuild@0.28.1)
+    optionalDependencies:
+      esbuild: 0.28.1
+    optional: true
+
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.109.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.44.0
+      webpack: 5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2)
+    optionalDependencies:
+      esbuild: 0.28.1
 
   minipass@7.1.3: {}
 
@@ -18661,10 +18733,6 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
-  path-to-regexp@1.9.0:
-    dependencies:
-      isarray: 0.0.1
-
   path-to-regexp@3.3.0: {}
 
   path-to-regexp@8.4.1: {}
@@ -18879,7 +18947,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  react-docgen@8.0.2(supports-color@8.1.1):
+  react-docgen@8.0.2:
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
@@ -18946,17 +19014,17 @@ snapshots:
       sucrase: 3.35.0
       use-editable: 2.3.3(react@19.2.0)
 
-  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.0):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
+      hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 19.2.0
-      remark-parse: 11.0.0(supports-color@8.1.1)
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -19011,35 +19079,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-router-dom@5.3.4(react@19.2.0):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      history: 4.10.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.2.0
-      react-router: 5.3.4(react@19.2.0)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
   react-router-dom@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-router: 7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-
-  react-router@5.3.4(react@19.2.0):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      history: 4.10.1
-      hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      path-to-regexp: 1.9.0
-      prop-types: 15.8.1
-      react: 19.2.0
-      react-is: 16.13.1
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
 
   react-router@7.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -19056,11 +19100,11 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.0(react@19.2.0)
 
-  react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(supports-color@8.1.1):
+  react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.0)
       '@floating-ui/dom': 1.7.6
       '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
       memoize-one: 6.0.0
@@ -19238,15 +19282,15 @@ snapshots:
       hastscript: 9.0.1
       parse-entities: 4.0.2
 
-  rehype-recma@1.0.0(supports-color@8.1.1):
+  rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3(supports-color@8.1.1)
+      hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
-  remark-flexible-toc@1.2.5(unified@11.0.5):
+  remark-flexible-toc@1.2.6(unified@11.0.5):
     dependencies:
       '@types/mdast': 4.0.4
       github-slugger: 2.0.0
@@ -19254,12 +19298,12 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.1.0
 
-  remark-gfm@4.0.1(supports-color@8.1.1):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@8.1.1)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -19267,17 +19311,17 @@ snapshots:
 
   remark-mark-highlight@0.1.1: {}
 
-  remark-mdx@3.1.1(supports-color@8.1.1):
+  remark-mdx@3.1.1:
     dependencies:
-      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
+      mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@8.1.1):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
+      mdast-util-from-markdown: 2.0.2
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -19297,10 +19341,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1(supports-color@8.1.1):
+  remark@15.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0(supports-color@8.1.1)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -19521,7 +19565,7 @@ snapshots:
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
-  serve-static@2.2.1(supports-color@8.1.1):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -19784,8 +19828,8 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@testing-library/jest-dom': 6.10.0(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
@@ -20149,9 +20193,20 @@ snapshots:
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(typescript@5.9.3)
       eslint: 10.8.0(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.66.0(eslint@10.8.0)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0)(typescript@5.9.3)
+      eslint: 10.8.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -20216,10 +20271,10 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-      '@volar/typescript': 2.4.28(typescript@5.9.3)
+      '@volar/typescript': 2.4.28
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
@@ -20233,7 +20288,7 @@ snapshots:
       rolldown: 1.2.2
       rollup: 4.62.4
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
-      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
+      webpack: 5.109.2(esbuild@0.28.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20378,9 +20433,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1)):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2(esbuild@0.28.1))
     optionalDependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.3)
       rollup: 4.62.4
@@ -20472,7 +20527,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
+      webpack: 5.109.2(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
       webpack-merge: 6.0.1
     optionalDependencies:
       js-yaml: 3.15.0
@@ -20488,7 +20543,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2):
+  webpack@5.109.2(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -20504,7 +20559,82 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack@5.109.2)
+      minimizer-webpack-plugin: 5.6.1(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack@5.109.2)
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    optionalDependencies:
+      webpack-cli: 7.2.2(js-yaml@3.15.0)(json5@2.2.3)(webpack@5.109.2)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.109.2(esbuild@0.28.1):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.5
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.109.2(esbuild@0.28.1))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
+
+  webpack@5.109.2(esbuild@0.28.1)(webpack-cli@7.2.2):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.5
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.109.2)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -213,9 +213,9 @@ catalogs:
   utils:
     dequal: ^2.0.3
     dotenv: ^17.4.2
-    dompurify: ^3.4.12
+    dompurify: ^3.4.13
     lodash: ^4.18.1
-    "@types/lodash": ^4.17.24
+    "@types/lodash": ^4.17.25
     "@types/node": ^24.13.3
     zod: ^4.4.3
     escape-html: ^1.0.3
@@ -235,7 +235,7 @@ catalogs:
     remark-gfm: ^4.0.1
     remend: ^1.3.0
     remark: ^15.0.1
-    remark-flexible-toc: ^1.2.5
+    remark-flexible-toc: ^1.2.6
     to-vfile: ^8.0.0
   # Private docs-app pins — not published to npm. Exact versions (no ^ or ~) so
   # Renovate updates are explicit PRs rather than silent range expansion.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,53 +124,53 @@ overrides:
 
 catalogs:
   tooling:
-    "@figma/code-connect": ^1.4.9
-    "@fission-ai/openspec": ^1.6.0
+    "@figma/code-connect": ^1.5.2
+    "@fission-ai/openspec": ^1.7.0
     eslint-plugin-react-hooks: ^7.1.1
-    globals: ^17.7.0
+    globals: ^17.9.0
     glob: ^13.0.6
     typescript: ~5.9.3
-    typescript-eslint: ^8.64.0
+    typescript-eslint: ^8.66.0
     tsup: ^8.5.1
-    tsx: ^4.23.1
+    tsx: ^4.23.5
     "@arethetypeswrong/cli": ^0.18.5
-    publint: ^0.3.21
-    "@commercetools-frontend/ui-kit": ^20.6.4
-    "@modelcontextprotocol/inspector": ^0.21.2
+    publint: ^0.3.23
+    "@commercetools-frontend/ui-kit": ^20.6.7
+    "@modelcontextprotocol/inspector": ^0.22.0
     "@babel/core": ^7.29.7
     "@babel/runtime": ^7.29.7
     "@babel/preset-typescript": ^7.29.7
     "@eslint/js": ^10.0.1
-    "@react-types/shared": ^3.36.0
-    eslint: ^10.7.0
+    "@react-types/shared": ^3.36.1
+    eslint: ^10.8.0
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.6
     eslint-plugin-react-refresh: ^0.5.3
-    express-rate-limit: ^8.6.0
-    prettier: ^3.9.5
+    express-rate-limit: ^8.6.2
+    prettier: ^3.9.6
     "@preconstruct/cli": ^2.8.13
     # Never below 2.31.1: earlier versions misread npm 12's array-wrapped `npm info --json` and republish live versions.
     "@changesets/cli": 2.31.1
-    "@vitejs/plugin-react": ^6.0.3
-    "@vitejs/plugin-react-swc": ^4.3.1
-    vite: ^8.1.5
-    webpack: ^5.108.4
-    webpack-cli: ^7.2.1
+    "@vitejs/plugin-react": ^6.0.5
+    "@vitejs/plugin-react-swc": ^4.3.3
+    vite: ^8.2.0
+    webpack: ^5.109.2
+    webpack-cli: ^7.2.2
     vite-bundle-analyzer: ^1.3.9
     vite-plugin-dts: ^5.0.3
-    rollup: ^4.62.2
+    rollup: ^4.62.4
     "@vitest/browser": ^4.1.10
     "@vitest/browser-playwright": ^4.1.10
     "@vitest/coverage-v8": ^4.1.10
     "@testing-library/dom": 10.4.1
-    "@testing-library/jest-dom": ^6.9.1
-    "@testing-library/user-event": ^14.6.1
+    "@testing-library/jest-dom": ^6.10.0
+    "@testing-library/user-event": ^14.6.3
     "@testing-library/react": ^16.3.2
-    playwright: ^1.61.1
+    playwright: ^1.62.1
     vitest: ^4.1.10
-    axe-core: ^4.11.0
-    "@typescript-eslint/types": ^8.48.1
-    "@typescript-eslint/typescript-estree": ^8.56.1
+    axe-core: ^4.12.1
+    "@typescript-eslint/types": ^8.66.0
+    "@typescript-eslint/typescript-estree": ^8.66.0
     react-docgen-typescript: ^2.4.0
     # Storybook pinned exact at 10.4.6: 10.5.0 wraps HTMLElement.focus in its CSF
     # runtime and throws "Illegal invocation" when react-aria's
@@ -186,7 +186,7 @@ catalogs:
     "@storybook/react-vite": 10.4.6
     "@vueless/storybook-dark-mode": ^10.0.8
     "@github-ui/storybook-addon-performance-panel": ^1.1.4
-    chromatic: ^17.7.2
+    chromatic: ^17.8.0
     jsdom: 29.0.1 # pinned: 29.0.2+ breaks Chakra/Emotion CSS in JSDOM (style assertions return padding: 0); reconfirmed against 29.1.0 on 2026-04-29
   react:
     "@types/react": ^19.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -189,8 +189,8 @@ catalogs:
     chromatic: ^17.8.0
     jsdom: 29.0.1 # pinned: 29.0.2+ breaks Chakra/Emotion CSS in JSDOM (style assertions return padding: 0); reconfirmed against 29.1.0 on 2026-04-29
   react:
-    "@types/react": ^19.2.17
-    "@types/react-dom": ^19.2.3
+    "@types/react": ^19.2.18
+    "@types/react-dom": ^19.2.4
     react: ^19.0.0
     react-dom: ^19.0.0
     "@emotion/react": ^11.14.0
@@ -198,14 +198,14 @@ catalogs:
     "@chakra-ui/cli": ^3.36.1
     "@chakra-ui/react": ^3.36.1
     next-themes: ^0.4.6
-    react-aria: 3.50.0
-    react-aria-components: 1.19.0
-    react-stately: 3.48.0
+    react-aria: 3.51.0
+    react-aria-components: 1.20.0
+    react-stately: 3.49.0
     "@react-aria/interactions": 3.28.1
     "@react-aria/utils": 3.34.1
-    "@react-aria/optimize-locales-plugin": 2.0.0
-    "@internationalized/date": ^3.12.2
-    "@internationalized/string": ^3.2.9
+    "@react-aria/optimize-locales-plugin": 2.0.1
+    "@internationalized/date": ^3.12.3
+    "@internationalized/string": ^3.2.10
     "@internationalized/string-compiler": ^3.4.1
     react-hotkeys-hook: ^5.3.3
     react-use: ^17.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -163,7 +163,12 @@ catalogs:
     "@vitest/browser-playwright": ^4.1.10
     "@vitest/coverage-v8": ^4.1.10
     "@testing-library/dom": 10.4.1
-    "@testing-library/jest-dom": ^6.10.0
+    # Pinned exact at 6.9.1: 6.10.0 is deprecated upstream as an "incorrect
+    # minor release with breaking changes" (raises the floor to Node >=22 and
+    # makes @testing-library/dom a required peer). A caret range can't hold it
+    # back — ^6.9.1 re-resolves straight to 6.10.0. The 6.x line ends here;
+    # moving forward means 7.0.0, which is a major and needs its own PR.
+    "@testing-library/jest-dom": 6.9.1
     "@testing-library/user-event": ^14.6.3
     "@testing-library/react": ^16.3.2
     playwright: ^1.62.1
@@ -241,17 +246,17 @@ catalogs:
   # Renovate updates are explicit PRs rather than silent range expansion.
   apps:
     "@mdx-js/mdx": 3.1.1
-    "@types/mdx": 2.0.13
+    "@types/mdx": 2.0.14
     "@types/react-syntax-highlighter": 15.5.13
     "@types/slug": 5.0.9
     chokidar: 5.0.0
-    fuse.js: 7.3.0
+    fuse.js: 7.5.0
     github-slugger: 2.0.0
-    jotai: 2.20.1
+    jotai: 2.20.2
     prism-react-renderer: 2.4.1
     react-live: 4.1.8
-    react-router: 8.1.0
-    react-router-dom: 7.17.0
+    react-router: 8.3.0
+    react-router-dom: 7.18.2
     react-syntax-highlighter: 16.1.1
     remark-mark-highlight: 0.1.1
     slug: 11.0.1


### PR DESCRIPTION
## Summary

Updates workspace catalog dependencies to their latest minor and patch versions, respecting semver constraints, the repo's `minimumReleaseAge` supply-chain gate, and existing deliberate pins. **41 packages updated** across four risk-ordered groups, each installed, built, and tested as its own checkpoint commit.

Only `pnpm-workspace.yaml`, `pnpm-lock.yaml`, and the changeset are touched.

## 🔧 Tooling (24 updated)

**Build & bundling**
- `vite`: 8.1.5 → 8.2.0
- `rollup`: 4.62.2 → 4.62.4
- `webpack`: 5.108.4 → 5.109.2
- `webpack-cli`: 7.2.1 → 7.2.2
- `@vitejs/plugin-react`: 6.0.3 → 6.0.5
- `@vitejs/plugin-react-swc`: 4.3.1 → 4.3.3
- `tsx`: 4.23.1 → 4.23.5

**Lint & types**
- `eslint`: 10.7.0 → 10.8.0
- `typescript-eslint`: 8.64.0 → 8.66.0
- `@typescript-eslint/types`: 8.48.1 → 8.66.0
- `@typescript-eslint/typescript-estree`: 8.56.1 → 8.66.0
- `prettier`: 3.9.5 → 3.9.6 (no reformatting required)
- `@react-types/shared`: 3.36.0 → 3.36.1

**Test**
- `playwright`: 1.61.1 → 1.62.1
- `@testing-library/user-event`: 14.6.1 → 14.6.3
- `axe-core`: 4.11.0 → 4.12.1

**Other tooling**
- `@commercetools-frontend/ui-kit`: 20.6.4 → 20.6.7
- `@figma/code-connect`: 1.4.9 → 1.5.2
- `@fission-ai/openspec`: 1.6.0 → 1.7.0
- `@modelcontextprotocol/inspector`: 0.21.2 → 0.22.0
- `chromatic`: 17.7.2 → 17.8.0
- `express-rate-limit`: 8.6.0 → 8.6.2
- `globals`: 17.7.0 → 17.9.0
- `publint`: 0.3.21 → 0.3.23

## ⚛️ React Ecosystem (8 updated)

The React Aria family moves as one coherent set — `react-aria@3.51.0` requires exactly `react-stately@3.49.0`, `@react-types/shared@^3.36.1`, `@internationalized/date@^3.12.3`, and `@internationalized/string@^3.2.10`, all of which are included:

- `react-aria`: 3.50.0 → 3.51.0
- `react-aria-components`: 1.19.0 → 1.20.0
- `react-stately`: 3.48.0 → 3.49.0
- `@react-aria/optimize-locales-plugin`: 2.0.0 → 2.0.1
- `@internationalized/date`: 3.12.2 → 3.12.3
- `@internationalized/string`: 3.2.9 → 3.2.10
- `@types/react`: 19.2.17 → 19.2.18
- `@types/react-dom`: 19.2.3 → 19.2.4

The `@react-aria/interactions` (3.28.1) and `@react-aria/utils` (3.34.1) overrides are unchanged — both are still the latest published versions, so they stay consistent with react-aria 3.51.0.

**⚠️ Frozen (consumer control)** — as a UI library, consumers must control these peer dependency versions:
- `react`: ^19.0.0
- `react-dom`: ^19.0.0
- `@emotion/react`: ^11.14.0

`@types/react` / `@types/react-dom` were treated as updateable rather than frozen: they are `devDependencies` only in `packages/nimbus` — absent from both `dependencies` and `peerDependencies` — so they are not part of the published surface consumers resolve. Both moves are patch-level.

## 🧰 Utils, Markdown & Docs App (9 updated)

**Utils**
- `dompurify`: 3.4.12 → 3.4.13 (bundled into `@commercetools/nimbus`; also the target of the `dompurify` override)
- `@types/lodash`: 4.17.24 → 4.17.25

**Markdown** (private packages only)
- `remark-flexible-toc`: 1.2.5 → 1.2.6

**Docs app** (private, not published)
- `react-router`: 8.1.0 → 8.3.0
- `react-router-dom`: 7.17.0 → 7.18.2
- `fuse.js`: 7.3.0 → 7.5.0
- `jotai`: 2.20.1 → 2.20.2
- `@types/mdx`: 2.0.13 → 2.0.14

`react-router-dom` has no 8.x line and hard-pins `react-router` to its own version, so the docs app continues to carry two react-router copies (8.3.0 direct + 7.18.2 via react-router-dom). That duplication predates this PR; both packages are used across the app.

## 🛑 Deliberately Not Updated

**`@testing-library/jest-dom` — pinned exact at 6.9.1 (was `^6.9.1`)**

This one is a behavior change worth a look. 6.10.0 is **deprecated upstream** as an *"incorrect minor release with breaking changes"* (raises the Node floor to >=22 and makes `@testing-library/dom` a required peer), with 6.9.1 named as the supported 6.x version. A caret range cannot hold that back — `^6.9.1` re-resolves straight to 6.10.0 on any re-resolution, which is exactly what happened mid-sweep. The entry is now pinned exact, matching how `storybook` and `jsdom` are held back. Moving forward means 7.0.0, a major, which needs its own PR.

`storybook@10.4.6` still pulls jest-dom 6.10.0 transitively for its `storybook/test` matchers. Left alone rather than forced via an override: the repo requires Node >=24.12 and CI runs Node 24, so 6.10.0's breaking changes are already satisfied there.

**Storybook — stays at 10.4.6 (10.5.6 available)**

The documented reason for the pin still stands: 10.5.0 wraps `HTMLElement.focus` in its CSF runtime and throws "Illegal invocation" from react-aria's `setupGlobalFocusEvents`, flaking browser story tests. Clearing it also means updating four transitive `@storybook/*` overrides. Worth its own focused PR that can actually verify the regression is fixed.

**jsdom — stays at 29.0.1 (29.1.1 available)**

Documented pin: 29.0.2+ breaks Chakra/Emotion CSS in JSDOM (style assertions return `padding: 0`), last reconfirmed against 29.1.0.

**⏳ Held back by `minimumReleaseAge`**

A newer minor/patch exists but is younger than the repo's 24h supply-chain gate, so the newest *aged* version was taken instead. These will pick up on a later run:
- `axe-core`: took 4.12.1 (4.13.0 published ~1.4h ago)
- `tsx`: took 4.23.5 (4.23.6/4.23.7/4.23.8 published ~17h/~12.7h/~3.1h ago)

No `minimumReleaseAgeExclude` entry was added, and none was needed — every install resolved cleanly under `minimumReleaseAgeStrict: true`.

**⏭️ Skipped (major version bumps)**

`typescript` (7.0.2), `@types/node` (26.1.2), `@babel/*` (8.x), `@huggingface/transformers` (4.2.0), `slug` (12.0.1).

## 🧪 Testing

- ✅ `pnpm build` — full build including docs and MCP
- ✅ `pnpm typecheck:strict` — the CI gate, clean
- ✅ `pnpm lint` — 0 errors (2 pre-existing `react-hooks` warnings, unrelated)
- ✅ `pnpm test:unit` — **1506 passed** (126 files)
- ✅ `pnpm test:storybook` — **1178 passed** (99 files)
- ✅ `pnpm check:package-shape` — attw + publint pass for all packages
- ✅ `pnpm check:bundle-size` — all within limits (`@commercetools/nimbus` actually **-6.4%**)

**A note on full-suite runs:** running `pnpm test` (both projects concurrently, 247 files) produced a small, *different* set of failures on each run — 6 to 11 tests across varying files, essentially all `Test timed out in 5000ms`, with individual files reporting 30–280s durations. Running each project on its own is completely green, and every individually flagged file passes in isolation. This is resource contention on the dev machine, not a regression from these updates; the failing set varied across runs with identical dependencies.

## 🔍 Review Notes

1. Each group is a separate commit, so any single group can be dropped independently.
2. The `@testing-library/jest-dom` exact pin is the only change that isn't a straight version bump — see the rationale above.
3. React runtime packages remain frozen for consumer control.
4. Chromatic runs automatically (the changed-files gate watches `pnpm-lock.yaml`); a lockfile change can't be traced to specific stories, so expect an effectively full snapshot. **Please review the visual diff before merging** — the react-aria 3.51.0 bump is the most likely source of visual movement.

## 📊 Summary

- ✅ **41 packages updated**
- ⏸️ **3 packages frozen** (react, react-dom, @emotion/react)
- 🛑 **8 held by deliberate pins** (6× Storybook, jsdom, jest-dom)
- ⏳ **2 partially held** by `minimumReleaseAge` (took newest aged version)
- ⏭️ **5+ skipped** (major versions)
- ✅ **0 packages failed**