### PR TITLE
chore(deps): pin pnpm renovate updates at 11.14.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -111,6 +111,11 @@
       "matchPackageNames": ["@babel/*"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "pnpm is pinned to 11.14.0 via packageManager. Versions past 11.14.0 have broken `deploy: legacy` support, which breaks `pnpm deploy` in our Docker build steps. Hold here until that's fixed upstream, then remove this rule.",
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Pins Renovate to stop proposing pnpm version bumps past `11.14.0` (the version currently pinned via `packageManager`).

## Why
Versions of pnpm past 11.14.0 have broken `deploy: legacy` support, which breaks `pnpm deploy` in our Docker build steps. Holding here until that's fixed upstream.

## How to resume updates
Remove the added `packageRules` entry for `pnpm` in `.github/renovate.json` once the upstream bug is fixed.