### PR TITLE
FEC-1180 & 1188 - Batch 9 & 17, Navigation, Lists & Combobox

### DIFF
--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -373,7 +373,8 @@ text) can go here too.
 
 **A matrix is only for interacting axes.** Build one only when a cross-cell is a
 visual neither axis produces alone (checked × invalid → a distinct critical
-fill). If the axes are **independent** - no novel cross-cell, one just
+fill). `compoundVariants` over two axes is the recipe declaring exactly that -
+build the matrix. If the axes are **independent** - no novel cross-cell, one just
 scales/recolors the other (`size × colorPalette`, `size × on/off`) - do **not**
 build a matrix, even a small 2×2; snapshot each axis as its own showcase story
 (`Sizes`, `ColorPalettes`, a states story). The cross-product adds cells, not
@@ -822,7 +823,8 @@ Gets Captured** above.
       distinct open surface is its own story; open/close & dismissal stay behavioral
 - [ ] **Portal** components (Toast/overlays): transient UI held open
       (`duration: Infinity`), awaited, and cleaned up between stories; the
-      component's own focus reached via its **real keyboard path**, not `.focus()`
+      component's own focus reached via its **real keyboard path**, not `.focus()`;
+      an overlay hanging below a short root given `minHeight` so the crop keeps it
 - [ ] **`placement`** snapshotted only when it changes the **layout** (Drawer
       side/top/bottom panels), not a mere reposition (Dialog = center only;
       Menu/Tooltip RA-positioning = behavioral)
@@ -866,8 +868,10 @@ Gets Captured** above.
       assertions, no un-`await`ed async helpers
 - [ ] No play added **for completeness** - each is there because the story's name
       makes a behavioral claim or its frame needs an interaction to exist
-- [ ] Text-entry `Focused` plays hide the caret
-      (`canvasElement.style.caretColor = "transparent"`) before tabbing
+- [ ] Any frame ending with focus in a text input hides the caret
+      (`canvasElement.style.caretColor = "transparent"`) - not just `Focused`
+      stories: an open Combobox keeps focus in its input, so six of its frames
+      needed it
 - [ ] **Determinism**: dates pinned to a fixed anchor (live "today" stays
       off-snapshot), no random values, async-derived state awaited
 - [ ] **Animated** states: paused frame confirmed to show the target; if an infinite
@@ -885,7 +889,8 @@ Gets Captured** above.
 - [ ] **Uniform, axis-independent** states are captured in a **dedicated** story, not
       folded into the matrix (`disabled` → its own `Disabled` snapshot)
 - [ ] Distinct **state-combinations** are covered, not just single flags
-      (selected-disabled is a separate look from unselected-disabled)
+      (selected-disabled ≠ unselected-disabled), and nothing else repaints what a
+      folded-out `disabled` dims
 - [ ] Each state checked for being rendered **more than one way** (mode-/variant-
       driven); each distinct surface gets its **own** story, not a folded gallery
       (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`)

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -157,8 +157,12 @@ story: open dialogs/drawers fill the viewport with a backdrop and can't share a
 frame, so there's no `SmokeTest` matrix (independent recipe variants become
 separate open showcases). open/close, focus trap and dismissal stay behavioral.
 
-**Portals land in the frame, so the capture is page-wide.** Hold transient UI
-open (`duration: Infinity` for toasts), await it, and clean up between stories
+**Portals land in the frame only if the page is tall enough.** An
+absolutely-positioned portal adds no document height, so an overlay below a
+short root is cropped - fine in Storybook, cut in the build. Dialog and Toast
+fill the viewport and escape it; a listbox under one input needs a decorator
+reserving room (Combobox's `roomForPopover`). Hold transient UI open
+(`duration: Infinity` for toasts), await it, and clean up between stories
 (Toast's `clearToasts()`) so nothing leaks into the next capture. A portal
 component can be focusable in its own right (Toast's root has `tabIndex=0` +
 `focusRing: outside`) - reach it the real way (hotkey + Tab), not a synthetic
@@ -316,9 +320,11 @@ separate frame, never a dropped state.
 **A matrix is only for _interacting_ axes.** When axes are independent - one
 just scales or recolors the other (Badge/Avatar `size × colorPalette`, Switch
 `size × on/off`) - snapshot each as its own showcase; the cross-product adds
-cells, not coverage. **Name the matrix `SmokeTest` and render it last** - the
-role name stays accurate as axes change, and the axis list goes in the doc
-comment.
+cells, not coverage. **`compoundVariants` settle it**: declaring one states the
+axes produce something neither yields alone, so the matrix is mandatory -
+Combobox has four, Link none. **Name the matrix `SmokeTest` and render it
+last** - the role name stays accurate as axes change, and the axis list goes in
+the doc comment.
 
 **Over the axes it does span, the matrix must be exhaustive.** A single-axis
 showcase varies one axis with the rest at defaults, so
@@ -334,6 +340,15 @@ it resolves to a single shared `layerStyle` (`opacity: 0.5` +
 `cursor: not-allowed`) identical across every palette/size/variant, so a
 `Disabled`/`DisabledGroup` story captures it once instead of the matrix
 re-rendering every cell at half opacity for no new coverage.
+
+**The fold-out only holds while what it dims is uniform**, so it loses to "cover
+distinct state-combinations" below. `layerStyle: "disabled"` dims whatever sits
+underneath, so once another state repaints that surface - Tree and DraggableList
+both tint `[data-selected]` - selected-disabled is a separate pixel and belongs
+in the matrix (FEC-1180: missed in both). Whether it exists at all depends on
+the selection model: React Aria reassigns single selection away from a disabled
+item (unreachable in Tabs), while consumer-owned props and multi-select allow
+it.
 
 **An axis the recipe hardcodes was never an axis.** MultilineTextInput pins
 `colorPalette: "neutral"`, so its matrix is `state × size × variant` with no

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -221,8 +221,10 @@ already-audited component → don't.
   ring actually renders.
 - **Overlays: snapshot the open state** and leave it open; each distinct open
   surface is its own story.
-- **Portals: capture is page-wide** - hold open, await, clean up between
-  stories; reach a portal's focus via its real keyboard path.
+- **Portals: capture is page-wide, but the page must be tall enough** - an
+  overlay hanging below a short root is cropped, so reserve `minHeight`. Hold
+  open, await, clean up between stories; reach a portal's focus via its real
+  keyboard path.
 - **Snapshot `placement` only when it changes the layout**, not when it
   repositions the same box.
 
@@ -263,7 +265,9 @@ already-audited component → don't.
 
 - **What to snapshot:** every prop-driven visual state. Interacting axes fold
   into one `SmokeTest`; independent axes get separate showcases; any state the
-  matrix can't render gets its own story. Never drop a state to save cost.
+  matrix can't render gets its own story. Never drop a state to save cost. A
+  recipe with `compoundVariants` over two axes has already declared they
+  interact - build the matrix.
 - **Name the interacting-axes matrix `SmokeTest`, rendered last** - the axis
   list lives in the doc comment.
 - **Axis arrays span the full supported range** - palettes iterate the 6
@@ -271,7 +275,8 @@ already-audited component → don't.
   recipe hardcodes isn't an axis; a uniform transform (`disabled`) folds out
   into its own story.
 - **Cover distinct state-combinations**, not just single flags
-  (selected-disabled ≠ unselected-disabled).
+  (selected-disabled ≠ unselected-disabled) - beats the fold-out above, when
+  reachable (React Aria reassigns selection off disabled items).
 - **One state rendered more than one way → one story each**, not a folded
   gallery.
 - **`chromatic.modes` is global config only** (viewport/theme/locale), never

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -6273,6 +6273,48 @@ export const ContentAreaScrollBehavior: Story = {
   },
 };
 
+/**
+ * Option: Label And Description
+ * The two-line option layout, composed from the `label` and `description` slots.
+ */
+export const OptionWithDescription: Story = {
+  // VRT: the only frame with `[slot="description"]`; the rest are plain-text options.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
+  render: () => (
+    <ComboBox.Root aria-label="Option descriptions" menuTrigger="focus">
+      <ComboBox.Trigger />
+      <ComboBox.Popover>
+        <ComboBox.ListBox>
+          <ComboBox.Option textValue="Koala">
+            <Text slot="label">Koala</Text>
+            <Text slot="description">Sleeps up to 20 hours a day</Text>
+          </ComboBox.Option>
+          <ComboBox.Option textValue="Platypus">
+            <Text slot="label">Platypus</Text>
+            <Text slot="description">Lays eggs and is venomous</Text>
+          </ComboBox.Option>
+        </ComboBox.ListBox>
+      </ComboBox.Popover>
+    </ComboBox.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
+    const canvas = within(canvasElement);
+
+    await step("Opens with two-line options", async () => {
+      await userEvent.click(canvas.getByRole("combobox"));
+      await waitFor(() => {
+        expect(getListBox(document)).toBeInTheDocument();
+      });
+      expect(
+        document.querySelector('[role="option"] [slot="description"]')
+      ).toBeInTheDocument();
+    });
+  },
+};
+
 // ============================================================
 // SMOKE TEST
 // ============================================================
@@ -6314,47 +6356,5 @@ export const SmokeTest: Story = {
         ))}
       </Stack>
     );
-  },
-};
-
-/**
- * Option: Label And Description
- * The two-line option layout, composed from the `label` and `description` slots.
- */
-export const OptionWithDescription: Story = {
-  // VRT: the only frame with `[slot="description"]`; the rest are plain-text options.
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
-  decorators: [roomForPopover],
-  render: () => (
-    <ComboBox.Root aria-label="Option descriptions" menuTrigger="focus">
-      <ComboBox.Trigger />
-      <ComboBox.Popover>
-        <ComboBox.ListBox>
-          <ComboBox.Option textValue="Koala">
-            <Text slot="label">Koala</Text>
-            <Text slot="description">Sleeps up to 20 hours a day</Text>
-          </ComboBox.Option>
-          <ComboBox.Option textValue="Platypus">
-            <Text slot="label">Platypus</Text>
-            <Text slot="description">Lays eggs and is venomous</Text>
-          </ComboBox.Option>
-        </ComboBox.ListBox>
-      </ComboBox.Popover>
-    </ComboBox.Root>
-  ),
-  play: async ({ canvasElement, step }) => {
-    canvasElement.style.caretColor = "transparent";
-    const canvas = within(canvasElement);
-
-    await step("Opens with two-line options", async () => {
-      await userEvent.click(canvas.getByRole("combobox"));
-      await waitFor(() => {
-        expect(getListBox(document)).toBeInTheDocument();
-      });
-      expect(
-        document.querySelector('[role="option"] [slot="description"]')
-      ).toBeInTheDocument();
-    });
   },
 };

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -6273,48 +6273,6 @@ export const ContentAreaScrollBehavior: Story = {
   },
 };
 
-/**
- * Option: Label And Description
- * The two-line option layout, composed from the `label` and `description` slots.
- */
-export const OptionWithDescription: Story = {
-  // VRT: the only frame with `[slot="description"]`; the rest are plain-text options.
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
-  decorators: [roomForPopover],
-  render: () => (
-    <ComboBox.Root aria-label="Option descriptions" menuTrigger="focus">
-      <ComboBox.Trigger />
-      <ComboBox.Popover>
-        <ComboBox.ListBox>
-          <ComboBox.Option textValue="Koala">
-            <Text slot="label">Koala</Text>
-            <Text slot="description">Sleeps up to 20 hours a day</Text>
-          </ComboBox.Option>
-          <ComboBox.Option textValue="Platypus">
-            <Text slot="label">Platypus</Text>
-            <Text slot="description">Lays eggs and is venomous</Text>
-          </ComboBox.Option>
-        </ComboBox.ListBox>
-      </ComboBox.Popover>
-    </ComboBox.Root>
-  ),
-  play: async ({ canvasElement, step }) => {
-    canvasElement.style.caretColor = "transparent";
-    const canvas = within(canvasElement);
-
-    await step("Opens with two-line options", async () => {
-      await userEvent.click(canvas.getByRole("combobox"));
-      await waitFor(() => {
-        expect(getListBox(document)).toBeInTheDocument();
-      });
-      expect(
-        document.querySelector('[role="option"] [slot="description"]')
-      ).toBeInTheDocument();
-    });
-  },
-};
-
 // ============================================================
 // SMOKE TEST
 // ============================================================
@@ -6356,5 +6314,47 @@ export const SmokeTest: Story = {
         ))}
       </Stack>
     );
+  },
+};
+
+/**
+ * Option: Label And Description
+ * The two-line option layout, composed from the `label` and `description` slots.
+ */
+export const OptionWithDescription: Story = {
+  // VRT: the only frame with `[slot="description"]`; the rest are plain-text options.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
+  render: () => (
+    <ComboBox.Root aria-label="Option descriptions" menuTrigger="focus">
+      <ComboBox.Trigger />
+      <ComboBox.Popover>
+        <ComboBox.ListBox>
+          <ComboBox.Option textValue="Koala">
+            <Text slot="label">Koala</Text>
+            <Text slot="description">Sleeps up to 20 hours a day</Text>
+          </ComboBox.Option>
+          <ComboBox.Option textValue="Platypus">
+            <Text slot="label">Platypus</Text>
+            <Text slot="description">Lays eggs and is venomous</Text>
+          </ComboBox.Option>
+        </ComboBox.ListBox>
+      </ComboBox.Popover>
+    </ComboBox.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
+    const canvas = within(canvasElement);
+
+    await step("Opens with two-line options", async () => {
+      await userEvent.click(canvas.getByRole("combobox"));
+      await waitFor(() => {
+        expect(getListBox(document)).toBeInTheDocument();
+      });
+      expect(
+        document.querySelector('[role="option"] [slot="description"]')
+      ).toBeInTheDocument();
+    });
   },
 };

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -1461,6 +1461,8 @@ export const InputPlaceholder: Story = {
   // VRT: the `[data-placeholder]` treatment; the play clears back to it.
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
+  // Clearing the input leaves the listbox open, so the frame needs the room.
+  decorators: [roomForPopover],
   render: () => {
     return (
       <ComposedComboBox

--- a/packages/nimbus/src/components/combobox/combobox.stories.tsx
+++ b/packages/nimbus/src/components/combobox/combobox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { useState, useCallback } from "react";
 import { userEvent, within, expect, waitFor } from "storybook/test";
 import { Box, Dialog, FormField, Stack, Text } from "@commercetools/nimbus";
@@ -82,6 +82,16 @@ const meta: Meta<typeof ComboBox.Root> = {
   title: "Components/ComboBox",
   component: ComboBox.Root,
 };
+
+/**
+ * The popover portals out and is absolutely positioned, so it adds no document
+ * height and Chromatic's crop cuts it off. Reserve room for any open-listbox frame.
+ */
+const roomForPopover: Decorator = (Story) => (
+  <Box minHeight="26rem">
+    <Story />
+  </Box>
+);
 
 export default meta;
 
@@ -336,6 +346,10 @@ export const MultiSelectCustomOptions: Story = {
  * - Error handling
  */
 export const AsyncLoading: Story = {
+  // VRT: the open listbox with async results loaded.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
   render: () => {
     const [error, setError] = useState<string | null>(null);
     const getPokemonValue = useCallback((pokemon: Pokemon) => pokemon.name, []);
@@ -371,6 +385,7 @@ export const AsyncLoading: Story = {
   },
 
   play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
     const canvas = within(canvasElement);
 
     await step("Type search query", async () => {
@@ -395,6 +410,19 @@ export const AsyncLoading: Story = {
       await waitFor(
         () => {
           expect(findOptionByText("pikachu")).toBeTruthy();
+        },
+        { timeout: 5000 }
+      );
+
+      // The option renders name-only, then grows when its details resolve; the frame
+      // should show the settled row.
+      await waitFor(
+        () => {
+          const sprite = document.querySelector<HTMLImageElement>(
+            '[role="option"] img'
+          );
+          expect(sprite?.complete).toBe(true);
+          expect(findOptionByText("electric")).toBeTruthy();
         },
         { timeout: 5000 }
       );
@@ -799,6 +827,9 @@ export const AsyncMultiSelectCustomOptions: Story = {
  * Tests that leading element (icon) displays correctly when provided
  */
 export const LayoutLeadingElement: Story = {
+  // VRT: the `leadingElement` slot; SmokeTest renders no leading icon.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <ComposedComboBox
@@ -1113,6 +1144,9 @@ export const MultiSelectTagsInline: Story = {
  * Tests that tags wrap to new lines when space is limited by measuring container height
  */
 export const MultiSelectTagsWrapping: Story = {
+  // VRT: tags wrapping the field to a second row.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     const [selectedKeys, setSelectedKeys] = useState<(string | number)[]>([1]);
 
@@ -1424,6 +1458,9 @@ export const InputWrapsToNewLine: Story = {
  * Tests that placeholder text displays when input is empty
  */
 export const InputPlaceholder: Story = {
+  // VRT: the `[data-placeholder]` treatment; the play clears back to it.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <ComposedComboBox
@@ -1435,6 +1472,7 @@ export const InputPlaceholder: Story = {
   },
 
   play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
     const canvas = within(canvasElement);
     const input = canvas.getByRole("combobox") as HTMLInputElement;
 
@@ -1685,6 +1723,10 @@ export const FocusLosesOnOutsideClick: Story = {
  * Tests that focus indicators are visible when navigating with keyboard
  */
 export const FocusIndicatorsVisible: Story = {
+  // VRT: `[data-focused]` outline on the active option.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
   render: () => {
     return (
       <ComposedComboBox aria-label="Test combobox" items={simpleOptions} />
@@ -1692,6 +1734,7 @@ export const FocusIndicatorsVisible: Story = {
   },
 
   play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
     const canvas = within(canvasElement);
     const input = canvas.getByRole("combobox");
 
@@ -2777,6 +2820,10 @@ export const OptionHoverFeedback: Story = {
  * Tests that selected options have visual distinction (aria-selected, styling)
  */
 export const OptionSelectedVisuallyDistinguished: Story = {
+  // VRT: all three option states at once - selected, unselected and disabled.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
   render: () => {
     const [selectedKeys, setSelectedKeys] = useState<(string | number)[]>([
       1, 3,
@@ -2789,12 +2836,15 @@ export const OptionSelectedVisuallyDistinguished: Story = {
         selectionMode="multiple"
         menuTrigger="focus"
         selectedKeys={selectedKeys}
+        // Disabled options render nowhere else: Base sets `disabledKeys` but never opens.
+        disabledKeys={[4]}
         onSelectionChange={setSelectedKeys}
       />
     );
   },
 
   play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
     const canvas = within(canvasElement);
     const input = canvas.getByRole("combobox");
 
@@ -2821,6 +2871,12 @@ export const OptionSelectedVisuallyDistinguished: Story = {
 
       // Unselected option should not be selected
       expect(isOptionSelected(kangarooOption)).toBe(false);
+    });
+
+    await step("A disabled option is rendered alongside them", async () => {
+      expect(
+        document.querySelector('[role="option"][data-disabled="true"]')
+      ).toBeInTheDocument();
     });
   },
 };
@@ -4247,6 +4303,10 @@ export const FilteringNoResultsState: Story = {
  * Tests section-aware filtering behavior with grouped options
  */
 export const FilteringWithSections: Story = {
+  // VRT: section headers inside the open listbox.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
   render: () => {
     const sectionsData = [
       {
@@ -4302,6 +4362,7 @@ export const FilteringWithSections: Story = {
   },
 
   play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
     const canvas = within(canvasElement);
     const input = canvas.getByRole("combobox");
 
@@ -4824,6 +4885,10 @@ export const EmptyStateMenuClosesDefault: Story = {
  * Tests that custom empty state message renders correctly
  */
 export const EmptyStateCustomMessage: Story = {
+  // VRT: the open listbox with no results - the empty-state render.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
   render: () => {
     return (
       <ComposedComboBox
@@ -4843,6 +4908,7 @@ export const EmptyStateCustomMessage: Story = {
   },
 
   play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
     const canvas = within(canvasElement);
     const input = canvas.getByRole("combobox");
 
@@ -5768,6 +5834,9 @@ export const StateIsReadOnly: Story = {
  * Tests that disabled state disables all interactive elements
  */
 export const StateIsDisabled: Story = {
+  // VRT: the disabled field - `[data-disabled]` dims the trigger and its buttons.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <ComposedComboBox
@@ -5792,6 +5861,9 @@ export const StateIsDisabled: Story = {
  * Tests that invalid state shows error styling
  */
 export const StateIsInvalid: Story = {
+  // VRT: `[data-invalid]` on the trigger border.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => {
     return (
       <ComposedComboBox
@@ -6195,6 +6267,92 @@ export const ContentAreaScrollBehavior: Story = {
 
       // Content should still be near the top (not scrolled to bottom)
       expect(content.scrollTop).toBeLessThan(50);
+    });
+  },
+};
+
+// ============================================================
+// SMOKE TEST
+// ============================================================
+
+/**
+ * SmokeTest
+ * The closed field across `size` x `variant` x `selectionMode`.
+ */
+export const SmokeTest: Story = {
+  // VRT: the axes interact via `compoundVariants`, so the cross-product is one frame.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => {
+    const sizes = ["sm", "md"] as const;
+    const variants = ["solid", "ghost"] as const;
+    const selectionModes = ["single", "multiple"] as const;
+
+    return (
+      <Stack gap="800" alignItems="flex-start">
+        {sizes.map((size) => (
+          <Stack key={size} gap="400" alignItems="flex-start">
+            <Text fontWeight="600">size={size}</Text>
+            {variants.map((variant) => (
+              <Stack key={variant} direction="row" gap="400">
+                {selectionModes.map((selectionMode) => (
+                  <ComposedComboBox<SimpleOption>
+                    key={selectionMode}
+                    aria-label={`${size} ${variant} ${selectionMode}`}
+                    items={simpleOptions}
+                    size={size}
+                    variant={variant}
+                    selectionMode={selectionMode}
+                    selectedKeys={[1]}
+                  />
+                ))}
+              </Stack>
+            ))}
+          </Stack>
+        ))}
+      </Stack>
+    );
+  },
+};
+
+/**
+ * Option: Label And Description
+ * The two-line option layout, composed from the `label` and `description` slots.
+ */
+export const OptionWithDescription: Story = {
+  // VRT: the only frame with `[slot="description"]`; the rest are plain-text options.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [roomForPopover],
+  render: () => (
+    <ComboBox.Root aria-label="Option descriptions" menuTrigger="focus">
+      <ComboBox.Trigger />
+      <ComboBox.Popover>
+        <ComboBox.ListBox>
+          <ComboBox.Option textValue="Koala">
+            <Text slot="label">Koala</Text>
+            <Text slot="description">Sleeps up to 20 hours a day</Text>
+          </ComboBox.Option>
+          <ComboBox.Option textValue="Platypus">
+            <Text slot="label">Platypus</Text>
+            <Text slot="description">Lays eggs and is venomous</Text>
+          </ComboBox.Option>
+        </ComboBox.ListBox>
+      </ComboBox.Popover>
+    </ComboBox.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    canvasElement.style.caretColor = "transparent";
+    const canvas = within(canvasElement);
+
+    await step("Opens with two-line options", async () => {
+      await userEvent.click(canvas.getByRole("combobox"));
+      await waitFor(() => {
+        expect(getListBox(document)).toBeInTheDocument();
+      });
+      expect(
+        document.querySelector('[role="option"] [slot="description"]')
+      ).toBeInTheDocument();
     });
   },
 };

--- a/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
+++ b/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
@@ -113,6 +113,9 @@ export const DragAndDrop: Story = {
 };
 
 export const EmptyState: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+
   render: () => {
     return <DraggableList.Root aria-label="empty list" />;
   },
@@ -473,6 +476,10 @@ export const DisabledItems: Story = {
       // Disabled item should still be in place
       const rows = await within(grid).findAllByRole("row");
       expect(rows[1]).toHaveAttribute("data-key", "2");
+
+      // Cancel any drag this attempt started so it can't leak into the next story.
+      await userEvent.keyboard("{Escape}");
+      disabledRow.blur();
     });
   },
 };
@@ -883,6 +890,9 @@ export const Field: Story = {
 };
 
 export const FieldWithError: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+
   render: () => {
     return (
       <DraggableList.Field
@@ -1309,9 +1319,96 @@ export const MultipleSelection: Story = {
 };
 
 /**
+ * Keyboard focus on a row. The `item` slot rings via `_focus`, not
+ * `_focusVisible`, so this ring also shows on mouse focus.
+ */
+export const FocusedItem: Story = {
+  // VRT: the ring is expected in this capture.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <DraggableList.Root aria-label="focus list" items={items} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Tab focuses the first row and paints a ring", async () => {
+      const row = await canvas.findByRole("row", {
+        name: items[0].label as string,
+      });
+      await userEvent.tab();
+      await expect(row).toHaveFocus();
+
+      // Without this, a ring that never paints baselines as a silent pass.
+      await expect(row).toHaveStyle({ outlineStyle: "solid" });
+    });
+  },
+};
+
+/** label, selected keys, disabled */
+const ROW_STATES = [
+  ["default", [], false],
+  ["selected", ["1", "3"], false],
+  ["disabled", [], true],
+  ["selected + disabled", ["1", "3"], true],
+] as const;
+
+/**
+ * `size` x row state, at rest.
+ *
+ * All four row states are here because `layerStyle: "disabled"` dims whichever
+ * background is underneath, and selected/unselected differ (`colorPalette.5` vs
+ * `.3`) — so selected-disabled is its own pixel, not a repeat of disabled.
+ */
+export const SmokeTest: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Flex direction="row" gap={800} alignItems="flex-start">
+      {(["sm", "md"] as const).map((size) => (
+        <Flex key={size} direction="column" gap={400}>
+          <Text fontWeight="600">{size}</Text>
+          {ROW_STATES.map(([label, selected, isDisabled]) => (
+            <Flex key={label} direction="column" gap={100}>
+              <Text fontSize="300" color="neutral.11">
+                {label}
+              </Text>
+              <DraggableList.Root
+                aria-label={`${size} ${label}`}
+                items={items.slice(0, 3).map((i) => ({ ...i, isDisabled }))}
+                size={size}
+                selectionMode="multiple"
+                selectedKeys={new Set(selected)}
+              />
+            </Flex>
+          ))}
+        </Flex>
+      ))}
+    </Flex>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step(
+      "All eight cells render, selection surviving disabled",
+      async () => {
+        await waitFor(() => {
+          expect(canvas.getAllByRole("grid")).toHaveLength(8);
+          // If disabled rows refused selection, cell four would copy cell three.
+          expect(
+            canvasElement.querySelectorAll("[data-selected][data-disabled]")
+          ).not.toHaveLength(0);
+        });
+      }
+    );
+  },
+};
+
+/**
  * Showcase Possible Color Palettes
  */
 export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+
   render: () => (
     <DisplayColorPalettes>
       {(palette) => {

--- a/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
+++ b/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
@@ -1343,34 +1343,6 @@ export const FocusedItem: Story = {
   },
 };
 
-/**
- * Showcase Possible Color Palettes
- */
-export const ColorPalettes: Story = {
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
-
-  render: () => (
-    <DisplayColorPalettes>
-      {(palette) => {
-        const itemsForPalette = fieldItems.map((item) => ({
-          ...item,
-          key: `${palette}-${item.key}`,
-        }));
-        return (
-          <DraggableList.Field
-            label={palette}
-            items={itemsForPalette}
-            removableItems
-            width="3600"
-            colorPalette={palette}
-          />
-        );
-      }}
-    </DisplayColorPalettes>
-  ),
-};
-
 /** label, selected keys, disabled */
 const ROW_STATES = [
   ["default", [], false],
@@ -1428,4 +1400,32 @@ export const SmokeTest: Story = {
       }
     );
   },
+};
+
+/**
+ * Showcase Possible Color Palettes
+ */
+export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+
+  render: () => (
+    <DisplayColorPalettes>
+      {(palette) => {
+        const itemsForPalette = fieldItems.map((item) => ({
+          ...item,
+          key: `${palette}-${item.key}`,
+        }));
+        return (
+          <DraggableList.Field
+            label={palette}
+            items={itemsForPalette}
+            removableItems
+            width="3600"
+            colorPalette={palette}
+          />
+        );
+      }}
+    </DisplayColorPalettes>
+  ),
 };

--- a/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
+++ b/packages/nimbus/src/components/draggable-list/draggable-list.stories.tsx
@@ -1343,6 +1343,34 @@ export const FocusedItem: Story = {
   },
 };
 
+/**
+ * Showcase Possible Color Palettes
+ */
+export const ColorPalettes: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+
+  render: () => (
+    <DisplayColorPalettes>
+      {(palette) => {
+        const itemsForPalette = fieldItems.map((item) => ({
+          ...item,
+          key: `${palette}-${item.key}`,
+        }));
+        return (
+          <DraggableList.Field
+            label={palette}
+            items={itemsForPalette}
+            removableItems
+            width="3600"
+            colorPalette={palette}
+          />
+        );
+      }}
+    </DisplayColorPalettes>
+  ),
+};
+
 /** label, selected keys, disabled */
 const ROW_STATES = [
   ["default", [], false],
@@ -1400,32 +1428,4 @@ export const SmokeTest: Story = {
       }
     );
   },
-};
-
-/**
- * Showcase Possible Color Palettes
- */
-export const ColorPalettes: Story = {
-  tags: ["vrt"],
-  parameters: { chromatic: { disableSnapshot: false } },
-
-  render: () => (
-    <DisplayColorPalettes>
-      {(palette) => {
-        const itemsForPalette = fieldItems.map((item) => ({
-          ...item,
-          key: `${palette}-${item.key}`,
-        }));
-        return (
-          <DraggableList.Field
-            label={palette}
-            items={itemsForPalette}
-            removableItems
-            width="3600"
-            colorPalette={palette}
-          />
-        );
-      }}
-    </DisplayColorPalettes>
-  ),
 };

--- a/packages/nimbus/src/components/link/link.stories.tsx
+++ b/packages/nimbus/src/components/link/link.stories.tsx
@@ -1,10 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Link, type LinkProps, Stack, Text } from "@commercetools/nimbus";
+import { OpenInNew as DemoIcon } from "@commercetools/nimbus-icons";
 import { userEvent, within, expect, fn } from "storybook/test";
 import { createRef } from "react";
 
 const sizes: LinkProps["size"][] = ["xs", "sm", "md"];
 const fontColors: LinkProps["fontColor"][] = ["primary", "inherit"];
+
+/** `fontColor` has no default, so unset is a third rendering, not an alias. */
+const smokeFontColors: LinkProps["fontColor"][] = [
+  undefined,
+  ...fontColors,
+] as const;
 
 /**
  * The Link component allows a user to navigate to a different page or resource.
@@ -28,6 +35,9 @@ type Story = StoryObj<typeof Link>;
  * Uses the args pattern for dynamic control panel inputs
  */
 export const Base: Story = {
+  // VRT: the only frame with `fontColor` and `size` both unset.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     children: "Demo Link",
     onClick: fn(),
@@ -56,6 +66,29 @@ export const Base: Story = {
       await userEvent.tab();
       await expect(link).toHaveFocus();
     });
+
+    link.blur();
+  },
+};
+
+/**
+ * Showcase the focus ring
+ */
+export const Focused: Story = {
+  // VRT: the ring is expected in this capture.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: {
+    children: "Demo Link",
+    href: "#",
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Shows a focus ring when tabbed to", async () => {
+      await userEvent.tab();
+      await expect(canvas.getByRole("link")).toHaveFocus();
+    });
   },
 };
 
@@ -82,6 +115,9 @@ export const Sizes: Story = {
  * Showcase FontColors
  */
 export const FontColors: Story = {
+  // VRT: snapshotted for the inline-in-text layout, not the colors.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: (args) => {
     return (
       <Stack direction="column">
@@ -97,6 +133,32 @@ export const FontColors: Story = {
 
   args: {
     children: "Link",
+  },
+};
+
+/**
+ * Showcase a link with a leading icon
+ */
+export const WithIcon: Story = {
+  // VRT: the only frame with an icon child, which base's `inline-flex` exists for.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: {
+    href: "https://commercetools.com",
+    target: "_blank",
+    rel: "noopener noreferrer",
+  },
+  render: (args) => {
+    return (
+      <Stack direction="column" gap="400" alignItems="flex-start">
+        {sizes.map((size) => (
+          <Link key={size as string} {...args} size={size}>
+            <DemoIcon />
+            Documentation
+          </Link>
+        ))}
+      </Stack>
+    );
   },
 };
 
@@ -177,6 +239,9 @@ export const WithCustomHref: Story = {
 };
 
 export const SmokeTest: Story = {
+  // VRT: independent axes, but one frame is cheaper than two showcases.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     children: "Demo Link",
     ["data-testid"]: "smoke-test",
@@ -184,8 +249,8 @@ export const SmokeTest: Story = {
   render: (args) => {
     return (
       <Stack gap="1200">
-        {fontColors.map((color) => (
-          <Stack key={color as string} direction="row" gap="400">
+        {smokeFontColors.map((color, index) => (
+          <Stack key={index} direction="row" gap="400">
             {sizes.map((size) => (
               <Stack direction="row" key={size as string}>
                 <Link {...args} size={size} fontColor={color} />

--- a/packages/nimbus/src/components/pagination/pagination.stories.tsx
+++ b/packages/nimbus/src/components/pagination/pagination.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within, expect } from "storybook/test";
-import { Box, Pagination, Stack, Text } from "@commercetools/nimbus";
+import {
+  Box,
+  NimbusProvider,
+  Pagination,
+  Stack,
+  Text,
+} from "@commercetools/nimbus";
 import { useState } from "react";
 
 const meta: Meta<typeof Pagination> = {
@@ -700,7 +706,8 @@ export const WithoutPageSizeSelector: Story = {
 
       // Test next navigation
       await userEvent.click(nextButton);
-      // Check page input value instead of navigation textContent (NumberInput value not captured in textContent)\n      const pageInputAfterNext = canvas.getByLabelText(\"Current page\");\n      await expect(pageInputAfterNext).toHaveValue(\"11\");
+      // The NumberInput's value is not in `navigation.textContent`.
+      await expect(canvas.getByLabelText("Current page")).toHaveValue("11");
 
       // Previous should now be enabled
       await expect(prevButton).toBeEnabled();
@@ -717,10 +724,129 @@ export const WithoutPageSizeSelector: Story = {
         await userEvent.clear(pageInput);
         await userEvent.type(pageInput, "128");
         await expect(pageInput).toHaveValue("128");
-
-        // Should still show 128 total pages
-        // Check that we have navigated to page 128 by checking the input value\n        const pageInput128 = canvas.getByLabelText(\"Current page\");\n        await expect(pageInput128).toHaveValue(\"128\");\n        \n        // Verify \"of 128\" text is visible\n        await expect(navigation).toHaveTextContent(/of\s+128/);
       }
     );
+  },
+};
+
+const noop = () => {};
+
+/**
+ * Every bound of the page range, in one frame. Which arrow is disabled is
+ * Pagination's own logic; the dimming itself is IconButton's.
+ */
+export const PageBounds: Story = {
+  // VRT: the four disabled-arrow combinations.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="600">
+      {[
+        { label: "First page - previous disabled", totalItems: 2560, page: 1 },
+        { label: "Middle page - both enabled", totalItems: 2560, page: 64 },
+        { label: "Last page - next disabled", totalItems: 2560, page: 128 },
+        { label: "Single page - both disabled", totalItems: 15, page: 1 },
+      ].map(({ label, totalItems, page }) => (
+        <Stack key={label} direction="column" gap="200">
+          <Text fontSize="300" color="neutral.11">
+            {label}
+          </Text>
+          <Pagination
+            totalItems={totalItems}
+            currentPage={page}
+            pageSize={20}
+            onPageChange={noop}
+            onPageSizeChange={noop}
+            // Distinct names, or axe flags `landmark-unique` on the repeated navs.
+            aria-label={label}
+          />
+        </Stack>
+      ))}
+    </Stack>
+  ),
+};
+
+/**
+ * The two feature toggles. Each removes or swaps a whole region of Pagination's
+ * own composition: the Select + label, or the NumberInput.
+ */
+export const ConfigurationToggles: Story = {
+  // VRT: the region-level layout shifts each toggle causes.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="600">
+      {(
+        [
+          // Both-on first: each toggle is named for what it removes, so the frame
+          // needs the full composition to read against.
+          ["Both enabled", {}],
+          ["Without page size selector", { enablePageSizeSelector: false }],
+          ["Without page input", { enablePageInput: false }],
+        ] as const
+      ).map(([label, override]) => (
+        <Stack key={label} direction="column" gap="200">
+          <Text fontSize="300" color="neutral.11">
+            {label}
+          </Text>
+          <Pagination
+            totalItems={2560}
+            currentPage={5}
+            pageSize={20}
+            onPageChange={noop}
+            onPageSizeChange={noop}
+            aria-label={label}
+            {...override}
+          />
+        </Stack>
+      ))}
+    </Stack>
+  ),
+};
+
+/**
+ * Pagination in each supported locale. Two Pagination-owned things move and are
+ * both invisible in an English-only frame: the translated label widths, and the
+ * total-pages count from its own `Intl.NumberFormat`. The page count is kept above
+ * 1000 so the formatter has a separator to place.
+ */
+export const Locales: Story = {
+  // VRT: translated label widths + the per-locale group separator.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="600">
+      {["en-US", "de-DE", "es-ES", "fr-FR", "pt-BR"].map((locale) => (
+        <Stack key={locale} direction="column" gap="200">
+          <Text fontSize="300" color="neutral.11">
+            {locale}
+          </Text>
+          <NimbusProvider locale={locale}>
+            <Pagination
+              totalItems={250000}
+              currentPage={2500}
+              // Must be one of the default pageSizeOptions, or the Select renders
+              // its placeholder and the translated label sits next to an empty box.
+              pageSize={100}
+              onPageChange={noop}
+              onPageSizeChange={noop}
+              aria-label={`Pagination ${locale}`}
+            />
+          </NimbusProvider>
+        </Stack>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Each locale formats the total-pages count", async () => {
+      await expect(canvas.getAllByRole("navigation")).toHaveLength(5);
+      // A bypassed formatter would render "2500" in both.
+      const nav = (locale: string) =>
+        canvas.getByRole("navigation", { name: `Pagination ${locale}` });
+      await expect(nav("en-US")).toHaveTextContent("2,500");
+      await expect(nav("de-DE")).toHaveTextContent("2.500");
+    });
   },
 };

--- a/packages/nimbus/src/components/pagination/pagination.stories.tsx
+++ b/packages/nimbus/src/components/pagination/pagination.stories.tsx
@@ -807,8 +807,7 @@ export const ConfigurationToggles: Story = {
 /**
  * Pagination in each supported locale. Two Pagination-owned things move and are
  * both invisible in an English-only frame: the translated label widths, and the
- * total-pages count from its own `Intl.NumberFormat`. The page count is kept above
- * 1000 so the formatter has a separator to place.
+ * total-pages count from its own `Intl.NumberFormat`.
  */
 export const Locales: Story = {
   // VRT: translated label widths + the per-locale group separator.
@@ -823,7 +822,8 @@ export const Locales: Story = {
           </Text>
           <NimbusProvider locale={locale}>
             <Pagination
-              totalItems={250000}
+              // Five digits of pages, or es-ES renders no separator at all.
+              totalItems={2500000}
               currentPage={2500}
               // Must be one of the default pageSizeOptions, or the Select renders
               // its placeholder and the translated label sits next to an empty box.
@@ -842,11 +842,12 @@ export const Locales: Story = {
 
     await step("Each locale formats the total-pages count", async () => {
       await expect(canvas.getAllByRole("navigation")).toHaveLength(5);
-      // A bypassed formatter would render "2500" in both.
+      // A bypassed formatter would render "25000" in all three.
       const nav = (locale: string) =>
         canvas.getByRole("navigation", { name: `Pagination ${locale}` });
-      await expect(nav("en-US")).toHaveTextContent("2,500");
-      await expect(nav("de-DE")).toHaveTextContent("2.500");
+      await expect(nav("en-US")).toHaveTextContent("25,000");
+      await expect(nav("de-DE")).toHaveTextContent("25.000");
+      await expect(nav("es-ES")).toHaveTextContent("25.000");
     });
   },
 };

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -448,11 +448,6 @@ export const WithDisabledItem: Story = {
   },
 };
 
-/**
- * Showcase the focus ring on each variant. The ring follows the item's own
- * `borderRadius` — square, `200`, `full` — so each variant is a separate surface,
- * and only one element can hold focus at a time.
- */
 const focusActiveItem = async (canvasElement: HTMLElement) => {
   const canvas = within(canvasElement);
   await userEvent.tab();
@@ -462,6 +457,11 @@ const focusActiveItem = async (canvasElement: HTMLElement) => {
   await expect(item).toHaveStyle({ outlineStyle: "solid" });
 };
 
+/**
+ * The focus ring on `line`. The ring follows the item's own `borderRadius`, so
+ * each variant is its own surface, and only one element can hold focus at a time,
+ * hence one story per variant.
+ */
 export const FocusedLine: Story = {
   // VRT: the ring is expected in this capture.
   tags: ["vrt"],
@@ -472,6 +472,7 @@ export const FocusedLine: Story = {
   play: async ({ canvasElement }) => focusActiveItem(canvasElement),
 };
 
+/** The same ring on `rounded`. */
 export const FocusedRounded: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -481,6 +482,7 @@ export const FocusedRounded: Story = {
   play: async ({ canvasElement }) => focusActiveItem(canvasElement),
 };
 
+/** The same ring on `pill`. */
 export const FocusedPill: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -669,17 +671,8 @@ export const DeprecatedVariantAlias: Story = {
 };
 
 /**
- * The full `variant` x `size` grid, each nav with its first item active.
- *
- * The axes interact rather than merely scaling each other: size drives the
- * `--tab-nav-*` padding and font-size vars, which set each item's box, which is
- * what `getGeometry` measures to place the indicator — so the highlight's shape
- * is a product of both (a 2px bar for `line`, a full-height rounded-rect or
- * capsule for `rounded`/`pill`, each at three widths).
- */
-/**
- * An item that is both current and disabled — reachable here because `isCurrent`
- * and `isDisabled` are independent props. `_disabled` dims the item, but the
+ * An item that is both current and disabled, reachable because `isCurrent` and
+ * `isDisabled` are independent props. `_disabled` dims the item, but the
  * indicator is a root-level sibling the dimming cannot reach, so the highlight
  * stays at full strength over a dimmed label.
  */
@@ -722,6 +715,15 @@ export const DisabledCurrentItem: Story = {
   },
 };
 
+/**
+ * The full `variant` x `size` grid, each nav with its first item active.
+ *
+ * Both axes shape the indicator, so neither alone covers the matrix: `size` sets
+ * the `--tab-nav-*` font-size and padding vars that size each item's box, and
+ * `getGeometry` measures that box to place the highlight. Hence a 2px bottom bar
+ * for `line` and a full-height rounded-rect or capsule for `rounded`/`pill`, at
+ * three item widths each.
+ */
 export const SmokeTest: Story = {
   // VRT: resting-visual carrier.
   tags: ["vrt"],

--- a/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
+++ b/packages/nimbus/src/components/tab-nav/tab-nav.stories.tsx
@@ -390,6 +390,9 @@ export const KeyboardNavigation: Story = {
  * React Aria's `useLink` handles the disabled behaviour.
  */
 export const WithDisabledItem: Story = {
+  // VRT: the shared `layerStyle: "disabled"`, folded out of SmokeTest.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <InteractiveTabNav
       aria-label="Order navigation"
@@ -437,6 +440,90 @@ export const WithDisabledItem: Story = {
 
         // Shipping is never focused
         await expect(shippingLink).not.toHaveFocus();
+
+        // Snapshotted: without this, the tabbing above leaves a ring in the frame.
+        itemsLink.blur();
+      }
+    );
+  },
+};
+
+/**
+ * Showcase the focus ring on each variant. The ring follows the item's own
+ * `borderRadius` — square, `200`, `full` — so each variant is a separate surface,
+ * and only one element can hold focus at a time.
+ */
+const focusActiveItem = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.tab();
+  const item = canvas.getByRole("link", { name: "General" });
+  await expect(item).toHaveFocus();
+  // Without this, a ring that never paints baselines as a silent pass.
+  await expect(item).toHaveStyle({ outlineStyle: "solid" });
+};
+
+export const FocusedLine: Story = {
+  // VRT: the ring is expected in this capture.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <InteractiveTabNav aria-label="Order navigation" variant="line" />
+  ),
+  play: async ({ canvasElement }) => focusActiveItem(canvasElement),
+};
+
+export const FocusedRounded: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <InteractiveTabNav aria-label="Order navigation" variant="rounded" />
+  ),
+  play: async ({ canvasElement }) => focusActiveItem(canvasElement),
+};
+
+export const FocusedPill: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <InteractiveTabNav aria-label="Order navigation" variant="pill" />
+  ),
+  play: async ({ canvasElement }) => focusActiveItem(canvasElement),
+};
+
+/**
+ * A TabNav whose route matches no item. Every other story has an active one, so
+ * without this frame an indicator left visible at the container corner would be
+ * caught by nothing.
+ */
+export const NoActiveItem: Story = {
+  // VRT: the indicator's hidden branch; a regression paints a stray highlight.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <TabNav.Root aria-label="Order navigation">
+      {ORDER_ITEMS.map((item) => (
+        <TabNav.Item key={item.href} href={item.href}>
+          {item.label}
+        </TabNav.Item>
+      ))}
+    </TabNav.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step(
+      "No item is current, so the indicator stays hidden",
+      async () => {
+        await expect(
+          canvas.queryAllByRole("link", { current: "page" })
+        ).toHaveLength(0);
+        await waitFor(() =>
+          expect(
+            canvasElement.querySelector<HTMLElement>(
+              ".nimbus-tab-nav__indicator"
+            )
+          ).toHaveStyle({ opacity: "0" })
+        );
       }
     );
   },
@@ -582,55 +669,106 @@ export const DeprecatedVariantAlias: Story = {
 };
 
 /**
- * Comprehensive smoke test showing multiple navigation items with one active
- * item. Validates the complete rendering of the TabNav component.
+ * The full `variant` x `size` grid, each nav with its first item active.
+ *
+ * The axes interact rather than merely scaling each other: size drives the
+ * `--tab-nav-*` padding and font-size vars, which set each item's box, which is
+ * what `getGeometry` measures to place the indicator — so the highlight's shape
+ * is a product of both (a 2px bar for `line`, a full-height rounded-rect or
+ * capsule for `rounded`/`pill`, each at three widths).
  */
-export const SmokeTest: Story = {
+/**
+ * An item that is both current and disabled — reachable here because `isCurrent`
+ * and `isDisabled` are independent props. `_disabled` dims the item, but the
+ * indicator is a root-level sibling the dimming cannot reach, so the highlight
+ * stays at full strength over a dimmed label.
+ */
+export const DisabledCurrentItem: Story = {
+  // VRT: dimmed label under an undimmed indicator.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
-    <InteractiveTabNav
-      aria-label="Page navigation"
-      items={[
-        { href: "/page/overview", label: "Overview" },
-        { href: "/page/details", label: "Details" },
-        { href: "/page/history", label: "History" },
-        { href: "/page/settings", label: "Settings" },
-      ]}
-    />
+    <Stack direction="column" gap="800">
+      {(["line", "rounded", "pill"] as const).map((variant) => (
+        <Stack key={variant} direction="column" gap="300">
+          <Text fontWeight="600">{variant}</Text>
+          <InteractiveTabNav
+            aria-label={`Order navigation (${variant})`}
+            variant={variant}
+            items={[
+              {
+                href: "/orders/123/general",
+                label: "General",
+                isDisabled: true,
+              },
+              { href: "/orders/123/items", label: "Items" },
+              { href: "/orders/123/shipping", label: "Shipping" },
+            ]}
+          />
+        </Stack>
+      ))}
+    </Stack>
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step("Renders nav landmark", async () => {
-      const nav = canvas.getByRole("navigation");
-      await expect(nav).toBeInTheDocument();
+    await step("The current item is also disabled", async () => {
+      const current = canvas.getAllByRole("link", { current: "page" });
+      await expect(current).toHaveLength(3);
+      await expect(
+        current.filter((el) => el.getAttribute("aria-disabled") !== "true")
+      ).toHaveLength(0);
+    });
+  },
+};
+
+export const SmokeTest: Story = {
+  // VRT: resting-visual carrier.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="800">
+      {(["line", "rounded", "pill"] as const).map((variant) => (
+        <Stack key={variant} direction="column" gap="300">
+          <Text fontWeight="600">{variant}</Text>
+          {(["sm", "md", "lg"] as const).map((size) => (
+            <InteractiveTabNav
+              key={size}
+              aria-label={`Order navigation (${variant} ${size})`}
+              variant={variant}
+              size={size}
+            />
+          ))}
+        </Stack>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Every cell renders a nav landmark", async () => {
+      await expect(canvas.getAllByRole("navigation")).toHaveLength(9);
     });
 
-    await step("Renders all navigation links", async () => {
-      const links = canvas.getAllByRole("link");
-      await expect(links).toHaveLength(4);
+    await step("Every cell has one active item", async () => {
+      await expect(
+        canvas.getAllByRole("link", { current: "page" })
+      ).toHaveLength(9);
     });
 
-    await step("Active item has correct aria-current", async () => {
-      const overviewLink = canvas.getByRole("link", { name: "Overview" });
-      await expect(overviewLink).toHaveAttribute("aria-current", "page");
-    });
-
-    await step("Inactive items lack aria-current", async () => {
-      const detailsLink = canvas.getByRole("link", { name: "Details" });
-      const historyLink = canvas.getByRole("link", { name: "History" });
-      const settingsLink = canvas.getByRole("link", { name: "Settings" });
-
-      await expect(detailsLink).not.toHaveAttribute("aria-current");
-      await expect(historyLink).not.toHaveAttribute("aria-current");
-      await expect(settingsLink).not.toHaveAttribute("aria-current");
-    });
-
-    await step("Links have correct href values", async () => {
-      const overviewLink = canvas.getByRole("link", { name: "Overview" });
-      const detailsLink = canvas.getByRole("link", { name: "Details" });
-
-      await expect(overviewLink).toHaveAttribute("href", "/page/overview");
-      await expect(detailsLink).toHaveAttribute("href", "/page/details");
+    await step("Every cell's indicator is positioned", async () => {
+      // If the hook stopped, the cells would render with no highlight.
+      const indicators = Array.from(
+        canvasElement.querySelectorAll<HTMLElement>(
+          ".nimbus-tab-nav__indicator"
+        )
+      );
+      await waitFor(() => {
+        expect(indicators.map((i) => i.style.opacity)).toEqual(
+          Array(9).fill("1")
+        );
+        expect(indicators.filter((i) => !i.style.transform)).toHaveLength(0);
+      });
     });
   },
 };

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
   Box,
   Button,
@@ -1328,11 +1328,6 @@ export const DeprecatedVariantAliases: Story = {
 
 const VARIANTS = ["line", "rounded", "pill"] as const;
 
-/**
- * Showcase the tab focus ring on each variant. The ring follows the tab's own
- * `borderRadius` — square, `200`, `full` — so each variant is a separate surface,
- * and only one element can hold focus at a time.
- */
 const focusSelectedTab = async (canvasElement: HTMLElement) => {
   const canvas = within(canvasElement);
   const tab = await canvas.findByRole("tab", { selected: true });
@@ -1344,6 +1339,11 @@ const focusSelectedTab = async (canvasElement: HTMLElement) => {
   await expect(tab).toHaveStyle({ outlineStyle: "solid" });
 };
 
+/**
+ * The tab focus ring on `line`. The ring follows the tab's own `borderRadius`, so
+ * each variant is its own surface, and only one element can hold focus at a time,
+ * hence one story per variant.
+ */
 export const FocusedTabLine: Story = {
   // VRT: the ring is expected in this capture.
   tags: ["vrt"],
@@ -1352,6 +1352,7 @@ export const FocusedTabLine: Story = {
   play: async ({ canvasElement }) => focusSelectedTab(canvasElement),
 };
 
+/** The same ring on `rounded`. */
 export const FocusedTabRounded: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -1363,6 +1364,7 @@ export const FocusedTabRounded: Story = {
   play: async ({ canvasElement }) => focusSelectedTab(canvasElement),
 };
 
+/** The same ring on `pill`. */
 export const FocusedTabPill: Story = {
   tags: ["vrt"],
   parameters: { chromatic: { disableSnapshot: false } },
@@ -1469,12 +1471,13 @@ export const SmokeTest: Story = {
       const indicators = Array.from(
         canvasElement.querySelectorAll<HTMLElement>(".nimbus-tabs__indicator")
       );
-      await expect(indicators.map((i) => i.style.opacity)).toEqual(
-        Array(9).fill("1")
-      );
-      await expect(indicators.filter((i) => !i.style.transform)).toHaveLength(
-        0
-      );
+      // The indicator is measured and positioned a beat after the tabs render.
+      await waitFor(() => {
+        expect(indicators.map((i) => i.style.opacity)).toEqual(
+          Array(9).fill("1")
+        );
+        expect(indicators.filter((i) => !i.style.transform)).toHaveLength(0);
+      });
     });
   },
 };

--- a/packages/nimbus/src/components/tabs/tabs.stories.tsx
+++ b/packages/nimbus/src/components/tabs/tabs.stories.tsx
@@ -680,6 +680,9 @@ export const WithDisabledKeys: Story = {
 };
 
 export const Disabled: Story = {
+  // VRT: the shared `layerStyle: "disabled"`, folded out of SmokeTest.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   args: {
     "data-testid": "disabled-tabs",
   },
@@ -786,6 +789,9 @@ export const Disabled: Story = {
 
       const activePanel = canvas.getByRole("tabpanel");
       await expect(activePanel).toHaveTextContent("This tab is also enabled.");
+
+      // Snapshotted: React Aria keeps `data-focus-visible` after a click.
+      enabledTab2.blur();
     });
   },
 };
@@ -1316,6 +1322,159 @@ export const DeprecatedVariantAliases: Story = {
       const tabs = await canvas.findAllByRole("tab");
       await expect(tabs).toHaveLength(3);
       await expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    });
+  },
+};
+
+const VARIANTS = ["line", "rounded", "pill"] as const;
+
+/**
+ * Showcase the tab focus ring on each variant. The ring follows the tab's own
+ * `borderRadius` — square, `200`, `full` — so each variant is a separate surface,
+ * and only one element can hold focus at a time.
+ */
+const focusSelectedTab = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const tab = await canvas.findByRole("tab", { selected: true });
+  // The Chromatic runner swallows the first `userEvent.tab()`, so focus directly.
+  // The outline assertion below proves the ring still paints.
+  tab.focus();
+  await expect(tab).toHaveFocus();
+  // Without this, a ring that never paints baselines as a silent pass.
+  await expect(tab).toHaveStyle({ outlineStyle: "solid" });
+};
+
+export const FocusedTabLine: Story = {
+  // VRT: the ring is expected in this capture.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { variant: "line", tabs: navigationTabs, tabListAriaLabel: "Sections" },
+  play: async ({ canvasElement }) => focusSelectedTab(canvasElement),
+};
+
+export const FocusedTabRounded: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: {
+    variant: "rounded",
+    tabs: navigationTabs,
+    tabListAriaLabel: "Sections",
+  },
+  play: async ({ canvasElement }) => focusSelectedTab(canvasElement),
+};
+
+export const FocusedTabPill: Story = {
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { variant: "pill", tabs: navigationTabs, tabListAriaLabel: "Sections" },
+  play: async ({ canvasElement }) => focusSelectedTab(canvasElement),
+};
+
+/**
+ * The panel is a second, independent focus surface: the `panel` slot has its own
+ * `_focusVisible`, and React Aria makes a childless panel tabbable.
+ */
+export const FocusedPanel: Story = {
+  // VRT: the panel slot's own ring, baselined nowhere else.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  args: { tabs: navigationTabs, tabListAriaLabel: "Sections" },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("The panel takes focus", async () => {
+      const panel = await canvas.findByRole("tabpanel");
+      // See `focusSelectedTab` on why this doesn't tab to the panel.
+      panel.focus();
+      await expect(panel).toHaveFocus();
+      await expect(panel).toHaveStyle({ outlineStyle: "solid" });
+    });
+  },
+};
+
+/**
+ * The `orientation` x `placement` grid, per variant — the axes every
+ * `compoundVariant` keys off, and the four branches `getGeometry` takes to place
+ * the indicator. `size` is held at the default, since SmokeTest spans it.
+ */
+export const LayoutMatrix: Story = {
+  // VRT: every `compoundVariant` and all four indicator-geometry branches.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="1200">
+      {VARIANTS.map((variant) => (
+        <Stack key={variant} direction="column" gap="600">
+          <Text fontWeight="600">{variant}</Text>
+          {(["horizontal", "vertical"] as const).map((orientation) =>
+            (["start", "end"] as const).map((placement) => (
+              <Stack key={`${orientation}-${placement}`} direction="column">
+                <Text fontSize="300" color="neutral.11">
+                  {orientation} / {placement}
+                </Text>
+                <Tabs.Root
+                  variant={variant}
+                  orientation={orientation}
+                  placement={placement}
+                  tabs={navigationTabs}
+                  tabListAriaLabel={`${variant} ${orientation} ${placement}`}
+                />
+              </Stack>
+            ))
+          )}
+        </Stack>
+      ))}
+    </Stack>
+  ),
+};
+
+/**
+ * The full `variant` x `size` grid. The axes interact: `size` writes the `--tabs-*`
+ * vars that size each tab's box, which is what `getGeometry` measures to place the
+ * indicator, and which `pill` derives its extra padding from.
+ */
+export const SmokeTest: Story = {
+  // VRT: resting-visual carrier.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="column" gap="1200">
+      {VARIANTS.map((variant) => (
+        <Stack key={variant} direction="column" gap="600">
+          <Text fontWeight="600">{variant}</Text>
+          {(["sm", "md", "lg"] as const).map((size) => (
+            <Tabs.Root
+              key={size}
+              variant={variant}
+              size={size}
+              tabs={navigationTabs}
+              tabListAriaLabel={`${variant} ${size}`}
+            />
+          ))}
+        </Stack>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Every cell has one selected tab", async () => {
+      await expect(
+        await canvas.findAllByRole("tab", { selected: true })
+      ).toHaveLength(9);
+    });
+
+    await step("Every cell's indicator is positioned", async () => {
+      // If the hook stopped, the cells would render with no highlight.
+      const indicators = Array.from(
+        canvasElement.querySelectorAll<HTMLElement>(".nimbus-tabs__indicator")
+      );
+      await expect(indicators.map((i) => i.style.opacity)).toEqual(
+        Array(9).fill("1")
+      );
+      await expect(indicators.filter((i) => !i.style.transform)).toHaveLength(
+        0
+      );
     });
   },
 };

--- a/packages/nimbus/src/components/tree/tree.stories.tsx
+++ b/packages/nimbus/src/components/tree/tree.stories.tsx
@@ -696,7 +696,165 @@ const SmokeTestView = () => {
   );
 };
 
+/**
+ * Selected, disabled, and both at once. They share one tree per size because
+ * `layerStyle: "disabled"` dims whichever background is underneath, so
+ * selected-disabled is its own pixel rather than a repeat of either.
+ */
+export const RowStates: Story = {
+  // VRT: Documents = selected, Project = disabled, Photos = both.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Stack direction="row" gap="800" alignItems="flex-start">
+      {(["sm", "md"] as const).map((size) => (
+        <Stack key={size} gap="200">
+          <Text fontWeight="700">{size}</Text>
+          <Tree.Root
+            aria-label={`Row states ${size}`}
+            size={size}
+            selectionMode="multiple"
+            selectedKeys={["documents", "photos"]}
+            disabledKeys={["project", "photos"]}
+            items={fileTree}
+            defaultExpandedKeys={["documents", "photos"]}
+          >
+            {renderNode}
+          </Tree.Root>
+        </Stack>
+      ))}
+    </Stack>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // React Aria builds the collection async; without this the frame can be empty.
+    await waitForTreeRows(canvas);
+    // A refusal to select disabled rows would drop the third state from the frame.
+    await expect(
+      canvasElement.querySelectorAll("[data-selected][data-disabled]")
+    ).not.toHaveLength(0);
+  },
+};
+
+/**
+ * The empty state, via `renderEmptyState`. No other story passes an empty
+ * collection, so the root's `&[data-empty]` rule renders nowhere else.
+ */
+export const EmptyState: Story = {
+  // VRT: root `&[data-empty]`; the only frame with an empty collection.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Tree.Root
+      aria-label="No files"
+      items={[]}
+      renderEmptyState={() => "No files yet"}
+    >
+      {renderNode}
+    </Tree.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step(
+      "Root carries data-empty and renders the placeholder",
+      async () => {
+        await canvas.findByText("No files yet");
+        // React Aria wraps the placeholder in a row, so row count proves nothing.
+        await expect(canvas.getByRole("treegrid")).toHaveAttribute(
+          "data-empty"
+        );
+      }
+    );
+  },
+};
+
+/**
+ * Keyboard focus on a row. The `item` slot's ring is `focusRing: "inside"`, unlike
+ * every other focus frame in this batch.
+ */
+export const FocusedRow: Story = {
+  // VRT: the ring is expected here, painted inside the row box.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <Tree.Root
+      aria-label="Files"
+      items={fileTree}
+      defaultExpandedKeys={["documents"]}
+    >
+      {renderNode}
+    </Tree.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const rows = await waitForTreeRows(canvas);
+
+    await step("Tab focuses the first row and paints a ring", async () => {
+      await userEvent.tab();
+      await expect(rows[0]).toHaveFocus();
+      // Without this, a ring that never paints baselines as a silent pass.
+      await expect(rows[0]).toHaveStyle({ outlineStyle: "solid" });
+    });
+  },
+};
+
+/**
+ * A drag held open mid-flight. Pointer dragging can't be paused for a capture, but
+ * the keyboard path can: Enter picks a row up and the drop target persists until
+ * Enter drops or Escape cancels. Nothing else renders `[data-dragging]` or
+ * `[data-drop-target]`.
+ */
+export const DragInProgress: Story = {
+  // VRT: deliberately captured mid-drag - the play must NOT complete the drop.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
+  // React Aria's keyboard drag session is a module global that only Enter or
+  // Escape ends - unmounting the story does not. Left live, it keeps `inert`
+  // over the page and an observer that re-applies it to whatever mounts next,
+  // so clicks in later stories go nowhere. Runs after Chromatic's capture.
+  beforeEach: () => () => {
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+  },
+  render: () => <FeatureTree aria-label="Files" selectionMode="none" />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
+
+    await step("Pick a row up from its drag handle", async () => {
+      const handle = canvas.getAllByRole("button", { name: /Drag/ })[0];
+      handle.focus();
+      await userEvent.keyboard("{Enter}");
+      await wait();
+    });
+
+    await step("Move the drop target down one position", async () => {
+      await userEvent.keyboard("{ArrowDown}");
+      await wait();
+
+      // Leave the drag open: this frame IS the snapshot.
+      await waitFor(() =>
+        expect(
+          canvasElement.querySelector("[data-drop-target]")
+        ).toBeInTheDocument()
+      );
+      // Keyboard DnD only offers row targets, so `DropIndicator` stays pointer-only.
+      await expect(
+        canvasElement.querySelector("[data-drop-target]")
+      ).toHaveAttribute("role", "row");
+      await expect(
+        canvasElement.querySelectorAll("[data-dragging]")
+      ).toHaveLength(1);
+    });
+  },
+};
+
 export const SmokeTest: Story = {
+  // VRT: resting-visual carrier.
+  tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => <SmokeTestView />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);


### PR DESCRIPTION
Things happened. This is take two for https://github.com/commercetools/nimbus/pull/1875

***

FEC-1180 & 1188 - Batch 9 & 17, Navigation & lists, Combobox

The PR contains VRTs for:
- TabNav 
- Tabs
- Combobox 
- Tree 
- DraggableList 
- Link 
- Pagination 

Known bug captured in a baseline: Pagination's page input clips page numbers above 999 (FEC-1272). Locales keeps currentPage={2500} so the clipping stays visible until it's fixed.

Associated docs continue to be revised & a full sweep will be done at the end.