### PR TITLE
fix(deps): switch pnpm catalogMode from strict to prefer

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,25 @@ packages:
 catalog:
   '@huggingface/transformers': ^3.8.1
 
-catalogMode: strict
+# catalogMode set to prefer rather than strict. Strict mode requires the
+# requested version to match the catalog specifier as an exact string, even
+# when the specifier is a range (as nearly every entry above and in the named
+# catalogs below is) that the requested version already satisfies. That exact
+# equality check breaks Renovate's targeted lockfile-update command,
+# `pnpm update <pkg>@<version> --recursive --lockfile-only`, which fails with
+# ERR_PNPM_CATALOG_VERSION_MISMATCH for any range-pinned catalog entry. This
+# is confirmed upstream pnpm behavior (pnpm/pnpm#11570, closed by #11706,
+# which declined to change the underlying comparison), so it will not be
+# fixed by a future pnpm release.
+#
+# Filed upstream: pnpm/pnpm#13715, proposing semver.satisfies for a range
+# catalog entry under strict mode instead of exact string equality. When that
+# lands and ships in a pnpm release, revisit switching this back to strict.
+#
+# Prefer mode still prefers the catalog version when compatible, but falls
+# back to the requested version with a warning instead of a hard error, which
+# unblocks Renovate.
+catalogMode: prefer
 
 # --- pnpm install & supply-chain settings (made explicit) ---
 # pnpm 11 ships these as built-in defaults. They are pinned here so the repo's


### PR DESCRIPTION
## Problem

Renovate PRs that bump a catalog-referenced dependency fail during the artifact update step with `ERR_PNPM_CATALOG_VERSION_MISMATCH`. This happens for any catalog entry that is a semver range (which is nearly every entry in this repo's catalogs, for example `tsx: ^4.23.5` in the `tooling` catalog), because Renovate's pnpm artifact updater runs a targeted lockfile bump:

```
pnpm update <pkg>@<version> --recursive --lockfile-only
```

Under `catalogMode: strict`, pnpm requires the requested version to be string-identical to the catalog specifier, even when the specifier is a range that the requested version already satisfies. A version like `4.23.9` satisfies `^4.23.5` in every practical sense, but strict mode compares the literal strings and rejects the update anyway.

This already hit `merchant-center-application-kit` across PRs #4047, #4049, and #4050 in that repo, and was fixed there in PR #4059 by making the same `catalogMode` change proposed here.

## Root cause

Confirmed upstream pnpm behavior, not a misconfiguration on our side:

- pnpm/pnpm#11570 reported the exact mismatch described above.
- pnpm/pnpm#11706 closed it, explicitly declining to change the underlying string comparison.
- pnpm/pnpm#13715 is a newer, still-open issue (filed by the same reporter) proposing the comparison switch to `semver.satisfies` for range catalog entries under strict mode. When that lands and ships in a pnpm release, this repo can revisit switching `catalogMode` back to `strict`.

## Fix

Switch `catalogMode` from `strict` to `prefer` in `pnpm-workspace.yaml`, with an inline comment explaining why and linking the upstream issues. Per pnpm's own docs (https://pnpm.io/settings#catalogmode), `prefer` still prefers the catalog version when it is compatible, but falls back to the requested direct version with a warning instead of a hard error when there is drift. This repo has no `check-workspace-constraints.js`-style CI script enforcing catalog usage, so `prefer`'s warning-only behavior does not remove any existing enforcement.

## Verification

Using the pinned `packageManager` version (`pnpm@11.10.0`, via `corepack pnpm`):

1. `pnpm install --lockfile-only` completes cleanly with a diff scoped to `pnpm-workspace.yaml` only, no unrelated lockfile or `package.json` reformatting.
2. Confirmed the failure mode still exists under the old setting: with `catalogMode` temporarily set back to `strict`, `pnpm update 'tsx@4.23.11' --recursive --lockfile-only` exits 1 with `ERR_PNPM_CATALOG_VERSION_MISMATCH` (`tsx` is catalog-pinned at `^4.23.5` in the `tooling` catalog, and `4.23.11` satisfies that range).
3. Restored `catalogMode: prefer` and re-ran the same style of command with `tsx@4.23.9` (a real, published, in-range patch release above `^4.23.5`, old enough to clear this repo's `minimumReleaseAge` supply-chain gate): `pnpm update 'tsx@4.23.9' --recursive --lockfile-only` exits 0, printing `[WARN] Catalog version mismatch for "tsx": using direct version "4.23.9" instead of catalog version "^4.23.5"` instead of hard-failing.
4. Reverted the test-only lockfile/`package.json` changes from step 3 with `git checkout --`, so this PR contains only the `pnpm-workspace.yaml` change.

## Not merging

Opening as draft. Not merging this myself.
