### PR TITLE
chore(deps): deny build script for @modelcontextprotocol/inspector

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,6 +75,10 @@ allowBuilds:
   style-dictionary: true
   "@fission-ai/openspec": false
   "@modelcontextprotocol/ext-apps": false
+  # v2's postinstall installs deps for its own clients/* checkout subfolders —
+  # a no-op when installed as a dependency. Deny per least-privilege rather
+  # than relying on that no-op holding true in future releases.
+  "@modelcontextprotocol/inspector": false
   core-js-pure: true
   # Transitive deps of @huggingface/transformers (docs browser semantic search).
   # The search runs entirely in a Web Worker on onnxruntime-web, so these native


### PR DESCRIPTION
## Why

Renovate PR #1907 (`@modelcontextprotocol/inspector` v1 → v2) fails
`build-and-test`/`chromatic` install with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @modelcontextprotocol/inspector@2.1.0
```

`pnpm-workspace.yaml` has `strictDepBuilds: true`, which fails install for any
dependency with a postinstall script that isn't explicitly reviewed in
`allowBuilds`. v2 adds one (`scripts/install-clients.mjs`) that v1 didn't have.

## What it does / why `false`

That postinstall cascades `npm install` into the package's own `clients/*`
sub-packages — only relevant for a from-source checkout of the Inspector repo
itself. It already no-ops when installed as a dependency (detects
`node_modules` in its own resolved path and exits, and the published tarball
omits the client `package.json` files it would need anyway).

Denying it (`false`) costs us nothing functionally today, and — unlike
`true` — keeps that guarantee independent of the script's own internal
checks, in case a future release changes them. Same pattern as the
`onnxruntime-node`/`protobufjs`/`sharp` entries already in this file.

## Verification

`pnpm install --frozen-lockfile` completes cleanly with the new entry (no
`ERR_PNPM_IGNORED_BUILDS`).

No changeset — tooling/CI-only change per `docs/changeset-conventions.md`.