### PR TITLE
fix(tree): reject moving a node into its own subtree and close Tree coverage gaps

### DIFF
--- a/.changeset/tree-move-subtree-guard.md
+++ b/.changeset/tree-move-subtree-guard.md
@@ -1,0 +1,10 @@
+---
+"@commercetools/nimbus": patch
+---
+
+`Tree`: `useTree`'s `move` no longer discards a node when it is moved into its
+own subtree. Passing the moved node itself, or any of its descendants, as the
+target parent previously removed the node and everything beneath it from the
+tree without reporting anything; it now throws, matching what `moveBefore` and
+`moveAfter` already did for the same case. Drag-and-drop was never affected —
+such a drop is refused before it reaches the tree.

--- a/packages/nimbus/src/components/tree/hooks/use-tree.spec.tsx
+++ b/packages/nimbus/src/components/tree/hooks/use-tree.spec.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { Key } from "react-aria-components";
+import { useTree } from "./use-tree";
+import { fileTree, type TreeNode } from "../utils/tree.test-data";
+
+/**
+ * `useTree` exposes React Stately's tree mutations — including `move` — as an
+ * imperative controller for programmatic edits, alongside the state it spreads
+ * onto `Tree.Root`. Moving a node *into its own subtree* is not a meaningful
+ * operation, and `move` neither rejects nor reports it: the node is detached,
+ * then re-attached under a parent key that no longer exists, so the dragged node
+ * and everything beneath it are dropped from the tree with no error raised.
+ *
+ * Drag-and-drop does not expose this. React Aria's `getDropOperation` cancels
+ * any internal drop targeting a dragged key or a descendant of one, for pointer
+ * and keyboard alike (`react-stately`'s `useDroppableCollectionState`), so
+ * `onMove` is never handed such a target — pinned by the
+ * `DropTargetsExcludeDraggedSubtree` story. The reachable path is a consumer
+ * calling `move` directly.
+ *
+ * The two failing cases below are the defect; the first test is a control
+ * proving the harness itself moves nodes correctly.
+ */
+
+/** Structural view of a `useTreeData` node, enough to walk the hierarchy. */
+interface WalkableNode {
+  key: Key;
+  children?: WalkableNode[] | null;
+}
+
+/** Every key in the tree, in document order. */
+const flattenKeys = (nodes: readonly WalkableNode[]): Key[] =>
+  nodes.flatMap((node) => [node.key, ...flattenKeys(node.children ?? [])]);
+
+/** The 7 keys of `fileTree`, in document order, before any mutation. */
+const ALL_KEYS = [
+  "documents",
+  "project",
+  "report",
+  "budget",
+  "photos",
+  "image-1",
+  "image-2",
+];
+
+const setup = () =>
+  renderHook(() =>
+    useTree<TreeNode>({
+      initialItems: fileTree,
+      getKey: (item) => item.id,
+      getChildren: (item) => item.children ?? [],
+      dragAndDrop: true,
+    })
+  );
+
+/**
+ * Run a tree mutation, capturing a throw rather than failing on it, so each
+ * case can report whether the call threw *and* whether the data survived
+ * instead of stopping at the first symptom.
+ */
+const attempt = (fn: () => void): unknown => {
+  let caught: unknown;
+  act(() => {
+    try {
+      fn();
+    } catch (error) {
+      caught = error;
+    }
+  });
+  return caught;
+};
+
+describe("useTree — move into own subtree", () => {
+  it("moves a node into an unrelated group (control)", () => {
+    const { result } = setup();
+    expect(flattenKeys(result.current.items)).toEqual(ALL_KEYS);
+
+    const error = attempt(() => result.current.move("report", "photos", 2));
+
+    expect(error).toBeUndefined();
+    expect(result.current.getItem("report")).toBeDefined();
+    expect(flattenKeys(result.current.items)).toHaveLength(ALL_KEYS.length);
+    expect(
+      result.current.getItem("photos")?.children?.map((child) => child.key)
+    ).toContain("report");
+  });
+
+  it("keeps the node and its subtree when moved into itself", () => {
+    const { result } = setup();
+    const index = result.current.getItem("documents")?.children?.length ?? 0;
+
+    const error = attempt(() =>
+      result.current.move("documents", "documents", index)
+    );
+
+    expect
+      .soft(error, "move() neither rejected nor reported the no-op")
+      .toBeUndefined();
+    expect
+      .soft(result.current.getItem("documents"), "moved node was dropped")
+      .toBeDefined();
+    expect(flattenKeys(result.current.items)).toEqual(ALL_KEYS);
+  });
+
+  it("keeps the node and its subtree when moved into its own descendant", () => {
+    const { result } = setup();
+    const index = result.current.getItem("project")?.children?.length ?? 0;
+
+    // "project" is a child of "documents".
+    const error = attempt(() =>
+      result.current.move("documents", "project", index)
+    );
+
+    expect
+      .soft(error, "move() neither rejected nor reported the invalid move")
+      .toBeUndefined();
+    expect
+      .soft(result.current.getItem("documents"), "moved node was dropped")
+      .toBeDefined();
+    expect(flattenKeys(result.current.items)).toEqual(
+      expect.arrayContaining(ALL_KEYS)
+    );
+  });
+});

--- a/packages/nimbus/src/components/tree/hooks/use-tree.spec.tsx
+++ b/packages/nimbus/src/components/tree/hooks/use-tree.spec.tsx
@@ -5,22 +5,19 @@ import { useTree } from "./use-tree";
 import { fileTree, type TreeNode } from "../utils/tree.test-data";
 
 /**
- * `useTree` exposes React Stately's tree mutations — including `move` — as an
- * imperative controller for programmatic edits, alongside the state it spreads
- * onto `Tree.Root`. Moving a node *into its own subtree* is not a meaningful
- * operation, and `move` neither rejects nor reports it: the node is detached,
- * then re-attached under a parent key that no longer exists, so the dragged node
- * and everything beneath it are dropped from the tree with no error raised.
+ * `useTree` exposes React Stately's tree mutations as an imperative controller
+ * for programmatic edits, alongside the state it spreads onto `Tree.Root`.
  *
- * Drag-and-drop does not expose this. React Aria's `getDropOperation` cancels
- * any internal drop targeting a dragged key or a descendant of one, for pointer
- * and keyboard alike (`react-stately`'s `useDroppableCollectionState`), so
- * `onMove` is never handed such a target — pinned by the
- * `DropTargetsExcludeDraggedSubtree` story. The reachable path is a consumer
- * calling `move` directly.
+ * Moving a node into its own subtree has no valid result: React Stately
+ * detaches the node, then re-attaches it under a parent key that no longer
+ * exists, so the node and every descendant are dropped from the tree. Left
+ * unguarded this happened silently — no throw, no rejection, no diagnostic —
+ * while `moveBefore` / `moveAfter` already threw for the same condition.
+ * `useTree` now rejects it, so the whole controller reports consistently.
  *
- * The two failing cases below are the defect; the first test is a control
- * proving the harness itself moves nodes correctly.
+ * Drag-and-drop never reached this: React Aria's `getDropOperation` cancels any
+ * internal drop targeting a dragged key or a descendant of one, for pointer and
+ * keyboard alike — pinned by the `DropTargetsExcludeDraggedSubtree` story.
  */
 
 /** Structural view of a `useTreeData` node, enough to walk the hierarchy. */
@@ -54,11 +51,7 @@ const setup = () =>
     })
   );
 
-/**
- * Run a tree mutation, capturing a throw rather than failing on it, so each
- * case can report whether the call threw *and* whether the data survived
- * instead of stopping at the first symptom.
- */
+/** Run a mutation, returning whatever it threw instead of failing the test. */
 const attempt = (fn: () => void): unknown => {
   let caught: unknown;
   act(() => {
@@ -72,21 +65,7 @@ const attempt = (fn: () => void): unknown => {
 };
 
 describe("useTree — move into own subtree", () => {
-  it("moves a node into an unrelated group (control)", () => {
-    const { result } = setup();
-    expect(flattenKeys(result.current.items)).toEqual(ALL_KEYS);
-
-    const error = attempt(() => result.current.move("report", "photos", 2));
-
-    expect(error).toBeUndefined();
-    expect(result.current.getItem("report")).toBeDefined();
-    expect(flattenKeys(result.current.items)).toHaveLength(ALL_KEYS.length);
-    expect(
-      result.current.getItem("photos")?.children?.map((child) => child.key)
-    ).toContain("report");
-  });
-
-  it("keeps the node and its subtree when moved into itself", () => {
+  it("rejects moving a node into itself, leaving the tree untouched", () => {
     const { result } = setup();
     const index = result.current.getItem("documents")?.children?.length ?? 0;
 
@@ -94,32 +73,108 @@ describe("useTree — move into own subtree", () => {
       result.current.move("documents", "documents", index)
     );
 
-    expect
-      .soft(error, "move() neither rejected nor reported the no-op")
-      .toBeUndefined();
-    expect
-      .soft(result.current.getItem("documents"), "moved node was dropped")
-      .toBeDefined();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/itself or one of its own/i);
+    expect(result.current.getItem("documents")).toBeDefined();
     expect(flattenKeys(result.current.items)).toEqual(ALL_KEYS);
   });
 
-  it("keeps the node and its subtree when moved into its own descendant", () => {
+  it("rejects moving a node into its own descendant", () => {
     const { result } = setup();
     const index = result.current.getItem("project")?.children?.length ?? 0;
 
-    // "project" is a child of "documents".
-    const error = attempt(() =>
+    // "project" is a child of "documents"; "report" a grandchild.
+    const intoChild = attempt(() =>
       result.current.move("documents", "project", index)
     );
-
-    expect
-      .soft(error, "move() neither rejected nor reported the invalid move")
-      .toBeUndefined();
-    expect
-      .soft(result.current.getItem("documents"), "moved node was dropped")
-      .toBeDefined();
-    expect(flattenKeys(result.current.items)).toEqual(
-      expect.arrayContaining(ALL_KEYS)
+    const intoGrandchild = attempt(() =>
+      result.current.move("documents", "report", 0)
     );
+
+    expect(intoChild).toBeInstanceOf(Error);
+    expect(intoGrandchild).toBeInstanceOf(Error);
+    expect(flattenKeys(result.current.items)).toEqual(ALL_KEYS);
+  });
+
+  it("still moves a node into an unrelated group", () => {
+    const { result } = setup();
+    expect(flattenKeys(result.current.items)).toEqual(ALL_KEYS);
+
+    const error = attempt(() => result.current.move("report", "photos", 2));
+
+    expect(error).toBeUndefined();
+    expect(
+      result.current.getItem("photos")?.children?.map((child) => child.key)
+    ).toContain("report");
+    expect(flattenKeys(result.current.items)).toHaveLength(ALL_KEYS.length);
+  });
+
+  it("still moves a node into its own parent and up to the root", () => {
+    const { result } = setup();
+
+    // A node's parent and ancestors are outside its subtree — the guard must
+    // not over-reach and block legitimate moves upward.
+    const intoParent = attempt(() =>
+      result.current.move("report", "documents", 0)
+    );
+    const toRoot = attempt(() => result.current.move("budget", null, 0));
+
+    expect(intoParent).toBeUndefined();
+    expect(toRoot).toBeUndefined();
+    expect(result.current.getItem("report")).toBeDefined();
+    expect(result.current.getItem("budget")).toBeDefined();
+    expect(flattenKeys(result.current.items)).toHaveLength(ALL_KEYS.length);
+  });
+});
+
+/**
+ * Sibling reordering is what `onMove` delegates to for `"before"` / `"after"`
+ * drop positions. The browser-level drop mechanics are React Aria's, and the
+ * `DragAndDrop` story covers a real keyboard drag end-to-end, but the ordering
+ * outcome itself is asserted here where it is deterministic rather than
+ * dependent on which insertion point a keypress lands on.
+ */
+describe("useTree — sibling reordering", () => {
+  const childKeysOf = (
+    result: ReturnType<typeof setup>["result"],
+    parent: Key
+  ) => result.current.getItem(parent)?.children?.map((child) => child.key);
+
+  it("moves a node before a sibling", () => {
+    const { result } = setup();
+    expect(childKeysOf(result, "photos")).toEqual(["image-1", "image-2"]);
+
+    act(() => {
+      result.current.moveBefore("image-1", ["image-2"]);
+    });
+
+    expect(childKeysOf(result, "photos")).toEqual(["image-2", "image-1"]);
+  });
+
+  it("moves a node after a sibling", () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.moveAfter("budget", ["report"]);
+    });
+
+    expect(childKeysOf(result, "project")).toEqual(["budget", "report"]);
+  });
+
+  it("keeps multiple moved nodes in document order, not selection order", () => {
+    const { result } = setup();
+
+    // `onMove` receives keys in selection order; a drag selected bottom-to-top
+    // must still land top-to-bottom.
+    act(() => {
+      result.current.moveBefore("image-1", ["budget", "report"]);
+    });
+
+    expect(childKeysOf(result, "photos")).toEqual([
+      "report",
+      "budget",
+      "image-1",
+      "image-2",
+    ]);
   });
 });

--- a/packages/nimbus/src/components/tree/hooks/use-tree.ts
+++ b/packages/nimbus/src/components/tree/hooks/use-tree.ts
@@ -22,6 +22,44 @@ function keysInTreeOrder<T extends object>(
 }
 
 /**
+ * Whether `candidate` is `ancestor` itself, or sits anywhere inside its
+ * subtree.
+ *
+ * Moving a node into its own subtree has no valid result: React Stately
+ * detaches the node first, then re-attaches it under a parent key that no
+ * longer exists, so the node and every descendant are dropped from the tree
+ * without an error being raised.
+ */
+function isSelfOrDescendant<T extends object>(
+  items: TreeData<T>["items"],
+  ancestor: Key,
+  candidate: Key
+): boolean {
+  if (ancestor === candidate) return true;
+
+  const findNode = (
+    nodes: TreeData<T>["items"]
+  ): TreeData<T>["items"][number] | undefined => {
+    for (const node of nodes) {
+      if (node.key === ancestor) return node;
+      const found = node.children ? findNode(node.children) : undefined;
+      if (found) return found;
+    }
+    return undefined;
+  };
+
+  const contains = (nodes: TreeData<T>["items"]): boolean =>
+    nodes.some(
+      (node) =>
+        node.key === candidate ||
+        (node.children ? contains(node.children) : false)
+    );
+
+  const subtree = findNode(items);
+  return subtree?.children ? contains(subtree.children) : false;
+}
+
+/**
  * Tree.Root configuration that `useTree` accepts and echoes back so the whole
  * result can be spread onto `Tree.Root`.
  */
@@ -147,12 +185,36 @@ export function useTree<T extends object>(
         // whose child count doesn't update mid-loop, so offset by `i` rather
         // than re-reading the length per key.
         const targetIndex = tree.getItem(e.target.key)?.children?.length ?? 0;
-        keysInTreeOrder(tree.items, e.keys).forEach((key, i) => {
-          tree.move(key, e.target.key, targetIndex + i);
-        });
+        keysInTreeOrder(tree.items, e.keys)
+          // React Aria's `getDropOperation` already cancels a drop onto a
+          // dragged key or its descendants, so this filter is belt-and-braces
+          // — it keeps a drop a no-op rather than destructive if a custom
+          // `getDropOperation` ever widens what reaches this handler.
+          .filter((key) => !isSelfOrDescendant(tree.items, key, e.target.key))
+          .forEach((key, i) => {
+            tree.move(key, e.target.key, targetIndex + i);
+          });
       }
     },
   });
+
+  /**
+   * `move`, with the invalid target rejected. `moveBefore` / `moveAfter`
+   * already throw for this condition inside React Stately, so without this the
+   * re-parent path is the only tree mutation that loses data instead of
+   * reporting the mistake.
+   */
+  const move: TreeData<T>["move"] = (key, toParentKey, index) => {
+    if (
+      toParentKey != null &&
+      isSelfOrDescendant(tree.items, key, toParentKey)
+    ) {
+      throw new Error(
+        "Cannot move an item into itself or one of its own descendants."
+      );
+    }
+    tree.move(key, toParentKey, index);
+  };
 
   return {
     ...(rootProps as ForwardableRootProps<T>),
@@ -165,7 +227,7 @@ export function useTree<T extends object>(
     append: tree.append,
     prepend: tree.prepend,
     remove: tree.remove,
-    move: tree.move,
+    move,
     moveBefore: tree.moveBefore,
     moveAfter: tree.moveAfter,
     update: tree.update,

--- a/packages/nimbus/src/components/tree/tree.a11y.mdx
+++ b/packages/nimbus/src/components/tree/tree.a11y.mdx
@@ -56,9 +56,11 @@ const App = () => (
   `aria-label` or `aria-labelledby`.
 - **Item text:** provide a meaningful `textValue` per `Tree.Item`. It supplies
   the type-ahead target and accessible name when the label is not plain text.
-- **Keyboard navigation:** Up/Down move between visible rows, Right/Left
-  expand/collapse (or move to a child/parent), Home/End jump to the first/last
-  visible row, and typing performs type-ahead.
+- **Keyboard navigation:** Up/Down move between visible rows, Right expands a
+  collapsed row (on an already-expanded row it moves into that row's own
+  controls, not to its first child), Left collapses an expanded row or moves to
+  its parent, Home/End jump to the first/last visible row, and typing performs
+  type-ahead.
 - **Expand/collapse control:** the `Tree.Indicator` chevron is given a localized
   accessible name by React Aria and is hidden for leaf rows.
 - **Drag and drop:** when drag-and-drop is enabled, `Tree.ItemContent`

--- a/packages/nimbus/src/components/tree/tree.dev.mdx
+++ b/packages/nimbus/src/components/tree/tree.dev.mdx
@@ -194,10 +194,13 @@ function DraggableTree() {
 }
 ```
 
-For custom drag data or accepted external drag types, pass an options object
-instead of `true`: `dragAndDrop={{ getItems, acceptedDragTypes }}`. For
-programmatic edits, the same `tree` object exposes `insert`, `remove`, `move`,
-`update`, and more.
+For custom drag data, pass an options object instead of `true`:
+`dragAndDrop={{ getItems }}`. `acceptedDragTypes` narrows which types an
+*internal* drag will accept; dropping from an external source is not wired up in
+this iteration, so external drops are always cancelled. For programmatic edits,
+the same `tree` object exposes `insert`, `remove`, `move`, `update`, and more —
+note `move` rejects a target inside the moved node's own subtree, which would
+otherwise discard it.
 
 ## Accessibility
 
@@ -221,7 +224,9 @@ pattern. It provides:
 **Keyboard navigation:**
 
 - `Up` / `Down` — move between visible rows
-- `Right` / `Left` — expand/collapse, or move to a child/parent
+- `Right` — expand a collapsed row; on an expanded row, move into that row's
+  own controls
+- `Left` — collapse an expanded row, or move to its parent
 - `Home` / `End` — move to the first/last visible row
 - _type characters_ — type-ahead to the next matching row
 

--- a/packages/nimbus/src/components/tree/tree.stories.tsx
+++ b/packages/nimbus/src/components/tree/tree.stories.tsx
@@ -892,3 +892,81 @@ export const SmokeTest: Story = {
     );
   },
 };
+
+/**
+ * Regression guard: React Aria must never offer the dragged subtree as a drop
+ * target.
+ *
+ * `useTree`'s `onMove` re-parents a `dropPosition: "on"` drop with
+ * `tree.move(key, target, index)` and does not itself check that the target
+ * sits outside the dragged subtree — a self- or descendant-target would destroy
+ * the dragged nodes (see `hooks/use-tree.spec.tsx`). What makes drag-and-drop
+ * safe is upstream: `useDroppableCollectionState`'s `getDropOperation` cancels
+ * any internal drop whose target is a dragged key or descends from one, for
+ * pointer and keyboard alike.
+ *
+ * This pins that guarantee, so supplying an `onItemDrop`/`getDropOperation` of
+ * our own, or a React Aria upgrade that moves the guard, fails here rather than
+ * silently exposing the destructive path.
+ */
+export const DropTargetsExcludeDraggedSubtree: Story = {
+  render: () => <FeatureTree aria-label="Files" selectionMode="none" />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await waitForTreeRows(canvas);
+
+    await step("Picks up the Documents folder with the keyboard", async () => {
+      const dragHandle = canvas.getByRole("button", { name: /Drag Documents/ });
+      dragHandle.focus();
+      await waitFor(() => expect(dragHandle).toHaveFocus());
+      await userEvent.keyboard("{Enter}");
+      await wait(150);
+    });
+
+    await step(
+      "Never offers the dragged folder or its descendants as an 'on' target",
+      async () => {
+        // One full cycle of React Aria's keyboard drop targets is 9 steps for
+        // this tree; 24 covers it more than twice over. Rows reachable as an
+        // "on" target are collected, before/after indicator positions (where no
+        // row carries `data-drop-target`) are skipped.
+        const offered = new Set<string>();
+
+        for (let i = 0; i < 24; i += 1) {
+          // React Aria's between-rows drop indicator is itself a
+          // `role="row"` carrying `aria-level` (valid treegrid markup), so it
+          // has to be excluded by class or it registers as an empty target.
+          const target = canvasElement.querySelector<HTMLElement>(
+            '[role="row"][data-drop-target="true"]:not(.react-aria-DropIndicator)'
+          );
+          if (target) offered.add((target.textContent ?? "").trim());
+          await userEvent.keyboard("{ArrowDown}");
+          await wait(80);
+        }
+
+        // Documents is dragged; Project / Weekly Report / Budget descend from
+        // it. Only the untouched Photos subtree may be dropped onto.
+        await expect([...offered].sort()).toEqual([
+          "Image 1",
+          "Image 2",
+          "Photos",
+        ]);
+      }
+    );
+
+    await step("Cancels the drag without losing the subtree", async () => {
+      await userEvent.keyboard("{Escape}");
+      await wait(150);
+
+      await expect(
+        canvas.getByRole("row", { name: /Documents/ })
+      ).toBeInTheDocument();
+      await expect(
+        canvas.getByRole("row", { name: /Weekly Report/ })
+      ).toBeInTheDocument();
+      await expect(
+        canvas.getByRole("row", { name: /Budget/ })
+      ).toBeInTheDocument();
+    });
+  },
+};

--- a/packages/nimbus/src/components/tree/tree.stories.tsx
+++ b/packages/nimbus/src/components/tree/tree.stories.tsx
@@ -239,6 +239,17 @@ export const KeyboardNavigation: Story = {
       );
     });
 
+    await step("Up arrow moves focus back through visible rows", async () => {
+      await userEvent.keyboard("{End}");
+      await waitFor(() =>
+        expect(canvas.getByRole("row", { name: /Image 2/ })).toHaveFocus()
+      );
+      await userEvent.keyboard("{ArrowUp}");
+      await waitFor(() =>
+        expect(canvas.getByRole("row", { name: /Image 1/ })).toHaveFocus()
+      );
+    });
+
     await step("Type-ahead jumps to a matching row", async () => {
       await userEvent.keyboard("Photos");
       await waitFor(() =>
@@ -638,10 +649,9 @@ const SIZES = ["sm", "md"] as const;
 /**
  * Smoke test — every visual permutation in one view: both sizes (`sm`, `md`),
  * all three selection modes (`none`, `single`, `multiple`), each rendered both
- * without drag-and-drop (the default roomy, equal-column layout) and with it
- * (the tighter layout whose drag handle separates the checkbox from the
- * chevron). Use it to eyeball control spacing and nested-row alignment across
- * the matrix at a glance.
+ * without drag-and-drop and with it (which adds a drag handle ahead of the
+ * shared leading-control column). Use it to eyeball control spacing and
+ * nested-row alignment across the matrix at a glance.
  */
 const SmokeTestView = () => {
   return (
@@ -796,6 +806,18 @@ export const FocusedRow: Story = {
       // Without this, a ring that never paints baselines as a silent pass.
       await expect(rows[0]).toHaveStyle({ outlineStyle: "solid" });
     });
+
+    await step(
+      "Root is not a scroll container, so rings aren't clipped",
+      async () => {
+        // The row's ring paints 2px outside a full-width row box, so a forced
+        // `overflow` on the root would clip it horizontally. The recipe sets none
+        // for exactly this reason; consumers opt into scrolling themselves.
+        const treegrid = canvas.getByRole("treegrid", { name: "Files" });
+        const { overflowX, overflowY } = getComputedStyle(treegrid);
+        await expect([overflowX, overflowY]).toEqual(["visible", "visible"]);
+      }
+    );
   },
 };
 


### PR DESCRIPTION
## Summary

FEC-1168 asks for a Tree component built on React Aria's `Tree` with
drag-and-drop. Nearly all of it is already shipped — the ticket was written
against in-flight branch commits about a month after the work merged, so several
of its acceptance criteria describe states that never reached `main`.

This PR verifies every criterion against `main`, then closes the three real gaps
that verification turned up: one defect, four missing regression guards, and two
inaccurate docs claims.

## Already in place

Tree shipped in `@commercetools/nimbus@3.3.0` via #1574 (FEC-985, Done) as a
net-new component — 19 files, ~2,500 lines. Verified criterion by criterion
against `main`:

| Criterion | Status | Evidence |
|---|---|---|
| Wraps React Aria Tree with Nimbus styling | ✅ In place | Every part delegates: `Tree`→`tree.root.tsx:24`, `TreeItem`→`tree.item.tsx:25`, `TreeItemContent`→`tree.item-content.tsx:37`, `Button slot="chevron"`→`tree.indicator.tsx:26`, `Collection`→`tree.sub-tree.tsx:30`. No hand-rolled collection, selection, focus or type-ahead logic; the five part files contain no React hooks at all. Styling is entirely the 4-slot Chakra recipe. |
| Checkbox selection without collision or misalignment | ✅ In place | Collision is structurally precluded, not merely absent: one flex row, uniform non-shrinking control boxes, no absolute positioning, no mode-conditional offsets. `--tree-indent-step` is *defined* as `control + gap`, which forces level-N's leading control onto level-(N−1)'s chevron column at both sizes. The two historical causes are fixed — the checkbox's label-width reservation is gated behind `:has([data-slot='label'])`, and chevron visibility is class-scoped so it can't hit the checkbox's own `data-slot="indicator"`. |
| Keyboard navigation (arrows expand/collapse, type-ahead) | ✅ In place | Fully delegated — `EXPANSION_KEYS` and `handleTreeExpansionKeys` live in react-aria's `useGridListItem`; `disallowTypeAhead` is never set, and `textValue` is a required prop, which is what type-ahead needs. |
| No forced `overflow:auto` on root | ✅ In place | No `overflow` in any slot, variant or state across the 240-line recipe; `tree.recipe.ts:32-35` records why. |
| Reorder-only story demonstrating DnD without selection | ✅ In place | `ReorderWithoutSelection` — DnD on, `selectionMode="none"`, asserts no checkboxes render. |
| Play tests for expand/collapse, selection, DnD | ✅ In place | Every story carries a play function. `DragAndDrop` performs a complete keyboard drag that re-parents a row and asserts the resulting order — covering the selection-order-vs-tree-order case too. |
| Existing stories updated to new API | ✅ In place | True within the branch: `425139332` migrated them off raw React Aria, swapping `<Collection>` for `<Tree.SubTree>` and a ~25-line inline `useTreeData`+`useDragAndDrop` block for one `useTree()` spread. Tree was net-new, so there were no stories on `main` to update. |
| DnD reordering with **token-based drag-handle optical offset** | ⚠️ Obsolete by design | Reordering and re-parenting are in place. The *offset* is not, and shouldn't be: it was built (`--tree-drag-offset`, a per-size `translateX`) and then deliberately replaced inside the same PR by the uniform leading-control-column layout, which removes the need for per-mode compensation. `--tree-drag-offset` has zero occurrences repo-wide; `tree.recipe.ts:20-27` explains the superseding approach. The criterion is a verbatim copy of the reverted sub-commit's title, and the canonical spec (`openspec/specs/tree/spec.md:148-187`) never mentions an offset. **No action taken — flagging for whoever refines the ticket.** |

## What needed doing

### 1. A defect: `move` silently discarded a subtree

`useTree` returns React Stately's mutations as an imperative controller for
programmatic edits. Passing the moved node itself, or a descendant, as the target
parent detached the node and re-attached it under a key that no longer existed —
so the node and everything beneath it were dropped from the tree with no throw,
no rejection, no diagnostic. A 7-node fixture came back with 3.

`moveBefore`/`moveAfter` already threw for this exact condition, so the
re-parent path was the only mutation that lost data instead of reporting. `move`
now rejects it too. The guard is deliberately narrow — moving a node to its own
parent, an ancestor, or the root stays valid, and that's covered.

**Drag-and-drop was never affected.** React Aria's `getDropOperation` cancels any
internal drop targeting a dragged key or a descendant of one, pointer and
keyboard alike. Walking the real keyboard drop targets while dragging
`Documents` confirms only the untouched `Photos` subtree is ever offered.

### 2. Four regression guards for behavior that was already correct

- **Drop-target exclusion.** The guarantee above is load-bearing and lived
  entirely upstream. `DropTargetsExcludeDraggedSubtree` now fails if a custom
  `getDropOperation`, or a React Aria upgrade that relocates the guard, exposes
  the destructive path.
- **`ArrowUp`** was documented but never pressed in any test.
- **Sibling reorder order** — what `onMove` delegates to for before/after drops
  — had no assertion, including the selection-order case `keysInTreeOrder`
  exists for. Asserted at controller level, so it doesn't depend on which
  insertion point a keypress happens to land on.
- **Root `overflow`** was recorded only in a source comment; `FocusedRow` now
  asserts the computed value.

### 3. Two docs claims that were wrong

- Both docs said `Right`/`Left` "expand/collapse, or move to a child/parent".
  Left-to-parent is correct; `Right` never moves to a child — on an expanded row
  React Aria moves *within* the row to its own controls.
- `acceptedDragTypes` was documented as accepting external drag types. No
  external-drop handler is wired up and the move path requires an internal drag,
  so external drops always cancel; the option can only narrow an internal drag.

## Test plan

- [x] `pnpm test:storybook:dev packages/nimbus/src/components/tree/tree.stories.tsx` — 17/17 pass
- [x] `pnpm test:unit packages/nimbus/src/components/tree/` — 11/11 pass
- [x] `pnpm --filter @commercetools/nimbus typecheck:dev` — clean
- [x] `eslint` + `prettier` — clean
- [x] Changeset added (`patch`)

## Feedback wanted

1. **Throw vs. no-op.** I chose throwing, for consistency with
   `moveBefore`/`moveAfter`. A silent no-op would be more forgiving for a
   consumer computing moves from user input. Easy to switch.
2. **The obsolete criterion.** Worth confirming the offset really is dead by
   design before FEC-1168 is refined — the uniform-column layout looks like the
   better approach, so I've left it alone rather than reinstating it.

FEC-1168
