### PR TITLE
fix(nimbus): bound postinstall chakra typegen with a hard timeout

### DIFF
--- a/.changeset/postinstall-typegen-timeout.md
+++ b/.changeset/postinstall-typegen-timeout.md
@@ -1,0 +1,6 @@
+---
+"@commercetools/nimbus": patch
+---
+
+Fixed an issue where installing this package could hang indefinitely during
+`postinstall` type generation in some environments.

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -152,7 +152,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.prod.json",
     "typecheck:dev": "tsc --noEmit -p tsconfig.json",
     "build-theme-typings": "pnpm chakra typegen ./src/theme/index.ts",
-    "postinstall": "test -f ./dist/index.es.js && chakra typegen ./dist/index.es.js || true",
+    "postinstall": "node scripts/postinstall-typegen.mjs ./dist/index.es.js",
     "bundles:analyze": "ANALYZE_BUNDLE=true vite build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/packages/nimbus/scripts/postinstall-typegen.mjs
+++ b/packages/nimbus/scripts/postinstall-typegen.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Best-effort, time-bounded `chakra typegen` runner for the published
+ * package's `postinstall` hook.
+ *
+ * This regenerates Chakra UI recipe/theme typings against the built theme
+ * entry point (`dist/index.es.js`) so consumers get typed component props
+ * without a manual step. It must never block or fail a consumer's install:
+ *
+ *   - If the entry point doesn't exist yet (e.g. a fresh clone before build,
+ *     or an environment that intentionally skips it), exit immediately.
+ *   - `chakra typegen` is run with a hard timeout via
+ *     scripts/lib/run-with-timeout.mjs, so a hang inside the upstream CLI
+ *     (observed in some Node/environment combinations) can never wedge the
+ *     install. See scripts/lib/run-with-timeout.mjs for the mechanism.
+ *   - Any non-success outcome (non-zero exit, timeout, spawn error) is
+ *     logged to stderr and swallowed — the process always exits 0.
+ *
+ * Usage:
+ *   node scripts/postinstall-typegen.mjs ./dist/index.es.js
+ */
+
+import { existsSync } from "node:fs";
+import { runWithTimeout } from "../../../scripts/lib/run-with-timeout.mjs";
+
+const POSTINSTALL_TIMEOUT_MS = 30_000;
+
+const entryPath = process.argv[2];
+
+if (!entryPath || !existsSync(entryPath)) {
+  process.exit(0);
+}
+
+const { code, timedOut, error } = await runWithTimeout(
+  "pnpm",
+  ["chakra", "typegen", entryPath],
+  { timeoutMs: POSTINSTALL_TIMEOUT_MS }
+);
+
+if (timedOut) {
+  console.error(
+    `[postinstall-typegen] chakra typegen timed out after ${POSTINSTALL_TIMEOUT_MS}ms — skipping type generation`
+  );
+} else if (error) {
+  console.error(
+    `[postinstall-typegen] chakra typegen failed to start (${error.message}) — skipping type generation`
+  );
+} else if (code !== 0) {
+  console.error(
+    `[postinstall-typegen] chakra typegen exited with code ${code} — skipping type generation`
+  );
+}
+
+process.exit(0);

--- a/scripts/lib/run-with-timeout.mjs
+++ b/scripts/lib/run-with-timeout.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * Runs a command in a child process with a hard wall-clock timeout, so a
+ * caller (e.g. a postinstall script) can never hang indefinitely regardless
+ * of what the invoked command does internally.
+ *
+ * This function is intentionally forgiving: it never rejects and never
+ * throws. Spawn failures (e.g. ENOENT for a missing binary) are captured
+ * into the resolved `error` field instead of propagating, matching the
+ * "best effort, non-blocking" contract callers like postinstall scripts
+ * need.
+ *
+ * On POSIX, the child is spawned detached (its own process group) so that
+ * on timeout the whole subtree can be killed via `process.kill(-pid, ...)`
+ * rather than leaving orphaned grandchildren behind. If the group kill fails
+ * (e.g. ESRCH because the group is already gone), it falls back to killing
+ * just the immediate child.
+ *
+ * The returned promise settles at (or very close to) `timeoutMs` on
+ * timeout — it does not wait for the child to confirm it has actually
+ * exited, since a sufficiently stuck child may never do so.
+ *
+ * Usage:
+ *   import { runWithTimeout } from "../../../scripts/lib/run-with-timeout.mjs";
+ *   const { code, timedOut, error } = await runWithTimeout("pnpm", ["build"], {
+ *     timeoutMs: 30_000,
+ *   });
+ */
+
+import { spawn } from "node:child_process";
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {{ timeoutMs?: number, cwd?: string, stdio?: import("node:child_process").StdioOptions }} [options]
+ * @returns {Promise<{ code: number|null, signal: NodeJS.Signals|null, timedOut: boolean, error: Error|null }>}
+ */
+export async function runWithTimeout(
+  command,
+  args = [],
+  { timeoutMs = 30_000, cwd, stdio = "inherit" } = {}
+) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer = null;
+
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(result);
+    };
+
+    let child;
+    try {
+      child = spawn(command, args, {
+        cwd,
+        stdio,
+        detached: process.platform !== "win32",
+      });
+    } catch (error) {
+      settle({ code: null, signal: null, timedOut: false, error });
+      return;
+    }
+
+    child.once("error", (error) => {
+      settle({ code: null, signal: null, timedOut: false, error });
+    });
+
+    child.once("exit", (code, signal) => {
+      settle({ code, signal, timedOut: false, error: null });
+    });
+
+    timer = setTimeout(() => {
+      if (settled) return;
+
+      try {
+        if (process.platform !== "win32") {
+          process.kill(-child.pid, "SIGKILL");
+        } else {
+          child.kill("SIGKILL");
+        }
+      } catch {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Process may already be gone; nothing more we can do.
+        }
+      }
+
+      settle({ code: null, signal: null, timedOut: true, error: null });
+    }, timeoutMs);
+  });
+}

--- a/scripts/lib/run-with-timeout.spec.mjs
+++ b/scripts/lib/run-with-timeout.spec.mjs
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { runWithTimeout } from "./run-with-timeout.mjs";
+
+describe("runWithTimeout", () => {
+  it("resolves promptly with exit code 0 for a fast, successful command", async () => {
+    const start = Date.now();
+    const result = await runWithTimeout(
+      process.execPath,
+      ["-e", "process.exit(0)"],
+      { timeoutMs: 5000, stdio: "ignore" }
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.code).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.error).toBeFalsy();
+    expect(elapsed).toBeLessThan(5000);
+  });
+
+  it("resolves with the non-zero exit code without throwing", async () => {
+    const result = await runWithTimeout(
+      process.execPath,
+      ["-e", "process.exit(7)"],
+      { timeoutMs: 5000, stdio: "ignore" }
+    );
+
+    expect(result.code).toBe(7);
+    expect(result.timedOut).toBe(false);
+    expect(result.error).toBeFalsy();
+  });
+
+  it("kills a hanging process and resolves near the timeout instead of waiting forever", async () => {
+    const timeoutMs = 250;
+    const start = Date.now();
+    const result = await runWithTimeout(
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000)"],
+      { timeoutMs, stdio: "ignore" }
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.timedOut).toBe(true);
+    // Generous upper bound so CI timing jitter doesn't flake this test.
+    expect(elapsed).toBeLessThan(timeoutMs * 5);
+  });
+
+  it("resolves with a populated error for a nonexistent command instead of throwing", async () => {
+    const result = await runWithTimeout(
+      "this-binary-does-not-exist-xyz",
+      [],
+      { timeoutMs: 5000, stdio: "ignore" }
+    );
+
+    expect(result.error).toBeTruthy();
+    expect(result.timedOut).toBe(false);
+  });
+});

--- a/scripts/lib/run-with-timeout.spec.mjs
+++ b/scripts/lib/run-with-timeout.spec.mjs
@@ -45,11 +45,10 @@ describe("runWithTimeout", () => {
   });
 
   it("resolves with a populated error for a nonexistent command instead of throwing", async () => {
-    const result = await runWithTimeout(
-      "this-binary-does-not-exist-xyz",
-      [],
-      { timeoutMs: 5000, stdio: "ignore" }
-    );
+    const result = await runWithTimeout("this-binary-does-not-exist-xyz", [], {
+      timeoutMs: 5000,
+      stdio: "ignore",
+    });
 
     expect(result.error).toBeTruthy();
     expect(result.timedOut).toBe(false);


### PR DESCRIPTION
## Problem

`@commercetools/nimbus`'s `postinstall` script runs `chakra typegen` against the built theme entry point so consumers get typed recipe/theme props without a manual step:

```json
"postinstall": "test -f ./dist/index.es.js && chakra typegen ./dist/index.es.js || true"
```

In some Node/environment combinations (confirmed on a Vercel build, Node 22.22.2, `@chakra-ui/cli@3.36.1`), `chakra typegen` throws `ReferenceError: process is not defined` inside its VM-based bundle loader (`loadViaVm`) — and instead of exiting, the Node process then **hangs indefinitely**. The existing `|| true` guard only protects against a non-zero *exit code*, not a process that never terminates, so the whole install (and the consumer's build) stalls forever.

Observed live: the `mc-app-kit-playground` Vercel preview deploy for [commercetools/merchant-center-application-kit#4081](https://github.com/commercetools/merchant-center-application-kit/pull/4081) was stuck "pending" because of this, while a sibling deploy without this dependency path completed normally.

## Fix

Bound `chakra typegen` with a hard wall-clock timeout so `postinstall` can never hang again, regardless of what the upstream CLI does internally:

- **`scripts/lib/run-with-timeout.mjs`** — spawns a command in a detached process group with a timeout; on timeout, force-kills the whole subtree (`SIGKILL` to the process group, falling back to the immediate child). Never rejects/throws — always resolves `{ code, signal, timedOut, error }`.
- **`packages/nimbus/scripts/postinstall-typegen.mjs`** — thin CLI wrapper: exits immediately if the built entry point doesn't exist, otherwise runs `chakra typegen` through the timeout wrapper (30s) and always exits `0`, logging a one-line note to stderr on any non-success outcome (timeout / non-zero exit / spawn error).
- **`packages/nimbus/package.json`** — `postinstall` now calls the wrapper. `build-theme-typings` (the internal maintainer build step) is intentionally untouched — it should still fail loudly if broken.
- Changeset added (patch, `@commercetools/nimbus`).

## Testing

TDD — `scripts/lib/run-with-timeout.spec.mjs` covers:
- fast successful exit
- non-zero exit code
- a genuinely hanging child process + timeout (asserts bounded wall-clock time)
- a nonexistent binary (spawn error)

Also reproduced the real `chakra typegen` crash live against this repo's built `dist/index.es.js` and confirmed the wrapper catches it and exits `0` instead of hanging.

```
pnpm vitest --project scripts run
# Test Files  3 passed (3)
#      Tests  70 passed (70)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
