### PR TITLE
chore(deps): update workspace dependencies to latest minor/patch versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ catalogs:
       specifier: ^10.0.1
       version: 10.0.1
     '@figma/code-connect':
-      specifier: ^1.5.2
-      version: 1.5.2
+      specifier: ^1.5.3
+      version: 1.5.3
     '@fission-ai/openspec':
       specifier: ^1.7.0
       version: 1.7.0
@@ -181,14 +181,14 @@ catalogs:
       specifier: ^16.3.2
       version: 16.3.2
     '@testing-library/user-event':
-      specifier: ^14.6.3
-      version: 14.6.3
+      specifier: ^14.6.4
+      version: 14.6.4
     '@typescript-eslint/types':
-      specifier: ^8.66.0
-      version: 8.66.0
+      specifier: ^8.67.0
+      version: 8.67.0
     '@typescript-eslint/typescript-estree':
-      specifier: ^8.66.0
-      version: 8.66.0
+      specifier: ^8.67.0
+      version: 8.67.0
     '@vitejs/plugin-react':
       specifier: ^6.0.5
       version: 6.0.5
@@ -211,11 +211,11 @@ catalogs:
       specifier: ^4.12.1
       version: 4.12.1
     chromatic:
-      specifier: ^18.0.0
-      version: 18.1.0
+      specifier: ^18.2.0
+      version: 18.2.0
     eslint:
-      specifier: ^10.8.0
-      version: 10.8.0
+      specifier: ^10.8.1
+      version: 10.8.1
     eslint-config-prettier:
       specifier: ^10.1.8
       version: 10.1.8
@@ -226,17 +226,17 @@ catalogs:
       specifier: ^7.1.1
       version: 7.1.1
     eslint-plugin-react-refresh:
-      specifier: ^0.5.3
-      version: 0.5.3
+      specifier: ^0.5.4
+      version: 0.5.4
     eslint-plugin-storybook:
-      specifier: 10.5.7
-      version: 10.5.7
+      specifier: 10.5.8
+      version: 10.5.8
     glob:
       specifier: ^13.0.6
       version: 13.0.6
     globals:
-      specifier: ^17.9.0
-      version: 17.9.0
+      specifier: ^17.11.0
+      version: 17.11.0
     playwright:
       specifier: ^1.62.1
       version: 1.62.1
@@ -256,14 +256,14 @@ catalogs:
       specifier: ^8.5.1
       version: 8.5.1
     tsx:
-      specifier: ^4.23.5
-      version: 4.23.5
+      specifier: ^4.23.12
+      version: 4.23.12
     typescript-eslint:
-      specifier: ^8.66.0
-      version: 8.66.0
+      specifier: ^8.67.0
+      version: 8.67.0
     vite:
-      specifier: ^8.2.0
-      version: 8.2.0
+      specifier: ^8.2.1
+      version: 8.2.1
     vite-bundle-analyzer:
       specifier: ^1.3.9
       version: 1.3.9
@@ -385,10 +385,10 @@ importers:
         version: link:packages/nimbus
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
+        version: 10.0.1(eslint@10.8.1(supports-color@8.1.1))
       '@figma/code-connect':
         specifier: catalog:tooling
-        version: 1.5.2
+        version: 1.5.3
       '@fission-ai/openspec':
         specifier: catalog:tooling
         version: 1.7.0(@types/node@24.13.3)
@@ -400,25 +400,25 @@ importers:
         version: 17.4.2
       eslint:
         specifier: catalog:tooling
-        version: 10.8.0(supports-color@8.1.1)
+        version: 10.8.1(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: catalog:tooling
-        version: 10.1.8(eslint@10.8.0(supports-color@8.1.1))
+        version: 10.1.8(eslint@10.8.1(supports-color@8.1.1))
       eslint-plugin-prettier:
         specifier: catalog:tooling
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)))(eslint@10.8.0(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.1(supports-color@8.1.1)))(eslint@10.8.1(supports-color@8.1.1))(prettier@3.9.6)
       eslint-plugin-react-hooks:
         specifier: catalog:tooling
-        version: 7.1.1(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.1.1(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-storybook:
         specifier: catalog:tooling
-        version: 10.5.7(eslint@10.8.0(supports-color@8.1.1))(storybook@10.5.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.5.8(eslint@10.8.1(supports-color@8.1.1))(storybook@10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
       glob:
         specifier: catalog:tooling
         version: 13.0.6
       globals:
         specifier: catalog:tooling
-        version: 17.9.0
+        version: 17.11.0
       playwright:
         specifier: catalog:tooling
         version: 1.62.1
@@ -430,22 +430,22 @@ importers:
         version: 0.3.23
       tsx:
         specifier: catalog:tooling
-        version: 4.23.5
+        version: 4.23.12
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       vite-bundle-analyzer:
         specifier: catalog:tooling
         version: 1.3.9
       vitest:
         specifier: catalog:tooling
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
 
   apps/blank-app:
     dependencies:
@@ -464,7 +464,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
+        version: 10.0.1(eslint@10.8.1(supports-color@8.1.1))
       '@types/react':
         specifier: catalog:react
         version: 19.2.18
@@ -473,25 +473,25 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
-        version: 10.8.0(supports-color@8.1.1)
+        version: 10.8.1(supports-color@8.1.1)
       eslint-plugin-react-refresh:
         specifier: catalog:tooling
-        version: 0.5.3(eslint@10.8.0(supports-color@8.1.1))
+        version: 0.5.4(eslint@10.8.1(supports-color@8.1.1))
       globals:
         specifier: catalog:tooling
-        version: 17.9.0
+        version: 17.11.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       webpack:
         specifier: catalog:tooling
         version: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
@@ -606,7 +606,7 @@ importers:
         version: link:../../packages/design-token-ts-plugin
       '@eslint/js':
         specifier: catalog:tooling
-        version: 10.0.1(eslint@10.8.0(supports-color@8.1.1))
+        version: 10.0.1(eslint@10.8.1(supports-color@8.1.1))
       '@types/lodash':
         specifier: catalog:utils
         version: 4.17.25
@@ -618,34 +618,34 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react-swc':
         specifier: catalog:tooling
-        version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 4.3.3(@swc/helpers@0.5.17)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       eslint:
         specifier: catalog:tooling
-        version: 10.8.0(supports-color@8.1.1)
+        version: 10.8.1(supports-color@8.1.1)
       eslint-plugin-react-refresh:
         specifier: catalog:tooling
-        version: 0.5.3(eslint@10.8.0(supports-color@8.1.1))
+        version: 0.5.4(eslint@10.8.1(supports-color@8.1.1))
       globals:
         specifier: catalog:tooling
-        version: 17.9.0
+        version: 17.11.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: catalog:tooling
-        version: 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: catalog:tooling
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       vite-plugin-compression:
         specifier: catalog:apps
-        version: 0.5.1(supports-color@8.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 0.5.1(supports-color@8.1.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
 
   apps/plugin-test:
     devDependencies:
       vite:
         specifier: catalog:tooling
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       webpack:
         specifier: catalog:tooling
         version: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
@@ -688,10 +688,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:tooling
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       vitest:
         specifier: catalog:tooling
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
 
   packages/i18n:
     devDependencies:
@@ -794,13 +794,13 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
       '@storybook/addon-vitest':
         specifier: catalog:tooling
         version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: catalog:tooling
-        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+        version: 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
       '@testing-library/jest-dom':
         specifier: catalog:tooling
         version: 6.9.1
@@ -809,7 +809,7 @@ importers:
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: catalog:tooling
-        version: 14.6.3(@testing-library/dom@10.4.1)
+        version: 14.6.4(@testing-library/dom@10.4.1)
       '@types/escape-html':
         specifier: catalog:utils
         version: 1.0.4
@@ -824,13 +824,13 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: catalog:tooling
-        version: 6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 6.0.5(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       '@vitest/browser':
         specifier: catalog:tooling
-        version: 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: catalog:tooling
-        version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: catalog:tooling
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -845,7 +845,7 @@ importers:
         version: 4.12.1
       chromatic:
         specifier: catalog:tooling
-        version: 18.1.0
+        version: 18.2.0
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
@@ -881,22 +881,22 @@ importers:
         version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       vite:
         specifier: catalog:tooling
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: catalog:tooling
-        version: 5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+        version: 5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
       vitest:
         specifier: catalog:tooling
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
 
   packages/nimbus-docs-build:
     dependencies:
       '@typescript-eslint/types':
         specifier: catalog:tooling
-        version: 8.66.0
+        version: 8.67.0
       '@typescript-eslint/typescript-estree':
         specifier: catalog:tooling
-        version: 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
+        version: 8.67.0(supports-color@8.1.1)(typescript@5.9.3)
       gray-matter:
         specifier: catalog:utils
         version: 4.0.3
@@ -983,10 +983,10 @@ importers:
         version: 24.13.3
       tsup:
         specifier: catalog:tooling
-        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.23.5)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.23.12)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: catalog:tooling
-        version: 4.23.5
+        version: 4.23.12
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -2177,8 +2177,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@figma/code-connect@1.5.2':
-    resolution: {integrity: sha512-TlTFDRU3G+1EDHJU7xXf41hxtOfZZa5qWMNp9NkQTE7mmg/W+xtFY/iGfRHx1d4lfACTCldTQcW5I6PXck4yLA==}
+  '@figma/code-connect@1.5.3':
+    resolution: {integrity: sha512-rQ3cBKVK0z5n8oNW0ypojcLm0rrmTm1y8W0IUHQdlhyf/STnz7eCsIdCRZ6k5iXRW4D6PF0IHPKK7V+6bTa7RQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4331,6 +4331,12 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@testing-library/user-event@14.6.4':
+    resolution: {integrity: sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokens-studio/sd-transforms@2.0.3':
     resolution: {integrity: sha512-PyrmRb7FuJBHzsbuWNk/O06hJbaZ+RL7chmK7PRbEptaSruhANai7Kxja5CiYnTcxOj373uRMDPxoFwCHaVpvA==}
     engines: {node: '>=18.0.0'}
@@ -4514,16 +4520,16 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
-  '@typescript-eslint/eslint-plugin@8.66.0':
-    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.66.0
+      '@typescript-eslint/parser': ^8.67.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ~5.9.3
 
-  '@typescript-eslint/parser@8.66.0':
-    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -4535,8 +4541,18 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
   '@typescript-eslint/scope-manager@8.66.0':
     resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.66.0':
@@ -4545,8 +4561,14 @@ packages:
     peerDependencies:
       typescript: ~5.9.3
 
-  '@typescript-eslint/type-utils@8.66.0':
-    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -4556,8 +4578,18 @@ packages:
     resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.66.0':
     resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: ~5.9.3
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: ~5.9.3
@@ -4569,8 +4601,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ~5.9.3
 
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ~5.9.3
+
   '@typescript-eslint/visitor-keys@8.66.0':
     resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -5294,8 +5337,8 @@ packages:
   chroma-js@3.1.2:
     resolution: {integrity: sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==}
 
-  chromatic@18.1.0:
-    resolution: {integrity: sha512-I9av8lUc5CQRlYzwKpmOG9cwYvZ4AFmTvtHeNrzOMC1353F9xYw45CHpSNIsNKuOiqqmzci9esXQd5akl0fi6w==}
+  chromatic@18.2.0:
+    resolution: {integrity: sha512-xyTKDhBQPDd4qrsXhJK7GAJyIStpRoSTs4b7EtPyliSL0luej3DcqkeCZ9osHxbiLXiViNyWfMxo5Xgzejex8A==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -5879,16 +5922,16 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-react-refresh@0.5.3:
-    resolution: {integrity: sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==}
+  eslint-plugin-react-refresh@0.5.4:
+    resolution: {integrity: sha512-7bqTKz7T0r+HKWFarNXByDE9/5+73wI2ru+M3zuqGbR7s/b/5/pQJXZoufWlrngqGqoZto73ZkGumCdLxk+4rw==}
     peerDependencies:
       eslint: ^9 || ^10
 
-  eslint-plugin-storybook@10.5.7:
-    resolution: {integrity: sha512-mLpamG1Rsica2jYbUzIZOEuy7Fm1IMtVLMvvxGTpjTVKUMxTXJsANx3MBpH2VSbGQB8Yzlt5399WL/O07K97Ig==}
+  eslint-plugin-storybook@10.5.8:
+    resolution: {integrity: sha512-bf9W5nZyWdIaCUZf4aEZnEeD1mn+csNYX8dYUQjAo6L7/DkSLtr65R4zFZ1xeS4m6dOXO6UtUySesCSw4e8w1g==}
     peerDependencies:
       eslint: '>=8'
-      storybook: ^10.5.7
+      storybook: ^10.5.8
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -5906,8 +5949,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.8.0:
-    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -6273,8 +6316,8 @@ packages:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
     engines: {node: '>=10.0'}
 
-  globals@17.9.0:
-    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
+  globals@17.11.0:
+    resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -8446,8 +8489,8 @@ packages:
       vite-plus:
         optional: true
 
-  storybook@10.5.7:
-    resolution: {integrity: sha512-oiKvWIwIoOhFP1i6dASYyMXwPHKEtVZMshqSB7EvIVYjWRh0l9H7gHEt1z4Gh2rLGFMekWdsm4s94rvwpR7gkg==}
+  storybook@10.5.8:
+    resolution: {integrity: sha512-rR4oFMSiWBSqI0lvsJPtcQUPj8+hzj3TkLu+Mw61Wo6YxPSb5FsLSHai0jZnuaIdKIlmu25KCfwlSQl4e1uvnA==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -8758,8 +8801,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.23.5:
-    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -8783,8 +8826,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typescript-eslint@8.66.0:
-    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -9027,8 +9070,8 @@ packages:
       vite:
         optional: true
 
-  vite@8.2.0:
-    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -9246,8 +9289,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.21.3:
-    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -12232,9 +12275,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1(supports-color@8.1.1))':
     dependencies:
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -12255,9 +12298,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.0(supports-color@8.1.1))':
+  '@eslint/js@10.0.1(eslint@10.8.1(supports-color@8.1.1))':
     optionalDependencies:
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -12268,7 +12311,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@figma/code-connect@1.5.2':
+  '@figma/code-connect@1.5.3':
     dependencies:
       boxen: 5.1.1
       chalk: 4.1.2
@@ -12673,11 +12716,11 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -14299,10 +14342,10 @@ snapshots:
       axe-core: 4.12.1
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.0)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -14324,33 +14367,33 @@ snapshots:
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.62.4
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
 
   '@storybook/global@5.0.0': {}
@@ -14369,11 +14412,11 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
       '@storybook/react': 10.4.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -14383,7 +14426,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -14619,6 +14662,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@testing-library/user-event@14.6.4(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokens-studio/sd-transforms@2.0.3(style-dictionary@5.4.4(tslib@2.8.1))':
     dependencies:
       '@bundled-es-modules/deepmerge': 4.3.2
@@ -14803,15 +14850,15 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.66.0
-      eslint: 10.8.0(supports-color@8.1.1)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      eslint: 10.8.1(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -14819,14 +14866,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.66.0
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14840,28 +14887,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.67.0(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.66.0':
     dependencies:
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
 
+  '@typescript-eslint/scope-manager@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+
   '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.66.0': {}
+
+  '@typescript-eslint/types@8.67.0': {}
 
   '@typescript-eslint/typescript-estree@8.66.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
@@ -14878,13 +14945,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.67.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@8.1.1))
+      '@typescript-eslint/project-service': 8.67.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.6
+      semver: 7.7.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.1(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14894,46 +14987,51 @@ snapshots:
       '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript-eslint/visitor-keys@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      eslint-visitor-keys: 5.0.1
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@visulima/boxen@2.0.10': {}
 
-  '@vitejs/plugin-react-swc@4.3.3(@swc/helpers@0.5.17)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
+  '@vitejs/plugin-react-swc@4.3.3(@swc/helpers@0.5.17)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       '@swc/core': 1.15.47(@swc/helpers@0.5.17)
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -14953,9 +15051,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14974,13 +15072,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -15992,7 +16090,7 @@ snapshots:
 
   chroma-js@3.1.2: {}
 
-  chromatic@18.1.0:
+  chromatic@18.2.0:
     dependencies:
       semver: 7.7.4
 
@@ -16489,40 +16587,40 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)):
+  eslint-config-prettier@10.1.8(eslint@10.8.1(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(supports-color@8.1.1)))(eslint@10.8.0(supports-color@8.1.1))(prettier@3.9.6):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.1(supports-color@8.1.1)))(eslint@10.8.1(supports-color@8.1.1))(prettier@3.9.6):
     dependencies:
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
       prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.8.0(supports-color@8.1.1))
+      eslint-config-prettier: 10.1.8(eslint@10.8.1(supports-color@8.1.1))
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.3(eslint@10.8.0(supports-color@8.1.1)):
+  eslint-plugin-react-refresh@0.5.4(eslint@10.8.1(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.8.0(supports-color@8.1.1)
+      eslint: 10.8.1(supports-color@8.1.1)
 
-  eslint-plugin-storybook@10.5.7(eslint@10.8.0(supports-color@8.1.1))(storybook@10.5.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-plugin-storybook@10.5.8(eslint@10.8.1(supports-color@8.1.1))(storybook@10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 10.8.0(supports-color@8.1.1)
-      storybook: 10.5.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.1(supports-color@8.1.1)
+      storybook: 10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16543,9 +16641,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0(supports-color@8.1.1):
+  eslint@10.8.1(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5(supports-color@8.1.1)
       '@eslint/config-helpers': 0.7.0
@@ -16986,7 +17084,7 @@ snapshots:
       semver: 7.7.4
       serialize-error: 7.0.1
 
-  globals@17.9.0: {}
+  globals@17.11.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -18588,12 +18686,12 @@ snapshots:
     dependencies:
       postcss-value-parser: 3.3.1
 
-  postcss-load-config@6.0.1(postcss@8.5.14)(tsx@4.23.5)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.14)(tsx@4.23.12)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.14
-      tsx: 4.23.5
+      tsx: 4.23.12
       yaml: 2.8.3
 
   postcss-value-parser@3.3.1: {}
@@ -19640,7 +19738,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/jest-dom': 6.10.0(@testing-library/dom@10.4.1)
-      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.4(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
@@ -19664,7 +19762,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  storybook@10.5.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  storybook@10.5.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -19682,7 +19780,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       use-sync-external-store: 1.6.0(react@19.2.0)
-      ws: 8.21.3
+      ws: 8.21.1
     optionalDependencies:
       '@types/react': 19.2.18
       prettier: 3.9.6
@@ -19964,7 +20062,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.23.5)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(@swc/core@1.15.47(@swc/helpers@0.5.17))(postcss@8.5.14)(supports-color@8.1.1)(tsx@4.23.12)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -19975,7 +20073,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.23.5)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.23.12)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.62.4
       source-map: 0.7.6
@@ -19994,7 +20092,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.23.5:
+  tsx@4.23.12:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -20020,13 +20118,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
+  typescript-eslint@8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 10.8.0(supports-color@8.1.1)
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.8.1(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -20091,7 +20189,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
       '@volar/typescript': 2.4.28
@@ -20107,7 +20205,7 @@ snapshots:
       esbuild: 0.28.1
       rolldown: 1.2.2
       rollup: 4.62.4
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.17))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.14)(webpack-cli@7.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -20244,22 +20342,22 @@ snapshots:
 
   vite-bundle-analyzer@1.3.9: {}
 
-  vite-plugin-compression@0.5.1(supports-color@8.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)):
+  vite-plugin-compression@0.5.1(supports-color@8.1.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(webpack@5.109.2)
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.53.1(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(webpack@5.109.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@24.13.3)
       rollup: 4.62.4
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -20269,7 +20367,7 @@ snapshots:
       - typescript
       - webpack
 
-  vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3):
+  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -20281,13 +20379,13 @@ snapshots:
       esbuild: 0.28.1
       fsevents: 2.3.3
       terser: 5.44.0
-      tsx: 4.23.5
+      tsx: 4.23.12
       yaml: 2.8.3
 
-  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -20304,11 +20402,11 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(terser@5.44.0)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.0.1
     transitivePeerDependencies:
@@ -20465,7 +20563,7 @@ snapshots:
 
   ws@8.21.0: {}
 
-  ws@8.21.3: {}
+  ws@8.21.1: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -150,15 +150,15 @@ overrides:
 
 catalogs:
   tooling:
-    "@figma/code-connect": ^1.5.2
+    "@figma/code-connect": ^1.5.3
     "@fission-ai/openspec": ^1.7.0
     eslint-plugin-react-hooks: ^7.1.1
-    globals: ^17.9.0
+    globals: ^17.11.0
     glob: ^13.0.6
     typescript: ~5.9.3
-    typescript-eslint: ^8.66.0
+    typescript-eslint: ^8.67.0
     tsup: ^8.5.1
-    tsx: ^4.23.5
+    tsx: ^4.23.12
     "@arethetypeswrong/cli": ^0.18.5
     publint: ^0.3.23
     "@commercetools-frontend/ui-kit": ^20.6.7
@@ -168,10 +168,10 @@ catalogs:
     "@babel/preset-typescript": ^7.29.7
     "@eslint/js": ^10.0.1
     "@react-types/shared": ^3.36.1
-    eslint: ^10.8.0
+    eslint: ^10.8.1
     eslint-config-prettier: ^10.1.8
     eslint-plugin-prettier: ^5.5.6
-    eslint-plugin-react-refresh: ^0.5.3
+    eslint-plugin-react-refresh: ^0.5.4
     express-rate-limit: ^8.6.2
     prettier: ^3.9.6
     "@preconstruct/cli": ^2.8.13
@@ -179,7 +179,7 @@ catalogs:
     "@changesets/cli": 2.31.1
     "@vitejs/plugin-react": ^6.0.5
     "@vitejs/plugin-react-swc": ^4.3.3
-    vite: ^8.2.0
+    vite: ^8.2.1
     webpack: ^5.109.2
     webpack-cli: ^7.2.2
     vite-bundle-analyzer: ^1.3.9
@@ -195,13 +195,13 @@ catalogs:
     # back — ^6.9.1 re-resolves straight to 6.10.0. The 6.x line ends here;
     # moving forward means 7.0.0, which is a major and needs its own PR.
     "@testing-library/jest-dom": 6.9.1
-    "@testing-library/user-event": ^14.6.3
+    "@testing-library/user-event": ^14.6.4
     "@testing-library/react": ^16.3.2
     playwright: ^1.62.1
     vitest: ^4.1.10
     axe-core: ^4.12.1
-    "@typescript-eslint/types": ^8.66.0
-    "@typescript-eslint/typescript-estree": ^8.66.0
+    "@typescript-eslint/types": ^8.67.0
+    "@typescript-eslint/typescript-estree": ^8.67.0
     react-docgen-typescript: ^2.4.0
     # Storybook pinned exact at 10.4.6: 10.5.0 wraps HTMLElement.focus in its CSF
     # runtime and throws "Illegal invocation" when react-aria's
@@ -210,14 +210,14 @@ catalogs:
     # ecosystem — including the copies pulled transitively by the @github-ui /
     # @vueless addons — off 10.5.0. Reconfirmed on 2026-07-15.
     storybook: 10.4.6
-    eslint-plugin-storybook: 10.5.7
+    eslint-plugin-storybook: 10.5.8
     "@storybook/addon-a11y": 10.4.6
     "@storybook/addon-docs": 10.4.6
     "@storybook/addon-vitest": 10.4.6
     "@storybook/react-vite": 10.4.6
     "@vueless/storybook-dark-mode": ^10.0.8
     "@github-ui/storybook-addon-performance-panel": ^1.1.4
-    chromatic: ^18.0.0
+    chromatic: ^18.2.0
     jsdom: 29.0.1 # pinned: 29.0.2+ breaks Chakra/Emotion CSS in JSDOM (style assertions return padding: 0); reconfirmed against 29.1.0 on 2026-04-29
   react:
     "@types/react": ^19.2.18


### PR DESCRIPTION
## Summary

Updates workspace catalog dependencies to their latest minor/patch versions, respecting semver constraints and the repo's `minimumReleaseAge` supply-chain gate.

Of 114 catalog entries, **12 were updated**, **2 were held back after failing verification**, 10 are pinned/frozen by policy, and 90 were already at their latest in-range version.

## 🔧 Tooling Dependencies Updated (12)

**Linting**

- `eslint`: ^10.8.0 → ^10.8.1 (patch)
- `typescript-eslint`: ^8.66.0 → ^8.67.0 (minor)
- `@typescript-eslint/types`: ^8.66.0 → ^8.67.0 (minor)
- `@typescript-eslint/typescript-estree`: ^8.66.0 → ^8.67.0 (minor)
- `eslint-plugin-storybook`: 10.5.7 → 10.5.8 (patch)
- `eslint-plugin-react-refresh`: ^0.5.3 → ^0.5.4 (patch)

**Build & dev tools**

- `vite`: ^8.2.0 → ^8.2.1 (patch)
- `tsx`: ^4.23.5 → ^4.23.12 (patch)
- `globals`: ^17.9.0 → ^17.11.0 (minor)

**Testing & tooling**

- `@testing-library/user-event`: ^14.6.3 → ^14.6.4 (patch)
- `chromatic`: ^18.0.0 → ^18.2.0 (minor)
- `@figma/code-connect`: ^1.5.2 → ^1.5.3 (patch)

**Transitive lockfile updates**

- `@typescript-eslint/eslint-plugin`, `/parser`, `/type-utils`: 8.66.0 → 8.67.0
- `storybook`: 10.5.7 → 10.5.8 and `ws`: 8.21.3 → 8.21.1 — **only** the peer instance belonging to `eslint-plugin-storybook`. The pinned 10.4.6 test/build toolchain still resolves `ws@8.21.0`, unchanged. Verified by mapping every `ws` reference to its dependent before and after.

## ⛔ Held Back After Failing Verification (2)

Neither was held back by `minimumReleaseAge` — **zero** packages were age-gated this run. Both failed a CI gate and were reverted per the rollback protocol. No `minimumReleaseAgeExclude` entry was added (audited).

### `axe-core` — stays at ^4.12.1 (4.13.0 available)

Bumping the catalog entry re-resolves **`@storybook/addon-a11y@10.4.6`'s own `axe-core: ^4.2.0`** up to 4.13.0. Since the addon is the engine that actually runs the a11y checks, this broke 2 story tests in `confirmation-dialog.stories.tsx`:

```
color-contrast-apca-custom
Element has insufficient APCA custom level contrast of 57.96Lc
  (foreground #ce2c31, background #ffdbdc, 12.0pt (16px), weight 500).
  Expected minimum APCA lightness contrast of 60Lc
```

⚠️ **This looks like a real design-token finding, not just a tool regression.** The colors are Nimbus's own `critical.11` on `critical.4` (`red.light.11` / `red.light.4`) as used by the button `subtle` variant, and the 60Lc threshold is the repo's own, set in `.storybook/apca-check/`. The pair is short by **2.04Lc**. The custom check consumes axe-core's internal `getBackgroundColor`/`getForegroundColor`, so 4.13.0 changing that resolution is what surfaced it.

Because `addon-a11y` declares an unpinned `^4.2.0`, **this will resurface on any future re-resolution of that subgraph.** Suggested follow-up: decide whether to adjust the token pair or the threshold, then either adopt 4.13.0 or pin it deliberately via `overrides`.

### `@fission-ai/openspec` — stays at ^1.7.0 (1.9.0 available)

1.9.0 adds a stricter MODIFIED-requirement rule that fails `pnpm openspec validate --all --strict` on a change already committed to main:

```
✗ change/add-button-allow-focus-when-disabled
  MODIFIED "useButton Hook Integration" omits scenario(s) the current spec
  still has: "Disabled state delegation". Copy them into the MODIFIED block
  (a MODIFIED requirement replaces the whole block, so archive refuses to
  drop them).
```

⚠️ **The new rule is catching a genuine latent defect** — archiving that change today would silently drop the `Disabled state delegation` scenario. Fixing an in-flight proposal is out of scope for a dependency sweep, so it is flagged rather than edited. Suggested follow-up: copy the missing scenario into the MODIFIED block, then adopt 1.9.0.

> **Note on caret ranges.** Neither package was held down by its range: `^4.12.1` permits 4.13.0 and `^1.7.0` permits 1.9.0. Main was on the older versions purely through **lockfile inertia**. Reverting only the catalog spec is a no-op — the lockfile entry has to be restored too. Both held-back versions were confirmed by reading the actually-linked `package.json` (`addon-a11y → axe-core 4.12.1`), not just the spec.

## ⚛️ React Ecosystem Status

**⏸️ Frozen (consumer control)** — as a UI library, consumers must control these peer dependency versions:

- `react`: ^19.0.0
- `react-dom`: ^19.0.0
- `@emotion/react`: ^11.14.0

**✅ Already at latest** — all 18 remaining entries in the `react` catalog, including `@types/react` 19.2.18, `@types/react-dom` 19.2.4, `@chakra-ui/react` + `@chakra-ui/cli` 3.36.1, `react-aria` 3.51.0, `react-aria-components` 1.20.0, `react-stately` 3.49.0, and `next-themes` 0.4.6.

No update required upgrading `react`, `react-dom`, or `@emotion/react`.

## 📊 Other Catalogs — No Eligible Updates

`utils` (13), `markdown` (6) and `apps` (17) entries are all already at their latest in-range versions.

**Pinned by policy in `tooling`** (documented in `pnpm-workspace.yaml`, left untouched): `storybook` + `@storybook/addon-a11y` / `addon-docs` / `addon-vitest` / `react-vite` at 10.4.6, `@testing-library/jest-dom` 6.9.1, `jsdom` 29.0.1.

**Skipped (major available, out of range):** `typescript` `~5.9.3` (latest 7.0.2 — and 5.9.3 is already the last of the 5.9 line), plus other entries whose newest release crosses a major.

## 🧪 Testing

Every gate from `.github/workflows/build-and-test.yml` was run on the final tree:

| Gate                                    | Result                                           |
| --------------------------------------- | ------------------------------------------------ |
| `pnpm build` (full, incl. docs)         | ✅ pass                                          |
| `pnpm lint`                             | ✅ pass                                          |
| `pnpm typecheck:strict`                 | ✅ pass                                          |
| `pnpm check:package-shape`              | ✅ pass (attw + publint)                         |
| `pnpm test`                             | ✅ **3225/3225** tests, 250/250 files            |
| `pnpm openspec validate --all --strict` | ⚠️ 120 passed / 2 failed — **identical to main** |

The 2 OpenSpec failures are `add-menubar-component` and `add-sidebar-component`, which are **empty leftover directories in the local working copy** (zero files, untracked — git cannot track empty dirs). They do not exist in a fresh checkout, so this gate is green in CI both before and after this PR. Baseline was confirmed by running the identical gate set on unmodified `main` first.

## 📝 Summary

- ✅ **12 packages updated** (all tooling)
- ⛔ **2 packages held back** after failing verification (`axe-core`, `@fission-ai/openspec`) — each with a real underlying issue worth a follow-up
- ⏳ **0 packages held back by `minimumReleaseAge`** (gate never tripped; no exclude entry added)
- ⏸️ **3 packages frozen** (React runtime + Emotion)
- ✅ **90 packages already current**
- ✅ **0 packages failed**

**No changeset**: all 12 updated packages are devDependencies only. Verified that none appear in the `dependencies` or `peerDependencies` of `@commercetools/nimbus`, `-tokens`, `-icons`, or `-design-token-ts-plugin`. The runtime catalogs (`react`, `utils`, `markdown`) had no eligible updates.

## 🔍 Review Notes

Low-risk: patch/minor updates within semver, devDependencies only, no published runtime surface touched. The two most notable items for reviewers are the **held-back** packages above — both surface pre-existing issues (a contrast shortfall and a spec block that would lose a scenario on archive) that outlive this PR.

Chromatic runs automatically since `pnpm-lock.yaml` changed; TurboSnap can't trace a lockfile change to specific stories, so expect a full snapshot.
