### PR TITLE
ci: auto-add changeset to Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
   "toolSettings": {
     "nodeMaxMemory": 2560
   },
+  "gitIgnoredAuthors": [
+    "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+  ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "description": "Force-enable vulnerability-fix PRs even for packages the packageRules below block on major updates (react/react-dom, @types/node, @babel/*). Without this, a CVE whose only fix crosses one of those major-version boundaries would be silently suppressed by our own ignore rules instead of raised.",

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -1,0 +1,44 @@
+name: Add changeset to Renovate PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, labeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  renovate-changeset:
+    if: >
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      contains(github.event.pull_request.labels.*.name, '🤖 Type: Dependencies')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Get GitHub token via the CT Changesets App so the resulting push
+      # re-triggers required status checks (the default GITHUB_TOKEN cannot).
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+
+      # This action talks entirely to the GitHub API (reads PR files/commits
+      # and writes the changeset via the Contents API) - no checkout needed.
+      - name: Add changeset for dependency update
+        uses: mscharley/dependency-changesets-action@874dac2372a085cb94f750e8bdf5b1173a838a75 # v1.2.5
+        with:
+          token: ${{ steps.generate_github_token.outputs.token }}
+          # Renovate's default commit prefix is "chore(deps): ...", which
+          # conventional-commit parsing treats as a non-releasable change
+          # (only fix/feat/breaking map to a bump type). Disable it so every
+          # dependency update gets a patch-level changeset instead of being
+          # silently skipped.
+          use-conventional-commits: false
+          commit-message: "chore(deps): add changeset for dependency update"
+          author-name: "github-actions[bot]"
+          author-email: "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## What

Adds `.github/workflows/renovate-changeset.yml`, which runs on Renovate
dependency-update PRs and pushes a changeset file (`.changeset/*.md`) into
the PR automatically, using
[`mscharley/dependency-changesets-action`](https://github.com/mscharley/dependency-changesets-action)
(pinned to `v1.2.5`).

Also updates `.github/renovate.json` with a `gitIgnoredAuthors` entry (see
"Why gitIgnoredAuthors" below).

## Why reuse the existing CT Changesets App instead of a new secret/PAT

The default `GITHUB_TOKEN` cannot be used to push a commit that re-triggers
other `pull_request` workflow runs (GitHub silently suppresses recursive
triggers from `GITHUB_TOKEN` pushes). `main`'s branch protection requires the
`build-and-test` status check, so a changeset pushed with `GITHUB_TOKEN` would
leave the PR permanently un-mergeable (stale/missing required check).

This repo already solves exactly this problem in `.github/workflows/release.yml`,
which mints an installation token from a dedicated GitHub App
(`CT_CHANGESETS_APP_ID` / `CT_CHANGESETS_APP_PEM` secrets, via
`tibdex/github-app-token@v2`) specifically so its pushes re-trigger CI. This PR
mirrors that exact mechanism rather than adding a new secret or PAT.

## Why `use-conventional-commits: false`

The action's README suggests enabling conventional-commit parsing to pick the
changeset bump type from the commit message (`fix:` → patch, `feat:` → minor,
`!`/`BREAKING CHANGE:` → major). Renovate's default commit prefix is
`chore(deps): ...`, and `chore` isn't `fix`/`feat`/breaking, so with parsing
enabled the action would classify every Renovate commit as bump type `none`
and silently skip the changeset entirely. Disabling conventional-commit
parsing makes the action always use `patch`, which matches how dependency
bumps are almost always released here.

## Why `gitIgnoredAuthors`

The action commits the changeset file back onto the Renovate PR's branch
under the identity `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`
(set via the action's `author-name`/`author-email` inputs, distinct from
Renovate's own commit identity). Without `gitIgnoredAuthors`, Renovate treats
that extra commit as a manual edit to the branch and stops force-pushing
further updates to it (its "has this PR been modified" safety check). Adding
the exact same "Name <email>" string to `gitIgnoredAuthors` tells Renovate to
disregard that specific commit author when making that determination. This is
a standard (non-admin-only) repo-level Renovate option — confirmed via
Renovate's own docs — and is exactly the config recommended in the action's
own README for Renovate.

## How it's scoped

The job only runs when:
- `github.event.pull_request.user.login == 'renovate[bot]'` (confirmed against
  recent PRs in this repo via the GitHub API — the REST payload's `user.login`
  is `renovate[bot]`, not `app/renovate`, which is only how `gh`'s GraphQL
  `author` field renders app authors).
- the PR has the `🤖 Type: Dependencies` label that Renovate already applies.

Trigger is `pull_request_target` (needed for secrets access), restricted to
`branches: [main]`, on `opened`/`synchronize`/`labeled`. No checkout step is
used — `mscharley/dependency-changesets-action` talks to the GitHub API
directly (reads PR files/commits, writes the changeset via the Contents API),
so there is nothing to check out.

## Verification note

This can't be fully exercised without a real Renovate PR. **Please verify
end-to-end on the next Renovate PR opened against `main`**: confirm the
workflow triggers, a changeset file lands in the PR, the push re-triggers
`build-and-test`, and Renovate continues to force-push subsequent updates to
the same PR without complaining about a modified branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)