### PR TITLE
chore: add CODEOWNERS with mc-foundation-team-devs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners for the nimbus repository
+* @commercetools/mc-foundation-team-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global code owners for the nimbus repository
-* @commercetools/mc-foundation-team-devs
+* @commercetools/merchant-center-foundations-team-devs


### PR DESCRIPTION
Adds a CODEOWNERS file to require review from `@commercetools/mc-foundation-team-devs` for all changes to the nimbus repository.