### PR TITLE
fix(nimbus): repair postinstall typegen hook and broken CJS chunk requires

### DIFF
--- a/.changeset/fix-postinstall-typegen-and-cjs-chunks.md
+++ b/.changeset/fix-postinstall-typegen-and-cjs-chunks.md
@@ -1,0 +1,18 @@
+---
+"@commercetools/nimbus": minor
+---
+
+Fixed the `postinstall` type-generation hook, which previously crashed
+(`process is not defined`) instead of generating theme typings. It now targets a
+new, lightweight `@commercetools/nimbus/theme` entry point instead of the full
+package bundle. If type generation didn't run automatically, the manual command
+from the installation guide has changed to:
+
+```bash
+npx @chakra-ui/cli typegen node_modules/@commercetools/nimbus/dist/theme.es.js
+```
+
+Also fixed `require("@commercetools/nimbus")` (the CommonJS build), which threw
+`MODULE_NOT_FOUND` due to a chunk-filename mismatch introduced by the Vite
+8/Rolldown migration. CommonJS consumers can now `require` the package
+correctly.

--- a/.changeset/fix-postinstall-typegen-and-cjs-chunks.md
+++ b/.changeset/fix-postinstall-typegen-and-cjs-chunks.md
@@ -1,18 +1,23 @@
 ---
 "@commercetools/nimbus": minor
+"@commercetools/nimbus-tokens": minor
 ---
 
-Fixed the `postinstall` type-generation hook, which previously crashed
-(`process is not defined`) instead of generating theme typings. It now targets a
-new, lightweight `@commercetools/nimbus/theme` entry point instead of the full
-package bundle. If type generation didn't run automatically, the manual command
-from the installation guide has changed to:
+`@commercetools/nimbus`: Fixed the `postinstall` type-generation hook, which
+previously crashed (`process is not defined`) instead of generating theme
+typings. It now targets a new, lightweight `@commercetools/nimbus/theme` entry
+point instead of the full package bundle. If type generation didn't run
+automatically, the manual command from the installation guide has changed to:
 
 ```bash
 npx @chakra-ui/cli typegen node_modules/@commercetools/nimbus/dist/theme.es.js
 ```
 
-Also fixed `require("@commercetools/nimbus")` (the CommonJS build), which threw
-`MODULE_NOT_FOUND` due to a chunk-filename mismatch introduced by the Vite
-8/Rolldown migration. CommonJS consumers can now `require` the package
-correctly.
+Also fixed `require("@commercetools/nimbus")` and
+`require("@commercetools/nimbus/<component>")` (the CommonJS build), which threw
+`MODULE_NOT_FOUND`. CommonJS consumers can now `require` the package and its
+component subpaths correctly.
+
+`@commercetools/nimbus-tokens`: Fixed `require("@commercetools/nimbus-tokens")`
+(the CommonJS build), which threw `MODULE_NOT_FOUND`. CommonJS consumers can now
+`require` the package correctly.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:mcp": "pnpm --filter @commercetools/nimbus-mcp build",
     "build:docs-data": "pnpm --filter docs build:docs",
     "build:docs": "pnpm --filter './apps/docs' build",
-    "build:tokens": "pnpm --filter @commercetools/nimbus-tokens run build && preconstruct build",
+    "build:tokens": "pnpm --filter @commercetools/nimbus-tokens run build && preconstruct build && node packages/tokens/scripts/postbuild-cjs-extensions.mjs",
     "build:storybook": "pnpm --filter @commercetools/nimbus build && pnpm --filter @commercetools/nimbus run build-storybook",
     "changeset": "changeset",
     "openspec": "openspec",

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -17,6 +17,16 @@
       }
     },
     "./package.json": "./package.json",
+    "./theme": {
+      "import": {
+        "types": "./dist/theme.d.ts",
+        "default": "./dist/theme.es.js"
+      },
+      "require": {
+        "types": "./dist/theme.d.cts",
+        "default": "./dist/theme.cjs"
+      }
+    },
     "./setup-jsdom-polyfills": {
       "import": {
         "types": "./dist/setup-jsdom-polyfills.d.ts",
@@ -67,6 +77,7 @@
       "plugins/webpack": ["./dist/plugins/webpack.d.ts"],
       "plugins/vite": ["./dist/plugins/vite.d.ts"],
       "plugins/stub": ["./dist/plugins/stub.d.ts"],
+      "theme": ["./dist/theme.d.ts"],
       "*": ["./dist/index.d.ts"]
     }
   },
@@ -152,7 +163,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.prod.json",
     "typecheck:dev": "tsc --noEmit -p tsconfig.json",
     "build-theme-typings": "pnpm chakra typegen ./src/theme/index.ts",
-    "postinstall": "test -f ./dist/index.es.js && chakra typegen ./dist/index.es.js || true",
+    "postinstall": "test -f ./dist/theme.es.js && chakra typegen ./dist/theme.es.js || true",
     "bundles:analyze": "ANALYZE_BUNDLE=true vite build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/packages/nimbus/scripts/postbuild-types.mjs
+++ b/packages/nimbus/scripts/postbuild-types.mjs
@@ -5,9 +5,12 @@
  *
  * Three tasks, in order:
  *
- *   1. Relocate setup-jsdom-polyfills.d.ts from dist/test/ to dist/ to match
- *      where the runtime files (.es.js / .cjs) land. vite-plugin-dts preserves
- *      src/ subdirs; vite emits the runtime flat for declared entry points.
+ *   1. Relocate setup-jsdom-polyfills.d.ts (from dist/test/) and theme.d.ts
+ *      (from dist/theme/index.d.ts) to dist/ to match where the runtime
+ *      files (.es.js / .cjs) land. vite-plugin-dts preserves src/ subdirs;
+ *      vite emits the runtime flat for declared entry points. dist/theme/
+ *      itself is kept — other components' .d.ts files still import from
+ *      ./theme/recipes, ./theme/tokens, etc.
  *
  *   2. Walk every .d.ts in dist/ and rewrite bare relative imports
  *      (`export * from './foo'`) to include explicit `.js` extensions
@@ -16,9 +19,10 @@
  *      moduleResolution: "nodenext". The shared rewriter lives at
  *      scripts/lib/rewrite-relative-imports.mjs.
  *
- *   3. Duplicate index.d.ts and setup-jsdom-polyfills.d.ts to .d.cts variants
- *      for the CJS exports path. Identical content; the extension flips how
- *      TypeScript interprets the module kind (CJS regardless of `"type"`).
+ *   3. Duplicate index.d.ts, theme.d.ts, and setup-jsdom-polyfills.d.ts to
+ *      .d.cts variants for the CJS exports path. Identical content; the
+ *      extension flips how TypeScript interprets the module kind (CJS
+ *      regardless of `"type"`).
  *
  * Steps 1 & 2 run before step 3 so the .d.cts copies inherit the rewritten
  * imports.
@@ -28,18 +32,11 @@
  * `vite build` (which emits dist/test/) before invoking this script.
  */
 
-import {
-  copyFileSync,
-  existsSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { copyFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { walkAndRewriteImports } from "../../../scripts/lib/rewrite-relative-imports.mjs";
+import { fixCjsChunkExtensions } from "../../../scripts/lib/rewrite-cjs-chunk-extensions.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const DIST = join(__dirname, "..", "dist");
@@ -51,6 +48,15 @@ const RELOCATIONS = [
   {
     from: join(DIST, "test", "setup-jsdom-polyfills.d.ts"),
     to: join(DIST, "setup-jsdom-polyfills.d.ts"),
+  },
+  {
+    // theme/index.d.ts only declares `system` typed against
+    // `@chakra-ui/react`'s public types — no relative imports to rewrite —
+    // so a plain copy is safe. Unlike dist/test/, dist/theme/ is NOT removed
+    // afterward: sibling component .d.ts files still import from
+    // ./theme/recipes, ./theme/tokens, etc.
+    from: join(DIST, "theme", "index.d.ts"),
+    to: join(DIST, "theme.d.ts"),
   },
 ];
 
@@ -78,6 +84,7 @@ console.log(`[postbuild-types] rewrote imports in ${rewritten} .d.ts file(s)`);
 
 const ENTRY_POINTS = [
   "index",
+  "theme",
   "setup-jsdom-polyfills",
   "plugins/webpack",
   "plugins/vite",
@@ -112,52 +119,20 @@ console.log(`[postbuild-types] wrote CJS stub content to plugins/stub.cjs`);
 // Rolldown names chunks with the template `[name]-[hash].[format].js`.
 // For CJS chunks this produces `.cjs.js`. In a `type: "module"` package,
 // Node treats `.js` files as ESM, so `require("./chunk.cjs.js")` fails.
-// Rename `.cjs.js` → `.cjs` and update references in CJS entry points.
+// Rename `.cjs.js` → `.cjs` and update references in CJS entry points AND
+// in every other chunk (chunks require each other, not just entry points —
+// see scripts/lib/rewrite-cjs-chunk-extensions.mjs for the regression this
+// guards against).
 
-const CHUNKS_DIR = join(DIST, "chunks");
-if (existsSync(CHUNKS_DIR)) {
-  const cjsChunks = readdirSync(CHUNKS_DIR).filter((f) =>
-    f.endsWith(".cjs.js")
+const cjsEntryFiles = [
+  join(DIST, "index.cjs"),
+  ...ENTRY_POINTS.filter((e) => e !== "index").map((e) =>
+    join(DIST, `${e}.cjs`)
+  ),
+];
+const { renamed, filesUpdated } = fixCjsChunkExtensions(DIST, cjsEntryFiles);
+if (renamed > 0) {
+  console.log(
+    `[postbuild-types] renamed ${renamed} CJS chunk(s): .cjs.js → .cjs (updated ${filesUpdated} referencing file(s))`
   );
-  const renames = new Map();
-
-  for (const oldName of cjsChunks) {
-    const newName = oldName.replace(/\.cjs\.js$/, ".cjs");
-    renameSync(join(CHUNKS_DIR, oldName), join(CHUNKS_DIR, newName));
-    renames.set(oldName, newName);
-
-    // Rename the sourcemap too
-    const oldMap = oldName + ".map";
-    const newMap = newName + ".map";
-    if (existsSync(join(CHUNKS_DIR, oldMap))) {
-      renameSync(join(CHUNKS_DIR, oldMap), join(CHUNKS_DIR, newMap));
-    }
-  }
-
-  // Update require() references in all CJS entry points
-  if (renames.size > 0) {
-    const cjsEntries = [
-      join(DIST, "index.cjs"),
-      ...ENTRY_POINTS.filter((e) => e !== "index").map((e) =>
-        join(DIST, `${e}.cjs`)
-      ),
-    ];
-
-    for (const entry of cjsEntries) {
-      if (!existsSync(entry)) continue;
-      let content = readFileSync(entry, "utf8");
-      let changed = false;
-      for (const [oldName, newName] of renames) {
-        if (content.includes(oldName)) {
-          content = content.replaceAll(oldName, newName);
-          changed = true;
-        }
-      }
-      if (changed) writeFileSync(entry, content);
-    }
-
-    console.log(
-      `[postbuild-types] renamed ${renames.size} CJS chunk(s): .cjs.js → .cjs`
-    );
-  }
 }

--- a/packages/nimbus/scripts/postbuild-types.mjs
+++ b/packages/nimbus/scripts/postbuild-types.mjs
@@ -37,6 +37,7 @@ import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { walkAndRewriteImports } from "../../../scripts/lib/rewrite-relative-imports.mjs";
 import { fixCjsChunkExtensions } from "../../../scripts/lib/rewrite-cjs-chunk-extensions.mjs";
+import { listCjsEntryFiles } from "../../../scripts/lib/list-cjs-entry-files.mjs";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const DIST = join(__dirname, "..", "dist");
@@ -51,10 +52,14 @@ const RELOCATIONS = [
   },
   {
     // theme/index.d.ts only declares `system` typed against
-    // `@chakra-ui/react`'s public types — no relative imports to rewrite —
-    // so a plain copy is safe. Unlike dist/test/, dist/theme/ is NOT removed
-    // afterward: sibling component .d.ts files still import from
-    // ./theme/recipes, ./theme/tokens, etc.
+    // `@chakra-ui/react`'s public types. A plain copy is safe here
+    // regardless of what it currently imports: step 2 below
+    // (walkAndRewriteImports) runs over every .d.ts in dist/ after
+    // relocation and rewrites relative imports unconditionally, so import
+    // paths are handled either way, not because this file happens to have
+    // none today. Unlike dist/test/, dist/theme/ is NOT removed afterward:
+    // sibling component .d.ts files still import from ./theme/recipes,
+    // ./theme/tokens, etc.
     from: join(DIST, "theme", "index.d.ts"),
     to: join(DIST, "theme.d.ts"),
   },
@@ -123,13 +128,15 @@ console.log(`[postbuild-types] wrote CJS stub content to plugins/stub.cjs`);
 // in every other chunk (chunks require each other, not just entry points —
 // see scripts/lib/rewrite-cjs-chunk-extensions.mjs for the regression this
 // guards against).
-
-const cjsEntryFiles = [
-  join(DIST, "index.cjs"),
-  ...ENTRY_POINTS.filter((e) => e !== "index").map((e) =>
-    join(DIST, `${e}.cjs`)
-  ),
-];
+//
+// Entry points aren't limited to the curated ENTRY_POINTS list above:
+// vite.config.ts's createEntries() also globs every
+// src/{components,patterns}/**/index.ts into its own CJS entry under
+// dist/components/*.cjs — well over a hundred of them. Any of those can
+// require() a renamed chunk too, so scan every entry `.cjs` file actually on
+// disk (skipping dist/chunks/ itself) rather than deriving the list from
+// ENTRY_POINTS.
+const cjsEntryFiles = listCjsEntryFiles(DIST);
 const { renamed, filesUpdated } = fixCjsChunkExtensions(DIST, cjsEntryFiles);
 if (renamed > 0) {
   console.log(

--- a/packages/nimbus/src/docs/home-installation.mdx
+++ b/packages/nimbus/src/docs/home-installation.mdx
@@ -97,7 +97,7 @@ Or run `pnpm approve-builds` after installation.
 If the postinstall doesn't run, generate types manually:
 
 ```bash
-npx @chakra-ui/cli typegen node_modules/@commercetools/nimbus/dist/index.es.js
+npx @chakra-ui/cli typegen node_modules/@commercetools/nimbus/dist/theme.es.js
 ```
 
 ### Design Token Autocomplete (Optional)

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -45,6 +45,14 @@ const createEntries = async () => {
   // markdown, icons, etc.) for typegen crashes: it forces `chakra-cli` to
   // fully evaluate browser-only code (e.g. `document.createElement` at
   // module scope) in a headless Node sandbox with no DOM.
+  //
+  // The `postinstall` script in package.json still ends in `|| true`: theme
+  // typegen is a nice-to-have (better editor autocomplete for theme tokens),
+  // not something a consumer's install may ever fail on. If this entry ever
+  // regresses back to crashing, `|| true` intentionally keeps that failure
+  // silent rather than breaking `pnpm install` for every consumer — the cost
+  // is no error trail, so if theme typegen stops working, this comment (and
+  // the entry above) is where to look first.
   entries.set(
     "theme",
     fileURLToPath(new URL("src/theme/index.ts", import.meta.url))

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -39,6 +39,16 @@ const createEntries = async () => {
   // Main entries — must match the `exports` field in `package.json`.
   // `index` bundles all non-component code (theme, hooks, etc).
   entries.set("index", fileURLToPath(new URL("src/index.ts", import.meta.url)));
+  // Theme-only entry (tokens/recipes/config — no React components, no DOM
+  // side effects). Consumers' `chakra typegen` postinstall hook targets this
+  // instead of `index`, since bundling the full component library (React,
+  // markdown, icons, etc.) for typegen crashes: it forces `chakra-cli` to
+  // fully evaluate browser-only code (e.g. `document.createElement` at
+  // module scope) in a headless Node sandbox with no DOM.
+  entries.set(
+    "theme",
+    fileURLToPath(new URL("src/theme/index.ts", import.meta.url))
+  );
   // Separate entry so the jest polyfill ships as CJS.
   entries.set(
     "setup-jsdom-polyfills",
@@ -157,7 +167,7 @@ export default defineConfig(async () => {
           // otherwise you get an error when you `require` them
           const extension = format === "cjs" ? `${format}` : `${format}.js`;
           // Keep main entrypoints at root, put everything else in subfolders
-          if (["index", "setup-jsdom-polyfills"].includes(entryName)) {
+          if (["index", "theme", "setup-jsdom-polyfills"].includes(entryName)) {
             return `${entryName}.${extension}`;
           }
           // Plugin entries keep their plugins/ prefix

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -7,7 +7,10 @@
   "exports": {
     ".": {
       "import": "./dist/commercetools-nimbus-tokens.esm.js",
-      "require": "./dist/commercetools-nimbus-tokens.cjs.js"
+      "require": {
+        "types": "./dist/commercetools-nimbus-tokens.d.cts",
+        "default": "./dist/commercetools-nimbus-tokens.cjs"
+      }
     }
   },
   "publishConfig": {

--- a/packages/tokens/scripts/postbuild-cjs-extensions.mjs
+++ b/packages/tokens/scripts/postbuild-cjs-extensions.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Post-processes preconstruct's CJS output for `@commercetools/nimbus-tokens`.
+ *
+ * `packages/tokens/package.json` declares `"type": "module"`, but
+ * preconstruct's CJS entrypoint (`dist/commercetools-nimbus-tokens.cjs.js`,
+ * which internally `require()`s `.cjs.dev.js` / `.cjs.prod.js` for the
+ * dev/prod split) is plain CJS syntax in files ending `.js` — which Node
+ * treats as ESM under `"type": "module"`, so the inner `require()` calls
+ * throw `MODULE_NOT_FOUND`. This is the same class of bug
+ * `scripts/lib/rewrite-cjs-chunk-extensions.mjs` fixes for the nimbus
+ * package's Rolldown chunks; here it's preconstruct's flat entrypoint trio
+ * instead of a chunk graph, so it's handled by the sibling helper
+ * `scripts/lib/rewrite-preconstruct-cjs-extensions.mjs`.
+ *
+ * Only `dist/` (the root `index.ts` entrypoint) is affected. The
+ * `generated/ts/dist/` and `generated/chakra/dist/` sub-entrypoints each ship
+ * their own `package.json` with no `"type"` field, so Node already treats
+ * their `.js` files as CommonJS by default — nothing to fix there.
+ *
+ * After renaming, also duplicates the `.cjs.d.ts` declaration file to
+ * `.d.cts`: TypeScript's node16/nodenext resolution looks for a `.d.cts`
+ * sibling for a `.cjs` runtime file, not a `.cjs.d.ts` one.
+ *
+ * Run after `preconstruct build` (which emits the `dist/` this script
+ * rewrites). Idempotent: safe to run against an already-fixed `dist/`.
+ */
+
+import { copyFileSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fixPreconstructCjsExtensions } from "../../../scripts/lib/rewrite-preconstruct-cjs-extensions.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const DIST = join(__dirname, "..", "dist");
+
+const { renamed, filesUpdated } = fixPreconstructCjsExtensions(DIST);
+if (renamed > 0) {
+  console.log(
+    `[postbuild-cjs-extensions] renamed ${renamed} CJS file(s): .cjs.js → .cjs (updated ${filesUpdated} referencing file(s))`
+  );
+}
+
+const cjsDts = join(DIST, "commercetools-nimbus-tokens.cjs.d.ts");
+const dCts = join(DIST, "commercetools-nimbus-tokens.d.cts");
+if (existsSync(cjsDts)) {
+  copyFileSync(cjsDts, dCts);
+  console.log(
+    `[postbuild-cjs-extensions] ${relative(DIST, cjsDts)} → ${relative(DIST, dCts)}`
+  );
+}

--- a/scripts/check-package-shape.mjs
+++ b/scripts/check-package-shape.mjs
@@ -37,11 +37,17 @@ const REPORT_ONLY = false;
 // package the changeset bot ships should be linted here.
 //
 // `@commercetools/nimbus-tokens` is intentionally excluded: it ships with a
-// pre-existing shape issue (preconstruct emits `.cjs.js` under a package that
-// declares `"type": "module"`, so the CJS path is broken at runtime, and the
-// exports map has no `types` condition). Tracked in
-// https://github.com/commercetools/nimbus/issues/1509 — re-add this entry when
-// that lands.
+// pre-existing shape issue tracked in
+// https://github.com/commercetools/nimbus/issues/1509. Two interacting
+// problems were reported there — preconstruct emits `.cjs.js` under a
+// package that declares `"type": "module"`, so the CJS path was broken at
+// runtime; and the `exports` map's `import` condition has no `types`
+// condition, so ESM consumers under node16/bundler resolution get no types.
+// The first (runtime CJS breakage) is fixed by
+// `packages/tokens/scripts/postbuild-cjs-extensions.mjs` and the `require`
+// condition's `types` entry in `packages/tokens/package.json`. The second
+// (missing ESM types) is still open — re-add this entry once that's
+// resolved too and `pnpm check:package-shape` exits 0 for this package.
 const PACKAGES = [
   { name: "@commercetools/nimbus", dir: join(ROOT, "packages/nimbus") },
   {

--- a/scripts/lib/list-cjs-entry-files.mjs
+++ b/scripts/lib/list-cjs-entry-files.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Recursively collects every CJS entry-point file (`*.cjs`) under `distDir`,
+ * skipping the top-level `chunks/` directory.
+ *
+ * `dist/chunks/` holds shared code split out of entry points by the
+ * bundler — those files are targets referenced BY entry points (via
+ * `require()`), not entry points themselves, so they're excluded here and
+ * handled separately by `rewrite-cjs-chunk-extensions.mjs`.
+ *
+ * Every other `.cjs` file anywhere under `dist/` is a real entry point:
+ * `dist/index.cjs`, `dist/theme.cjs`, `dist/plugins/*.cjs`, and one
+ * `dist/components/<name>.cjs` per component/pattern glob'd by
+ * `vite.config.ts`'s `createEntries()` — all of which may contain
+ * `require()` calls into `dist/chunks/` and so need their chunk references
+ * fixed up alongside the chunks themselves.
+ *
+ * Usage:
+ *   import { listCjsEntryFiles } from "./list-cjs-entry-files.mjs";
+ *   const cjsEntryFiles = listCjsEntryFiles(distDir);
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * @param {string} distDir
+ * @returns {string[]} absolute paths to every entry `.cjs` file under distDir
+ */
+export function listCjsEntryFiles(distDir) {
+  const results = [];
+
+  const walk = (dir) => {
+    for (const name of readdirSync(dir)) {
+      if (dir === distDir && name === "chunks") continue;
+
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+      } else if (name.endsWith(".cjs")) {
+        results.push(full);
+      }
+    }
+  };
+
+  walk(distDir);
+  return results;
+}

--- a/scripts/lib/list-cjs-entry-files.spec.mjs
+++ b/scripts/lib/list-cjs-entry-files.spec.mjs
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listCjsEntryFiles } from "./list-cjs-entry-files.mjs";
+
+let distDir;
+
+beforeEach(() => {
+  distDir = mkdtempSync(join(tmpdir(), "nimbus-postbuild-types-entries-"));
+});
+
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true });
+});
+
+describe("listCjsEntryFiles", () => {
+  it("collects top-level .cjs entry files", () => {
+    writeFileSync(join(distDir, "index.cjs"), "");
+    writeFileSync(join(distDir, "theme.cjs"), "");
+    writeFileSync(join(distDir, "index.d.ts"), "");
+
+    const result = listCjsEntryFiles(distDir);
+
+    expect(result.sort()).toEqual(
+      [join(distDir, "index.cjs"), join(distDir, "theme.cjs")].sort()
+    );
+  });
+
+  it("recurses into nested entry directories (e.g. components/, plugins/)", () => {
+    mkdirSync(join(distDir, "components"));
+    writeFileSync(join(distDir, "components", "button.cjs"), "");
+    writeFileSync(join(distDir, "components", "button.d.ts"), "");
+    mkdirSync(join(distDir, "plugins"));
+    writeFileSync(join(distDir, "plugins", "webpack.cjs"), "");
+
+    const result = listCjsEntryFiles(distDir);
+
+    expect(result.sort()).toEqual(
+      [
+        join(distDir, "components", "button.cjs"),
+        join(distDir, "plugins", "webpack.cjs"),
+      ].sort()
+    );
+  });
+
+  it("skips the chunks directory entirely", () => {
+    writeFileSync(join(distDir, "index.cjs"), "");
+    mkdirSync(join(distDir, "chunks"));
+    writeFileSync(join(distDir, "chunks", "leaf-abc123.cjs"), "");
+
+    const result = listCjsEntryFiles(distDir);
+
+    expect(result).toEqual([join(distDir, "index.cjs")]);
+  });
+
+  it("returns an empty array when there are no .cjs files", () => {
+    writeFileSync(join(distDir, "index.d.ts"), "");
+    expect(listCjsEntryFiles(distDir)).toEqual([]);
+  });
+});

--- a/scripts/lib/rewrite-cjs-chunk-extensions.mjs
+++ b/scripts/lib/rewrite-cjs-chunk-extensions.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * Renames Rolldown-emitted `.cjs.js` chunk files to `.cjs` and rewrites every
+ * `require(".../<old-name>")` reference to match.
+ *
+ * Rolldown names chunks with the template `[name]-[hash].[format].js`. For
+ * CJS chunks this produces `<name>-<hash>.cjs.js`. In a `"type": "module"`
+ * package, Node treats any `.js` file as ESM regardless of content, so
+ * `require("./chunk.cjs.js")` throws `ERR_REQUIRE_ESM` — renaming to `.cjs`
+ * sidesteps that, since the `.cjs` extension is always CommonJS.
+ *
+ * Renaming alone isn't enough: chunks commonly `require()` *other* chunks
+ * (not just entry points), and those cross-chunk references embed the old
+ * `.cjs.js` name as a literal string. Skipping them leaves a real
+ * `MODULE_NOT_FOUND` at runtime — the renamed file no longer matches the
+ * string still baked into whichever chunk imported it. This scans every
+ * `.cjs` file inside the chunks directory (post-rename) in addition to the
+ * caller-supplied entry-point files, so both directions get fixed.
+ *
+ * Usage:
+ *   import { fixCjsChunkExtensions } from "./rewrite-cjs-chunk-extensions.mjs";
+ *   const { renamed, filesUpdated } = fixCjsChunkExtensions(distDir, [
+ *     join(distDir, "index.cjs"),
+ *   ]);
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * @param {string} distDir - directory containing a `chunks/` subfolder
+ * @param {string[]} entryPointCjsFiles - absolute paths to top-level `.cjs`
+ *   entry points that may reference chunks (e.g. `dist/index.cjs`)
+ * @returns {{ renamed: number, filesUpdated: number }}
+ */
+export function fixCjsChunkExtensions(distDir, entryPointCjsFiles) {
+  const chunksDir = join(distDir, "chunks");
+  if (!existsSync(chunksDir)) {
+    return { renamed: 0, filesUpdated: 0 };
+  }
+
+  const cjsJsChunks = readdirSync(chunksDir).filter((f) =>
+    f.endsWith(".cjs.js")
+  );
+  const renames = new Map();
+
+  for (const oldName of cjsJsChunks) {
+    const newName = oldName.replace(/\.cjs\.js$/, ".cjs");
+    renameSync(join(chunksDir, oldName), join(chunksDir, newName));
+    renames.set(oldName, newName);
+
+    const oldMap = `${oldName}.map`;
+    const newMap = `${newName}.map`;
+    if (existsSync(join(chunksDir, oldMap))) {
+      renameSync(join(chunksDir, oldMap), join(chunksDir, newMap));
+    }
+  }
+
+  if (renames.size === 0) {
+    return { renamed: 0, filesUpdated: 0 };
+  }
+
+  // Candidates for cross-references: the caller's entry points, plus every
+  // chunk file itself (post-rename) — chunks require each other constantly.
+  const chunkFiles = readdirSync(chunksDir)
+    .filter((f) => f.endsWith(".cjs"))
+    .map((f) => join(chunksDir, f));
+  const candidates = [...entryPointCjsFiles, ...chunkFiles];
+
+  let filesUpdated = 0;
+  for (const file of candidates) {
+    if (!existsSync(file)) continue;
+    let content = readFileSync(file, "utf8");
+    let changed = false;
+    for (const [oldName, newName] of renames) {
+      if (content.includes(oldName)) {
+        content = content.replaceAll(oldName, newName);
+        changed = true;
+      }
+    }
+    if (changed) {
+      writeFileSync(file, content);
+      filesUpdated++;
+    }
+  }
+
+  return { renamed: renames.size, filesUpdated };
+}

--- a/scripts/lib/rewrite-cjs-chunk-extensions.spec.mjs
+++ b/scripts/lib/rewrite-cjs-chunk-extensions.spec.mjs
@@ -98,4 +98,54 @@ describe("fixCjsChunkExtensions", () => {
     const result = fixCjsChunkExtensions(distDir, []);
     expect(result).toEqual({ renamed: 0, filesUpdated: 0 });
   });
+
+  it("leaves bare/non-relative require() calls to other packages untouched", () => {
+    // A chunk requiring an actual npm package (not a renamed chunk) should
+    // never be rewritten, even if the package name happens to contain a
+    // renamed chunk's old filename as a substring.
+    writeFileSync(
+      join(chunksDir, "leaf-abc123.cjs.js"),
+      "module.exports = {};\n"
+    );
+    const indexFile = join(distDir, "index.cjs");
+    writeFileSync(
+      indexFile,
+      'const react = require("react");\n' +
+        'const leaf = require("./chunks/leaf-abc123.cjs.js");\n' +
+        "module.exports = { react, leaf };\n"
+    );
+
+    fixCjsChunkExtensions(distDir, [indexFile]);
+
+    const content = readFileSync(indexFile, "utf8");
+    expect(content).toContain('require("react")');
+    expect(content).toContain('require("./chunks/leaf-abc123.cjs")');
+  });
+
+  it("is idempotent: running it a second time against an already-fixed dist is a no-op", () => {
+    writeFileSync(
+      join(chunksDir, "parent-hash1.cjs.js"),
+      'const { leaf } = require("./leaf-hash2.cjs.js");\nmodule.exports = { leaf };\n'
+    );
+    writeFileSync(
+      join(chunksDir, "leaf-hash2.cjs.js"),
+      "module.exports = { leaf: true };\n"
+    );
+    const indexFile = join(distDir, "index.cjs");
+    writeFileSync(
+      indexFile,
+      'module.exports = require("./chunks/parent-hash1.cjs.js");\n'
+    );
+
+    const first = fixCjsChunkExtensions(distDir, [indexFile]);
+    expect(first.renamed).toBe(2);
+
+    const second = fixCjsChunkExtensions(distDir, [indexFile]);
+    expect(second).toEqual({ renamed: 0, filesUpdated: 0 });
+
+    // Content from the first pass is unchanged by the second, no-op pass.
+    expect(readFileSync(indexFile, "utf8")).toBe(
+      'module.exports = require("./chunks/parent-hash1.cjs");\n'
+    );
+  });
 });

--- a/scripts/lib/rewrite-cjs-chunk-extensions.spec.mjs
+++ b/scripts/lib/rewrite-cjs-chunk-extensions.spec.mjs
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fixCjsChunkExtensions } from "./rewrite-cjs-chunk-extensions.mjs";
+
+let distDir;
+let chunksDir;
+
+beforeEach(() => {
+  distDir = mkdtempSync(join(tmpdir(), "nimbus-postbuild-types-"));
+  chunksDir = join(distDir, "chunks");
+  mkdirSync(chunksDir);
+});
+
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true });
+});
+
+describe("fixCjsChunkExtensions", () => {
+  it("renames .cjs.js chunk files to .cjs (and their sourcemaps)", () => {
+    writeFileSync(
+      join(chunksDir, "leaf-abc123.cjs.js"),
+      "module.exports = {};\n"
+    );
+    writeFileSync(join(chunksDir, "leaf-abc123.cjs.js.map"), "{}");
+
+    const result = fixCjsChunkExtensions(distDir, []);
+
+    expect(result.renamed).toBe(1);
+    expect(readFileSync(join(chunksDir, "leaf-abc123.cjs"), "utf8")).toBe(
+      "module.exports = {};\n"
+    );
+    expect(readFileSync(join(chunksDir, "leaf-abc123.cjs.map"), "utf8")).toBe(
+      "{}"
+    );
+  });
+
+  it("rewrites chunk-to-chunk require() references, not just entry points", () => {
+    // Regression case: a chunk that requires another chunk (not an entry
+    // point) must also have its require() string updated, otherwise the
+    // renamed target no longer matches the literal string on disk.
+    writeFileSync(
+      join(chunksDir, "parent-hash1.cjs.js"),
+      'const { leaf } = require("./leaf-hash2.cjs.js");\nmodule.exports = { leaf };\n'
+    );
+    writeFileSync(
+      join(chunksDir, "leaf-hash2.cjs.js"),
+      "module.exports = { leaf: true };\n"
+    );
+
+    const result = fixCjsChunkExtensions(distDir, []);
+
+    expect(result.renamed).toBe(2);
+    const parentContent = readFileSync(
+      join(chunksDir, "parent-hash1.cjs"),
+      "utf8"
+    );
+    expect(parentContent).toContain('require("./leaf-hash2.cjs")');
+    expect(parentContent).not.toContain(".cjs.js");
+  });
+
+  it("rewrites references from top-level entry-point .cjs files", () => {
+    writeFileSync(
+      join(chunksDir, "chunk-hash3.cjs.js"),
+      "module.exports = {};\n"
+    );
+    const indexFile = join(distDir, "index.cjs");
+    writeFileSync(
+      indexFile,
+      'module.exports = require("./chunks/chunk-hash3.cjs.js");\n'
+    );
+
+    fixCjsChunkExtensions(distDir, [indexFile]);
+
+    expect(readFileSync(indexFile, "utf8")).toBe(
+      'module.exports = require("./chunks/chunk-hash3.cjs");\n'
+    );
+  });
+
+  it("is a no-op when there is no chunks directory", () => {
+    rmSync(chunksDir, { recursive: true, force: true });
+    const result = fixCjsChunkExtensions(distDir, []);
+    expect(result).toEqual({ renamed: 0, filesUpdated: 0 });
+  });
+
+  it("is a no-op when no .cjs.js chunks exist", () => {
+    writeFileSync(
+      join(chunksDir, "already-fine.cjs"),
+      "module.exports = {};\n"
+    );
+    const result = fixCjsChunkExtensions(distDir, []);
+    expect(result).toEqual({ renamed: 0, filesUpdated: 0 });
+  });
+});

--- a/scripts/lib/rewrite-preconstruct-cjs-extensions.mjs
+++ b/scripts/lib/rewrite-preconstruct-cjs-extensions.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * Renames preconstruct-emitted CJS build artifacts so Node treats them as
+ * CommonJS regardless of a package's `"type": "module"` declaration, and
+ * rewrites the `require(...)` calls between them to match.
+ *
+ * Preconstruct's CJS output for an entrypoint is a trio of flat files:
+ *
+ *   - `<name>.cjs.js`      — the public entry, dispatches on NODE_ENV
+ *   - `<name>.cjs.dev.js`  — required by the entry in development
+ *   - `<name>.cjs.prod.js` — required by the entry in production
+ *
+ * All three are plain CJS syntax, but end in `.js`. In a package whose
+ * `package.json` declares `"type": "module"`, Node treats every `.js` file
+ * as ESM regardless of content, so the entry's own
+ * `require("./<name>.cjs.dev.js")` throws `MODULE_NOT_FOUND` (Node can't
+ * resolve a `.js` specifier to what it's decided is an ESM module via
+ * `require`). Renaming to `.cjs` sidesteps that, since the `.cjs` extension
+ * is always CommonJS.
+ *
+ *   `<name>.cjs.js`      → `<name>.cjs`
+ *   `<name>.cjs.dev.js`  → `<name>.cjs.dev.cjs`
+ *   `<name>.cjs.prod.js` → `<name>.cjs.prod.cjs`
+ *
+ * Only files directly inside `distDir` are considered — this targets flat
+ * preconstruct entrypoint output, not a nested chunk graph (see
+ * `rewrite-cjs-chunk-extensions.mjs` for that case). Requires that point
+ * outside `distDir` (e.g. into a sibling sub-entrypoint's own `dist/`) are
+ * left untouched: those directories have their own `package.json`, so their
+ * `.js` files are unaffected by this package's `"type": "module"`.
+ *
+ * Usage:
+ *   import { fixPreconstructCjsExtensions } from "./rewrite-preconstruct-cjs-extensions.mjs";
+ *   const { renamed, filesUpdated } = fixPreconstructCjsExtensions(distDir);
+ */
+
+import {
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const MAIN_RE = /\.cjs\.js$/;
+const DEV_PROD_RE = /\.cjs\.(dev|prod)\.js$/;
+
+/**
+ * @param {string} distDir - flat directory containing preconstruct's CJS
+ *   entrypoint output (`<name>.cjs.js`, `<name>.cjs.dev.js`, `<name>.cjs.prod.js`)
+ * @returns {{ renamed: number, filesUpdated: number }}
+ */
+export function fixPreconstructCjsExtensions(distDir) {
+  const files = readdirSync(distDir).filter((f) =>
+    statSync(join(distDir, f)).isFile()
+  );
+
+  const renames = new Map();
+  for (const file of files) {
+    if (DEV_PROD_RE.test(file)) {
+      renames.set(file, file.replace(/\.js$/, ".cjs"));
+    } else if (MAIN_RE.test(file)) {
+      renames.set(file, file.replace(MAIN_RE, ".cjs"));
+    }
+  }
+
+  if (renames.size === 0) {
+    return { renamed: 0, filesUpdated: 0 };
+  }
+
+  for (const [oldName, newName] of renames) {
+    renameSync(join(distDir, oldName), join(distDir, newName));
+  }
+
+  const remaining = readdirSync(distDir).filter(
+    (f) => statSync(join(distDir, f)).isFile() && f.endsWith(".cjs")
+  );
+
+  let filesUpdated = 0;
+  for (const file of remaining) {
+    const filePath = join(distDir, file);
+    let content = readFileSync(filePath, "utf8");
+    let changed = false;
+    for (const [oldName, newName] of renames) {
+      // Only rewrite relative requires that resolve within distDir
+      // (`./<oldName>`), not bare package requires or requires that reach
+      // into other directories.
+      const needle = `./${oldName}`;
+      if (content.includes(needle)) {
+        content = content.replaceAll(needle, `./${newName}`);
+        changed = true;
+      }
+    }
+    if (changed) {
+      writeFileSync(filePath, content);
+      filesUpdated++;
+    }
+  }
+
+  return { renamed: renames.size, filesUpdated };
+}

--- a/scripts/lib/rewrite-preconstruct-cjs-extensions.spec.mjs
+++ b/scripts/lib/rewrite-preconstruct-cjs-extensions.spec.mjs
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fixPreconstructCjsExtensions } from "./rewrite-preconstruct-cjs-extensions.mjs";
+
+let distDir;
+
+beforeEach(() => {
+  distDir = mkdtempSync(join(tmpdir(), "nimbus-tokens-postbuild-"));
+});
+
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true });
+});
+
+describe("fixPreconstructCjsExtensions", () => {
+  it("renames the main .cjs.js file to .cjs, and the dev/prod .cjs.*.js files to .cjs.*.cjs", () => {
+    writeFileSync(
+      join(distDir, "pkg.cjs.js"),
+      "'use strict';\n" +
+        'if (process.env.NODE_ENV === "production") {\n' +
+        '  module.exports = require("./pkg.cjs.prod.js");\n' +
+        "} else {\n" +
+        '  module.exports = require("./pkg.cjs.dev.js");\n' +
+        "}\n"
+    );
+    writeFileSync(join(distDir, "pkg.cjs.dev.js"), "module.exports = 1;\n");
+    writeFileSync(join(distDir, "pkg.cjs.prod.js"), "module.exports = 2;\n");
+
+    const result = fixPreconstructCjsExtensions(distDir);
+
+    expect(result.renamed).toBe(3);
+    expect(readFileSync(join(distDir, "pkg.cjs"), "utf8")).toContain(
+      'require("./pkg.cjs.prod.cjs")'
+    );
+    expect(readFileSync(join(distDir, "pkg.cjs"), "utf8")).toContain(
+      'require("./pkg.cjs.dev.cjs")'
+    );
+    expect(readFileSync(join(distDir, "pkg.cjs"), "utf8")).not.toContain(
+      ".cjs.js"
+    );
+    expect(readFileSync(join(distDir, "pkg.cjs.dev.cjs"), "utf8")).toBe(
+      "module.exports = 1;\n"
+    );
+    expect(readFileSync(join(distDir, "pkg.cjs.prod.cjs"), "utf8")).toBe(
+      "module.exports = 2;\n"
+    );
+  });
+
+  it("leaves bare/non-relative require() calls to other packages untouched", () => {
+    writeFileSync(
+      join(distDir, "pkg.cjs.js"),
+      'const other = require("some-package");\n' +
+        'module.exports = require("./pkg.cjs.dev.js");\n'
+    );
+    writeFileSync(join(distDir, "pkg.cjs.dev.js"), "module.exports = 1;\n");
+
+    fixPreconstructCjsExtensions(distDir);
+
+    expect(readFileSync(join(distDir, "pkg.cjs"), "utf8")).toContain(
+      'require("some-package")'
+    );
+  });
+
+  it("leaves requires into other directories (e.g. sub-entrypoints) untouched", () => {
+    writeFileSync(
+      join(distDir, "pkg.cjs.js"),
+      "'use strict';\n" +
+        'var a = require("../other/dist/other-pkg.cjs.dev.js");\n' +
+        'module.exports = require("./pkg.cjs.dev.js");\n'
+    );
+    writeFileSync(join(distDir, "pkg.cjs.dev.js"), "module.exports = 1;\n");
+
+    fixPreconstructCjsExtensions(distDir);
+
+    const content = readFileSync(join(distDir, "pkg.cjs"), "utf8");
+    expect(content).toContain('require("../other/dist/other-pkg.cjs.dev.js")');
+    expect(content).toContain('require("./pkg.cjs.dev.cjs")');
+  });
+
+  it("is a no-op when there are no .cjs.js files", () => {
+    writeFileSync(join(distDir, "already-fine.cjs"), "module.exports = {};\n");
+    const result = fixPreconstructCjsExtensions(distDir);
+    expect(result).toEqual({ renamed: 0, filesUpdated: 0 });
+  });
+
+  it("is idempotent: running it twice does not error or change anything further", () => {
+    writeFileSync(
+      join(distDir, "pkg.cjs.js"),
+      'module.exports = require("./pkg.cjs.dev.js");\n'
+    );
+    writeFileSync(join(distDir, "pkg.cjs.dev.js"), "module.exports = 1;\n");
+
+    fixPreconstructCjsExtensions(distDir);
+    const second = fixPreconstructCjsExtensions(distDir);
+
+    expect(second).toEqual({ renamed: 0, filesUpdated: 0 });
+  });
+});


### PR DESCRIPTION
## What was broken

1. **`postinstall` crashed with `process is not defined`** — `chakra typegen` was pointed at `dist/index.es.js`, the entire component library. `@chakra-ui/cli@3.36.1` (latest) can't `require()` an ESM file, falls back to evaluating the bundle in a bare `vm` sandbox with no Node globals, and crashes on React's `process.env` check. Even patching that hole open, the bundle contains DOM-touching code at module scope (from a markdown dependency), which a headless sandbox can never satisfy — bundling the whole UI library for typegen was the wrong approach. The `|| true` in the script masked the crash from `pnpm install`'s exit code, so it silently never generated types.
2. **Found while verifying the fix: `require("@commercetools/nimbus")` was completely broken.** The Vite 8/Rolldown migration renames CJS chunks `.cjs.js` → `.cjs`, but only rewrote references from entry-point files, not chunk-to-chunk `require()` calls. Any CJS consumer hit `MODULE_NOT_FOUND`.

## What changed

- Added a lightweight `@commercetools/nimbus/theme` export (tokens/recipes/config only — no React, no DOM) and repointed `postinstall` + the docs' manual-generation command at `dist/theme.es.js`. Sidesteps both bugs above with no dependency patch needed.
- Extracted the chunk-rename logic into `scripts/lib/rewrite-cjs-chunk-extensions.mjs` (TDD: failing spec first, then the fix) so it rewrites chunk-to-chunk references too, not just entry points.
- Added a changeset (`minor`, since it adds a new export).

## Verification

- `pnpm run postinstall` succeeds cleanly end-to-end (no crash).
- `require('./dist/index.cjs')` no longer fails on chunk-name mismatches (a separate, already-tracked `@commercetools/nimbus-tokens` CJS bug — [#1509](https://github.com/commercetools/nimbus/issues/1509) — surfaces next; out of scope here).
- `pnpm typecheck:strict` clean.
- `pnpm check:package-shape` shows `@commercetools/nimbus/theme` green across node10/16(CJS)/16(ESM)/bundler.
- `pnpm check:bundle-size` flat (~0%).
- `pnpm test:unit` (1506 tests) and the new spec (5 tests) all pass.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>