### PR TITLE
FEC-1190 -  tidy up Chromatic docs

### DIFF
--- a/.claude/agents/nimbus-reviewer.md
+++ b/.claude/agents/nimbus-reviewer.md
@@ -115,20 +115,21 @@ no `tags: ["vrt"]` story reads as finished while having zero visual coverage.
 Nothing else in the review will catch that, so check it explicitly.
 
 Read the component's recipe first - the surface list is derived from the recipe,
-never from the story names. Glob `*.recipe.*`, not just `*.recipe.ts`: 9 recipes
-are `.recipe.tsx` (menu, select, icon, popover, money-input, split-button,
-tag-group, field-errors, toggle-button-group), so a `.ts`-only check would
-wrongly conclude those components have no recipe and no surfaces to cover. Then
-verify:
+never from the story names. Glob `*.recipe.*`, not just `*.recipe.ts`: some
+recipes are `.recipe.tsx`, so a `.ts`-only check would wrongly conclude those
+components have no recipe and no surfaces to cover. Then verify:
 
-- [ ] Some story opts in (`tags: ["vrt"]` +
-      `parameters: { chromatic: { disableSnapshot: false } }`), **or** the
-      recipe paints nothing and `meta` carries a one-line note saying so
+- [ ] Some story opts in, **or** the recipe paints nothing and `meta` carries a
+      one-line note saying so
+- [ ] Opting in means **both** `tags: ["vrt"]` and
+      `parameters: { chromatic: { disableSnapshot: false } }` on the same story.
+      Don't read the tag as proof of coverage - Chromatic never reads it, so a
+      tag without the parameter snapshots nothing while looking audited
 - [ ] Every state the recipe paints distinctly is reachable in some snapshotted
       frame - including the ones no prop names (RTL, an inherited
       `colorPalette`) and every child type a comma-separated selector reaches
-- [ ] Interacting axes folded into one `SmokeTest` (rendered last); independent
-      axes given their own showcase stories rather than a cross-product
+- [ ] Interacting axes folded into one `SmokeTest`; independent axes given their
+      own showcase stories rather than a cross-product
 - [ ] States a matrix can't hold have their own snapshotted story - `Focused`
       per **independent** focus surface, open overlays, condition-fired states
       (sticky/overflow/variant-zeroed)

--- a/.claude/commands/propose-component.md
+++ b/.claude/commands/propose-component.md
@@ -132,8 +132,8 @@ The task list MUST include these file creation steps in this order:
 
    Acceptance criteria for the task:
    - Every state the recipe paints distinctly is reachable in some snapshotted
-     frame; interacting axes folded into one `SmokeTest` (rendered last),
-     independent axes given their own showcase stories
+     frame; interacting axes folded into one `SmokeTest`, independent axes given
+     their own showcase stories
    - States a matrix can't hold have their own snapshotted story (`Focused` per
      independent focus surface, open overlay, condition-fired states)
    - Behavior-only stories left un-snapshotted (project default), and any state

--- a/.claude/skills/writing-stories/SKILL.md
+++ b/.claude/skills/writing-stories/SKILL.md
@@ -86,7 +86,7 @@ stories snapshot rather than writing one to a settled spec:
 cat docs/chromatic-visual-testing.md
 ```
 
-That doc is rationale and worked precedent, not instructions; it is ~5k tokens and
+That doc is rationale and worked precedent, not instructions; it is long and
 adds nothing for mechanical authoring. See
 "Chromatic Snapshots: What Gets Captured" below for the specific calls that
 warrant reading it. For CI behavior (triggers, baselines, gating) see
@@ -150,9 +150,8 @@ Stories MUST be exported in this order:
 5. **States** - Disabled, Invalid, Required, etc.
 6. **Controlled** - Controlled state example
 7. **Complex** - Advanced scenarios, edge cases
-8. **SmokeTest** - the interacting-axes matrix, last story. Omit it entirely when
-   the axes are independent; don't substitute a cross-product that adds no
-   coverage
+8. **SmokeTest** - the interacting-axes matrix. Omit it entirely when the axes
+   are independent; don't substitute a cross-product that adds no coverage
 
 ## Create Mode
 
@@ -177,9 +176,9 @@ about snapshots:
   the default and gets no story of its own. If the recipe sets no color, border or
   spacing at all, the component gets no VRT (see "What Gets Captured").
 
-Not every component has one - 70 do (61 `.ts` + 9 `.tsx`). Genuinely having none
-is itself the answer for pass-through style primitives, so glob both extensions
-before concluding a component has no recipe.
+Not every component has one, and recipes come in both `.ts` and `.tsx`.
+Genuinely having none is itself the answer for pass-through style primitives, so
+glob both extensions before concluding a component has no recipe.
 
 Then analyze:
 
@@ -382,26 +381,34 @@ coverage. So not every component has a `SmokeTest` - components with only
 independent axes (Avatar, Badge, Switch) use dedicated showcase snapshots
 instead.
 
-Don't fold in an axis that applies a uniform, axis-independent transform:
-`disabled` resolves to one shared style regardless of palette/size/variant, so
-capture it once in a dedicated `Disabled` story, not multiplied through the grid.
 (Hover and pressed can't be forced from a play at all, so they're not matrix
 axes either - see "What Gets Captured".)
 
-**Span the full supported range, not a dev subset** - a trimmed or commented-out
-axis (three sizes when the component has five) leaves those cells covered by
-nothing. Palettes iterate the 6 `SEMANTIC_COLOR_PALETTES`; the `BRAND` (3) and
-`SYSTEM` (25) palettes run the same token machinery and aren't snapshotted.
+**Span the recipe's live keys, not a dev subset** - an array that trims a value
+the recipe still ships (three sizes when the component has five) leaves those
+cells covered by nothing. Mirroring one the recipe itself comments out is fine:
+Button's `sizes` omits `lg` and `2xl` because the recipe does. A component with
+no recipe of its own takes the range of the one it borrows - IconButton has none
+and extends `ButtonProps`, so Button's live keys are its supported range. A
+value the recipe **hardcodes** collapses the axis entirely: MultilineTextInput
+pins `colorPalette: "neutral"`, so its matrix is `state x size x variant`.
 
-**An axis the recipe hardcodes isn't an axis** - full-range applies only to axes
-the component varies. MultilineTextInput pins `colorPalette: "neutral"`, so its
-matrix is `state x size x variant`, no palette axis. (Distinct from the uniform
-transform above: `disabled` is a real axis folded out; a pinned palette was never
-an axis.)
+**Palette scope depends on which frame you're in.** As a matrix **axis**,
+palettes iterate `SEMANTIC_COLOR_PALETTES` - the `BRAND` and `SYSTEM` sets run
+the same token machinery and would multiply every cell for no new coverage. A
+standalone **`ColorPalettes` showcase** is a single frame however many swatches
+it holds, so it uses the shared `DisplayColorPalettes` helper (`@/utils`), which
+renders all three groups labelled.
 
 **Cover distinct state-combinations, not just single flags** - selected-disabled
 is a separate look from unselected-disabled, so a `Disabled` story showing only
 the unselected case leaves a gap.
+
+**`disabled` folds out of the grid only while what it dims is uniform** - it
+normally resolves to one shared style regardless of palette/size/variant, so a
+dedicated `Disabled` story captures it once instead of every cell rendering at
+half opacity. Once another state repaints that surface (a tinted
+`[data-selected]`), the combination goes back in the matrix.
 
 **Thin wrappers get no matrix** - a component that only forwards a wrapped
 component's props snapshots only the axis it introduces (+ `Focused`/`Disabled`
@@ -464,22 +471,30 @@ Snapshots** validation checklist repeats them as checkboxes under the same five
 headings, and is what you tick off when validating.
 
 **Escalate to `docs/chromatic-visual-testing.md` only when a rule doesn't settle
-the case** - it is ~5k tokens of rationale and worked examples, so don't load it
-by default. Read it when you hit one of these, because each is a call the terse
-rule states but cannot decide for you:
+the case** - it is a long file of rationale and worked examples, so don't load
+it by default. Read it when you hit one of these, because each is a call the terse
+rule states but cannot decide for you. **Follow the link and read that section
+only** - none of these needs the whole file:
 
 - **Does this state paint differently from the default?** Read-only is the
   classic - the answer is component-dependent (MoneyInput yes, TextInput no).
-- **Do these two axes interact, or are they independent?** Decides `SmokeTest`
-  matrix vs. separate showcase stories.
-- **A recipe variant that zeroes the surface**, or an inherited property with
-  nothing to inherit - the state is inert in the default frame.
-- **One rule with a comma-separated selector list** - how many frames it needs.
-- **A compound component with optional slots** - which arrangements are genuine
-  surfaces rather than the same slots rearranged.
-- **A focus ring possibly styled on a slot that never receives focus.**
+  → [1. Does it paint?](../../../docs/chromatic-visual-testing.md#1-does-it-paint)
 - Any **"renders like default"** verdict you are about to write without having
   named the exact delta you checked.
+  → [1. Does it paint?](../../../docs/chromatic-visual-testing.md#1-does-it-paint)
+- **One rule with a comma-separated selector list** - how many frames it needs.
+  → [1. Does it paint?](../../../docs/chromatic-visual-testing.md#1-does-it-paint)
+- **A recipe variant that zeroes the surface**, or an inherited property with
+  nothing to inherit - the state is inert in the default frame.
+  → [2. Is the state reachable in this frame?](../../../docs/chromatic-visual-testing.md#2-is-the-state-reachable-in-this-frame)
+- **A focus ring possibly styled on a slot that never receives focus.**
+  → [2. Is the state reachable in this frame?](../../../docs/chromatic-visual-testing.md#2-is-the-state-reachable-in-this-frame)
+- **A compound component with optional slots** - which arrangements are genuine
+  surfaces rather than the same slots rearranged.
+  → [3. Who owns the pixels?](../../../docs/chromatic-visual-testing.md#3-who-owns-the-pixels)
+- **Do these two axes interact, or are they independent?** Decides `SmokeTest`
+  matrix vs. separate showcase stories.
+  → [5. Packing the surfaces into frames](../../../docs/chromatic-visual-testing.md#5-packing-the-surfaces-into-frames)
 
 Rule of thumb: **auditing** a component's coverage for the first time → read it.
 **Authoring** a story into an already-audited component, or fixing a play → don't.
@@ -782,12 +797,23 @@ You MUST validate against these requirements:
 - [ ] Focused story (if component is focusable)
 - [ ] Disabled story (for interactive components)
 - [ ] Controlled story (for stateful components)
-- [ ] SmokeTest story if the component has interacting axes (MUST be last); independent axes use dedicated showcase stories instead
+- [ ] SmokeTest story if the component has interacting axes; independent axes use dedicated showcase stories instead
 
 #### Chromatic Snapshots
 
 One line per check; the rule and its reasoning are in **Chromatic Snapshots: What
 Gets Captured** above.
+
+**0. Is the opt-in actually wired?** Mechanical, and checked first - the rest of
+this list assumes the frames exist.
+
+- [ ] **Every** story with `tags: ["vrt"]` also carries
+      `parameters: { chromatic: { disableSnapshot: false } }`, on that same
+      story. The tag alone captures nothing (Chromatic never reads it), so a tag
+      without the parameter is a story that claims a baseline and has none - the
+      failure is silent in both directions
+- [ ] No story restates the project default (`disableSnapshot: true`); a
+      deliberate omission is recorded as a comment, not a redundant parameter
 
 **1. Does it paint?**
 
@@ -801,9 +827,14 @@ Gets Captured** above.
 - [ ] A state with **no distinct recipe surface** gets no dedicated story
       (read-only with no `data-readonly` rule renders like default)
 - [ ] **Primitives that paint no surface** get **no VRT at all**, with a one-line
-      note on `meta` - pass-through style props, a recipe that paints nothing
-      (Group), headless `display: contents` (Region). Check whether the recipe
-      **paints**, not whether it exists (Separator and Icon get normal audits)
+      `meta` note in the format
+      `// No VRT: <reason> (see chromatic-visual-testing.md).` - pass-through
+      style props, a recipe that paints nothing (Group, CollapsibleMotion),
+      headless `display: contents` (Region), no DOM of its own (providers,
+      MakeElementFocusable, VisuallyHidden), or every axis owned by another
+      recipe (InlineSvg → Icon, whose covering stories the note names). Check
+      whether the recipe **paints**, not whether it exists (Separator and Icon
+      get normal audits)
 
 **2. Is the state reachable in this frame?**
 
@@ -822,9 +853,14 @@ Gets Captured** above.
 - [ ] **Overlays** snapshot the **open** state (rendered open, left open); each
       distinct open surface is its own story; open/close & dismissal stay behavioral
 - [ ] **Portal** components (Toast/overlays): transient UI held open
-      (`duration: Infinity`), awaited, and cleaned up between stories; the
-      component's own focus reached via its **real keyboard path**, not `.focus()`;
-      an overlay hanging below a short root given `minHeight` so the crop keeps it
+      (`duration: Infinity`) and awaited; the component's own focus reached via
+      its **real keyboard path**, not `.focus()`; an overlay hanging below a
+      short root given `minHeight` so the crop keeps it
+- [ ] State that outlives unmount (toast queue, React Aria drag session) is
+      cleared in **the teardown a `beforeEach` returns** - it runs after the
+      capture, so it can't disturb the frame, and it still fires when the
+      leaking story is last in the file. The run is `isolate: false`; a file's
+      stories share one page. Not cleaned at the top of the next play
 - [ ] **`placement`** snapshotted only when it changes the **layout** (Drawer
       side/top/bottom panels), not a mere reposition (Dialog = center only;
       Menu/Tooltip RA-positioning = behavioral)
@@ -858,43 +894,53 @@ Gets Captured** above.
       intended. A play can be assertion-honest yet snapshot the wrong picture
 - [ ] A story left focused by **`userEvent.click`** is blurred - React Aria keeps
       `data-focus-visible` set after a synthetic click
-- [ ] No `No` verdict rests on the play's **end state**; snapshotted stories that end
-      focused call `blur()`
-- [ ] No `No` verdict rests on an assertion that tests **state instead of pixels** -
-      `aria-*` values, callback arguments and attributes prove the state, not the
-      rendered layout
-- [ ] Every `step()` name matches what it asserts; where it overstated, the
-      **assertion was raised to the name** (not the name lowered). No tautological
-      assertions, no un-`await`ed async helpers
+- [ ] Nothing is left un-snapshotted because of its play's **end state** - fix the
+      play; snapshotted stories that end focused call `blur()`
+- [ ] Nothing is left un-snapshotted because a play already asserts the state -
+      `aria-*` values, callback arguments and attributes prove state, not pixels
+- [ ] Every `step()` name matches what it asserts; raise the **assertion to the
+      name**, never lower the name. No tautological assertions, no un-`await`ed
+      async helpers
 - [ ] No play added **for completeness** - each is there because the story's name
       makes a behavioral claim or its frame needs an interaction to exist
 - [ ] Any frame ending with focus in a text input hides the caret
       (`canvasElement.style.caretColor = "transparent"`) - not just `Focused`
-      stories: an open Combobox keeps focus in its input, so six of its frames
-      needed it
+      stories: an open Combobox keeps focus in its input too
 - [ ] **Determinism**: dates pinned to a fixed anchor (live "today" stays
       off-snapshot), no random values, async-derived state awaited
-- [ ] **Animated** states: paused frame confirmed to show the target; if an infinite
-      animation's endpoints both hide it (indeterminate progress), the play **pins** a
-      representative frame (`animation: none` + explicit `transform`)
+- [ ] **Animated** states: paused frame confirmed to show the target. Frozen via
+      the component's **own animation-off prop** where it has one
+      (`animation="none"`); the play-level **pin** (`animation: none` + explicit
+      `transform`) used only where it doesn't, and required where an infinite
+      animation's endpoints both hide the content (indeterminate progress)
+- [ ] **Reduced motion** left off-snapshot - no Chromatic mode is configured and
+      JS can't fake `@media (prefers-reduced-motion)`. The story instead asserts
+      the compiled `_motionReduce` rule still ships, anchored to the element's
+      own hashed class rather than a hardcoded selector
 
 **5. Packing the surfaces into frames**
 
 - [ ] `SmokeTest` matrix is **exhaustive** over the interacting axes the component
       has (e.g. size x variant x palette, plus selected/unselected for toggles)
-- [ ] Axis arrays span the **full supported range** - no trimmed or commented-out
-      values; palettes use the 6 `SEMANTIC_COLOR_PALETTES`
-- [ ] Axes the recipe **hardcodes** are dropped from the grid (MultilineTextInput's
-      neutral-only recipe gives `state x size x variant`)
-- [ ] **Uniform, axis-independent** states are captured in a **dedicated** story, not
-      folded into the matrix (`disabled` → its own `Disabled` snapshot)
+- [ ] Axis arrays span the **recipe's live keys** - mirroring a value the recipe
+      itself comments out is fine (Button's `lg`/`2xl`); trimming one it still
+      ships is a gap. A component with no recipe takes the range of the one it
+      borrows (IconButton → Button), and a value the recipe **hardcodes**
+      collapses the axis (MultilineTextInput gives `state x size x variant`)
+- [ ] **Palette scope matches the frame** - a matrix _axis_ uses
+      `SEMANTIC_COLOR_PALETTES`; a standalone `ColorPalettes` showcase costs one
+      frame regardless, so it uses `DisplayColorPalettes` (`@/utils`), covering
+      all three groups
 - [ ] Distinct **state-combinations** are covered, not just single flags
-      (selected-disabled ≠ unselected-disabled), and nothing else repaints what a
-      folded-out `disabled` dims
+      (selected-disabled ≠ unselected-disabled), where the selection model makes
+      them reachable
+- [ ] **`disabled` is folded out** into its own story - but only while what it
+      dims is uniform; once another state repaints that surface (a tinted
+      `[data-selected]`), the combination is back in the matrix
 - [ ] Each state checked for being rendered **more than one way** (mode-/variant-
       driven); each distinct surface gets its **own** story, not a folded gallery
       (MoneyInput: `Focused` + `FocusedWithCurrencyLabel`)
-- [ ] The interacting-axes matrix is named **`SmokeTest`** and rendered **last** (not
+- [ ] The interacting-axes matrix is named **`SmokeTest`** (not
       `Variants`/`VariantsAndSizes`); the axis list lives in the doc comment
 - [ ] Only behavior-only stories and stories whose look is already in `SmokeTest` left
       snapshot-off (project default) - never drop a visual state to save cost

--- a/docs/chromatic-ci.md
+++ b/docs/chromatic-ci.md
@@ -105,7 +105,10 @@ Two things defeat it, both by design:
 - **Storybook config files.** `preview.tsx` and other `.storybook/` globals are
   injected at the document level, so no story imports them and Chromatic can't
   link them to specific stories. Any change disables TurboSnap for that build.
-  Batch such edits into one commit so only one full build fires.
+  Batch such edits into one commit so only one full build fires, and keep barrel
+  imports out of `preview.tsx` - importing the package barrel puts every
+  component in its dependency graph, so unrelated component edits start
+  invalidating it too.
 - **Dependency bumps.** The gate watches `pnpm-lock.yaml`, and a lockfile change
   can't be traced to specific stories. That's the safe scope anyway - a React
   Aria or Chakra bump can shift pixels anywhere. Grouped Dependabot PRs keep
@@ -172,16 +175,13 @@ Conflating them is the most common source of confusion:
 | `Chromatic / chromatic (pull_request)` | The **GHA job** in this workflow                                                                   | The action's exit code. With `exitOnceUploaded: true` the job returns at upload - _before_ diffing - so it's **green whenever the upload succeeds**, diffs or not. |
 | `UI Tests` (orange Chromatic icon)     | A status check **posted by Chromatic's servers**, asynchronously (the `exitOnceUploaded` behavior) | Chromatic's own verdict. It **still reports the diff** and goes red on an unaccepted diff, independent of the GHA job.                                             |
 
-So "the check stays green" refers **only** to the GHA job row:
-`exitOnceUploaded: true` makes the action exit before Chromatic diffs.
+So "the check stays green" refers **only** to the GHA job row, which answers
+**"did the job run without breaking?"**, not "are there visual changes?"
 (`exitZeroOnChanges` is **not** set; it would only matter if we dropped
-`exitOnceUploaded`.)
-
-That row answers **"did the job run without breaking?"**, not "are there visual
-changes?" Genuine breakage still turns it red: Storybook fails to build,
-dependency install / `./.github/actions/ci` fails, `chromaui/action` errors
-(missing or invalid `CHROMATIC_PROJECT_TOKEN`, upload/network/API failure), or a
-malformed workflow. It can also show **cancelled** when
+`exitOnceUploaded`.) Genuine breakage still turns it red: Storybook fails to
+build, dependency install / `./.github/actions/ci` fails, `chromaui/action`
+errors (missing or invalid `CHROMATIC_PROJECT_TOKEN`, upload/network/API
+failure), or a malformed workflow. It can also show **cancelled** when
 `concurrency: cancel-in-progress` supersedes the run with a newer push, or on
 timeout.
 

--- a/docs/chromatic-visual-testing.md
+++ b/docs/chromatic-visual-testing.md
@@ -1,10 +1,8 @@
 # Chromatic Visual Regression: Authoring Stories
 
-Which stories get snapshotted, and why. Nimbus runs
-[Chromatic](https://www.chromatic.com/) over Storybook, capturing each opted-in
-story in a consistent cloud browser and diffing it against a stored baseline -
-so a story is a visual test, and this doc is how you decide what it should
-capture.
+Chromatic captures each opted-in story in a consistent cloud browser and diffs
+it against a stored baseline. A story is therefore a visual test, and this doc
+is how you decide what it should capture.
 
 This is the _why_ behind the two rule-docs that sit closer to the code: the
 Chromatic section of [`stories.md`](./file-type-guidelines/stories.md) (terse
@@ -17,8 +15,7 @@ headings used below.
 > acceptance, the two PR checks, and merge gating live in
 > [`chromatic-ci.md`](./chromatic-ci.md).
 
-Four questions decide every snapshot call, and nearly every rule below is an
-instance of one:
+Four questions decide every snapshot call:
 
 1. **Does it paint?** Is there a component-owned pixel at all.
 2. **Is the state reachable in this frame?** Inert props, zeroing variants,
@@ -32,26 +29,6 @@ Work them in order, then
 [pack what survives](#5-packing-the-surfaces-into-frames) into as few frames as
 the axes allow.
 
-## How the mechanism works
-
-**Snapshots are opt-in, at three levels.** `chromatic.disableSnapshot` is
-settable at story, component and project level - our layering is
-`disableSnapshot: true` as the project default in `preview.tsx`, overridden to
-`false` on the VRT stories. Chromatic's docs recommend disabling for
-interaction-focused tests to "prevent false positives," which is why `WithRef`
-and Button's context/DOM-filtering stories stay off.
-
-**Crop padding is global, not per story.** Chromatic crops each snapshot to the
-story's rendered content, so a ring painted outside layout (box-shadow, CSS
-outline) clips at the crop edge when content sits flush against it - body or
-`layout: "padded"` padding sits outside the crop and can't reach in. A
-`preview.tsx` decorator wraps every non-`fullscreen` story in `1rem`, giving
-rings room inside the crop and keeping the canvas from jumping as you browse.
-`fullscreen` stories are exempt because they mean to touch the edges.
-
-**Keep barrel imports out of `preview.tsx`** - they trigger full rebuilds under
-TurboSnap.
-
 ## 1. Does it paint?
 
 **Enumerate surfaces from source, not memory.** Read the recipe (every painting
@@ -61,7 +38,7 @@ conditional render or prop, e.g. `isDisabled={x || isReadOnly}`). Coverage is
 the **cross-product** of recipe states × conditional branches: a read-only field
 that stays undimmed but disables its trailing button is a distinct surface even
 though the field "looks like default." Any "renders like default" call must name
-the exact delta you checked. Three things that get missed:
+the exact delta you checked. What gets missed:
 
 - **Ambient axes** - nothing in the prop list names these: RTL/`dir` (mirrored
   adornment layout), locale, theme. Same for built-in adornments.
@@ -77,33 +54,42 @@ the exact delta you checked. Three things that get missed:
 recipe rule for it, a dedicated `ReadOnly` / `Disabled` / `Invalid` story is a
 redundant baseline, not coverage. Read-only is the trap because the call is
 component-dependent: MoneyInput styles it (it disables the currency Select) and
-carries `ReadOnlyState`; MultilineTextInput / NumberInput / TextInput have no
+carries `ReadOnlyState`; MultilineTextInput, NumberInput and TextInput have no
 `data-readonly` rule and correctly carry none.
 
 **Primitives with no painted surface get no VRT at all.** The test isn't "has a
 recipe file" - it's **does it paint, and is there a state space to enumerate?**
-(Glob `*.recipe.*` when checking: 9 recipes are `.recipe.tsx`, so a `.ts`-only
-look concludes they have none.) Three shapes fail it, each getting zero
-snapshots plus a one-line `meta` note so the omission reads as deliberate:
+(Glob `*.recipe.*` when checking: some recipes are `.recipe.tsx`, so a
+`.ts`-only look concludes they have none.) Each such component gets zero
+snapshots plus a one-line `meta` note -
+`// No VRT: <reason> (see chromatic-visual-testing.md).` - so the omission reads
+as deliberate rather than forgotten. The shapes:
 
-- **Pass-through style-prop primitives** (Box, Flex, Stack, Grid, SimpleGrid,
-  Spacer - a `<div>`, no recipe). Every appearance comes from consumer style
-  props, so a snapshot tests Chakra + tokens, not the component.
+- **Pass-through style-prop primitives** (Box, Flex, Stack, Grid, Spacer - a
+  `<div>`, no recipe). Every appearance comes from consumer style props, so a
+  snapshot tests Chakra + tokens, not the component.
 - **A recipe that paints nothing** (Group: `inline-flex` + `alignItems`, zero
   variants). It sets no color, border or spacing, so the pixels are the
   children's.
 - **Headless / layout-transparent** (Region: `display: contents`). No box is
   rendered; the stories assert _where content lands_, which is DOM containment.
+- **No DOM of its own** - providers, and behavior-only wrappers that alter a
+  child without painting (MakeElementFocusable). VisuallyHidden is the same call
+  inverted: it paints, but off-screen by design, so there's nothing in frame to
+  diff.
+- **Every axis owned by another recipe** - InlineSvg reuses `iconRecipe`, so
+  Icon's `Sizes` and `CustomColor` already baseline it. Name the covering
+  stories in the note, not just the delegation.
 
 The inverse is the more common case: a primitive whose recipe **does** paint
 gets a normal audit - Separator's `orientation` over a `colorPalette.6` fill,
-Icon's six-value `size`.
+Icon's `size`.
 
 ## 2. Is the state reachable in this frame?
 
 **A state can be inert in the default frame - snapshot the condition that fires
 it.** Nothing looks wrong: the prop is set, the story renders, and the baseline
-records the state _off_ while reading as coverage. Four triggers seen so far:
+records the state _off_ while reading as coverage. The triggers seen so far:
 
 - **Sticky.** `position: sticky` (a recipe variant in DefaultPage, an inline
   prop on PageContent.Column) paints nothing until content passes beneath it, so
@@ -118,24 +104,24 @@ records the state _off_ while reading as coverage. Four triggers seen so far:
   it wants tall content, not a scroll.
 - **A variant that zeroes the surface.** ScrollArea's default `hover` sets
   `scrollbar { opacity: 0 }`, so a frame has to pin `always` to paint a track at
-  all - its `Sizes` showcase, left at the default, renders four empty boxes
-  while its width assertions still pass.
+  all - its `Sizes` showcase, left at the default, renders empty boxes while its
+  width assertions still pass.
 - **An inherited property with nothing to inherit.** ScrollArea's viewport sets
   `borderRadius: inherit`, inert until a consumer passes a radius, so the
   rounded-corner clipping was baselined nowhere until the matrix cells set one.
 
 **Hover and pressed need a forced pseudo-class, which a play can't deliver.**
-`userEvent.hover` fires DOM events without recomputing the pseudo-class - a
-spike confirmed it yields neither a real CSS `:hover` nor React Aria's
-`data-hovered`, and a synthetic `pointerenter` doesn't either. The two
-conventions in our recipes fail differently: Chakra `_hover` / `_active` compile
-to CSS pseudo-classes, which page JS cannot force at all, while React Aria's
-`[data-hovered]` / `[data-pressed]` are JS-set attributes a play _could_ set by
-hand. Don't - our recipes are split across both, so forcing the attribute styles
-only part of the frame and baselines a half-hovered state, which is worse than
-no snapshot. Pressed isn't automatically a no-op either: Button sets
-`data-pressed` but styles no rule for it, while NumberInput's steppers paint
-`_active` (`bg: neutral.4`). Check the recipe.
+`userEvent.hover` fires DOM events without recomputing the pseudo-class - it
+yields neither a real CSS `:hover` nor React Aria's `data-hovered`, and a
+synthetic `pointerenter` doesn't either. The two conventions in our recipes fail
+differently: Chakra `_hover` / `_active` compile to CSS pseudo-classes, which
+page JS cannot force at all, while React Aria's `[data-hovered]` /
+`[data-pressed]` are JS-set attributes a play _could_ set by hand. Don't - our
+recipes are split across both, so forcing the attribute styles only part of the
+frame and baselines a half-hovered state, which is worse than no snapshot.
+Pressed isn't automatically a no-op either: Button sets `data-pressed` but
+styles no rule for it, while NumberInput's steppers paint `_active`. Check the
+recipe.
 
 **Everything else a play _can_ drive, snapshot settled** - drag-over
 (`data-drop-target`), option focus (`data-focused`), selection
@@ -146,27 +132,37 @@ play-dispatchable event.
 sub-controls, and `_focusWithin` on more than one region, need a focus story per
 target - each side's ring clears the seam differently. There is no "all focused"
 state, since only one element holds focus at a time, so the per-target stories
-are the complete set (don't add a combined-ring snapshot). **Confirm the ring
-renders first**: on a slot that never gets the focus state the snapshot captures
-nothing (DropZone: ring on the root, focus on a hidden inner element).
+are the complete set. **Confirm the ring renders first**: on a slot that never
+gets the focus state the snapshot captures nothing (DropZone: ring on the root,
+focus on a hidden inner element).
 
 **Overlays: snapshot the _open_ state** - `defaultOpen` (Dialog/Drawer/Menu) or
 open it in the play and await the portal - and leave it open; the entrance
 animation settles on its last frame. Each distinct open surface is its own
 story: open dialogs/drawers fill the viewport with a backdrop and can't share a
-frame, so there's no `SmokeTest` matrix (independent recipe variants become
-separate open showcases). open/close, focus trap and dismissal stay behavioral.
+frame, so there's no `SmokeTest` matrix. Opening, closing, focus trap and
+dismissal stay behavioral.
 
 **Portals land in the frame only if the page is tall enough.** An
 absolutely-positioned portal adds no document height, so an overlay below a
 short root is cropped - fine in Storybook, cut in the build. Dialog and Toast
 fill the viewport and escape it; a listbox under one input needs a decorator
 reserving room (Combobox's `roomForPopover`). Hold transient UI open
-(`duration: Infinity` for toasts), await it, and clean up between stories
-(Toast's `clearToasts()`) so nothing leaks into the next capture. A portal
+(`duration: Infinity` for toasts) and await it before the capture. A portal
 component can be focusable in its own right (Toast's root has `tabIndex=0` +
 `focusRing: outside`) - reach it the real way (hotkey + Tab), not a synthetic
 `.focus()`.
+
+**Stories in a file share one browser page, so teardown is a snapshot concern.**
+The run sets `browser.isolate: false` (`vitest.storybook.config.ts`), so
+anything held outside React survives unmount into the next story's frame:
+Chakra's toast manager keeps its portal mounted, and React Aria's keyboard drag
+session is a module global that only Enter or Escape ends - left live it holds
+`inert` over the page and re-applies it to whatever mounts next. Clean up in
+**the teardown a `beforeEach` returns**, not at the top of the next play:
+Storybook runs it after the story, so it can't disturb the frame just captured,
+and it still fires when the leaking story is last in the file. Snippet in
+[stories.md](./file-type-guidelines/stories.md).
 
 **Snapshot `placement` only when it changes the _layout_**, not when it merely
 repositions the same box:
@@ -188,8 +184,8 @@ un-snapshotted behavioral stories (MoneyInput's `MoneyInputExample` renders a
 baseline and flaps on every value change. The line is **load-bearing and
 static**, not "is it a wrapper": a wrapper the component needs to resolve at all
 (DefaultPage's fixed-height `overflow: auto` Box), or visible children for a
-component that paints nothing (PageContent's placeholder boxes). Both are
-static; a read-out isn't.
+component that paints nothing (PageContent's placeholder boxes) both qualify. A
+read-out doesn't, because it isn't static.
 
 **Thin wrappers get no matrix.** A component that only constrains or forwards a
 wrapped component's props re-covers nothing by re-rendering the wrapped grid.
@@ -217,27 +213,26 @@ isn't forwarded when it is.
 **A compound component's unit is the recipe rule, not the realistic
 composition.** With several optional slots the pull is to snapshot every
 plausible arrangement - DefaultPage's info/form/tabular × main/detail. Slot
-presence only makes a new surface where a **rule keys off it** (there, two
-`:has()` selectors); the rest is the same slots in a different grid row. Ask
-which rule the frame alone fires - "it's a realistic page" means documentation,
-not a snapshot.
+presence only makes a new surface where a **rule keys off it** (there, `:has()`
+selectors); the rest is the same slots in a different grid row. Ask which rule
+the frame alone fires - "it's a realistic page" means documentation, not a
+snapshot.
 
 **An inherited token makes a cross-cell neither audit covers.** `colorPalette`
 cascades, so a child with no palette default takes its host's - FormActionBar's
-spinner strokes `primary.10` in save, `critical.10` in delete. One frame per
-host palette.
+spinner strokes the save palette in one frame and the delete palette in another.
+One frame per host palette.
 
 ## 4. Does the play land the frame?
 
-**The snapshot is the play's end state.** "Chromatic waits for the entire play
-function to execute and captures a snapshot only at the end," so IconButton's
-six-`step()` `Base` produces exactly one. Nothing blurs the element for you:
-whatever the last step leaves (a stray focus ring, a cleared value, a left-open
-overlay) is what gets captured. Separate axis from assertion-honesty - a play
-can assert exactly what its step names claim and still leave the wrong picture,
-which is how an honest-looking `ReadOnly` / `Clearable` snapshots a focused or
-emptied control. For an intermediate state, split it into its own story rather
-than expect a mid-play capture.
+**The snapshot is the play's end state.** Chromatic waits for the entire play to
+execute and captures only at the end, so a multi-`step()` play still produces
+exactly one frame. Nothing blurs the element for you: whatever the last step
+leaves (a stray focus ring, a cleared value, a left-open overlay) is what gets
+captured. A play can assert exactly what its step names claim and still leave
+the wrong picture - that's how an honest-looking `ReadOnly` or `Clearable` ends
+up snapshotting a focused or emptied control. For an intermediate state, split
+it into its own story rather than expect a mid-play capture.
 
 **A play's end state is never a reason to skip a snapshot.** "Ends focused",
 "ends open", "ends cleaned up", "drifts because nothing is pinned" are work to
@@ -247,133 +242,106 @@ in the baseline - and **a click leaves it focused**: React Aria keeps
 `data-focus-visible` set after `userEvent.click`, so a clicked trigger paints
 its ring even though a real mouse click wouldn't.
 
-**Don't add a play to a snapshotted story for completeness.** Each interaction
-is another frame to land deliberately, while a resting visual props alone
-produce is already tested by the snapshot plus the always-on a11y check. Where a
-play does belong the two aren't in tension - a story can both assert behavior
-and be snapshotted. The rule is per **component**, not per story; see
-[stories.md](./file-type-guidelines/stories.md) for which stories need one.
-
-**Hide the blinking text caret on a focused input.** Focusing paints the
-browser's native caret, which Chromatic can't stabilize (its
-[animations docs](https://www.chromatic.com/docs/animations/) cover only CSS and
-JS animations), so the snapshot diffs on whichever blink phase it lands on.
-`caret-color` inherits, so one line on the canvas cascades to the input - scoped
-to the story, not the shared `preview.tsx`:
-
-```typescript
-play: async ({ canvasElement }) => {
-  canvasElement.style.caretColor = "transparent"; // native caret can't be paused
-  await userEvent.tab();
-  // ...assert the ring
-},
-```
+**Hide the blinking text caret on a focused input.** Chromatic's animation
+pausing covers
+[CSS and JS animations](https://www.chromatic.com/docs/animations/) but not the
+browser's native caret, so a focused input diffs on whichever blink phase it
+lands on - not a Chromatic bug to chase. `caret-color` inherits, so one line on
+the canvas cascades to the input. Snippet in
+[stories.md](./file-type-guidelines/stories.md).
 
 **Animated components: know where Chromatic pauses.** It auto-pauses CSS
 transitions, CSS/SVG animations and videos (not JS animations - pause those
-manually) and seeks a **fixed** frame. The default pause point is the **last**
-frame of the cycle (`pauseAnimationAtEnd: false` switches it to the first). The
-trap is an `iteration-count: infinite` animation whose endpoints both hide the
-content: `progress-indeterminate` sweeps a 40% pill `translateX(-100% → 300%)`,
-parking it off the track at both ends, so the default snapshot is an empty
-track. **Pin a representative frame** in the play (`animation: none` + an
-explicit transform), as ProgressBar's `Indeterminate` does with
-`translateX(75%)`. A full-turn `spin` needs no pin - both endpoints render
-identically. The docs don't spell out the infinite case, so confirm the paused
-frame on the first run.
+manually) and seeks a **fixed** frame, by default the **last** of the cycle
+(`pauseAnimationAtEnd: false` switches it to the first). The trap is an
+`iteration-count: infinite` animation whose endpoints both hide the content:
+ProgressBar's indeterminate fill sweeps a pill off the track at both ends, so
+the default snapshot is an empty track. A full-turn `spin` needs no handling -
+both endpoints render identically. The docs don't spell out the infinite case,
+so confirm the paused frame on the first run.
 
-**Pin dates; opt live ones out.** A snapshotted date story pins a fixed anchor
-(a `CalendarDate` / `CalendarDateTime` in the args or `defaultValue` /
-`defaultFocusedValue`). One rendering a live "today" drifts the baseline daily,
-so it omits `tags: ["vrt"]` and verifies its behavior with a play instead.
+**Freeze an animation with the component's own prop where it has one.** Skeleton
+takes `animation="none"`, which holds its showcase still without reaching into
+the DOM, and its `SmokeTest` still covers the animated values as an axis. Only
+where no such prop exists does the play **pin** a frame by hand
+(`animation: none` + an explicit transform), as ProgressBar's `Indeterminate`
+does.
 
-**Await state your component _derives_ from an image load.** Chromatic waits for
-images to load, but not for that (Avatar hides its `<img>` until `onLoad`, and
-swaps to a fallback on error). Serve images locally (`staticDirs`) to avoid a
-flaky network dependency, and wait in the play for the post-load / post-error
-state you mean to snapshot. See [stories.md](./file-type-guidelines/stories.md)
-for the pattern.
-
-**Fonts/async loading can shift tooltips/menus** - relevant to IconButton's
-`ColorPalettes` story (it wraps each button in a `Tooltip`). Preload fonts or
-add a delay if those snapshots turn out flaky.
+**Reduced motion can't be snapshotted, so assert the rule instead.**
+`_motionReduce` compiles to a real `@media (prefers-reduced-motion: reduce)`
+query: a JS `matchMedia` mock can't influence it, and forcing it would need a
+Chromatic mode, which we don't configure (see **Modes are for global config**
+below). So a `ReducedMotion` story stays off-snapshot and asserts the compiled
+stylesheet still ships the `_motionReduce` block, anchored to the element's own
+hashed class so dropping the rule fails the test.
 
 ## 5. Packing the surfaces into frames
-
-**Coverage is the target; the matrix is only the cheapest container.** Cost has
-two levers and no others: TurboSnap bills unchanged snapshots at 1/5, and
-folding a `colorPalette × size × variant × state` grid into one `SmokeTest`
-keeps combinatorial coverage to a single billable snapshot (a reviewer also
-catches cross-axis regressions in one image). The `vrt` selection means "don't
-re-snapshot a state an on-snapshot already covers", never "snapshot fewer
-states". The matrix's tradeoff is granularity: a diff in any cell flags the
-whole snapshot, and editing it re-snapshots the whole grid, so reserve
-standalone snapshots for states needing distinct setup or isolated review
-(`Focused`, `DisabledGroup`, an open menu), not straight recipe output.
 
 **Any state the matrix can't render in one static image gets its own snapshotted
 story.** This is the governing rule behind the whole section - focus rings,
 disabled-but-focusable, an open tooltip/popover, special layouts. The matrix
 holds the interacting axes; a state it structurally can't hold becomes a
-separate frame, never a dropped state.
+separate frame, never a dropped state. Granularity is what the matrix costs you:
+a diff in any cell flags the whole snapshot and editing it re-snapshots the
+whole grid, so a state you want to triage independently is better off in its own
+frame too.
 
 **A matrix is only for _interacting_ axes.** When axes are independent - one
-just scales or recolors the other (Badge/Avatar `size × colorPalette`, Switch
-`size × on/off`) - snapshot each as its own showcase; the cross-product adds
-cells, not coverage. **`compoundVariants` settle it**: declaring one states the
-axes produce something neither yields alone, so the matrix is mandatory -
-Combobox has four, Link none. **Name the matrix `SmokeTest` and render it
-last** - the role name stays accurate as axes change, and the axis list goes in
-the doc comment.
+just scales or recolors the other (`size × colorPalette`, `size × on/off`) -
+snapshot each as its own showcase; the cross-product adds cells, not coverage.
+**`compoundVariants` settle it**: declaring one states the axes produce
+something neither yields alone, so the matrix is mandatory. **Name the matrix
+`SmokeTest`** - the role name stays accurate as axes change, and the axis list
+goes in the doc comment.
 
 **Over the axes it does span, the matrix must be exhaustive.** A single-axis
 showcase varies one axis with the rest at defaults, so
 `size="2xs" variant="ghost" colorPalette="critical"` is captured by **nothing**
-but the matrix - exactly where recipe regressions hide. Axis arrays span the
-**full supported range**; a trimmed or commented-out value leaves those cells
-covered by nothing. Scope call: matrices iterate the 6
-`SEMANTIC_COLOR_PALETTES`; the `BRAND` (3) and `SYSTEM` (25) palettes run the
-same token machinery and are deliberately not snapshotted.
+but the matrix - exactly where recipe regressions hide. Axis arrays span **the
+recipe's live keys**, not every key the type union names: mirroring a value the
+recipe itself comments out is fine, while trimming one it still ships leaves
+those cells covered by nothing. For a component with no recipe, read the one it
+borrows - IconButton has none and takes `ButtonProps`, so Button's live keys are
+its supported range. A value the recipe **hardcodes** collapses the axis
+entirely: MultilineTextInput pins `colorPalette: "neutral"`, so its matrix is
+`state × size × variant` and forcing a palette sweep onto it would render the
+same cell repeatedly.
 
-**Fold an axis in only if it interacts.** `disabled` is the canonical exception:
-it resolves to a single shared `layerStyle` (`opacity: 0.5` +
-`cursor: not-allowed`) identical across every palette/size/variant, so a
-`Disabled`/`DisabledGroup` story captures it once instead of the matrix
-re-rendering every cell at half opacity for no new coverage.
-
-**The fold-out only holds while what it dims is uniform**, so it loses to "cover
-distinct state-combinations" below. `layerStyle: "disabled"` dims whatever sits
-underneath, so once another state repaints that surface - Tree and DraggableList
-both tint `[data-selected]` - selected-disabled is a separate pixel and belongs
-in the matrix (FEC-1180: missed in both). Whether it exists at all depends on
-the selection model: React Aria reassigns single selection away from a disabled
-item (unreachable in Tabs), while consumer-owned props and multi-select allow
-it.
-
-**An axis the recipe hardcodes was never an axis.** MultilineTextInput pins
-`colorPalette: "neutral"`, so its matrix is `state × size × variant` with no
-palette axis - don't force the full `SEMANTIC_COLOR_PALETTES` sweep onto a
-recipe that can only ever render one. Distinct from the uniform-transform case
-above: `disabled` is a real axis folded out; a hardcoded palette had nothing to
-fold.
+**Palette scope depends on whether it multiplies.** As a **matrix axis**,
+palettes iterate `SEMANTIC_COLOR_PALETTES` - the `BRAND` and `SYSTEM` sets run
+the same token machinery and would multiply every cell for no new coverage. A
+**standalone `ColorPalettes` showcase** is one frame however many swatches it
+holds, so it uses the shared `DisplayColorPalettes` helper (`@/utils`), which
+renders all three groups labelled. Leaving such a showcase off-snapshot because
+only the semantic set is in scope is a defensible call rather than a rule, but
+it forgoes coverage the single frame would have carried for free.
 
 **Cover distinct state-combinations, not just single flags.** With multiple
 booleans (selected, disabled, invalid, read-only), each combination that renders
 differently needs coverage: selected-disabled is visually distinct from
 unselected-disabled, so a `Disabled` story showing only the unselected case
-leaves a gap.
+leaves a gap. Whether a combination exists at all depends on the selection
+model: React Aria reassigns single selection away from a disabled item
+(unreachable in Tabs), while consumer-owned props and multi-select allow it.
+
+**`disabled` folds out of the matrix only while what it dims is uniform.** It
+normally resolves to a single shared `layerStyle` identical across every
+palette/size/variant, so a `Disabled`/`DisabledGroup` story captures it once
+instead of the matrix re-rendering every cell at half opacity for no new
+coverage. But `layerStyle: "disabled"` dims whatever sits underneath, so once
+another state repaints that surface - Tree and DraggableList both tint
+`[data-selected]` - selected-disabled is a separate pixel and goes back in the
+matrix.
 
 **One state rendered more than one way → one story each, not a gallery frame.**
 Check whether the component renders `Focused` / `Disabled` / `ReadOnly` /
 `Invalid` mode- or variant-driven before assuming one story covers it.
 MoneyInput renders focus and disabled two ways - dropdown mode (a currency
-Select) and label mode (`currencies={[]}`, a static label with its own
-`currencyLabel[data-disabled] { opacity: 0.5 }` rule) - so it carries
-`Focused` + `FocusedWithCurrencyLabel` and `DisabledState` +
-`DisabledWithCurrencyLabel`. Independent surfaces don't interact the way matrix
-axes do, so folding them into one render trades away their independent baselines
-and per-surface triage. Snapshot count isn't a performance concern (Chromatic
-parallelizes; TurboSnap keeps a stable extra story near free).
+Select) and label mode (`currencies={[]}`, a static label with its own disabled
+rule) - so it carries `Focused` + `FocusedWithCurrencyLabel` and
+`DisabledState` + `DisabledWithCurrencyLabel`. Folding them into one render
+trades away their independent baselines and per-surface triage to save a
+snapshot, which isn't a cost worth saving.
 
 **Modes are for global config, not component props.** Chromatic
 [modes](https://www.chromatic.com/docs/modes/) (`chromatic.modes`) capture the

--- a/docs/file-type-guidelines/stories.md
+++ b/docs/file-type-guidelines/stories.md
@@ -174,16 +174,27 @@ export const SmokeTest: Story = {
 label for finding snapshot stories - keep the two together).
 
 Crop padding is global, not per story: a `preview.tsx` decorator wraps every
-non-`fullscreen` story in `1rem` so focus rings aren't clipped.
+non-`fullscreen` story in `1rem` so focus rings aren't clipped. Don't reach for
+`layout: "padded"` when a ring clips - Chromatic crops to the rendered content,
+so that padding sits outside the crop and can't reach in.
 
 The rules below are enough to author a story. **Read
 [chromatic-visual-testing.md](../chromatic-visual-testing.md) when a rule
 doesn't settle the case** - it holds the worked precedent for the calls a terse
-rule can state but not decide: whether a state paints differently from the
-default (read-only), whether two axes interact (matrix vs. separate showcases),
-a variant that zeroes its surface, how many frames a comma-separated selector
-needs, which slot arrangements are genuine surfaces, and any "renders like
-default" verdict. It groups them under the same five headings used below.
+rule can state but not decide. It groups them under the same five headings used
+below, so jump to the one you need rather than reading it through:
+
+- Whether a state paints differently from the default (read-only), how many
+  frames a comma-separated selector needs, any "renders like default" verdict →
+  [1. Does it paint?](../chromatic-visual-testing.md#1-does-it-paint)
+- A variant that zeroes its surface, an inherited property with nothing to
+  inherit, a focus ring on a slot that never focuses →
+  [2. Is the state reachable?](../chromatic-visual-testing.md#2-is-the-state-reachable-in-this-frame)
+- Which slot arrangements are genuine surfaces →
+  [3. Who owns the pixels?](../chromatic-visual-testing.md#3-who-owns-the-pixels)
+- Whether two axes interact (matrix vs. separate showcases) →
+  [5. Packing the surfaces into frames](../chromatic-visual-testing.md#5-packing-the-surfaces-into-frames)
+
 Auditing coverage for the first time → read it; adding a story to an
 already-audited component → don't.
 
@@ -199,8 +210,11 @@ already-audited component → don't.
 - **A state with no distinct recipe surface gets no story** - read-only is the
   component-dependent trap.
 - **Primitives that paint no surface get no VRT** - pass-through style props, a
-  recipe that paints nothing, or headless `display: contents`. Note it on
-  `meta`.
+  recipe that paints nothing, headless `display: contents`, anything rendering
+  no DOM of its own (providers, behavior-only wrappers, VisuallyHidden), or a
+  component whose every axis belongs to another recipe (InlineSvg → Icon).
+  Record it on `meta` in the settled format:
+  `// No VRT: <reason> (see chromatic-visual-testing.md).`
 
 **2. Is the state reachable in this frame?**
 
@@ -223,8 +237,13 @@ already-audited component → don't.
   surface is its own story.
 - **Portals: capture is page-wide, but the page must be tall enough** - an
   overlay hanging below a short root is cropped, so reserve `minHeight`. Hold
-  open, await, clean up between stories; reach a portal's focus via its real
-  keyboard path.
+  transient UI open and await it; reach a portal's focus via its real keyboard
+  path.
+- **State held outside React leaks into the next story's frame** - the run is
+  `isolate: false`, so a file's stories share one page and a live toast queue or
+  React Aria drag session outlives unmount. Clear it in the teardown a
+  `beforeEach` returns, which runs after the capture, not at the top of the next
+  play (snippet below).
 - **Snapshot `placement` only when it changes the layout**, not when it
   repositions the same box.
 
@@ -258,8 +277,12 @@ already-audited component → don't.
   name** - don't rename the step down.
 - **Pin dates** in a snapshotted story; a live "today" stays off-snapshot and
   behavioral.
-- Caret, sticky scroll, animation pinning and image-derived state have snippets
-  below.
+- **Freeze an animation with the component's own prop** where it has one
+  (`animation="none"`); hand-pin a frame only when it doesn't. **Reduced motion
+  isn't snapshottable** - no mode is configured and JS can't fake a media query,
+  so assert the compiled `_motionReduce` rule still ships instead.
+- Caret, sticky scroll, animation pinning, teardown and image-derived state have
+  snippets below.
 
 **5. Packing the surfaces into frames**
 
@@ -268,15 +291,24 @@ already-audited component → don't.
   matrix can't render gets its own story. Never drop a state to save cost. A
   recipe with `compoundVariants` over two axes has already declared they
   interact - build the matrix.
-- **Name the interacting-axes matrix `SmokeTest`, rendered last** - the axis
-  list lives in the doc comment.
-- **Axis arrays span the full supported range** - palettes iterate the 6
-  `SEMANTIC_COLOR_PALETTES`, not the `BRAND` or `SYSTEM` sets. An axis the
-  recipe hardcodes isn't an axis; a uniform transform (`disabled`) folds out
-  into its own story.
+- **Name the interacting-axes matrix `SmokeTest`** - the axis list lives in the
+  doc comment.
+- **Axis arrays span the recipe's live keys**, not every key the type union
+  names - mirroring a value the recipe itself comments out is fine, trimming one
+  it still ships is a gap. A component with no recipe inherits the range of the
+  one it borrows (IconButton → Button); a value the recipe hardcodes collapses
+  the axis entirely.
+- **Palette scope depends on the frame** - as a **matrix axis**,
+  `SEMANTIC_COLOR_PALETTES` only, since every extra multiplies the cells. A
+  **standalone `ColorPalettes` showcase** costs one frame either way, so it uses
+  the shared `DisplayColorPalettes` helper (`@/utils`), which covers all three
+  groups.
 - **Cover distinct state-combinations**, not just single flags
-  (selected-disabled ≠ unselected-disabled) - beats the fold-out above, when
-  reachable (React Aria reassigns selection off disabled items).
+  (selected-disabled ≠ unselected-disabled), where the selection model makes
+  them reachable (React Aria reassigns selection off disabled items).
+- **`disabled` folds out into its own story only while what it dims is
+  uniform** - once another state repaints that surface (a tinted
+  `[data-selected]`), the combination goes back in the matrix.
 - **One state rendered more than one way → one story each**, not a folded
   gallery.
 - **`chromatic.modes` is global config only** (viewport/theme/locale), never
@@ -331,10 +363,27 @@ play: async ({ canvasElement }) => {
     timeout: 3000,
   });
 };
+
+// Teardown under isolate: false: the returned fn runs AFTER the capture.
+// On meta, for state every story in the file can leave behind:
+const meta: Meta = {
+  beforeEach: () => clearToasts, // toast.remove() + toast.reset(), awaited
+};
+
+// On one story, for state only it creates:
+export const DragInProgress: Story = {
+  beforeEach: () => () => {
+    // React Aria's keyboard drag is a module global; unmounting doesn't end it.
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+  },
+};
 ```
 
-Full rationale, edge cases, CI, baselines and TurboSnap are in
-[Chromatic Visual Testing](../chromatic-visual-testing.md).
+Full rationale and edge cases are in
+[Chromatic Visual Testing](../chromatic-visual-testing.md); triggers, baselines
+and TurboSnap are in the [Chromatic CI Runbook](../chromatic-ci.md).
 
 ## File Structure
 
@@ -481,8 +530,8 @@ play coverage in its file, not on every story it exports.
   snapshot and the always-on a11y check are the test.
 
 Never add a play for completeness; on a snapshotted story every interaction is
-one more frame to land deliberately. Rationale in
-[chromatic-visual-testing.md](../chromatic-visual-testing.md).
+one more frame to land deliberately, and a resting visual is already tested by
+the snapshot plus the always-on a11y check.
 
 ### Play Function Structure
 

--- a/packages/nimbus/src/components/item-group/item-group.stories.tsx
+++ b/packages/nimbus/src/components/item-group/item-group.stories.tsx
@@ -16,7 +16,9 @@ type Story = StoryObj<typeof ItemGroup.Root>;
  * Base — a group of Item rows divided by separators.
  */
 export const Base: Story = {
+  // VRT: the separator's own `colorPalette.6` fill - no Item story snapshots a group.
   tags: ["vrt"],
+  parameters: { chromatic: { disableSnapshot: false } },
   render: () => (
     <ItemGroup.Root aria-label="Account">
       <Item.Root>

--- a/packages/nimbus/src/components/item/item.stories.tsx
+++ b/packages/nimbus/src/components/item/item.stories.tsx
@@ -385,9 +385,10 @@ export const LinkWithActions: Story = {
  * - **`ItemGroup.Root` + `ItemGroup.Separator`** for grouped sections, and a
  *   standalone `Item.Root` outside any group.
  *
- * Not VRT-snapshotted (the network imagery would flake, and `SmokeTest` already
- * owns visual coverage with an offline image); the play function asserts
- * behavior and the deterministic image `src`.
+ * Not VRT-snapshotted (the network imagery would flake); the play function
+ * asserts behavior and the deterministic image `src`. Item's visuals live in
+ * `SmokeTest` with an offline image, ItemGroup's in its own `Base` - `SmokeTest`
+ * renders no group.
  */
 const onMemberSettings = fn();
 

--- a/packages/nimbus/src/components/tooltip/make-element-focusable.stories.tsx
+++ b/packages/nimbus/src/components/tooltip/make-element-focusable.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { within, expect } from "storybook/test";
 import { MakeElementFocusable, Tooltip } from "@commercetools/nimbus";
 
+// No VRT: adds focusability to its child, paints nothing of its own
+// (see chromatic-visual-testing.md).
 const meta: Meta<typeof MakeElementFocusable> = {
   title: "Components/Tooltip/MakeElementFocusable",
   component: MakeElementFocusable,


### PR DESCRIPTION
Closes the documentation re-evaluation step of FEC-1190. Reconciles the three canonical Chromatic docs against what the rollout batches actually established, and fixes the coverage gaps  found on the way.