### PR TITLE
chore(deps): bump pnpm to 11.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "check:package-shape": "node scripts/check-package-shape.mjs",
     "bundle-sizes:trend": "node scripts/bundle-sizes-trend.mjs"
   },
-  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85",
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:tooling",
     "@babel/core": "catalog:tooling",


### PR DESCRIPTION
## What

Bumps the pinned `packageManager` in `package.json` from `pnpm@11.10.0` to:

```
pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85
```

This matches the version already running cleanly in `commercetools/merchant-center-application-kit`.

## Why

Three open Renovate PRs on this repo (#1886, #1885, #1880) are currently failing with `FATAL ERROR: JavaScript heap out of memory` while Renovate's Node process updates lockfile artifacts. The pinned `pnpm@11.10.0` predates two confirmed, since-fixed upstream pnpm memory regressions that are the likely root cause:

- [pnpm/pnpm#12868](https://github.com/pnpm/pnpm/issues/12868): pnpm 11 resolution uses ~47% more memory than pnpm 10 on a cold metadata cache. Fixed by [pnpm/pnpm#12870](https://github.com/pnpm/pnpm/pull/12870), merged 2026-07-09.
- [pnpm/pnpm#13077](https://github.com/pnpm/pnpm/issues/13077): pnpm 11.11+ OOMs by re-serializing full package metadata for concurrent workspace cache hits. Fixed by [pnpm/pnpm#13079](https://github.com/pnpm/pnpm/pull/13079), merged 2026-07-16.

pnpm 11.14.0 (released 2026-07-17) postdates both fixes.

This is intentionally a separate PR from #1890 (`catalogMode: strict` → `prefer` in `pnpm-workspace.yaml`) and #1891 (`toolSettings.nodeMaxMemory` Renovate config change). It branches from current `main` and does not touch either of those files.

## Changes

- `package.json`: `packageManager` field updated to the exact pnpm 11.14.0 string above.
- `pnpm-lock.yaml`: no changes. Running a full `pnpm install` under pnpm 11.14.0 resolved the existing dependency graph identically to 11.10.0, so the lockfile diff is empty.

## Verification

All run locally against a fresh clone of this branch, after a full `pnpm install` under pnpm 11.14.0 (not `--lockfile-only`) and a full `pnpm run build`:

| Check | Command | Result |
|---|---|---|
| Install | `pnpm install` | Clean, lockfile unchanged, supply-chain policy check passed |
| Build | `pnpm run build` | Passed (tokens, packages, docs app, MCP server) |
| Typecheck | `pnpm run typecheck:strict` | Passed, 0 errors, all 5 workspace packages |
| Lint | `pnpm run lint` | Passed, 0 errors (2 pre-existing warnings unrelated to this change) |
| Unit tests | `pnpm run test:unit` | Passed, 126 test files / 1506 tests |
| Package shape | `pnpm run check:package-shape` | Passed (`attw` + `publint` clean on all publishable packages) |

Nothing broke as a result of the pnpm bump. Note: `pnpm run typecheck` (the non-strict root script) fails on a clean install before `pnpm run build` runs, because workspace packages resolve types from their `dist` output; this is pre-existing repo behavior (confirmed independent of this change) and not something this PR needs to address.

## Not merging

Draft PR per instructions, not merging.
