### PR TITLE
fix(deps): revert minimatch security-floor override to 3.1.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ overrides:
   js-yaml: ^3.15.0
   dompurify: ^3.4.13
   qs: '>=6.15.2'
-  minimatch@>=3.0.0 <3.1.4: 10.2.6
+  minimatch@>=3.0.0 <3.1.4: 3.1.5
   svgo: '>=4.0.2'
   hono: '>=4.12.27'
   esbuild: '>=0.28.1'
@@ -7193,6 +7193,9 @@ packages:
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
@@ -16945,7 +16948,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 10.2.6
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -17141,7 +17144,7 @@ snapshots:
 
   ignore-walk@3.0.4:
     dependencies:
-      minimatch: 10.2.6
+      minimatch: 3.1.5
 
   ignore@5.3.2: {}
 
@@ -18111,6 +18114,10 @@ snapshots:
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 2.1.2
 
   minimatch@5.1.9:
     dependencies:
@@ -19349,7 +19356,7 @@ snapshots:
       bytes: 3.0.0
       content-disposition: 0.5.2
       mime-types: 2.1.18
-      minimatch: 10.2.6
+      minimatch: 3.1.5
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,7 +108,13 @@ overrides:
   # GHSA cluster (…-cmwh-pvxp-8882, …-rp9w-3fw7-7cwq, …-76mc-f452-cxcm, etc.).
   dompurify: "catalog:utils"
   qs: ">=6.15.2"
-  "minimatch@>=3.0.0 <3.1.4": "10.2.6"
+  # Pinned to the 3.x line, not the current v10 major: v10's CJS entry is a
+  # named-exports object ({ minimatch, match, ... }), not the callable
+  # `require('minimatch')(path, pattern)` default that serve-handler (via
+  # @modelcontextprotocol/inspector) and other transitive <9 consumers expect.
+  # 10.2.6 broke `pnpm --filter @commercetools/nimbus-mcp inspector` with
+  # "TypeError: minimatch is not a function" — see git history on this line.
+  "minimatch@>=3.0.0 <3.1.4": "3.1.5"
   svgo: ">=4.0.2"
   hono: ">=4.12.27"
   esbuild: ">=0.28.1"


### PR DESCRIPTION
## Problem

`pnpm mcp-inspector` (in `packages/nimbus-mcp`) crashed on startup:

```
TypeError: minimatch is not a function
    at sourceMatches (serve-handler/src/index.js:59:17)
```

## Root cause

The `minimatch@>=3.0.0 <3.1.4` security-floor override in `pnpm-workspace.yaml` was bumped from `3.1.5` → `10.2.6` in #1904 ("trivial major-version dependency migrations"), moving affected transitive consumers onto the v10 major.

minimatch v10's CJS entry exports a named-exports object (`{ minimatch, match, ... }`), not the callable `require('minimatch')(path, pattern)` default that older consumers expect. `serve-handler@6.1.6` (pulled in via `@modelcontextprotocol/inspector` → `@commercetools/nimbus-mcp`) uses that old callable API, so it broke at runtime the moment the inspector's dev server tried to serve a static file.

#1904's verification (`install`/`build`/`typecheck:strict`/`lint`/`test:unit`) never actually exercised `serve-handler` at runtime, so this API-shape break slipped through.

## Fix

Revert the override target to `3.1.5` — the last known-good value. It still satisfies the same `>=3.0.0 <3.1.4` security floor while keeping the callable-function export shape that v3–v8 consumers rely on. Regenerated the lockfile.

## Verification

- `require('minimatch')` under `serve-handler` resolves to `3.1.5` and is callable again
- `pnpm mcp-inspector` starts cleanly, opens the proxy on `:6277` and the browser UI on `:6274`, and successfully proxies an STDIO session with no crash