### PR TITLE
chore(renovate): raise Node heap limit for artifact updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>commercetools/renovate-config"]
+  "extends": ["github>commercetools/renovate-config"],
+  "toolSettings": {
+    "nodeMaxMemory": 2560
+  }
 }


### PR DESCRIPTION
## Problem

Renovate's artifact update step (pnpm-lock.yaml regeneration) is crashing with a JavaScript heap out of memory error on multiple open PRs (#1886, #1885, #1880), regardless of which package is being bumped:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

All three crashes share the identical Mark-Compact / Ineffective-mark-compacts signature, on Node 24.12.0 inside Renovate's containerbase runner, with peak heap usage clustering around 2020 to 2050 MB right before the crash. This happens on PRs touching completely unrelated packages (@huggingface/transformers, the Babel monorepo, minimatch), which rules out any single dependency's subtree as the cause; it is a property of the full pnpm-lock.yaml resolution, not of any one heavy package.

## Root cause

- pnpm 11's cold-cache dependency resolution has a confirmed, currently-open upstream memory regression versus pnpm 10 (roughly 47 percent higher peak RSS on the same graph) that is known to OOM-kill Mend-hosted Renovate's runners: pnpm/pnpm#12868, pnpm/pnpm#11860.
- This repo's pnpm-workspace.yaml supply-chain settings (minimumReleaseAge, minimumReleaseAgeStrict, minimumReleaseAgeIgnoreMissingTime, blockExoticSubdeps) add further registry-metadata fetch and retention pressure on top of that baseline regression, consistent with what the pnpm maintainers' own reproduction identifies as the memory driver.
- The combination pushes peak memory right up against the runner's effective heap ceiling (about 2048 MB), which is exactly where all three crashes land.

## Fix

Mend's hosted Renovate FAQ documents `toolSettings.nodeMaxMemory` as the supported, repo-level lever for exactly this failure mode, recommending a range of 1.5 GB to 2.5 GB, and states Mend-hosted apps do not otherwise cap this setting.

This PR sets it to 2560 MB, giving the pnpm resolution step more headroom than whatever the current implicit default is, without touching pnpm-workspace.yaml or any supply-chain security setting.

## Note

This is one mitigation, not a guaranteed fix. The underlying pnpm 11 memory regression is still open upstream, and if the hosted runner's actual container memory ceiling is at or below about 2560 MB total, this will not be enough and the failure may resurface as a kernel OOM kill instead of a clean V8 heap error. The next lever after this one is pnpm-workspace.yaml's minimumReleaseAge-related settings, which carries a real supply-chain tradeoff and is intentionally out of scope for this PR.

Draft because this needs to be verified against a currently failing branch (for example by rebasing #1880) before merging.
