### PR TITLE
ci: replace renovate-changeset with shared workflow

### DIFF
--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -5,54 +5,14 @@ on:
     types: [opened, synchronize, labeled]
     branches:
       - main
-
-permissions:
-  contents: read
-  pull-requests: write
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 
 jobs:
-  renovate-changeset:
-    if: >
-      github.event.pull_request.user.login == 'renovate[bot]' &&
-      contains(github.event.pull_request.labels.*.name, '🤖 Type: Dependencies')
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      # Get GitHub token via the CT Changesets App so the resulting push
-      # re-triggers required status checks (the default GITHUB_TOKEN cannot).
-      - name: Generate GitHub token (via CT Changesets App)
-        id: generate_github_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
-          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
-
-      # This action talks entirely to the GitHub API (reads PR files/commits
-      # and writes the changeset via the Contents API) - no checkout needed.
-      - name: Add changeset for dependency update
-        id: add_changeset
-        uses: mscharley/dependency-changesets-action@874dac2372a085cb94f750e8bdf5b1173a838a75 # v1.2.5
-        with:
-          token: ${{ steps.generate_github_token.outputs.token }}
-          # Renovate's default commit prefix is "chore(deps): ...", which
-          # conventional-commit parsing treats as a non-releasable change
-          # (only fix/feat/breaking map to a bump type). Disable it so every
-          # dependency update gets a patch-level changeset instead of being
-          # silently skipped.
-          use-conventional-commits: false
-          commit-message: "chore(deps): add changeset for dependency update"
-          author-name: "github-actions[bot]"
-          author-email: "41898282+github-actions[bot]@users.noreply.github.com"
-
-      # The action no-ops (and leaves this output unset/false) when a
-      # changeset already exists for the PR, e.g. on the re-run its own
-      # commit triggers via `synchronize`. Only label on an actual write.
-      - name: Label PR when a changeset was added
-        if: steps.add_changeset.outputs.created-changeset == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --add-label "changeset-added"
+  changeset:
+    uses: commercetools/merchant-center-application-kit/.github/workflows/renovate-changeset.yml@main
+    with:
+      package-dirs: 'packages'
+    secrets: inherit


### PR DESCRIPTION
Replaces the local renovate-changeset workflow with the shared one from merchant-center-application-kit.

## What changes
- **mscharley/dependency-changesets-action** → shared `workflow_call` to `merchant-center-application-kit`'s tested script (fixes [single-quoted YAML bug](https://github.com/mscharley/dependency-changesets-action/issues/691))
- **tibdex/github-app-token** → `actions/create-github-app-token` (tibdex is archived)
- Adds `paths` filter so non-npm Renovate PRs (GitHub Actions, Docker) don't trigger the workflow
- Adds sticky PR comments showing changeset status
- `package-dirs: 'packages'` — only `packages/*` are published; all `apps/*` are `private`, so they're excluded from the changeset scan
- `gitIgnoredAuthors` was already present in `.github/renovate.json` (as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`), so no change was needed there

## Notes
- The shared workflow's job condition (in merchant-center-application-kit, not overridable from this repo) requires the PR label `🤖 Type: Dependencies`. This matches the label nimbus's previous workflow already checked for, so no mismatch was found.
- Requires `CT_CHANGESETS_APP_ID` / `CT_CHANGESETS_APP_PEM` secrets to be available to this repo (passed via `secrets: inherit`), same as before.