### PR TITLE
test: stabilize flaky storybook interaction tests

### DIFF
--- a/packages/nimbus/src/components/rich-text-input/rich-text-input.stories.tsx
+++ b/packages/nimbus/src/components/rich-text-input/rich-text-input.stories.tsx
@@ -1045,9 +1045,12 @@ export const PendingMarksConsistency: Story = {
 
     // Close menu explicitly and wait for it to be gone to avoid toggle races
     await userEvent.keyboard("{Escape}");
-    await waitFor(() => {
-      expect(ui.queryByRole("menu")).not.toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(ui.queryByRole("menu")).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
 
     // Reopen and verify the Code mark stays checked (consistency)
     await userEvent.click(formattingMenuButton, { pointerEventsCheck: 0 });
@@ -1058,9 +1061,12 @@ export const PendingMarksConsistency: Story = {
     expect(codeMenuItemAfter).toHaveAttribute("aria-checked", "true");
 
     await userEvent.keyboard("{Escape}");
-    await waitFor(() => {
-      expect(ui.queryByRole("menu")).not.toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(ui.queryByRole("menu")).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
 
     // All three marks should wrap the selected text
     await waitFor(() => {

--- a/packages/nimbus/src/components/split-button/split-button.stories.tsx
+++ b/packages/nimbus/src/components/split-button/split-button.stories.tsx
@@ -134,7 +134,7 @@ export const Basic: Story = {
           () => {
             expect(portalCanvas.queryByRole("menu")).not.toBeInTheDocument();
           },
-          { timeout: 3000 }
+          { timeout: 8000 }
         );
 
         // Primary button should still show the first action (Save)
@@ -576,7 +576,7 @@ export const AccessibilityTest: Story = {
           () => {
             expect(portalCanvas.queryByRole("menu")).not.toBeInTheDocument();
           },
-          { timeout: 3000 }
+          { timeout: 8000 }
         );
 
         // Primary button should still show first action (Send Message)

--- a/packages/nimbus/src/components/splitter/splitter.stories.tsx
+++ b/packages/nimbus/src/components/splitter/splitter.stories.tsx
@@ -540,6 +540,24 @@ export const RestoreDefaultsWithZeroSize: Story = {
     await waitFor(() => {
       expect(Number(handle.getAttribute("aria-valuenow"))).toBe(0);
     });
+
+    // Zag's ResizeObserver-driven overflow detection (which drives the ScrollArea
+    // viewport's conditional tabIndex) settles asynchronously after the resize -
+    // wait for it so the a11y check below doesn't run mid-transition and flag a
+    // transiently non-focusable-but-scrollable viewport.
+    await waitFor(() => {
+      const viewports = Array.from(
+        canvasElement.querySelectorAll<HTMLElement>('[data-part="viewport"]')
+      );
+      for (const viewport of viewports) {
+        const overflowing =
+          viewport.scrollWidth > viewport.clientWidth ||
+          viewport.scrollHeight > viewport.clientHeight;
+        if (overflowing) {
+          expect(viewport).toHaveAttribute("tabindex", "0");
+        }
+      }
+    });
   },
 };
 

--- a/packages/nimbus/src/patterns/dialogs/info-dialog/info-dialog.stories.tsx
+++ b/packages/nimbus/src/patterns/dialogs/info-dialog/info-dialog.stories.tsx
@@ -80,9 +80,12 @@ export const Base: Story = {
     await step("Closes via the X button and restores focus", async () => {
       await userEvent.click(canvas.getByRole("button", { name: /close/i }));
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
 
       await waitFor(
         () => {
@@ -223,9 +226,12 @@ export const WithReactNodeTitle: Story = {
     await step("Closes via the X button and restores focus", async () => {
       await userEvent.click(canvas.getByRole("button", { name: /close/i }));
 
-      await waitFor(() => {
-        expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
 
       await waitFor(
         () => {

--- a/packages/nimbus/src/patterns/fields/date-range-picker-field/date-range-picker-field.stories.tsx
+++ b/packages/nimbus/src/patterns/fields/date-range-picker-field/date-range-picker-field.stories.tsx
@@ -135,10 +135,15 @@ export const Base: Story = {
 
       // Close calendar
       await userEvent.keyboard("{Escape}");
-      await waitFor(async () => {
-        const calendarAfter = within(document.body).queryByRole("application");
-        await expect(calendarAfter).not.toBeInTheDocument();
-      });
+      await waitFor(
+        async () => {
+          const calendarAfter = within(document.body).queryByRole(
+            "application"
+          );
+          await expect(calendarAfter).not.toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
 
       // Escape returns focus to the calendar button; keep it out of the snapshot.
       (document.activeElement as HTMLElement | null)?.blur();


### PR DESCRIPTION
## Summary

CI run [#31410284715](https://github.com/commercetools/nimbus/actions/runs/31410284715/job/93526422415) (PR #1897) failed 7 story tests across 5 files. That PR only touched a CI workflow file (`.github/workflows/renovate-changeset.yml`) — zero component/test code — confirming these are pre-existing flakes, not regressions.

All 7 failures trace back to the same root cause class: a `waitFor` assertion checking that a portal-rendered menu/dialog/popover has closed, timing out under CI resource contention (`browser.isolate: false` in `vitest.storybook.config.ts` runs many browser test files concurrently against one storybook dev server).

## Changes

- **rich-text-input**, **info-dialog**, **date-range-picker-field**: add explicit `{ timeout: 5000 }` to `waitFor` calls that had no timeout override (default 1000ms was too short).
- **split-button**: bump an existing `{ timeout: 3000 }` (added by #1808 for the same flake class) to `{ timeout: 8000 }` — 3s was no longer enough headroom.
- **splitter** ("Restore Defaults With Zero Size"): different symptom, same root cause class — an axe a11y violation (`scrollable-region-focusable`), because Zag's `ResizeObserver`-driven `tabIndex` update on the `ScrollArea` viewport hadn't settled before the `afterEach` a11y check ran. Added a `waitFor` asserting any overflowing viewport has `tabindex="0"` before the play function ends, rather than adjusting a timeout. `ScrollArea`'s own implementation is correct and untouched.

All new timeouts stay well under the project's 60s `testTimeout`.

## Testing

- Each file's play function fixed and verified individually.
- All 5 files run together: 83/83 tests passing.
- Splitter fix specifically re-run 4x to rule out residual flakiness (no a11y violations across any run).
- `prettier --check` and `eslint` clean on all 5 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)