### PR TITLE
fix(bundle): reduce consumer bundle size by 57% (377→163 KB gz)

### DIFF
--- a/.changeset/bundle-optimization-icons-tokens.md
+++ b/.changeset/bundle-optimization-icons-tokens.md
@@ -1,0 +1,18 @@
+---
+"@commercetools/nimbus": minor
+"@commercetools/nimbus-icons": patch
+---
+
+`@commercetools/nimbus-icons` and `@commercetools/nimbus-tokens` are no longer
+required peer dependencies. Nimbus now bundles the icons and tokens it uses
+internally, so consumers only need to install `@chakra-ui/react` and `react` as
+peers.
+
+- Consumers who import icons directly from `@commercetools/nimbus-icons` for
+  their own UI should keep it as a regular dependency — it continues to work
+  independently and now tree-shakes correctly.
+- Consumers who only had `nimbus-icons` and `nimbus-tokens` installed because
+  nimbus required them can remove both packages.
+
+`@commercetools/nimbus-icons`: fixed tree-shaking — bundlers now correctly
+eliminate unused icons instead of including all 2,000+.

--- a/apps/blank-app/.gitignore
+++ b/apps/blank-app/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+bundle-report.html
 dist-ssr
 dist-webpack
 *.local

--- a/apps/blank-app/package.json
+++ b/apps/blank-app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:analyze": "ANALYZE_BUNDLE=true tsc -b && ANALYZE_BUNDLE=true vite build",
     "build:webpack": "webpack --mode production",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -26,6 +27,7 @@
     "globals": "catalog:tooling",
     "typescript": "catalog:tooling",
     "typescript-eslint": "catalog:tooling",
+    "rollup-plugin-visualizer": "^5.14.0",
     "vite": "catalog:tooling",
     "webpack": "catalog:tooling",
     "webpack-cli": "catalog:tooling"

--- a/apps/blank-app/vite.config.ts
+++ b/apps/blank-app/vite.config.ts
@@ -3,6 +3,24 @@ import react from "@vitejs/plugin-react-swc";
 import { UNSAFE_nimbusOptionalDependency } from "@commercetools/nimbus/plugins/vite";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), UNSAFE_nimbusOptionalDependency()],
+export default defineConfig(() => {
+  const isAnalyzeMode = !!process.env.ANALYZE_BUNDLE;
+
+  return {
+    plugins: [
+      react(),
+      UNSAFE_nimbusOptionalDependency(),
+      // Bundle visualizer — run with `pnpm build:analyze` to generate bundle-report.html
+      ...(isAnalyzeMode
+        ? [
+            import("rollup-plugin-visualizer").then((m) =>
+              m.visualizer({
+                filename: "bundle-report.html",
+                gzipSize: true,
+              })
+            ),
+          ]
+        : []),
+    ],
+  };
 });

--- a/packages/nimbus-icons/scripts/postbuild.mjs
+++ b/packages/nimbus-icons/scripts/postbuild.mjs
@@ -30,8 +30,8 @@ const DIST = join(__dirname, "..", "dist");
 // Step 1: dual-package markers
 
 const MARKERS = [
-  ["esm", { type: "module" }],
-  ["cjs", { type: "commonjs" }],
+  ["esm", { type: "module", sideEffects: false }],
+  ["cjs", { type: "commonjs", sideEffects: false }],
 ];
 
 for (const [subdir, contents] of MARKERS) {

--- a/packages/nimbus/package.json
+++ b/packages/nimbus/package.json
@@ -146,8 +146,6 @@
   },
   "peerDependencies": {
     "@chakra-ui/react": "catalog:react",
-    "@commercetools/nimbus-icons": "workspace:^",
-    "@commercetools/nimbus-tokens": "workspace:^",
     "react": "19.x",
     "slate": "^0.123.0",
     "slate-history": "^0.115.0",

--- a/packages/nimbus/src/components/money-input/money-input.tsx
+++ b/packages/nimbus/src/components/money-input/money-input.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useSlotRecipe } from "@chakra-ui/react/styled-system";
 import { useId, useLocale as useAriaLocale } from "react-aria";
-import { designTokens } from "@commercetools/nimbus-tokens";
+import { themeTokens } from "@commercetools/nimbus-tokens";
 import {
   NumberInput,
   Select,
@@ -369,7 +369,7 @@ export const MoneyInput = (props: MoneyInputProps) => {
                   color={isDisabled ? "neutral.8" : "neutral.11"}
                   aria-label={msg.format("highPrecisionPrice")}
                   // Position the badge correctly as we don't want layout shift that occurs with trailingElement use in the underlying NumberInput
-                  transform={`translateX(-${designTokens.spacing["1200"]})`}
+                  transform={`translateX(-${themeTokens.spacing["1200"].value})`}
                 />
               </MakeElementFocusable>
               <Tooltip.Content placement="top">

--- a/packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.ts
+++ b/packages/nimbus/src/components/multiline-text-input/multiline-text-input.recipe.ts
@@ -1,5 +1,5 @@
 import { defineSlotRecipe } from "@chakra-ui/react/styled-system";
-import { designTokens } from "@commercetools/nimbus-tokens";
+import { themeTokens } from "@commercetools/nimbus-tokens";
 
 /**
  * Recipe configuration for the MultilineTextInput component.
@@ -35,7 +35,7 @@ export const multilineTextInputRecipe = defineSlotRecipe({
             <rect width="1.03391" height="8.27125" transform="matrix(0.716448 0.69764 -0.716448 0.69764 5.87891 -0.0262451)" fill="currentColor"/>
           </mask>
           <g mask="url(#mask0_4610_25787)">
-            <rect width="8" height="8" fill="${designTokens.color["semantic-palettes"].primary.light[9]}"/>
+            <rect width="8" height="8" fill="${themeTokens.color["semantic-palettes"].primary["9"].value._light}"/>
           </g>
         </svg>
       `)}")`,

--- a/packages/nimbus/src/components/toast/components/toast.outlet.impl.tsx
+++ b/packages/nimbus/src/components/toast/components/toast.outlet.impl.tsx
@@ -1,0 +1,62 @@
+import { Toaster, Toast as ChakraToast } from "@chakra-ui/react/toast";
+import { getToasterEntries } from "../services/toast.toasters";
+import { ToastContent } from "./toast.content";
+import { COLOR_PALETTE_MAP } from "../constants";
+import type { ChakraToastData, ToastType } from "../toast.types";
+
+/**
+ * Returns the correct ARIA role and live-region politeness for a toast type.
+ * Error toasts use `role="alert"` with `aria-live="assertive"`,
+ * all others use `role="status"` with `aria-live="polite"`.
+ *
+ * An explicit `ariaLive` override (from `ToastOptions`) takes precedence
+ * over the type-based default.
+ */
+const getARIAAttributes = (
+  type?: ToastType,
+  ariaLive?: "polite" | "assertive" | "off"
+) => {
+  const liveDefault = type === "error" ? "assertive" : "polite";
+  const live = ariaLive ?? liveDefault;
+  const role = live === "assertive" ? ("alert" as const) : ("status" as const);
+  return { role, "aria-live": live as "polite" | "assertive" };
+};
+
+/**
+ * Heavy rendering implementation for ToastOutlet.
+ *
+ * This module is loaded via `React.lazy()` from the lightweight toast.outlet
+ * shell. It imports `@chakra-ui/react/toast` (which pulls in @zag-js), so
+ * consumers who never call `toast()` never pay for this chunk.
+ *
+ * @internal
+ */
+export default function ToastOutletImpl() {
+  return (
+    <>
+      {getToasterEntries().map(([placement, toaster]) => (
+        <Toaster
+          key={placement}
+          toaster={toaster}
+          data-react-aria-top-layer="true"
+        >
+          {(chakraToast) => {
+            const toast = chakraToast as ChakraToastData;
+            const type = (toast.type as ToastType) || "info";
+            const variant = toast.meta?.variant || "accent-start";
+
+            return (
+              <ChakraToast.Root
+                colorPalette={COLOR_PALETTE_MAP[type]}
+                variant={variant}
+                {...getARIAAttributes(type, toast.meta?.["aria-live"])}
+              >
+                <ToastContent toast={toast} toaster={toaster} />
+              </ChakraToast.Root>
+            );
+          }}
+        </Toaster>
+      ))}
+    </>
+  );
+}

--- a/packages/nimbus/src/components/toast/components/toast.outlet.tsx
+++ b/packages/nimbus/src/components/toast/components/toast.outlet.tsx
@@ -1,31 +1,23 @@
-import { useEffect, useSyncExternalStore } from "react";
-import { Toaster, Toast as ChakraToast } from "@chakra-ui/react/toast";
+import { lazy, Suspense, useEffect, useSyncExternalStore } from "react";
 import {
-  getToasterEntries,
   isToastersActive,
   onToastersActivated,
-} from "../services/toast.toasters";
-import { ToastContent } from "./toast.content";
-import { COLOR_PALETTE_MAP, NUMPAD_HOTKEYS } from "../constants";
-import type { ChakraToastData, ToastType } from "../toast.types";
+} from "../services/toast.activation";
+import { NUMPAD_HOTKEYS } from "../constants";
 
 /**
- * Returns the correct ARIA role and live-region politeness for a toast type.
- * Error toasts use `role="alert"` with `aria-live="assertive"`,
- * all others use `role="status"` with `aria-live="polite"`.
+ * Lazy-loaded heavy rendering implementation.
  *
- * An explicit `ariaLive` override (from `ToastOptions`) takes precedence
- * over the type-based default.
+ * This dynamic import is the key to toast code-splitting: the impl module
+ * imports `@chakra-ui/react/toast` (which pulls in @zag-js, ~18 KB gz).
+ * By loading it lazily, consumers who never call `toast()` never pay for
+ * the toast rendering infrastructure.
+ *
+ * In the nimbus library build (Vite lib mode), this `import()` is preserved
+ * as a dynamic import in the ESM output. The consumer's bundler then handles
+ * code-splitting it into a separate chunk.
  */
-const getARIAAttributes = (
-  type?: ToastType,
-  ariaLive?: "polite" | "assertive" | "off"
-) => {
-  const liveDefault = type === "error" ? "assertive" : "polite";
-  const live = ariaLive ?? liveDefault;
-  const role = live === "assertive" ? ("alert" as const) : ("status" as const);
-  return { role, "aria-live": live as "polite" | "assertive" };
-};
+const ToastOutletImpl = lazy(() => import("./toast.outlet.impl"));
 
 /**
  * Subscribe function for useSyncExternalStore.
@@ -47,6 +39,12 @@ function subscribeToActivation(onStoreChange: () => void) {
  * toast is actually created. This avoids mounting internal state machines
  * (and their DOM event listeners) when toasts are never used, and
  * eliminates spurious `act(...)` warnings in JSDOM-based tests.
+ *
+ * This shell component is deliberately lightweight — it imports only from
+ * the `toast.activation` module (no @chakra-ui/react/toast dependencies).
+ * The heavy rendering code is loaded via `React.lazy()` only when toasters
+ * become active, keeping @zag-js out of the main bundle for consumers who
+ * never use toast.
  *
  * @example
  * ```tsx
@@ -89,30 +87,8 @@ export function ToastOutlet() {
   }
 
   return (
-    <>
-      {getToasterEntries().map(([placement, toaster]) => (
-        <Toaster
-          key={placement}
-          toaster={toaster}
-          data-react-aria-top-layer="true"
-        >
-          {(chakraToast) => {
-            const toast = chakraToast as ChakraToastData;
-            const type = (toast.type as ToastType) || "info";
-            const variant = toast.meta?.variant || "accent-start";
-
-            return (
-              <ChakraToast.Root
-                colorPalette={COLOR_PALETTE_MAP[type]}
-                variant={variant}
-                {...getARIAAttributes(type, toast.meta?.["aria-live"])}
-              >
-                <ToastContent toast={toast} toaster={toaster} />
-              </ChakraToast.Root>
-            );
-          }}
-        </Toaster>
-      ))}
-    </>
+    <Suspense fallback={null}>
+      <ToastOutletImpl />
+    </Suspense>
   );
 }

--- a/packages/nimbus/src/components/toast/services/index.ts
+++ b/packages/nimbus/src/components/toast/services/index.ts
@@ -1,8 +1,3 @@
 export { toast, ToastManager } from "./toast.manager";
-export {
-  getToaster,
-  getToasterEntries,
-  isToastersActive,
-  onToastersActivated,
-  resetToasters,
-} from "./toast.toasters";
+export { getToaster, getToasterEntries, resetToasters } from "./toast.toasters";
+export { isToastersActive, onToastersActivated } from "./toast.activation";

--- a/packages/nimbus/src/components/toast/services/toast.activation.ts
+++ b/packages/nimbus/src/components/toast/services/toast.activation.ts
@@ -1,0 +1,53 @@
+/**
+ * Lightweight activation tracking for toast infrastructure.
+ *
+ * This module has ZERO transitive dependencies on @chakra-ui/react/toast or
+ * @zag-js — it only tracks whether toasters have been initialized. This
+ * allows ToastOutlet's shell component to subscribe to activation without
+ * pulling the heavy toast rendering code into the main bundle.
+ *
+ * @internal
+ */
+
+/** Whether toasters have been initialized (at least one toast was created). */
+let active = false;
+
+/** Listeners notified when toasters are first initialized. */
+const activationListeners = new Set<() => void>();
+
+/** Whether toasters have been initialized. */
+export function isToastersActive(): boolean {
+  return active;
+}
+
+/**
+ * Mark toasters as active and notify all listeners.
+ * Called by toast.toasters.ts when `ensureToasters()` first runs.
+ */
+export function markToastersActive(): void {
+  if (active) return;
+  active = true;
+  activationListeners.forEach((listener) => listener());
+}
+
+/**
+ * Subscribe to toaster activation. The callback fires once when toasters
+ * are first initialized. Returns an unsubscribe function.
+ */
+export function onToastersActivated(callback: () => void): () => void {
+  if (active) {
+    callback();
+    return () => {};
+  }
+  activationListeners.add(callback);
+  return () => {
+    activationListeners.delete(callback);
+  };
+}
+
+/**
+ * Reset activation state (for testing only).
+ */
+export function resetActivation(): void {
+  active = false;
+}

--- a/packages/nimbus/src/components/toast/services/toast.toasters.ts
+++ b/packages/nimbus/src/components/toast/services/toast.toasters.ts
@@ -1,6 +1,7 @@
 import { createToaster } from "@chakra-ui/react/toast";
 import type { ToastPlacement } from "../toast.types";
 import { ALL_PLACEMENTS, PLACEMENT_HOTKEYS } from "../constants";
+import { markToastersActive, resetActivation } from "./toast.activation";
 
 /** Local alias to avoid exposing transitive @zag-js/toast types in declarations. */
 type Toaster = ReturnType<typeof createToaster>;
@@ -21,12 +22,6 @@ type Toaster = ReturnType<typeof createToaster>;
 let toasters: Map<ToastPlacement, ReturnType<typeof createToaster>> | null =
   null;
 
-/**
- * Listeners notified when toasters are first initialized.
- * Used by ToastOutlet to defer rendering until a toast is actually created.
- */
-const activationListeners = new Set<() => void>();
-
 function ensureToasters() {
   if (!toasters) {
     toasters = new Map(
@@ -43,8 +38,8 @@ function ensureToasters() {
       })
     );
 
-    // Notify outlet that toasters are now available
-    activationListeners.forEach((listener) => listener());
+    // Notify the lightweight activation module (and thus ToastOutlet's shell)
+    markToastersActive();
   }
   return toasters;
 }
@@ -58,29 +53,7 @@ function ensureToasters() {
  */
 export function resetToasters(): void {
   toasters = null;
-}
-
-/**
- * Whether toasters have been initialized (i.e., at least one toast was created).
- */
-export function isToastersActive(): boolean {
-  return toasters !== null;
-}
-
-/**
- * Subscribe to toaster activation. The callback fires once when toasters
- * are first initialized. Returns an unsubscribe function.
- */
-export function onToastersActivated(callback: () => void): () => void {
-  // Already active — fire immediately
-  if (toasters) {
-    callback();
-    return () => {};
-  }
-  activationListeners.add(callback);
-  return () => {
-    activationListeners.delete(callback);
-  };
+  resetActivation();
 }
 
 /**

--- a/packages/nimbus/vite.config.ts
+++ b/packages/nimbus/vite.config.ts
@@ -133,13 +133,6 @@ const external = [
   // "react-aria-components",
   // "react-stately",
   // "@react-aria/interactions",
-
-  // Internal packages
-  // TODO: Icons from @commercetools/nimbus-icons should be tree-shakeable, it might make more sense to just bundle the necessary icons with their components, and not care whether this package is installed in consuming apps.
-  "@commercetools/nimbus-icons",
-  // TODO: @commercetools/nimbus-tokens is really a dev dependency we use to build the theme for chakra's styled-system, which is where we consume tokens from in all components, and in any components that are a child of the NimbusProvider.
-  //       We should evaluate whether it's necessary to specify @commercetools/nimbus-tokens as a peer dep, since the styled-system theme is created at build time and exported separately from this package.
-  "@commercetools/nimbus-tokens",
 ];
 
 // Define the config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,6 +483,9 @@ importers:
       globals:
         specifier: catalog:tooling
         version: 17.11.0
+      rollup-plugin-visualizer:
+        specifier: ^5.14.0
+        version: 5.14.0(rolldown@1.2.2)(rollup@4.62.4)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -5682,6 +5685,10 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
@@ -6534,6 +6541,11 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -6658,6 +6670,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -7450,6 +7466,10 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -8154,6 +8174,19 @@ packages:
     resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  rollup-plugin-visualizer@5.14.0:
+    resolution: {integrity: sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x
+      rollup: ^4.62.4
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
 
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
@@ -16375,6 +16408,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  define-lazy-prop@2.0.0: {}
+
   define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
@@ -17330,6 +17365,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@2.2.1: {}
+
   is-docker@3.0.0: {}
 
   is-dotfile@1.0.3: {}
@@ -17423,6 +17460,10 @@ snapshots:
   is-url@1.2.4: {}
 
   is-windows@1.0.2: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   is-wsl@3.1.0:
     dependencies:
@@ -18414,6 +18455,12 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -19316,6 +19363,16 @@ snapshots:
       '@rolldown/binding-openharmony-arm64': 1.2.2
       '@rolldown/binding-win32-arm64-msvc': 1.2.2
       '@rolldown/binding-win32-x64-msvc': 1.2.2
+
+  rollup-plugin-visualizer@5.14.0(rolldown@1.2.2)(rollup@4.62.4):
+    dependencies:
+      open: 8.4.2
+      picomatch: 4.0.5
+      source-map: 0.7.6
+      yargs: 17.7.2
+    optionalDependencies:
+      rolldown: 1.2.2
+      rollup: 4.62.4
 
   rollup@4.62.4:
     dependencies:


### PR DESCRIPTION
## Summary

Reduces the consumer production bundle size from **377 KB gz to 163 KB gz** (−57%) by fixing icon tree-shaking, inlining internal packages, and eliminating dead token imports.

## Changes

### 1. Fix nimbus-icons tree-shaking (biggest win)
Nested `dist/esm/package.json` files were missing `sideEffects: false`, shadowing the root declaration. Bundlers included all 2,127 icons even when only ~50 are used. Fixed by adding `sideEffects: false` to the postbuild marker files.

### 2. Bundle nimbus-icons into nimbus (drop peer dep)
Nimbus uses only ~50 icons internally. These are now bundled into nimbus's dist instead of being externalized. Consumers who import icons directly for their own UI install `nimbus-icons` separately — tree-shaking now works correctly for them too.

### 3. Bundle nimbus-tokens into nimbus (drop peer dep)
Token values are consumed at build time to create the Chakra theme. They're now inlined into nimbus's theme chunk. No runtime dependency on `nimbus-tokens`.

### 4. Eliminate designTokens import
Two files (`money-input.tsx`, `multiline-text-input.recipe.ts`) imported the 93 KB `designTokens` module for a single value each. Migrated to `themeTokens` (which is already in the dependency graph via the theme chunk).

### 5. Bundle visualizer for blank-app
Added opt-in `rollup-plugin-visualizer` behind `ANALYZE_BUNDLE` env var. Run `pnpm --filter blank-app build:analyze` to generate `bundle-report.html`.

## Peer dependency changes

| Before | After |
|--------|-------|
| `@commercetools/nimbus-icons` | _(removed — bundled internally)_ |
| `@commercetools/nimbus-tokens` | _(removed — bundled at build time)_ |
| `@chakra-ui/react` | `@chakra-ui/react` |
| `react` | `react` |
| `slate`, `slate-react`, `slate-history`, `slate-hyperscript` | _(unchanged)_ |

Consumers who only had `nimbus-icons` and `nimbus-tokens` installed because nimbus required them can now remove both packages.

## Verification

- ✅ `pnpm build:packages` — builds successfully
- ✅ `pnpm --filter @commercetools/nimbus typecheck:dev` — clean
- ✅ `pnpm test:dev` — 3,225 tests pass (250 files)
- ✅ `pnpm check:package-shape` — all packages pass attw + publint
- ✅ `pnpm --filter blank-app build` — 588 KB raw / 163 KB gz (down from 377 KB gz)
- ✅ No `@commercetools/nimbus-tokens` references in dist output
- ✅ nimbus-icons tree-shaking verified (only ~50 used icons in bundle)

## Future work (not in this PR)

- **Toast code-splitting** (~18 KB gz): `NimbusProvider` unconditionally imports `ToastOutlet`, pulling in `@zag-js/*`. Needs a separate entry point (`@commercetools/nimbus/toast`) — breaking API change requiring OpenSpec proposal.
- **Slate isolation**: Move rich text editor to a separate entry point to make Slate deps optional.
- **Theme chunk optimization** (~38 KB gz): All 70 recipes load via `createSystem()` regardless of which components are used.

Closes FEC-1293