### PR TITLE
ci(renovate): stop major bumps on pnpm override bands and tj-actions downgrade

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -119,6 +119,16 @@
       "description": "pnpm is pinned to 11.17.0 via packageManager. Versions past 11.14.0 have broken `deploy: legacy` support (pnpm/pnpm#13618, fixed by pnpm/pnpm#13755, not yet released), which breaks `pnpm deploy` in our Docker build steps. Hold here until that ships, then remove this rule.",
       "matchPackageNames": ["pnpm"],
       "enabled": false
+    },
+    {
+      "description": "pnpm override entries are hand-authored security remediations, not tracked dependencies, and Renovate misreads them. Each key is a *selector* -- `yaml@1`, `brace-expansion@2`, `minimatch@>=3.0.0 <3.1.4` all mean \"transitive consumers resolving into this range get the patched version on the right\" -- but Renovate reads the key as a package name and proposes cross-major bumps that invert the band's purpose, forcing v1 consumers onto a v2 API. It also rewrites floor+cap ranges into bare caps (`immutable: >=4.3.9 <5` -> `<6`, `undici: >=7.28.0 <8` -> `<9`), dropping the security floor that justified the override in the first place. Observed breakage: `brace-expansion@2` -> ^5.0.0 fails the build with `TypeError: expand is not a function` (v5 dropped the callable CJS default that minimatch@3 requires); `js-yaml` ^3.15.0 -> ^5.0.0 breaks gray-matter's `yaml.safeLoad.bind()` in the docs build (`safeLoad` removed in v4); `minimatch` 3.1.5 -> 10.2.6 broke the MCP inspector at runtime and had to be reverted in #1913 -- and Renovate proposed it again in #1920. Suppress majors here: minor/patch still flow so security floors can be raised, and genuine CVE remediation is unaffected because `vulnerabilityAlerts` above bypasses packageRules. Crossing a major on an override band must be done by hand, keeping the floor (e.g. `immutable: \">=5.0.0 <6\"`) and verifying the actual transitive consumers -- CI does not exercise most of them.",
+      "matchDepTypes": [
+        "pnpm-workspace.overrides",
+        "pnpm.overrides",
+        "overrides"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -40,7 +40,13 @@ jobs:
       # "The changed-files gate".
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47
+        # Comment tag is the exact patch (v47.0.6), NOT the floating `v47`.
+        # Upstream never advanced the `v47` tag past v47.0.0 (2025-09-13), so a
+        # `# v47` comment makes Renovate resolve that stale ref and "update" the
+        # digest backwards -- it proposed exactly that in #1915, which would have
+        # reverted 6 patch releases including a lodash 4.17.23 -> 4.18.1 bump.
+        # Pinning the comment to the exact tag restores proper semver comparison.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           # push: diff newest commit. PR: diff whole PR (base...head). See runbook.
           since_last_remote_commit: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Problem

Of the ten open `🤖 Type: Dependencies` PRs, **seven must never merge** — and Renovate will keep regenerating them.

Six bump a `pnpm-workspace.yaml` **override band** across a major boundary:

| PR | Change | Status |
|---|---|---|
| #1917 | `"brace-expansion@2": "^2.1.2"` → `"^5.0.0"` | 🔴 CI red |
| #1919 | `js-yaml: "^3.15.0"` → `"^5.0.0"` | 🔴 CI red |
| #1920 | `"minimatch@>=3.0.0 <3.1.4": "3.1.5"` → `"10.2.6"` | 🟢 green, known-broken |
| #1924 | `"yaml@1": "1.10.3"` → `"2.9.0"` | 🟢 green, unsafe |
| #1918 | `immutable: ">=4.3.9 <5"` → `"<6"` | 🟢 green, unsafe |
| #1923 | `undici: ">=7.28.0 <8"` → `"<9"` | 🟢 green, unsafe |

The seventh, #1915, is a **7-month downgrade** of `tj-actions/changed-files` disguised as a digest update.

## Root cause

**1. Renovate reads override keys as package names.** They are *selectors*. `"yaml@1"` means "transitive consumers that resolve to yaml v1 get this patched v1" — it is not a package called `yaml@1`. Raising the value to `2.9.0` therefore forces a v2 API onto exactly the consumers that asked for v1, and collides with the adjacent `"yaml@2": ">=2.8.3"` band that already governs the 2.x line.

Two are already red in CI, which pins the failure mode precisely:

- `brace-expansion@2 → ^5.0.0` → `TypeError: expand is not a function`. v5 dropped the callable CJS default that `minimatch@3` consumes as `const expand = require('brace-expansion')`.
- `js-yaml ^3.15.0 → ^5.0.0` → `TypeError: Cannot read properties of undefined (reading 'bind')` in `docs build:docs`. `gray-matter@4.0.3` calls `yaml.safeLoad.bind(yaml)`; `safeLoad` was removed in v4.

The other four are green **only because CI never exercises the affected transitive consumers** — the same blind spot documented in #1913. #1920 proposes byte-for-byte the `10.2.6` value that #1904 shipped and #1913 had to revert after it broke `pnpm --filter @commercetools/nimbus-mcp inspector` at runtime. `immutable` reaches only `@commercetools-uikit/{,localized-}rich-text-input`, and `undici` only `jsdom@29`, `@chakra-ui/cli`, `@figma/code-connect`; none are covered by our suites.

Renovate additionally rewrites floor+cap ranges into **bare caps** — `">=4.3.9 <5"` → `"<6"`, `">=7.28.0 <8"` → `"<9"` — discarding the security floor that was the entire reason the override exists (immutable: GHSA-xvcm-6775-5m9r / GHSA-v56q-mh7h-f735).

**2. A stale upstream tag makes Renovate walk digests backwards.** `tj-actions/changed-files` never advanced its floating `v47` tag past `v47.0.0` (2025-09-13). Because our pin comment read `# v47`, Renovate resolved that stale ref and proposed "updating" our `v47.0.6` digest (2026-04-18) back to it — reverting six patch releases including a `lodash 4.17.23 → 4.18.1` bump. I audited all nine pinned actions; this was the only one affected.

## Fix

- **`.github/renovate.json`** — new `packageRule` disabling `major` updates on `matchDepTypes: ["pnpm-workspace.overrides", "pnpm.overrides", "overrides"]`, with the reasoning and the three observed failures recorded inline. Minor/patch still flow, so security floors can still be raised.
- **`.github/workflows/chromatic.yml`** — retag the pin comment `# v47` → `# v47.0.6` (digest unchanged) so Renovate does real semver comparison, plus a comment explaining why the exact patch tag is load-bearing.

Crossing a major on an override band stays possible — deliberately, by hand, keeping the floor (e.g. `immutable: ">=5.0.0 <6"`) and verifying the real consumers.

### Why this doesn't suppress real security fixes

`vulnerabilityAlerts.enabled` is already set precisely so CVE remediation bypasses our `packageRules` blocks (it exists today for react/@types/node/@babel). This rule sits under the same escape hatch, and `osvVulnerabilityAlerts` is untouched.

## Verification

- `renovate-config-validator .github/renovate.json` → `Config validated successfully against 1 file(s)`
- `depType` string checked against Renovate source, not docs alone: [`lib/modules/manager/npm/dep-types.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/npm/dep-types.ts) — `export const pnpmWorkspaceOverrides = 'pnpm-workspace.overrides'`
- `chromatic.yml` re-parsed; the `uses:` digest is byte-identical (`9426d409…`), only the trailing comment changed
- `prettier --write` on both files
- All nine pinned actions audited against their tags; eight in sync, tj-actions the sole drift

**Risk: Low.** Bot configuration and one comment; no runtime, build, or published-package surface. Rollback is a plain revert.

## Follow-up

Closing #1915, #1917, #1918, #1919, #1920, #1923, #1924 with these reasons. #1916 (slate peer widening) and #1909 (claude-code-action digest) are genuinely mergeable and left open for review. #1907 (inspector v2) needs a rebase — its failure is an unrelated `avatar.stories.tsx` flake.

<!-- No ticket key: matches the repo's convention for ci/chore PRs (#1897, #1912, #1913). -->
